### PR TITLE
Remove admin login link. Not relevant to current normal users.

### DIFF
--- a/src/components/auth/login.js
+++ b/src/components/auth/login.js
@@ -153,8 +153,6 @@ class Login extends React.Component {
               <br/>
               Trouble logging in? Please contact us via <a href='mailto:support@giantswarm.io'>support@giantswarm.io</a>
             </div>
-
-            <Link className='login_form--admin-link' to='/admin-login'>Login as an Administrator</Link>
           </div>
         </ReactCSSTransitionGroup>
       </div>


### PR DESCRIPTION
Because I don't want to confuse people who will inevitably click on this link out of curiosity.