### PR TITLE
Hide the 'use same configuration for all nodes' checkbox on aws

### DIFF
--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -223,12 +223,17 @@ class CreateCluster extends React.Component {
             <div className='row section'>
               <div className='col-12'>
                 <h3 className='table-label'>Worker Node Configuration</h3>
-                <div className='checkbox'>
-                  <label htmlFor='syncWorkers'>
-                    <input type='checkbox' ref='syncWorkers' id='syncWorkers' onChange={this.syncWorkersChanged} checked={this.state.syncWorkers}/>
-                    Use same configuration for all worker nodes
-                  </label>
-                </div>
+                {
+                  window.config.createClusterWorkerType === 'kvm' ?
+                    <div className='checkbox'>
+                      <label htmlFor='syncWorkers'>
+                        <input type='checkbox' ref='syncWorkers' id='syncWorkers' onChange={this.syncWorkersChanged} checked={this.state.syncWorkers}/>
+                        Use same configuration for all worker nodes
+                      </label>
+                    </div>
+                  :
+                    undefined
+                }
               </div>
             </div>
             <div className='row'>


### PR DESCRIPTION
Discussed here: https://github.com/giantswarm/cluster-service/issues/150#issuecomment-318278997

Heterogeneous clusters on AWS lead to problem when trying to scale, and are actually not supported.
So hide the checkbox for now, since all workers must have the same instance type.