### PR TITLE
Make sure code blocks are font-size: 15px

### DIFF
--- a/src/styles/components/_codeblock.sass
+++ b/src/styles/components/_codeblock.sass
@@ -20,6 +20,7 @@
     line-height: auto
     padding-right: 55px
     overflow: visible
+    font-size: 15px
 
   .content
     overflow-x: auto


### PR DESCRIPTION
Self descriptive title.