### PR TITLE
Bake bootstrap's css into the distribution instead of pulling it from a cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-router": "~2.6.1",
     "react-router-scroll": "0.3.1",
     "underscore": "~1.8.3",
+    "bootstrap": "3.3.7",
     "validate.js": "~0.10.0",
     "superagent-bluebird-promise": "^3.0.0",
     "superagent": "1.8.2",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -22,6 +22,7 @@ import Home from './home';
 import AirbrakeClient from 'airbrake-js';
 
 require('normalize.css');
+require('bootstrap/dist/css/bootstrap.min.css');
 require('../styles/app.scss');
 require('react-datepicker/dist/react-datepicker.css');
 

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,6 @@
   <link rel="apple-touch-icon" sizes="128x128" href="/images/app_icon_128.png">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:100,300,700,300italic|Inconsolata:400,700|Roboto+Condensed:400,700" type="text/css">
   <script src="https://use.fonticons.com/d940f7eb.js"></script>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
   <meta name="robots" content="noindex, nofollow">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,24 @@ module.exports = {
     }, {
       test: /\.(png|jpg|svg)$/,
       loader: 'url-loader?limit=8192'
-    }]
+    },
+    {
+      test: /\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=application/font-woff'
+    },
+    {
+      test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=application/octet-stream'
+    },
+    {
+      test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'file'
+    },
+    {
+      test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=image/svg+xml'
+    }
+    ]
   },
 
   plugins: [

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -60,6 +60,22 @@ module.exports = {
     }, {
       test: /\.(png|jpg|svg)$/,
       loader: 'url-loader?limit=8192'
+    },
+    {
+      test: /\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=application/font-woff'
+    },
+    {
+      test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=application/octet-stream'
+    },
+    {
+      test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'file'
+    },
+    {
+      test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+      loader: 'url?limit=10000&mimetype=image/svg+xml'
     }]
   }
 };


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/happa/issues/94