### PR TITLE
fix nginx.conf mount in happa-deployment.yaml

### DIFF
--- a/helm/happa-chart/templates/happa-deployment.yaml
+++ b/helm/happa-chart/templates/happa-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- end }}
         - name: nginx-config
           configMap:
-            secretName: happa-nginx-config
+            name: happa-nginx-config
       containers:
       - name: happa
         image: quay.io/giantswarm/happa


### PR DESCRIPTION
fixed a copy and paste error from the secret mount.