### PR TITLE
Fix too many cluster detail requests on home page.

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -19,7 +19,7 @@ class Home extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (! _.isEqual(this.props.clusters, prevProps.clusters)) {
+    if (! _.isEqual(_.map(this.props.clusters, x => x.id), _.map(prevProps.clusters, x => x.id))) {
       this.fetchClusterDetails(this.props.clusters);
     }
   }


### PR DESCRIPTION
Happa was doing a crazy amount of requests for cluster details on the home page.

For every cluster, it would refetch all cluster details of all clusters.

This is because the code I used to check whether or not there were new clusters to fetch details for was comparing against the cluster object, which would get updated after the details got fetched. Thus triggering another fetch of details. Now I just check on cluster id's.