### PR TITLE
Change kubernetes version to 1.8.4

### DIFF
--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -17,7 +17,7 @@ class CreateCluster extends React.Component {
     super(props);
 
     this.state = {
-      k8sVersion: '1.8.1',
+      k8sVersion: '1.8.4',
       clusterName: 'My cluster',
       workerCount: 3,
       syncWorkers: true,


### PR DESCRIPTION
While Release Version is being finalized, go ahead and change the hardcoded version for now since we are creating 1.8.4 clusters.

Originally I didn't want to make this change since the release version selector would've made it clear that we're making 1.8.4 clusters,
but we can't bring that out just yet.