### PR TITLE
Fix cluster dropdown in times of metrics errors

### DIFF
--- a/src/components/home/cluster_dashboard.js
+++ b/src/components/home/cluster_dashboard.js
@@ -40,6 +40,28 @@ class ClusterDashboard extends React.Component {
 
   render() {
     return <div className={this.props.className + ' cluster-dashboard well ' + (this.props.cluster.errorLoadingMetrics ? 'loading' : '')}>
+      <h1 className="cluster-dashboard--name">
+        {this.props.cluster.name}<div className="cluster-dashboard--id"> — <code>{this.props.cluster.id}</code></div>
+
+        <ButtonGroup>
+          <DropdownButton title="" id="add_node_dropdown" className="outline">
+            <MenuItem onClick={this.configureDocsFor.bind(this, this.props.cluster.id)}>Access Via kubectl</MenuItem>
+            <MenuItem componentClass={Link}
+                      href={'/organizations'}
+                      to={'/organizations/' + this.props.selectedOrganization + '/clusters/' + this.props.cluster.id }>
+                      Cluster Details
+            </MenuItem>
+            <MenuItem onClick={this.showDeleteClusterModal.bind(this, this.props.cluster.id)}>Delete Cluster</MenuItem>
+
+            {/*
+              <MenuItem>Open in Kubernetes Dashboard</MenuItem>
+              <MenuItem>Configure Persistent Storage</MenuItem>
+              <MenuItem>Launch Cluster Like This</MenuItem>
+              <MenuItem>Rename cluster</MenuItem>
+            */}
+          </DropdownButton>
+        </ButtonGroup>
+      </h1>
       {
         this.props.children ?
         <div className="cluster-dashboard--overlay">
@@ -52,29 +74,6 @@ class ClusterDashboard extends React.Component {
       <img className='loader' src='/images/loader_oval_light.svg' />
 
       <div className={'cluster-dashboard--inner'}>
-        <h1 className="cluster-dashboard--name">
-          {this.props.cluster.name}<div className="cluster-dashboard--id"> — <code>{this.props.cluster.id}</code></div>
-
-          <ButtonGroup>
-            <DropdownButton title="" id="add_node_dropdown" className="outline">
-              <MenuItem onClick={this.configureDocsFor.bind(this, this.props.cluster.id)}>Access Via kubectl</MenuItem>
-              <MenuItem componentClass={Link}
-                        href={'/organizations'}
-                        to={'/organizations/' + this.props.selectedOrganization + '/clusters/' + this.props.cluster.id }>
-                        Cluster Details
-              </MenuItem>
-              <MenuItem onClick={this.showDeleteClusterModal.bind(this, this.props.cluster.id)}>Delete Cluster</MenuItem>
-
-              {/*
-                <MenuItem>Open in Kubernetes Dashboard</MenuItem>
-                <MenuItem>Configure Persistent Storage</MenuItem>
-                <MenuItem>Launch Cluster Like This</MenuItem>
-                <MenuItem>Rename cluster</MenuItem>
-              */}
-            </DropdownButton>
-          </ButtonGroup>
-        </h1>
-
         <div className='gadgets'>
           <DonutGadget
             label='RAM'

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -78,10 +78,9 @@ class Home extends React.Component {
             _.map(_.sortBy(this.props.clusters, (cluster) => cluster.id), (cluster) => {
               if (cluster.errorLoadingMetrics) {
                 return <ClusterDashboard cluster={cluster} key={cluster.id + 'error'} className='empty-slate'>
-                  <h1>Couldn't load metrics for cluster <code>{cluster.id}</code></h1>
-                  <p>We're currently improving our metrics gathering.</p>
-                  <p>If you need metrics, you can <a href='https://docs.giantswarm.io/guides/kubernetes-prometheus/' target="_blank">set up your own monitoring with Prometheus easily</a></p>
+                  <h1>Couldn't load metrics for this cluster</h1>
                   <p>Thanks for your patience! If you have any questions don't hesitate to contact support: <a href='mailto:support@giantswarm.io'>support@giantswarm.io</a></p>
+                  <p>Tip: you can <a href='https://docs.giantswarm.io/guides/kubernetes-prometheus/' target="_blank">set up your own monitoring with Prometheus easily</a></p>
                 </ClusterDashboard>;
               } else if (cluster.metricsLoading && ! cluster.metricsLoadedFirstTime) {
                 return <ClusterDashboard selectedOrganization={this.props.selectedOrganization} cluster={cluster} key={cluster.id} className='loading' />;

--- a/src/styles/components/_cluster_dashboard.sass
+++ b/src/styles/components/_cluster_dashboard.sass
@@ -29,6 +29,8 @@
 
     &.cluster-dashboard--name
       font-size: 26px
+      z-index: 120
+      position: relative
 
     .cluster-dashboard--id
       display: inline


### PR DESCRIPTION
This ensures the dropdown is still interactable when the metrics error message is up.