### PR TITLE
Template the env variable that sets CreateClusterWorkerType

### DIFF
--- a/kubernetes/production/production.yml
+++ b/kubernetes/production/production.yml
@@ -34,6 +34,8 @@ spec:
           value: {{ .Installation.V1.GiantSwarm.Desmotes.Address | urlString }}
         - name: ENVIRONMENT
           value: kubernetes
+        - name: CREATE_CLUSTER_WORKER_TYPE
+          value: {{ .Installation.V1.GiantSwarm.Happa.CreateClusterWorkerType }}
         livenessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
This is the last little step needed to get Happa to correctly start up in 'aws' mode when deployed to aws.