### PR TITLE
Get the unauthorized action firing again instead of redirecting the browser.

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -14,8 +14,9 @@ import forgot_password_index from './forgot_password/index';
 import forgot_password_set_password from './forgot_password/set_password';
 import { Provider } from 'react-redux';
 import configureStore from '../stores/configureStore';
+import history from '../stores/history';
 import { ConnectedRouter } from 'connected-react-router';
-import { createBrowserHistory } from 'history';
+
 
 require('normalize.css');
 require('bootstrap/dist/css/bootstrap.min.css');
@@ -24,8 +25,8 @@ require('react-datepicker/dist/react-datepicker.css');
 
 var appContainer = document.getElementById('app');
 
-const history = createBrowserHistory();
-const store = configureStore({}, history);
+
+const store = configureStore({});
 
 render(
   <Provider store={store}>

--- a/src/lib/giantswarm_v4_client_wrapper.js
+++ b/src/lib/giantswarm_v4_client_wrapper.js
@@ -5,8 +5,11 @@
 
 import GiantSwarmV4 from 'giantswarm-v4';
 import Auth0 from '../lib/auth0';
+import configureStore from '../stores/configureStore';
+import { unauthorized } from '../actions/userActions';
 
 const auth0 = new Auth0();
+const store = configureStore({});
 
 var defaultClient = GiantSwarmV4.ApiClient.instance;
 defaultClient.basePath = window.config.apiEndpoint;
@@ -49,11 +52,11 @@ returnType) {
                              bodyParam, authNames, contentTypes, accepts, returnType);
         })
         .catch((err) => {
-          window.location.href = '/login';
+          store.dispatch(unauthorized());
           throw(err);
         });
       } else if (err.status == 401) {
-          window.location.href = '/login';
+          store.dispatch(unauthorized());
           throw(err);
       } else {
         throw err;

--- a/src/stores/configureStore.js
+++ b/src/stores/configureStore.js
@@ -4,10 +4,11 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import { connectRouter, routerMiddleware } from 'connected-react-router';
 import rootReducer from '../reducers';
 import thunk from 'redux-thunk';
+import history from './history';
 
 var store;
 
-export default function configureStore(initialState, history) {
+export default function configureStore(initialState) {
   if (store) {
     return store;
   } else {

--- a/src/stores/history.js
+++ b/src/stores/history.js
@@ -1,0 +1,7 @@
+'use strict';
+
+import { createBrowserHistory } from 'history';
+
+const history = createBrowserHistory();
+
+export default history;


### PR DESCRIPTION
This fixes a hack I implemented while doing the change to newer versions of react / redux / and react router.

Instead of forcing the browrser to change location we actually fire the unauthorized action, which handles the redirect back to the login page more gracefully.