### PR TITLE
Refresh a SSO token before using it if it's expired.

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -56,8 +56,8 @@ export function refreshUserInfo() {
       var userData = {
         email: data.email,
         auth: {
-          scheme: scheme,
-          token: token
+          scheme: getState().app.loggedInUser.auth.scheme,
+          token: getState().app.loggedInUser.auth.token,
         }
       };
 

--- a/src/reducers/appReducer.js
+++ b/src/reducers/appReducer.js
@@ -62,10 +62,10 @@ export default function appReducer(state = {
 
     case types.LOGIN_SUCCESS:
       localStorage.setItem('user', JSON.stringify(action.userData));
-        var defaultClient = GiantSwarmV4.ApiClient.instance;
-        var defaultClientAuth = defaultClient.authentications['AuthorizationHeaderToken'];
-        defaultClientAuth.apiKey = action.userData.authToken;
-        defaultClientAuth.apiKeyPrefix = 'giantswarm';
+      var defaultClient = GiantSwarmV4.ApiClient.instance;
+      var defaultClientAuth = defaultClient.authentications['AuthorizationHeaderToken'];
+      defaultClientAuth.apiKey = action.userData.auth.token;
+      defaultClientAuth.apiKeyPrefix = action.userData.auth.scheme;
 
       return Object.assign({}, state, {
         loggedInUser: action.userData


### PR DESCRIPTION
Originally we relied on a `401` response from the server as the 'trigger' to attempt a token refresh.

This can be handled in a smarter way, we know when the token is expired, so we can simply do a reauth before using the token.

Fixes: https://github.com/giantswarm/giantswarm/issues/4292
Fixes: https://github.com/giantswarm/happa/issues/364