### PR TITLE
Fix a bug showing the cluster detail page for clusters without a release

### DIFF
--- a/src/components/organizations/cluster_detail.js
+++ b/src/components/organizations/cluster_detail.js
@@ -240,7 +240,11 @@ class ClusterDetail extends React.Component {
               </div>
               <ScaleClusterModal ref={(s) => {this.scaleClusterModal = s;}} cluster={this.props.cluster} user={this.props.user}/>
             </div>
-            <ReleaseDetailsModal ref={(r) => {this.releaseDetailsModal = r;}} releases={[this.props.release]} />
+            {
+              this.props.release ?
+              <ReleaseDetailsModal ref={(r) => {this.releaseDetailsModal = r;}} releases={[this.props.release]} />
+              : undefined
+            }
           </div>
         :
           undefined


### PR DESCRIPTION
The release details modal should not be loaded if the cluster we are looking at is one of the older clusters without a release.
I thought I had guarded against this in all places, but apparently this slipped through despite my checks.