### PR TITLE
Fixing docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,13 +223,6 @@ services:
     ports:
      - "9005:8000"
 
-  # etcd:
-  #   image: quay.io/coreos/etcd:v3.1.2
-  #   command: etcd --listen-client-urls 'http://0.0.0.0:2379'
-  #                 --advertise-client-urls 'http://0.0.0.0:2379'
-  #   ports:
-  #     - "9006:2379"
-
   vault:
     image: vault
     volumes:


### PR DESCRIPTION
Updates flags for companyd, tokend, and userd to get rid of etcd as storage. Uses latest images.