### PR TITLE
fix nginx.conf path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM nginx:1.11
 RUN rm -r /etc/nginx/conf.d
 ADD dist /www
-ADD nginx.conf /etc/nginx/
+RUN mkdir -p /etc/nginx/config
+ADD nginx.conf /etc/nginx/config
 ADD start.sh /
 ADD test/certs /etc/nginx/certs
 CMD ["/start.sh"]

--- a/helm/happa-chart/templates/happa-deployment.yaml
+++ b/helm/happa-chart/templates/happa-deployment.yaml
@@ -29,7 +29,7 @@ spec:
 
         volumeMounts:
         - name: nginx-config
-          mountPath: /etc/nginx/
+          mountPath: /etc/nginx/config
 
         {{- if not .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
         - name: giantswarm-cert

--- a/start.sh
+++ b/start.sh
@@ -35,4 +35,4 @@ sed -i "s|VERSION|$(cat /www/VERSION)|" /etc/nginx/nginx.conf
 
 echo ""
 echo "--- Starting Happa nginx server ---"
-exec nginx -g "daemon off;"
+exec nginx -c /etc/nginx/config/nginx.conf -g "daemon off;"


### PR DESCRIPTION
since kubernetes mounts a whole directory for the configmap it is better
to move the nginx config to a subfolder. otherwise things like
`mime.types` will get lost from `/etc/nginx`.