### PR TITLE
Upgrade to latest nodejs v6.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:6.2.2-slim
-RUN apt-get update -y && apt-get install -y --no-install-recommends git build-essential python
+RUN apt-get update -y && apt-get install -y --no-install-recommends git build-essential python && rm -rf /var/cache/apk/*
 
 # Create app directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
A quick edit to the docker file which upgrades to the latest node. 

Fixes https://github.com/giantswarm/happa/issues/12

<!---
@huboard:{"custom_state":"archived"}
-->
