### PR TITLE
Fix label regarding no org members

### DIFF
--- a/src/components/organizations/detail.js
+++ b/src/components/organizations/detail.js
@@ -87,7 +87,7 @@ class OrganizationDetail extends React.Component {
                   <div className='col-9'>
                     {
                       this.props.organization.members.length === 0 ?
-                      <p>This organization has no members, which shouldn&apos;t really be possible</p>
+                      <p>This organization has no members</p>
                       :
                       <table>
                         <thead>


### PR DESCRIPTION
The label for an empty org said `This organization has no members, which shouldn't really be possible`.

This is quite possible, especially now with SSO.