### PR TITLE
Add version and environment to exception reports

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -15,6 +15,7 @@ services:
     environment:
       API_ENDPOINT: https://api.giantswarm.io
       INTERCOM_APP_ID: ictssdcu
+      ENVIRONMENT: pre-production
 
   passage:
     image: registry.giantswarm.io/giantswarm/passage:latest

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -26,11 +26,17 @@ require('bootstrap/dist/css/bootstrap.min.css');
 require('../styles/app.scss');
 require('react-datepicker/dist/react-datepicker.css');
 
-new AirbrakeClient({
+var airbrake = new AirbrakeClient({
   projectId: 'b623d794488458d023f2fcbea93954ca',
   projectKey: 'b623d794488458d023f2fcbea93954ca',
   reporter: 'xhr',
   host: 'https://exceptions.giantswarm.io'
+});
+
+airbrake.addFilter(function(notice) {
+  notice.context.environment = window.config.environment;
+  notice.context.version = window.config.version;
+  return notice;
 });
 
 var appContainer = document.getElementById('app');

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,9 @@
     passageEndpoint: 'http://docker.dev:5000',
     desmotesEndpoint: 'http://docker.dev:9001',
     intercomAppId: 'bdvx0cb8',
-    domainValidatorEndpoint: 'http://docker.dev:5001'
+    domainValidatorEndpoint: 'http://docker.dev:5001',
+    environment: 'development',
+    version: 'development'
   }
   window.config = config;
   </script>

--- a/start.sh
+++ b/start.sh
@@ -19,6 +19,14 @@ if [ -n "$DOMAIN_VALIDATOR_ENDPOINT" ]; then
   sed -i "s|domainValidatorEndpoint: 'http://docker.dev:5001'|domainValidatorEndpoint: '$DOMAIN_VALIDATOR_ENDPOINT'|" /www/index.html
 fi
 
+if [ -n "$ENVIRONMENT" ]; then
+  sed -i "s|environment: 'development'|environment: '$ENVIRONMENT'|" /www/index.html
+else
+  sed -i "s|environment: 'development'|environment: 'docker-container'|" /www/index.html
+fi
+
+sed -i "s|version: 'development'|version: '$(cat /www/VERSION)'|" /www/index.html
+
 sed -i "s|VERSION|$(cat /www/VERSION)|" /etc/nginx/nginx.conf
 
 nginx -g "daemon off;"


### PR DESCRIPTION
This adds more context to the exception notification. 

It adds the version number 
Version is `development` if not running from production built container, and otherwise equal to the version that we get from builder. 

It also adds a configurable `environment` to the context.
`environment` is `development` when working locally, and `pre-production` by default if running from the production ready docker container, but configurable using the `ENVIRONMENT` environment variable. 

