### PR TITLE
Switch to org when viewing the org

### DIFF
--- a/src/components/organizations/index.js
+++ b/src/components/organizations/index.js
@@ -15,6 +15,7 @@ class Organizations extends React.Component {
   }
 
   viewOrganization(orgId) {
+    this.selectOrganization(orgId);
     this.context.router.push('/organizations/' + orgId);
   }
 
@@ -68,7 +69,6 @@ class Organizations extends React.Component {
                                                 key={organization.id}
                                                 onClick={this.viewOrganization.bind(this, organization.id)}
                                                 onDelete={this.deleteOrganization.bind(this, organization.id)}
-                                                onSelect={this.selectOrganization.bind(this, organization.id)}
                                  />;
                         }
                       )

--- a/src/components/organizations/organizationRow.js
+++ b/src/components/organizations/organizationRow.js
@@ -14,10 +14,6 @@ class OrganizationRow extends React.Component {
             <i className='fa fa-times clickable'
                title='Delete this organization'
                onClick={this.props.onDelete} />
-            &nbsp;
-            <i className='fa fa-flag clickable'
-               title='Switch to this organization'
-               onClick={this.props.onSelect} />
           </div>
         </td>
       </tr>


### PR DESCRIPTION
Related to: https://github.com/giantswarm/happa/issues/152

This removes the little 'switch to org' flag next to the organization delete button. 
Nobody probably knew what it did, and it's not really clear what it would do anyways. 

<img width="1091" alt="screen shot 2017-06-08 at 12 59 35" src="https://user-images.githubusercontent.com/455309/26925557-808c41d2-4c4a-11e7-8150-b3ba3333775a.png">

Now when you click to view the organization, the selected organization also switches to
the org you just clicked on.