### PR TITLE
Fix 'server is undefined' when downloading a key pair via cluster details screen

### DIFF
--- a/src/components/organizations/cluster_detail.js
+++ b/src/components/organizations/cluster_detail.js
@@ -6,15 +6,48 @@ import { bindActionCreators } from 'redux';
 import * as clusterActions from '../../actions/clusterActions';
 import ClusterKeyPairs from './cluster_key_pairs';
 import DocumentTitle from 'react-document-title';
+import { flashAdd } from '../../actions/flashMessageActions';
 
 class ClusterDetail extends React.Component {
+  constructor (props){
+    super(props);
+
+    this.state = {
+      loading: true
+    };
+  }
+
+  componentDidMount() {
+    this.setState({
+      loading: true
+    });
+
+    this.props.actions.clusterLoadDetails(this.props.cluster.id)
+    .then(() => {
+      this.setState({
+        loading: false
+      });
+    })
+    .catch(() => {
+      this.props.dispatch(flashAdd({
+        message: 'Something went wrong while trying to load cluster details. Please try again later or contact support: support@giantswarm.io',
+        class: 'danger',
+        ttl: 3000
+      }));
+
+      this.setState({
+        loading: 'failed'
+      });
+    });
+  }
+
   render() {
     return (
       <DocumentTitle title={'Cluster Details | ' + this.props.cluster.name +  ' | Giant Swarm'}>
-        <div>
+        <div className="cluster-details">
           <div className='row'>
             <div className='col-12'>
-              <h1>Details for cluster: {this.props.cluster.name}</h1>
+              <h1>Details for cluster: {this.props.cluster.name} {this.state.loading ? <img className='loader' width="25px" height="25px" src='/images/loader_oval_light.svg'/> : ''} </h1>
             </div>
           </div>
 
@@ -29,7 +62,7 @@ class ClusterDetail extends React.Component {
             // </div>
           }
 
-          <ClusterKeyPairs cluster={this.props.cluster} />
+          {this.state.loading ? '' : <ClusterKeyPairs cluster={this.props.cluster} />}
         </div>
       </DocumentTitle>
     );
@@ -38,7 +71,9 @@ class ClusterDetail extends React.Component {
 
 ClusterDetail.propTypes = {
   cluster: React.PropTypes.object,
-  clusters: React.PropTypes.object
+  clusters: React.PropTypes.object,
+  dispatch: React.PropTypes.func,
+  actions: React.PropTypes.object
 };
 
 function mapStateToProps(state, ownProps) {

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -103,9 +103,9 @@ export default function clusterReducer(state = {lastUpdated: 0, isFetching: fals
     case types.CLUSTER_LOAD_PARTIAL_DETAILS:
       items = Object.assign({}, state.items);
 
-      items[action.cluster.id] = ensureMetricKeysAreAvailable(action.cluster);
-      items[action.cluster.id].nodes = [];
-      items[action.cluster.id].keyPairs = [];
+      items[action.cluster.id] = Object.assign({}, items[action.cluster.id], ensureMetricKeysAreAvailable(action.cluster));
+      items[action.cluster.id].nodes = items[action.cluster.id].nodes || [];
+      items[action.cluster.id].keyPairs = items[action.cluster.id].keyPairs || [];
 
       return {
         lastUpdated: state.lastUpdated,


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/happa/issues/148

Going to the cluster details screen via manage organizations would result in server being undefined.
This is because the manage organization screen does a request for all organizations, which includes cluster details, 
but not _all_ cluster details. This organizations request would overwrite previously fetched detail on a cluster, namely the api_endpoint.

These changes ensure that when we are on the cluster detail screen and looking at the keypairs list, that the cluster
detail request has happened.