### PR TITLE
Allow guest cluster upgrade for Azure release_version > 1.0.0

### DIFF
--- a/helm/happa-chart/templates/ingress.yaml
+++ b/helm/happa-chart/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: happa
   annotations:
+    kubernetes.io/ingress.class: "nginx"
     {{- if .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
     kubernetes.io/tls-acme: "true"
     {{- end }}


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/2022

This additionally enables the upgrade button for provider = azure, release_version >= 1.0.0, only for admins.