### PR TITLE
Expose BYOC info in cluster creation

### DIFF
--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -11,6 +11,7 @@ import NewKVMWorker from './new_kvm_worker.js';
 import NewAWSWorker from './new_aws_worker.js';
 import NewAzureWorker from './new_azure_worker.js';
 import ReleaseSelector from './release_selector.js';
+import ProviderCredentials from './provider_credentials.js';
 import PropTypes from 'prop-types';
 import { push } from 'connected-react-router';
 import { Breadcrumb } from 'react-breadcrumbs';
@@ -324,6 +325,8 @@ class CreateCluster extends React.Component {
                 <ReleaseSelector releaseSelected={this.selectRelease} />
               </div>
             </div>
+
+            <ProviderCredentials organizationName={this.props.selectedOrganization} provider={this.props.provider} />
 
             <div className='row section new-cluster--launch'>
               <div className='col-12'>

--- a/src/components/create_cluster/number_picker.js
+++ b/src/components/create_cluster/number_picker.js
@@ -5,14 +5,6 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 
 class NumberPicker extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
-  componentDidMount() {
-
-  }
-
   formatValue() {
     if (this.props.formatter) {
       return this.props.formatter(this.props.value);

--- a/src/components/create_cluster/provider_credentials.js
+++ b/src/components/create_cluster/provider_credentials.js
@@ -1,0 +1,68 @@
+'use strict';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { organizationCredentialsLoad } from '../../actions/organizationActions';
+
+class ProviderCredentials extends React.Component {
+  componentDidMount() {
+    this.props.dispatch(organizationCredentialsLoad(this.props.organizationName));
+  }
+
+  awsAccountIDFromARN(arn) {
+    // get account ID from ARN like 'arn:aws:iam::<YOUR_ACCOUNT_ID>:role/GiantSwarmAdmin'
+    var parts = arn.split(':');
+    return parts[4];
+  }
+
+  render() {
+    console.log('props', this.props);
+
+    var showInfo = false;
+    var details = <span>Provider credentials for {this.props.organizationName} {this.props.provider}</span>;
+
+    if (!this.props.credentials.isFetching && this.props.credentials.items.length > 0) {
+      if (this.props.provider === 'aws') {
+        showInfo = true;
+        details = <p>This cluster will be created in AWS account <code>{this.awsAccountIDFromARN(this.props.credentials.items[0].aws.roles.awsoperator)}</code>, as set for this organization.</p>;
+      } else if (this.props.provider === 'azure') {
+        showInfo = true;
+        details = <p>This cluster will be created in Azure subscription <code>{this.props.credentials.items[0].azure.credential.subscription_id}</code> and tenant <code>{this.props.credentials.items[0].azure.credential.tenant_id}</code>, as set for this organization.</p>;
+      }
+    }
+
+    if (showInfo) {
+      return (
+        <div className='row section'>
+          <div className='col-3'>
+            <h3 className='table-label'>Provider Credentials</h3>
+          </div>
+          <div className='col-9'>
+            {details}
+          </div>
+        </div>
+      );
+    } else {
+      return <div />;
+    }
+  }
+}
+
+ProviderCredentials.propTypes = {
+  dispatch: PropTypes.func,
+  provider: PropTypes.string,
+  organizationName: PropTypes.string,
+  actions: PropTypes.object,
+  credentials: PropTypes.object,
+  app: PropTypes.object,
+};
+
+function mapStateToProps(state) {
+  return {
+    credentials: state.entities.credentials,
+    app: state.app,
+  };
+}
+
+export default connect(mapStateToProps)(ProviderCredentials);


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3987

This adds a line of info in the cluster creation page when the owner org has BYOC credentials set.

![image](https://user-images.githubusercontent.com/273727/47494437-e8885700-d851-11e8-86c0-d160c5223bb1.png)

This should reassure BYOC users when creating a cluster.

If there are no specific credentials set for the org, the entire line does not appear.