### PR TITLE
Add a error checking case for access-control-allow-origin policy errors.

### DIFF
--- a/src/components/auth/login.js
+++ b/src/components/auth/login.js
@@ -94,22 +94,22 @@ class Login extends React.Component {
           authenticating: false
         });
 
+        var heading = 'Could not log in';
+        var message = 'Something went wrong. Please try again later or contact support: support@giantswarm.io';
+
         if (error.response && error.response.body && error.response.body.code === 'INVALID_CREDENTIALS') {
-          this.props.dispatch(flashAdd({
-            message: <span><b>Could not log in.</b><br/> Credentials appear to be incorrect.</span>,
-            class: 'danger'
-          }));
+          message = 'Credential appear to be incorrect.';
         } else if (error.response && error.response.body && error.response.body.code === 'TOO_MANY_REQUESTS') {
-          this.props.dispatch(flashAdd({
-            message: <span><b>Too many requests</b><br/>Please wait 5 minutes and try again.</span>,
-            class: 'danger'
-          }));
-        } else {
-          this.props.dispatch(flashAdd({
-            message: 'Could not log in. Something went wrong. Please try again later or contact support: support@giantswarm.io',
-            class: 'danger'
-          }));
+          heading = 'Too many requests';
+          message = 'Please wait 5 minutes and try again.';
+        } else if (error.message && error.message.includes('Access-Control-Allow-Origin')) {
+          message = 'Please ensure you have installed the required certificates to talk to the API server.';
         }
+
+        this.props.dispatch(flashAdd({
+          message: <div><b>{heading}</b><br/>{message}</div>,
+          class: 'danger'
+        }));
       });
     }
   }

--- a/src/components/forgot_password/index.js
+++ b/src/components/forgot_password/index.js
@@ -48,8 +48,17 @@ class ForgotPassword extends React.Component {
           }));
           break;
         default:
+          var heading = 'Unable to reset password';
+          var message = 'Something went wrong. Our servers might be down, or perhaps you\'ve made too many requests in a row. Please try again in 5 minutes.';
+
+          if (error.message) {
+            if (error.message.includes('Access-Control-Allow-Origin')) {
+              message = 'Please ensure you have installed the required certificates to talk to the API server.';
+            }
+          }
+
           this.props.dispatch(flashAdd({
-            message: 'Something went wrong. Our servers might be down, or perhaps you\'ve made too many requests in a row. Please try again in 5 minutes.',
+            message: <div><b>{heading}</b><br/>{message}</div>,
             class: 'danger'
           }));
       }


### PR DESCRIPTION
When a user does not have the right certificate installed in their system to talk to the API of the installation, then Happa's login and password reset fails with a generic message which might cause them to think their password or account is no longer existing.

This PR adds error checking for this specific case, and produces a more helpful error message.