### PR TITLE
Switch to legacy tag v2017 for giantswarm-js-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-addons-css-transition-group": "~15.4.2",
     "react-addons-update": "~15.4.2",
     "react-addons-test-utils": "~15.4.2",
-    "giantswarm": "git://github.com/giantswarm/giantswarm-js-client#master",
+    "giantswarm": "git://github.com/giantswarm/giantswarm-js-client#v2017",
     "react-codemirror": "~0.2.6",
     "react-dom": "~15.4.2",
     "react-router": "~2.6.1",


### PR DESCRIPTION
This PR sets the giantswarm-js-client version to use in happa to `v2017`.