### PR TITLE
Remove ambiguous believe it or not text next to Launch New Cluster button

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -65,7 +65,7 @@ class Home extends React.Component {
               this.props.clusters.length === 0 ?
               'Ready to launch your first cluster? Click the green button!'
               :
-              'Believe it or not, you can have as many clusters as you like.'
+              ''
             }
 
           </div>


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/happa/issues/177

The statement that you can have as many clusters as you want isn't totally true. There are (uncommunicated) limits depending on the installation.