### PR TITLE
Fix valid signup form despite TOS being unchecked.

### DIFF
--- a/src/components/signup/index.js
+++ b/src/components/signup/index.js
@@ -12,6 +12,7 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import { validatePassword } from '../../lib/password_validation';
 import { push } from 'connected-react-router';
+import Button from '../button';
 
 // TODO: Figure out a way to make the test suite know about our standard
 // 'window.config' object. Or change the way these config params are passed
@@ -25,8 +26,8 @@ export class SignUp extends React.Component {
     super(props);
 
     this.state = {
-      statusMessage: 'verify_started',
-      checkInviteStatus: 'started',
+      statusMessage: 'verify_completed',
+      checkInviteStatus: 'completed',
       email: undefined,
       passwordField: {value: '', valid: false},
       passwordConfirmationField: {value: '', valid: false},
@@ -103,19 +104,19 @@ export class SignUp extends React.Component {
 
     this.setState({
       currentStep: nextStep
+    }, () => {
+      if (nextStep === 1) {
+        this.password.focus();
+      } else if (nextStep === 2) {
+        this.passwordConfirmation.focus();
+      } else if (nextStep === 3) {
+        this.setState({
+          statusMessage: 'tos_intro'
+        });
+
+        this.passwordConfirmation.blur();
+      }
     });
-
-    if (nextStep === 1) {
-      this.password.focus();
-    } else if (nextStep === 2) {
-      this.passwordConfirmation.focus();
-    } else if (nextStep === 3) {
-      this.setState({
-        statusMessage: 'tos_intro'
-      });
-
-      this.passwordConfirmation.blur();
-    }
   }
 
   accountCreated() {
@@ -368,14 +369,16 @@ export class SignUp extends React.Component {
           </div>
 
           <StatusMessage status={this.state.statusMessage} />
-
-          <div className='signup--submitButton'>
-            {
-              this.state.buttonText[this.state.currentStep] !== '' ? <button className='primary' disabled={ (! this.state.advancable) || this.state.submitting }>{this.state.buttonText[this.state.currentStep]}</button> : null
+            { this.state.buttonText[this.state.currentStep] != '' ?
+              <Button type='submit'
+                    bsStyle='primary'
+                    bsSize='large'
+                    disabled={ (! this.state.advancable) || this.state.submitting }
+                    loading={this.state.submitting}
+                    onClick={this.logIn}>{this.state.buttonText[this.state.currentStep]}</Button>
+              :
+              ''
             }
-
-            { this.state.submitting ? <img className='loader' src='/images/loader_oval_light.svg' /> : null }
-          </div>
         </form>
 
 

--- a/src/components/signup/index.js
+++ b/src/components/signup/index.js
@@ -26,8 +26,8 @@ export class SignUp extends React.Component {
     super(props);
 
     this.state = {
-      statusMessage: 'verify_completed',
-      checkInviteStatus: 'completed',
+      statusMessage: 'verify_started',
+      checkInviteStatus: 'started',
       email: undefined,
       passwordField: {value: '', valid: false},
       passwordConfirmationField: {value: '', valid: false},

--- a/src/styles/components/_progress_button.sass
+++ b/src/styles/components/_progress_button.sass
@@ -27,6 +27,7 @@
     height: 22px
     margin: 0px
     margin-right: 10px
+    margin-left: 10px
 
   button
     vertical-align: middle

--- a/src/styles/components/_signup.sass
+++ b/src/styles/components/_signup.sass
@@ -62,9 +62,3 @@
   .error
     color: #fc1e70
     background-color: transparent
-
-.signup--submitButton
-  .loader
-    position: relative
-    top: 6px
-    left: 12px


### PR DESCRIPTION
There appears to have been a regression in the sign up form. When reaching the final step, where the TOS has to be checked,
the button would appear green instead of disabled.

Clicking on the green button without checking the TOS would put the user in a invalid state.

This ensures the form does not go 'green' when reaching the final step.