### PR TITLE
make nginx.conf configurable via helm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM nginx:1.11
 RUN rm -r /etc/nginx/conf.d
 ADD dist /www
 ADD nginx.conf /etc/nginx/
-ADD start.sh /etc/nginx/
+ADD start.sh /
 ADD test/certs /etc/nginx/certs
-CMD ["/etc/nginx/start.sh"]
+CMD ["/start.sh"]

--- a/helm/happa-chart/templates/happa-deployment.yaml
+++ b/helm/happa-chart/templates/happa-deployment.yaml
@@ -14,21 +14,29 @@ spec:
       labels:
         app: happa
     spec:
-      {{- if not .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
       volumes:
+        {{- if not .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
         - name: giantswarm-cert
           secret:
             secretName: giantswarm-cert
-      {{- end }}
+        {{- end }}
+        - name: nginx-config
+          configMap:
+            secretName: happa-nginx-config
       containers:
       - name: happa
         image: quay.io/giantswarm/happa
-        {{- if not .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
+
         volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/
+
+        {{- if not .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
         - name: giantswarm-cert
           mountPath: /etc/nginx/certs
           readOnly: true
         {{- end }}
+
         env:
         - name: PASSAGE_ENDPOINT
           valueFrom:

--- a/helm/happa-chart/templates/nginx-config.yaml
+++ b/helm/happa-chart/templates/nginx-config.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ConfigMap
+
+metadata:
+  name: happa-nginx-config
+  namespace: giantswarm
+
+data:
+  nginx.conf: |
+    error_log stderr warn;
+    worker_processes 1;
+
+    events {
+      worker_connections 100;
+    }
+
+    http {
+      keepalive_timeout 5s;
+
+      default_type  application/octet-stream;
+      gzip on;
+      gzip_proxied any;
+
+      gzip_types text/plain text/xml text/css
+                 text/comma-separated-values
+                 text/javascript application/javascript
+                 application/atom+xml application/json
+                 image/svg+xml;
+
+      log_format  custom  '"$request" '
+          '$status $body_bytes_sent $request_time '
+          '"$http_x_forwarded_for" '
+          '"$http_user_agent" "$http_referer"';
+
+      server {
+        {{- if .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
+        listen 8000;
+        {{- else }}
+        listen 8000 ssl;
+
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA512:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:ECDH+AESGCM:ECDH+AES256:DH+AESGCM:DH+AES256:RSA+AESGCM:!aNULL:!eNULL:!LOW:!RC4:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS;
+
+        ssl_certificate /etc/nginx/certs/crt;
+        ssl_certificate_key /etc/nginx/certs/key;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # If they come here using HTTP, bounce them to the correct scheme
+        error_page 497 https://$host$request_uri;
+        {{- end }}
+
+        access_log /dev/stdout custom;
+        client_max_body_size 0;
+        chunked_transfer_encoding on;
+        index index.html;
+        root /www;
+
+        add_header X-Backend-Server $hostname;
+        add_header X-Version VERSION;
+
+        try_files $uri $uri/ /index.html;
+
+        error_page 404 /404.html;
+
+        location = /404.html {
+          root   /www;
+          add_header Cache-Control "no-cache" always;
+        }
+
+        location /assets {
+          expires max;
+        }
+
+        location /vendor {
+          expires max;
+        }
+      }
+    }


### PR DESCRIPTION
since we want to switch between http and https because of letsencrypt i
had to move the nginx.conf into a configmap. i took desmotes and passage
as an example because there it is already like that.

i also moved the start.sh script out of /etc/nginx/ since this is now
mounted by the configmap.