### PR TITLE
Fix Cannot read property 'instance_type' of undefined

### DIFF
--- a/src/components/organizations/cluster_detail.js
+++ b/src/components/organizations/cluster_detail.js
@@ -83,7 +83,7 @@ class ClusterDetail extends React.Component {
 
   render() {
     var awsInstanceType = <tr/>;
-    if (this.props.cluster.workers && this.props.cluster.workers[0].aws.instance_type) {
+    if (window.config.createClusterWorkerType === 'aws') {
       awsInstanceType = (
         <tr>
           <td>AWS instance type</td>

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -52,6 +52,20 @@ var ensureMetricKeysAreAvailable = function (clusterDetails) {
   return clusterDetails;
 };
 
+// ensureWorkersHaveAWSkey
+// -----------------------
+// Since the API omits the 'aws' key from workers on kvm installations, I will
+// add it back here with dummy values if it is not present.
+var ensureWorkersHaveAWSkey = function (clusterDetails) {
+  clusterDetails.workers = clusterDetails.workers || [];
+
+  for (var i = 0; i < clusterDetails.workers.length; i++) {
+    clusterDetails.workers[i].aws = clusterDetails.workers[i].aws || {instance_type: ''};
+  }
+
+  return clusterDetails;
+};
+
 // determineIfOutdated
 // ----------------------------
 // Loop over all metrics and add outdated: true where the timestamp
@@ -128,6 +142,7 @@ export default function clusterReducer(state = {lastUpdated: 0, isFetching: fals
       items = Object.assign({}, state.items);
 
       items[action.cluster.id] = Object.assign({}, items[action.cluster.id], action.cluster);
+      items[action.cluster.id] = Object.assign({}, items[action.cluster.id], ensureWorkersHaveAWSkey(action.cluster));
 
       return {
         lastUpdated: state.lastUpdated,


### PR DESCRIPTION
The API no longer returns aws keys with empty values. Happa was relying on this in this line:

```
if (this.props.cluster.workers && this.props.cluster.workers[0].aws.instance_type) {
```

This line is actually trying to determine if happa is on an AWS installation. So I've change that to check on the configuration value.

After that I ensure the keys are there as extra safety by adding them during the clusterReducer (Which is what handles all incoming cluster data)

This shouldn't be needed though, since the check for being on an aws installation should mean we are talking to an API that returns aws instance information too. But it gives some peace of mind.