### PR TITLE
Fix number precision in various places, update azure capabilities.

### DIFF
--- a/src/components/create_cluster/azure_capabilities.js
+++ b/src/components/create_cluster/azure_capabilities.js
@@ -1,191 +1,23 @@
 export default [
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 4,
-    'memoryInMb': 4096,
-    'name': 'Standard_A2_v2',
-    'numberOfCores': 2,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 20480
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 8,
-    'memoryInMb': 8192,
-    'name': 'Standard_A4_v2',
-    'numberOfCores': 4,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 40960
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 16,
-    'memoryInMb': 16384,
-    'name': 'Standard_A8_v2',
-    'numberOfCores': 8,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 81920
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 4,
-    'memoryInMb': 8192,
-    'name': 'Standard_D2_v3',
-    'numberOfCores': 2,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 51200
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 8,
-    'memoryInMb': 16384,
-    'name': 'Standard_D4_v3',
-    'numberOfCores': 4,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 102400
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 16,
-    'memoryInMb': 32768,
-    'name': 'Standard_D8_v3',
-    'numberOfCores': 8,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 204800
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 32,
-    'memoryInMb': 65536,
-    'name': 'Standard_D16_v3',
-    'numberOfCores': 16,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 409600
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 32,
-    'memoryInMb': 131072,
-    'name': 'Standard_D32_v3',
-    'numberOfCores': 32,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 819200
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 4,
-    'memoryInMb': 8192,
-    'name': 'Standard_D2s_v3',
-    'numberOfCores': 2,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 16384
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 8,
-    'memoryInMb': 16384,
-    'name': 'Standard_D4s_v3',
-    'numberOfCores': 4,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 32768
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 16,
-    'memoryInMb': 32768,
-    'name': 'Standard_D8s_v3',
-    'numberOfCores': 8,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 65536
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 32,
-    'memoryInMb': 65536,
-    'name': 'Standard_D16s_v3',
-    'numberOfCores': 16,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 131072
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 32,
-    'memoryInMb': 131072,
-    'name': 'Standard_D32s_v3',
-    'numberOfCores': 32,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 262144
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 8,
-    'memoryInMb': 32768,
-    'name': 'Standard_E4s_v3',
-    'numberOfCores': 4,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 65536
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 16,
-    'memoryInMb': 65536,
-    'name': 'Standard_E8s_v3',
-    'numberOfCores': 8,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 131072
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 32,
-    'memoryInMb': 131072,
-    'name': 'Standard_E16s_v3',
-    'numberOfCores': 16,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 262144
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 32,
-    'memoryInMb': 262144,
-    'name': 'Standard_E32s_v3',
-    'numberOfCores': 32,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 524288
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 8,
-    'memoryInMb': 8192,
-    'name': 'Standard_F4s_v2',
-    'numberOfCores': 4,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 32768
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 16,
-    'memoryInMb': 16384,
-    'name': 'Standard_F8s_v2',
-    'numberOfCores': 8,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 65536
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 32,
-    'memoryInMb': 32768,
-    'name': 'Standard_F16s_v2',
-    'numberOfCores': 16,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 131072
-  },
-  {
-    'additionalProperties': {},
-    'maxDataDiskCount': 32,
-    'memoryInMb': 65536,
-    'name': 'Standard_F32s_v2',
-    'numberOfCores': 32,
-    'osDiskSizeInMb': 1047552,
-    'resourceDiskSizeInMb': 262144
-  }
+  {'additionalProperties': {},'maxDataDiskCount': 4,'memoryInMb': 4294.967296,'name': 'Standard_A2_v2','numberOfCores': 2,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 21474.83648},
+  {'additionalProperties': {},'maxDataDiskCount': 8,'memoryInMb': 8589.934592,'name': 'Standard_A4_v2','numberOfCores': 4,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 42949.67296},
+  {'additionalProperties': {},'maxDataDiskCount': 16,'memoryInMb': 17179.869184,'name': 'Standard_A8_v2','numberOfCores': 8,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 85899.34592},
+  {'additionalProperties': {},'maxDataDiskCount': 4,'memoryInMb': 8589.934592,'name': 'Standard_D2_v3','numberOfCores': 2,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 53687.0912},
+  {'additionalProperties': {},'maxDataDiskCount': 8,'memoryInMb': 17179.869184,'name': 'Standard_D4_v3','numberOfCores': 4,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 107374.1824},
+  {'additionalProperties': {},'maxDataDiskCount': 16,'memoryInMb': 34359.738368,'name': 'Standard_D8_v3','numberOfCores': 8,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 21474.836480},
+  {'additionalProperties': {},'maxDataDiskCount': 32,'memoryInMb': 68719.476736,'name': 'Standard_D16_v3','numberOfCores': 16,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 42949.672960},
+  {'additionalProperties': {},'maxDataDiskCount': 32,'memoryInMb': 137438.953472,'name': 'Standard_D32_v3','numberOfCores': 32,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 85899.345920},
+  {'additionalProperties': {},'maxDataDiskCount': 4,'memoryInMb': 8589.934592,'name': 'Standard_D2s_v3','numberOfCores': 2,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 17179.869184},
+  {'additionalProperties': {},'maxDataDiskCount': 8,'memoryInMb': 17179.869184,'name': 'Standard_D4s_v3','numberOfCores': 4,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 34359.738368},
+  {'additionalProperties': {},'maxDataDiskCount': 16,'memoryInMb': 34359.738368,'name': 'Standard_D8s_v3','numberOfCores': 8,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 68719.476736},
+  {'additionalProperties': {},'maxDataDiskCount': 32,'memoryInMb': 68719.476736,'name': 'Standard_D16s_v3','numberOfCores': 16,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 137438.953472},
+  {'additionalProperties': {},'maxDataDiskCount': 32,'memoryInMb': 137438.953472,'name': 'Standard_D32s_v3','numberOfCores': 32,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 274877.906944},
+  {'additionalProperties': {},'maxDataDiskCount': 8,'memoryInMb': 34359.738368,'name': 'Standard_E4s_v3','numberOfCores': 4,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 68719.476736},
+  {'additionalProperties': {},'maxDataDiskCount': 16,'memoryInMb': 68719.476736,'name': 'Standard_E8s_v3','numberOfCores': 8,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 137438.953472},
+  {'additionalProperties': {},'maxDataDiskCount': 32,'memoryInMb': 137438.953472,'name': 'Standard_E16s_v3','numberOfCores': 16,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 274877.906944},
+  {'additionalProperties': {},'maxDataDiskCount': 32,'memoryInMb': 274877.906944,'name': 'Standard_E32s_v3','numberOfCores': 32,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 549755.813888},
+  {'additionalProperties': {},'maxDataDiskCount': 8,'memoryInMb': 8589.934592,'name': 'Standard_F4s_v2','numberOfCores': 4,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 34359.738368},
+  {'additionalProperties': {},'maxDataDiskCount': 16,'memoryInMb': 17179.869184,'name': 'Standard_F8s_v2','numberOfCores': 8,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 68719.476736},
+  {'additionalProperties': {},'maxDataDiskCount': 32,'memoryInMb': 34359.738368,'name': 'Standard_F16s_v2','numberOfCores': 16,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 137438.953472},
+  {'additionalProperties': {},'maxDataDiskCount': 32,'memoryInMb': 68719.476736,'name': 'Standard_F32s_v2','numberOfCores': 32,'osDiskSizeInMb': 1047552,'resourceDiskSizeInMb': 274877.906944}
 ];

