### PR TITLE
switch to http if letsencrypt

### DIFF
--- a/helm/happa-chart/templates/happa-deployment.yaml
+++ b/helm/happa-chart/templates/happa-deployment.yaml
@@ -14,17 +14,21 @@ spec:
       labels:
         app: happa
     spec:
+      {{- if not .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
       volumes:
         - name: giantswarm-cert
           secret:
             secretName: giantswarm-cert
+      {{- end }}
       containers:
       - name: happa
-        image: quay.io/giantswarm/happa:{{ .SHA }}
+        image: quay.io/giantswarm/happa
+        {{- if not .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
         volumeMounts:
         - name: giantswarm-cert
           mountPath: /etc/nginx/certs
           readOnly: true
+        {{- end }}
         env:
         - name: PASSAGE_ENDPOINT
           valueFrom:
@@ -54,15 +58,23 @@ spec:
           httpGet:
             path: /
             port: 8000
+            {{- if .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
+            scheme: HTTP
+            {{- else }}
             scheme: HTTPS
+            {{- end }}
           initialDelaySeconds: 10
           timeoutSeconds: 1
         readinessProbe:
           httpGet:
             path: /
             port: 8000
+            {{- if .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
+            scheme: HTTP
+            {{- else }}
             scheme: HTTPS
-          initialDelaySeconds: 10
+            {{- end }}
+           initialDelaySeconds: 10
           timeoutSeconds: 1
         resources:
           requests:

--- a/helm/happa-chart/templates/ingress.yaml
+++ b/helm/happa-chart/templates/ingress.yaml
@@ -23,3 +23,4 @@ spec:
   tls:
   - hosts:
     - {{ .Values.Installation.V1.GiantSwarm.Happa.Host }}
+    secretName: giantswarm-happa-tls


### PR DESCRIPTION
make sure that if requests are terminated in the ingress controller via
letsencrypt the service runs via http.

architect is currently replacing the SHAs in our helm charts. it's
hardcoded that architect will template files called deployment.yaml.
this is why i renamed the deployment.yaml to
happa-deployment.yaml. the problem is now that architect doesn't
replace
the SHA anymore. so helm doesn't apply this against the cluster anymore.

the temporary fix is to install the latest version of happa image.

also distinguish lego secrets by a name. otherwise lego complains about
the
duplicate ingresses.

```
the secret giantswarm/ is used multiple times. These linked TLS ingress
elements where ignored: ingress giantswarm/api (hosts:
api.g8s.heisenberg.eu-central-1.aws.gigantic.io), ingress
giantswarm/desmotes (hosts:
desmotes.g8s.heisenberg.eu-central-1.aws.gigantic.io), ingress
giantswarm/happa (hosts:
happa.g8s.heisenberg.eu-central-1.aws.gigantic.io), ingress
giantswarm/passage (hosts:
passage.g8s.heisenberg.eu-central-1.aws.gigantic.io)
```

See: https://github.com/jetstack/kube-lego/issues/35