### PR TITLE
Add tasks to pause and resume pingdom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,28 @@ npm-check-updates:
 # Run tests (of which there are none right now)
 test: docker-build
 	docker run -ti -p 8000:8000 -v ${PWD}/src:/usr/src/app/src happa-dev npm test
+
+#----------------------------------------------------
+# Some tasks to pause and resume pingdom alerts
+# Relies on the environment variable "PINGDOM_PASSWORD":
+#
+# export PINGDOM_PASSWORD=our_pingdom_password_from_keepass
+#
+# Happa check ID: 2206566
+# Desmotes check ID: 2346568
+
+pause-pingdom:
+	curl https://api.pingdom.com/api/2.0/checks/2206566 \
+	-u "accounts@giantswarm.io:$(PINGDOM_PASSWORD)" \
+	-X PUT \
+	-d 'paused=true' \
+	-H "App-Key: lyhqne9wyya2x5v7kq8mr9onogik4r34"
+
+resume-pingdom:
+	curl https://api.pingdom.com/api/2.0/checks/2206566 \
+	-u "accounts@giantswarm.io:$(PINGDOM_PASSWORD)" \
+	-X PUT \
+	-d 'paused=false' \
+	-H "App-Key: lyhqne9wyya2x5v7kq8mr9onogik4r34"
+
+


### PR DESCRIPTION
Hey whaddaya think of this? 

Part of deploying Happa should be to pause the alerts, so that if something
goes wrong, we don't bother people with an alert that isn't important.

This makes it a bit quicker to do that, which means we should end up
doing it more often.

It doesn't try to do it automatically on deploys or anything like that.
It just lowers the barrier to actually do it.
