### PR TITLE
Enable SELinux labels on volumes & use memory storage for cluster-service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ production: dist docker-build-prod
 dist: docker-build-dev
 	rm -rf dist
 	mkdir dist
-	docker run -p 8000:8000 -v ${PWD}/src:/usr/src/app/src -v ${PWD}/dist:/usr/src/app/dist happa-dev grunt build
+	docker run -p 8000:8000 -v ${PWD}/src:/usr/src/app/src:Z -v ${PWD}/dist:/usr/src/app/dist:Z happa-dev grunt build
 
 # Build the production docker container, which is just an nginx server
 # with the files from the dist folder
@@ -72,7 +72,7 @@ npm-check-updates:
 
 # Run tests
 test: docker-build-dev
-	docker run -ti -p 8000:8000 -p 8080:8080 -v ${PWD}/src:/usr/src/app/src happa-dev npm test
+	docker run -ti -p 8000:8000 -p 8080:8080 -v ${PWD}/src:/usr/src/app/src:Z happa-dev npm test
 
 # update dependency images
 pull-images:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - "./src:/usr/src/app/src"
+      - "./src:/usr/src/app/src:Z"
     links:
       - passage
 
@@ -100,7 +100,7 @@ services:
                     --service.vault.token="dev-token"
                     --service.release.collectinterval="5m"
                     --service.release.endpoints="http://cert-operator:8000,http://aws-operator:8000"
-                    --service.storage.kind="tpr"
+                    --service.storage.kind="memory"
                     --service.provider.kind="aws"
                     --service.provider.aws.ec2.instance.allowed="m5.large,m3.large,m3.xlarge,m3.2xlarge,r3.large,r3.xlarge,r3.2xlarge,r3.4xlarge,r3.8xlarge"
                     --service.provider.aws.ec2.instance.available="m1.small,m1.medium,m1.large,m1.xlarge,c1.medium,c1.xlarge,cc2.8xlarge,cg1.4xlarge,m2.xlarge,m2.2xlarge,m2.4xlarge,cr1.8xlarge,i2.xlarge,i2.2xlarge,i2.4xlarge,i2.8xlarge,hi1.4xlarge,hs1.8xlarge,t1.micro,t2.nano,t2.micro,t2.small,t2.medium,t2.large,t2.xlarge,t2.2xlarge,m4.large,m4.xlarge,m4.2xlarge,m4.4xlarge,m4.10xlarge,m4.16xlarge,m3.medium,m3.large,m3.xlarge,m3.2xlarge,c4.large,c4.xlarge,c4.2xlarge,c4.4xlarge,c4.8xlarge,c3.large,c3.xlarge,c3.2xlarge,c3.4xlarge,c3.8xlarge,p2.xlarge,p2.8xlarge,p2.16xlarge,g2.2xlarge,g2.8xlarge,x1.16xlarge,x1.32xlarge,r4.large,r4.xlarge,r4.2xlarge,r4.4xlarge,r4.8xlarge,r4.16xlarge,r3.large,r3.xlarge,r3.2xlarge,r3.4xlarge,r3.8xlarge,i3.large,i3.xlarge,i3.2xlarge,i3.4xlarge,i3.8xlarge,i3.16xlarge,d2.xlarge,d2.2xlarge,d2.4xlarge,d2.8xlarge,f1.2xlarge,f1.16xlarge"


### PR DESCRIPTION
Use in-memory storage for cluster-service as tpr is now phased out.

While here: In order to be able to use docker volumes with SELinux
enabled, volumes must be labeled. From Docker documentation: "The Z
option indicates that the bind mount content is private and unshared."

https://docs.docker.com/engine/admin/volumes/bind-mounts/#configure-the-selinux-label