### PR TITLE
Remove current-context from kube-config

### DIFF
--- a/src/components/docs/2_configure_kubectl.js
+++ b/src/components/docs/2_configure_kubectl.js
@@ -129,7 +129,6 @@ var ConfigKubeCtl = React.createClass ({
             user:
               client-certificate-data: ${btoa(this.state.keyPair.data.client_certificate_data)}
               client-key-data: ${btoa(this.state.keyPair.data.client_key_data)}
-          current-context: "giantswarm-default"
           `}
         </FileBlock>
       );


### PR DESCRIPTION
I added this line because I wasn't using kubectl as recommended and couldn't get
it to work.
