### PR TITLE
Add k8s version from the Release to the cluster create screen

### DIFF
--- a/src/components/create_cluster/release_selector.js
+++ b/src/components/create_cluster/release_selector.js
@@ -115,9 +115,17 @@ class ReleaseSelector extends React.Component {
   }
 
   loadedContent() {
+    var kubernetes = _.find(this.props.releases[this.state.selectedRelease].components, (x) => { return x.name === 'kubernetes'});
+
     return <div>
       <p>{ this.state.selectedRelease }</p>
-      <Button onClick={this.openModal}>{ this.buttonText() }</Button>
+      <Button onClick={this.openModal}>{ this.buttonText() }</Button><br/><br/>
+
+      <p>This releases contains:</p>
+      <div className='release-selector-modal--component contrast'>
+        <span className='release-selector-modal--component--name'>kubernetes</span>
+        <span className='release-selector-modal--component--version'>{kubernetes.version}</span>
+      </div>
     </div>;
   }
 

--- a/src/styles/components/_release_selector.sass
+++ b/src/styles/components/_release_selector.sass
@@ -105,3 +105,11 @@
   font-weight: 200
 
 .release-selector-modal--component--version
+
+.contrast
+  .release-selector-modal--component--name
+    background-color: #3c5f73
+    border-color: #3c5f73
+
+  .release-selector-modal--component--version
+    border-color: #3c5f73


### PR DESCRIPTION
contrary to what I said here: https://github.com/giantswarm/happa/pull/261#issuecomment-351852544

The commit to show the k8s version on the cluster create screen was not pushed.

So this PR brings it in.