### PR TITLE
Remove master sizing row from cluster creation

### DIFF
--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -325,15 +325,6 @@ class CreateCluster extends React.Component {
               </div>
             </div>
 
-            <div className='row'>
-              <div className='col-3'>
-                <h3 className='table-label'>Master Sizing</h3>
-              </div>
-              <div className='col-9'>
-                <p>Auto Sized (Default)</p>
-              </div>
-            </div>
-
             <div className='row section new-cluster--launch'>
               <div className='col-12'>
                 <p>Create this cluster now and it will be available for you to use as soon as possible.</p>


### PR DESCRIPTION
Different than expected, this (master sizing) hasn't become a feature and it's still not in sight. I'd like to remove this confusing row completely.