### PR TITLE
Fix edge case error when clusters load before org list.

### DIFF
--- a/src/reducers/organizationReducer.js
+++ b/src/reducers/organizationReducer.js
@@ -28,7 +28,7 @@ export default function organizationReducer(state = {lastUpdated: 0, isFetching:
       items = Object.assign({}, state.items);
 
       _.each(action.clusters, (cluster) => {
-        var org = items[cluster.owner] || {clusters: []};
+        var org = items[cluster.owner] || {clusters: [], id: cluster.owner, members: []};
         var clusters = [...org.clusters, cluster.id].sort();
         clusters = _.uniq(clusters, true);
 


### PR DESCRIPTION
When the call to list clusters loads before the orgs have loaded, a bug occurs because the table attempts to get a count of members for a poorly formed organization object.

I think I will make a note of improvement to just make this sequential and put up a loader and dim out the organization list instead of trying to do clusters + organization requests in parallel while keeping the organization list visible.