### PR TITLE
Fix silent reauth.

### DIFF
--- a/src/lib/giantswarm_v4_client_wrapper.js
+++ b/src/lib/giantswarm_v4_client_wrapper.js
@@ -36,6 +36,7 @@ returnType) {
         .then((result) => {
           store.dispatch(auth0Login(result));
 
+          defaultClientAuth.apiKeyPrefix = 'Bearer';
           defaultClientAuth.apiKey = result.accessToken;
 
           return origCallApi(path, httpMethod, pathParams, queryParams, headerParams, formParams,


### PR DESCRIPTION
For some reason, it was replaying the failed api call using the `giantswarm` scheme and not the `Bearer` scheme.
This forces it to `Bearer`.