### PR TITLE
Make use of the latest image in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,7 @@ services:
 #########
 
   api:
-    image: quay.io/giantswarm/api:c55175c3d5cb24d67ff9cf20f8f2ed7687732885
+    image: quay.io/giantswarm/api:latest
     command: daemon --server.listen.address=http://0.0.0.0:8000
                     --add-admin-token=test:test
                     --companyd-address=http://companyd:8000


### PR DESCRIPTION
@oponder What was the reason again to use specific image versions in docker-compose? I found it inconvenient, as it makes us verify manually how old that version.

Using a specific version should be the exception during development. Normally latest should be fine.