### PR TITLE
Use double quote in export KUBECONFIG line, otherwise it is not interpolated

### DIFF
--- a/src/components/docs/2_configure_kubectl.js
+++ b/src/components/docs/2_configure_kubectl.js
@@ -198,7 +198,7 @@ var ConfigKubeCtl = React.createClass ({
 
           <CodeBlock>
             <Prompt>
-              {`export KUBECONFIG='\$\{KUBECONFIG\}:/path/to/giantswarm-kubeconfig'`}
+              {`export KUBECONFIG="\$\{KUBECONFIG\}:/path/to/giantswarm-kubeconfig"`}
             </Prompt>
           </CodeBlock>
 


### PR DESCRIPTION
Just a small typo I noticed when running through the guide.

The command we suggest them to run will not do the string interpolation of the environment variable:

`export KUBECONFIG='${KUBECONFIG}:/path/to/giantswarm-kubeconfig'`

The right way to do it would be with double quotes:

`export KUBECONFIG="${KUBECONFIG}:/path/to/giantswarm-kubeconfig"`

See: http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_02_02

rfr @marians
