### PR TITLE
Removing left padding

### DIFF
--- a/src/styles/components/_breadcrumbs.sass
+++ b/src/styles/components/_breadcrumbs.sass
@@ -15,8 +15,3 @@
 
   a
     color: lighten($darkblue, 80%)
-
-
-  .breadcrumbs
-    padding-left: 36px
-


### PR DESCRIPTION
I think it's cleaner with the breadcrumb being left-align with the rest. WDYT?