### PR TITLE
Add mail domain column to user lists

### DIFF
--- a/src/components/organizations/detail.js
+++ b/src/components/organizations/detail.js
@@ -93,6 +93,7 @@ class OrganizationDetail extends React.Component {
                         <thead>
                           <tr>
                             <th>Email</th>
+                            <th>Email Domain</th>
                             <th></th>
                           </tr>
                         </thead>
@@ -101,7 +102,8 @@ class OrganizationDetail extends React.Component {
                             _.sortBy(this.props.organization.members, 'email').map((member) => {
                               return (
                                 <tr key={member.email}>
-                                  <td>{member.email}</td>
+                                  <td>{ member.email }</td>
+                                  <td>{ member.email.split("@")[1] }</td>
                                   <td>
                                     <div className='contextual'>
                                       <i className='fa fa-times clickable'

--- a/src/components/users/index.js
+++ b/src/components/users/index.js
@@ -123,6 +123,7 @@ class Users extends React.Component {
                     <thead>
                       <tr>
                         <th>Email</th>
+                        <th>Email Domain</th>
                         <th>Expires</th>
                         <th></th>
                       </tr>

--- a/src/components/users/user_row.js
+++ b/src/components/users/user_row.js
@@ -19,6 +19,7 @@ class UserRow extends React.Component {
     return (
       <tr>
         <td onClick={this.props.onClick}>{this.props.user.email}</td>
+        <td>{ this.props.user.email.split("@")[1] }</td>
         <td className={expiryClass}>
           { this.props.user.expiry == NEVER_EXPIRES ?
             ''


### PR DESCRIPTION
The rationale here is to improve the "scannability" of the user tables and make it visible which domains (in many cases equalling companies) a user comes from. Check for example https://happa.g8s.gollum.westeurope.azure.gigantic.io/users/ for an installation with many users.

In a next step, these tables could be made sortable. Then having this column would allow to sort by email domain.

One thing I am unsure of: Would it be better to truncate the content of the `Email` column to the first part only? Like this:

| Email | Email Domain
|------|------|
| foo@ | example.com |
| bar@ | example.com |

This kind of defaces the email address as such.

### Preview

![image](https://user-images.githubusercontent.com/273727/45437883-0a6cb680-b6b6-11e8-8e48-00b9f75404fe.png)


![image](https://user-images.githubusercontent.com/273727/45437910-13f61e80-b6b6-11e8-9d09-d5c76dc54c85.png)
