### PR TITLE
Show WIP Message instead of getting started docs

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -13,6 +13,7 @@ var signup                = require('./signup/index');
 var notFound              = require('./not_found/index');
 var forgot_password_index = require('./forgot_password/index');
 var forgot_password_set_password = require('./forgot_password/set_password');
+var wip = require('./wip');
 
 var UserActions = require('../actions/user_actions');
 var UserStore   = require('../stores/user_store');
@@ -42,7 +43,7 @@ render((
     <Route path = "/signup/:contactId/:token" component={signup} />
 
     <Route path="/" component={Layout}>
-      <IndexRoute component={docs} onEnter={requireAuth} />
+      <IndexRoute component={wip} onEnter={requireAuth} />
       <Route path = "/docs" component={docs} onEnter={requireAuth} />
       <Route path = "/docs/:pageId" component={docs} onEnter={requireAuth} />
       <Route path="*" component={notFound} />

--- a/src/components/wip/index.js
+++ b/src/components/wip/index.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var React   = require('react');
+var ReactCSSTransitionGroup = require('react-addons-css-transition-group');
+var {Link}  = require('react-router');
+
+module.exports = React.createClass({
+  render: function() {
+    return (
+      <div>
+        <h1>Hi there!</h1>
+        <p>You've reached a under-development part of Giant Swarm</p>
+        <p>
+          There isn't too much to see here yet! Chances are you just used this to reset your password.</p>
+        <p>
+          You might want to go to <a href="https://app.giantswarm.io">app.giantswarm.io</a> now, or use our CLI to continue working on your things.
+        </p>
+
+        <p>If you have any questions, you know where to reach us!</p>
+        <p>
+          Email: <a href="mailto:support@giantswarm.io">support@giantswarm.io</a><br/>
+          Twitter: <a href="https://www.twitter.com/giantswarm" target="_blank">@giantswarm</a>
+        </p>
+
+      </div>
+    );
+  }
+});


### PR DESCRIPTION
Happa's reset password flow is useful, but sending users to Happa and having them click around in the getting started docs is probably not desirable.

This adds a WIP message which is shown to the user on login. This way we can let people use the reset password feature already.

<img width="721" alt="screen shot 2016-08-18 at 10 49 05" src="https://cloud.githubusercontent.com/assets/455309/17760099/00cd819e-6538-11e6-9b04-2049a37b68ac.png">
