### PR TITLE
fix mimetypes in nginx config template

### DIFF
--- a/helm/happa-chart/templates/nginx-config.yaml
+++ b/helm/happa-chart/templates/nginx-config.yaml
@@ -16,8 +16,10 @@ data:
 
     http {
       keepalive_timeout 5s;
-
+      
+      include /etc/nginx/mime.types;
       default_type  application/octet-stream;
+      
       gzip on;
       gzip_proxied any;
 


### PR DESCRIPTION
images were not delivered with a correct mime type.