--- a/src/components/create_cluster/new_azure_worker.js
+++ b/src/components/create_cluster/new_azure_worker.js
@@ -141,8 +141,8 @@ class NewAzureWorker extends React.Component {
                       <td><input type='radio' readOnly checked={vmSize.name === this.state.preSelectedVMSize}/></td>
                       <td>{vmSize.name}</td>
                       <td className="numeric">{vmSize.numberOfCores}</td>
-                      <td className="numeric">{vmSize.memoryInMb / 1024} GB</td>
-                      <td className="numeric">{vmSize.resourceDiskSizeInMb / 1024} GB</td>
+                      <td className="numeric">{(vmSize.memoryInMb / 1000).toFixed(2)} GB</td>
+                      <td className="numeric">{(vmSize.resourceDiskSizeInMb / 1000).toFixed(2)} GB</td>
                     </tr>;
                   })
                 }

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -21,7 +21,7 @@ class ClusterDashboardItem extends React.Component {
     for (var i=0; i<this.props.cluster.workers.length; i++) {
       m += this.props.cluster.workers[i].memory.size_gb;
     }
-    return m;
+    return m.toFixed(2);
   }
 
   getStorageTotal() {
@@ -32,7 +32,7 @@ class ClusterDashboardItem extends React.Component {
     for (var i=0; i<this.props.cluster.workers.length; i++) {
       s += this.props.cluster.workers[i].storage.size_gb;
     }
-    return s;
+    return s.toFixed(2);
   }
 
   getCpusTotal() {

--- a/src/components/organizations/cluster_detail.js
+++ b/src/components/organizations/cluster_detail.js
@@ -77,7 +77,7 @@ class ClusterDetail extends React.Component {
     for (var i=0; i<this.props.cluster.workers.length; i++) {
       m += this.props.cluster.workers[i].memory.size_gb;
     }
-    return m;
+    return m.toFixed(2);
   }
 
   getStorageTotal() {
@@ -88,7 +88,7 @@ class ClusterDetail extends React.Component {
     for (var i=0; i<this.props.cluster.workers.length; i++) {
       s += this.props.cluster.workers[i].storage.size_gb;
     }
-    return s;
+    return s.toFixed(2);
   }
 
   getCpusTotal() {


### PR DESCRIPTION
Now that we have the right values for Azure machines, Happa needs an update as well.
Since these values have a lot of decimals, we also apply a rounding to only show 2 decimals at most.

Related to: https://github.com/giantswarm/cluster-service/pull/287