### PR TITLE
Handle invalid tokens better.

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -21,6 +21,9 @@ class Layout extends React.Component {
     this.props.actions.refreshUserInfo().then(() => {
       this.props.dispatch(organizationsLoad());
       return null;
+    })
+    .catch((error) => {
+      throw(error);
     });
   }
 

--- a/src/lib/auth0.js
+++ b/src/lib/auth0.js
@@ -31,6 +31,10 @@ export default class Auth {
 
   renewToken() {
     return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        reject('timeout while trying to renew your session');
+      }, 10000);
+
       this.auth0.checkSession({}, (err, result) => {
         if (!err) {
           resolve(result);


### PR DESCRIPTION
This is a change in the way unauthorized calls to the API are handled.

Before, Happa would treat every unauthorized response as an opportunity to refresh the `Bearer` token.
Happa should instead check if the token is a `Bearer` token or a `giantswarm` token first.

If it's a `giantswarm` token, there is no way to renew the token, so log out the user and show him the login page.

If it's a bearer token, but the attempt to renew it fails, then don't spend too much time waiting for auth0 to reply.

For some reason it takes auth0 a really long time to respond when the session is invalid, so I added a timeout here.