### PR TITLE
Adds initial requests and limits

### DIFF
--- a/kubernetes/production/production.yml
+++ b/kubernetes/production/production.yml
@@ -50,6 +50,13 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
           timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+          limits:
+            cpu: 250m
+            memory: 250Mi
       imagePullSecrets:
       - name: circleci-giantswarm-registry
 

--- a/kubernetes/staging/staging.yml
+++ b/kubernetes/staging/staging.yml
@@ -48,6 +48,13 @@ spec:
             scheme: HTTPS
           initialDelaySeconds: 10
           timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+          limits:
+            cpu: 250m
+            memory: 250Mi
       imagePullSecrets:
       - name: circleci-giantswarm-registry
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1105

For reference, happa is currently using < 3Mb, so this is more
than enough.