### PR TITLE
Build in docker container on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,8 +18,9 @@ test:
   override:
     # Just a little smoke test. Starts the production container and checks
     # if a line of text from index.html is in there.
-    - docker run -p 8000:8000 -d quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
-    - curl -k https://localhost:8000 | grep Happa # Grep returns non 0 exit code if it can't find the text, which fails the smoke test
+    - docker run --name testcontainer -p 8000:8000 -d quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+    - curl -s -k https://localhost:8000 | grep Happa # Grep returns non 0 exit code if it can't find the text, which fails the smoke test
+    - docker kill testcontainer
 
 deployment:
   master:


### PR DESCRIPTION
Build in a docker image, to make the build use node 6 and be more reproducible.