### PR TITLE
Fix borders on hover of dropdowns that _should_ have an oultine

### DIFF
--- a/src/styles/components/_button.sass
+++ b/src/styles/components/_button.sass
@@ -101,3 +101,9 @@ button:disabled:hover, button:disabled
       background-color: #31556a
       color: #fff
       border: inherit
+
+
+.dropdown
+  button.outline
+    &:focus, &:active, &:hover, &:active:focus, &:hover:focus, &:hover:active
+      border: 1px solid #fff


### PR DESCRIPTION
In my fix to dropdowns that shouldn't have an outline, I broke the outline
for dropdowns that should have an outline. (The ones on the cluster dashboard)

I make a topic for myself to clean up the styling around the buttons later, because
I am fighting a lot against some bootstrap styles, and it is now very crufty.