### PR TITLE
Fix undefined in breadcrumb when selecting cluster details from the dashboard

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -77,7 +77,7 @@ class Home extends React.Component {
           {
             _.map(_.sortBy(this.props.clusters, (cluster) => cluster.id), (cluster) => {
               if (cluster.errorLoadingMetrics) {
-                return <ClusterDashboard cluster={cluster} key={cluster.id + 'error'} className='empty-slate'>
+                return <ClusterDashboard selectedOrganization={this.props.selectedOrganization} cluster={cluster} key={cluster.id + 'error'} className='empty-slate'>
                   <h1>Couldn't load metrics for this cluster</h1>
                   <p>Thanks for your patience! If you have any questions don't hesitate to contact support: <a href='mailto:support@giantswarm.io'>support@giantswarm.io</a></p>
                   <p>Tip: you can <a href='https://docs.giantswarm.io/guides/kubernetes-prometheus/' target="_blank">set up your own monitoring with Prometheus easily</a></p>


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/happa/issues/156

Just forgot to pass down the selected organization to a component that needed it.