### PR TITLE
Remove componentWillMount

### DIFF
--- a/src/components/auth/oauth_callback.js
+++ b/src/components/auth/oauth_callback.js
@@ -5,7 +5,6 @@ import React from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import {connect} from 'react-redux';
 import { Link } from 'react-router-dom';
-// import { flashClearAll } from '../../actions/flashMessageActions';
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import Auth from '../../lib/auth0';
@@ -13,27 +12,25 @@ import { push } from 'connected-react-router';
 import PropTypes from 'prop-types';
 
 class OauthCallback extends React.Component {
+  state = {
+    error: null
+  }
+
   constructor(props) {
     super(props);
 
-    this.state = {
-      error: null
-    };
-  }
-
-  componentWillMount() {
     const auth = new Auth();
 
-    if (/id_token|error/.test(this.props.location.hash)) {
+    if (/id_token|error/.test(props.location.hash)) {
       auth.handleAuthentication((err, authResult) => {
         if (err === null) {
           // Login user officially
-          this.props.actions.auth0Login(authResult)
+          props.actions.auth0Login(authResult)
           .then(() => {
-            this.props.dispatch(push('/'));
+            props.dispatch(push('/'));
           })
           .catch((err) => {
-            console.log(err);
+            console.error(err);
           });
         } else {
           this.setState({error: err});

--- a/src/components/organizations/cluster_detail.js
+++ b/src/components/organizations/cluster_detail.js
@@ -21,35 +21,29 @@ import PropTypes from 'prop-types';
 import { Breadcrumb } from 'react-breadcrumbs';
 
 class ClusterDetail extends React.Component {
+  state = {
+    loading: true
+  }
+  
   constructor (props){
     super(props);
 
-    this.state = {
-      loading: true
-    };
-  }
-
-  componentWillMount() {
-    this.setState({
-      loading: true
-    });
-
-    if (this.props.cluster === undefined) {
-      this.props.dispatch(push('/organizations/'+this.props.organizationId));
+    if (props.cluster === undefined) {
+      props.dispatch(push('/organizations/'+props.organizationId));
       this.setState({
         notfound: true
       });
 
-      this.props.dispatch(flashAdd({
-        message: <div><b>Cluster &quot;{this.props.clusterId}&quot; not found.</b><br/>Please make sure the Cluster ID is correct and that you have access to the organization that it belongs to.</div>,
+      props.dispatch(flashAdd({
+        message: <div><b>Cluster &quot;{props.clusterId}&quot; not found.</b><br/>Please make sure the Cluster ID is correct and that you have access to the organization that it belongs to.</div>,
         class: 'info',
         ttl: 6000
       }));
 
     } else {
-      this.props.releaseActions.loadReleases()
+      props.releaseActions.loadReleases()
       .then(() => {
-        return this.props.clusterActions.clusterLoadDetails(this.props.cluster.id);
+        return props.clusterActions.clusterLoadDetails(props.cluster.id);
       })
       .then(() => {
         this.setState({


### PR DESCRIPTION
I came accros some uses of `componentWillMount`, which is to be deprecated in React 16.3. See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state

This is so far only tested locally. Needs testing in SSO/OAuth context.

This also uses the most simple way to initialize the component state.