### PR TITLE
Redirect to /login if there is no user in the state. Do not pass go, do not collect 200 dollars.

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -39,6 +39,14 @@ export function logoutError(errorMessage) {
 export function refreshUserInfo() {
   return function(dispatch, getState) {
     var usersApi = new GiantSwarmV4.UsersApi();
+
+    if (!getState().app.loggedInUser) {
+      dispatch({
+        type: types.REFRESH_USER_INFO_ERROR,
+        error: 'No logged in user to refresh.'
+      });
+      throw('No logged in user to refresh.');
+    }
     var token = getState().app.loggedInUser.auth.token;
     var scheme = getState().app.loggedInUser.auth.scheme;
 

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -34,17 +34,17 @@ class Layout extends React.Component {
     if (this.props.user) {
       defaultClientAuth.apiKeyPrefix = this.props.user.auth.scheme;
       defaultClientAuth.apiKey = this.props.user.auth.token;
+
+      this.props.actions.refreshUserInfo().then(() => {
+        this.props.dispatch(organizationsLoad());
+        return null;
+      })
+      .catch((error) => {
+        throw(error);
+      });
     } else {
       this.props.dispatch(push('/login'));
     }
-
-    this.props.actions.refreshUserInfo().then(() => {
-      this.props.dispatch(organizationsLoad());
-      return null;
-    })
-    .catch((error) => {
-      throw(error);
-    });
   }
 
   selectOrganization = (orgId) => {


### PR DESCRIPTION
Fixes a bug that can occur if you try to visit the root page of Happa without a valid user object in the state.
This would happen after a password reset.