### PR TITLE
 Add $.Release.Time to deployment descriptor

### DIFF
--- a/helm/happa-chart/templates/deployment.yaml
+++ b/helm/happa-chart/templates/deployment.yaml
@@ -13,7 +13,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         releasetime: {{ $.Release.Time }}
       labels:
         app: happa


### PR DESCRIPTION
In order to make Helm always deploy PODs on deploy event, add release
time to deployment annotation. This changes on every deploy event which
changes deployment descriptor and therefore triggers Helm.

Towards https://github.com/giantswarm/giantswarm/issues/3395