### PR TITLE
Show friendly cluster name in Configure Kubectl dropdown and heading

### DIFF
--- a/src/styles/components/_cluster_dashboard.sass
+++ b/src/styles/components/_cluster_dashboard.sass
@@ -32,19 +32,27 @@
       z-index: 120
       position: relative
 
-    .cluster-dashboard--id
-      display: inline
-      color: inherit
-
-      code
-        background-color: transparent
-        border-radius: 4px
-        padding: 3px 4px
-        margin: 0px 1px
-        color: inherit
-
   h3
     font-size: 20px
+
+
+h1
+  .cluster-dashboard--id
+    display: inline
+    color: inherit
+    font-size: 22px
+    top: -3px
+    position: relative
+
+    code
+      background-color: transparent
+      border-radius: 4px
+      padding: 3px 4px
+      margin: 0px 1px
+      color: inherit
+      font-size: 26px
+      top: 1px
+      position: relative
 
 .cluster-dashboard--overlay
   text-align: center


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/happa/issues/157

<img width="843" alt="screen shot 2017-06-08 at 11 56 26" src="https://user-images.githubusercontent.com/455309/26924178-f70d6490-4c44-11e7-9324-8754f79b636e.png">

I've also adjusted the behavior in the case that the user arrives on this page from an organization
that has no clusters.