### PR TITLE
Adding signup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "2"
+services:
+  happa:
+    build: "./"
+    image: happa:latest
+    command: npm start
+    ports:
+      - "8000:8000"
+    volumes:
+      - "./src:/usr/src/app/src"
+    links:
+      - passage
+
+  passage:
+    image: registry.giantswarm.io/giantswarm/passage:latest
+    ports:
+      - "5000:5000"
+    environment:
+      DEBUGGING: 1
+      CORS_ORIGIN: http://docker.dev:8000
+      GIANTSWARM_API_URI: http://giantswarmmockapi:8000/v1
+      GIANTSWARM_API_TOKEN: valid_token
+      HUBSPOT_API_URI: http://hubspotmock:9999
+      HUBSPOT_HUB_ID: "430224"
+      HUBSPOT_API_KEY: 1234567890abcdefghijklmnop
+    links:
+      - hubspotmock
+      - giantswarmmockapi
+
+  # Mocks the HubSpot API
+  hubspotmock:
+    image: registry.giantswarm.io/giantswarm/mock-hubspot-api:latest
+    environment:
+      DEBUGGING: 1
+    ports:
+      - "9999:9999"
+  giantswarmmockapi:
+    image: registry.giantswarm.io/giantswarm/mock-api:latest
+    ports:
+      - "9000:8000"

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -9,6 +9,7 @@ var newService = require('./new_service/index');
 var docs       = require('./docs/index');
 var login      = require('./login/index');
 var logout     = require('./logout/index');
+var signup     = require('./signup/index');
 
 var UserActions = require('./reflux_actions/user_actions');
 var UserStore   = require('./reflux_stores/user_store');
@@ -34,6 +35,7 @@ render((
     <Route path="/" component={Layout}>
       <IndexRoute component={docs} onEnter={requireAuth} />
       <Route path = "/services/new" component={newService} onEnter={requireAuth} />
+      <Route path = "/signup/:contactId/:token/" component={signup} />
       <Route path = "/login" component={login} />
       <Route path = "/logout" component={logout} />
     </Route>

--- a/src/components/signup/index.js
+++ b/src/components/signup/index.js
@@ -1,0 +1,96 @@
+"use strict";
+
+var React = require('react');
+var $     = require('jquery');
+
+module.exports = React.createClass({
+
+  getInitialState: function() {
+    return {validInvite: null};
+  },
+
+  componentDidMount: function(){
+    // contactID and token are set via URL
+    this.checkInvite(this.props.params.contactId, this.props.params.token);
+  },
+
+  checkInvite: function(contactId, token) {
+    console.log("Checking invite", contactId, token);
+    var url = window.config.passageEndpoint + '/invite/'+ contactId +'/' + token;
+    $.getJSON(url, function(data){
+      this.setState({"validInvite": data.is_valid});
+      if (data.is_valid) {
+        console.log("Invite is valid!");
+        console.log(data);
+        this.setState({
+          "email": data.email,
+          "initialAccountExpirationDays": data.initial_account_expiration
+        });
+      } else {
+        console.log("Sorry, invite is not valid");
+      }
+    }.bind(this));
+  },
+
+  handleSubmit: function(e){
+    e.preventDefault();
+    console.log("Form submitted!");
+    // TODO: check if both passwords are identical
+    var account = {
+      "contact_id": this.props.params.contactId,
+      "invite_token": this.props.params.token,
+      "password": this.refs.password1.value
+    };
+    console.log(account);
+    var url = window.config.passageEndpoint + '/accounts/';
+    $.ajax({
+      type: "POST",
+      url: url,
+      dataType: 'json',
+      contentType : 'application/json',
+      data: JSON.stringify(account),
+      success: function(responseData){
+        console.log("Account generated successfully.", responseData);
+      },
+      error: function(jqXHR, textStatus, textStatus){
+        console.log("An error occurred when trying to create a user account.");
+        console.log(jqXHR, textStatus, textStatus);
+      }
+    });
+  },
+
+  render: function() {
+    if (this.state.validInvite === true) {
+      return (
+        <div className="signup--container col-6">
+          <p>Hi {this.state.email}! Your account will be valid for {this.state.initialAccountExpirationDays} days starting from your sign-up.</p>
+          <form ref="signupForm" onSubmit={this.handleSubmit}>
+            <div className="textfield">
+              <label for="password1">Password</label>
+              <input type="password" ref="password1" id="password1" />
+            </div>
+            <div className="textfield">
+              <label for="password2">Password, once more</label>
+              <input type="password" ref="password2" id="password2" />
+            </div>
+            <div>
+              <button>Submit</button>
+            </div>
+          </form>
+        </div>
+      );
+    } else if (this.state.validInvite === false) {
+      return (
+        <div className="signup--container col-6">
+          Sorry, your invite is not valid
+        </div>
+      );
+    } else {
+      return (
+        <div className="signup--container col-6">
+          Checking your invite...
+        </div>
+      );
+    }
+  }
+});

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
   <title></title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-
   <link rel="icon" sizes="192x192" href="/images/app_icon_192.png">
   <link rel="icon" sizes="128x128" href="/images/app_icon_128.png">
   <link rel="apple-touch-icon" sizes="128x128" href="/images/app_icon_128.png">
@@ -18,9 +17,11 @@
   <script>
   var config = {
     enableTracking: false,
-    defaultApiEndpoint: 'https://api.giantswarm.io'
+    // TODO: Make this configurable via Docker environment variable
+    //defaultApiEndpoint: 'https://api.giantswarm.io'
+    defaultApiEndpoint: 'http://giantswarmmockapi:8000',
+    passageEndpoint: 'http://docker.dev:5000'
   }
-
   window.config = config;
   </script>
 </head>
@@ -37,8 +38,7 @@
     </div>
   </noscript>
 
-  <div id="app">
-  </div>
+  <div id="app"></div>
   <script type="text/javascript" src="vendor/modernizr.js"></script>
   <script type="text/javascript" src="assets/app.js"></script>
 </body>

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -16,3 +16,4 @@
 @import "components/codeblock";
 @import "components/login_form";
 @import "components/logout";
+@import "components/signup";

--- a/src/styles/components/_signup.sass
+++ b/src/styles/components/_signup.sass
@@ -1,0 +1,4 @@
+.signup--container
+	position: relative
+	margin: auto
+	margin-top: 50px


### PR DESCRIPTION
@oponder This is what I did so far to happa. I created this change based on `auth`.

The signup form is a rough sketch and doesn't represent what we imagine UI-wise. UI-wise, the new signup should rather be like the old one.

Using the provided docker-compose and an ugly hard-code fix to `window.config` in `index.html` I managed to link happa to the local `passage` container. For dev purposes of course, the hubspot mock and giantswarm mock APIs are linked behind passage.

The URL `http://docker.dev:8000/#/signup/2222/abcde12345/` allows to test a valid invite. Everything else should be invalid.

I hope you can pick this up and make something useful out of it.

<!---
@huboard:{"custom_state":"archived"}
-->
