### PR TITLE
Key-pair creation dialog: make labels static, adjust layout

### DIFF
--- a/src/components/organizations/expiry_hours_picker.js
+++ b/src/components/organizations/expiry_hours_picker.js
@@ -34,22 +34,6 @@ class ExpiryHoursPicker extends React.Component {
     });
   }
 
-  isPlural(number) {
-    if (parseInt(number) === 1) {
-      return false;
-    } else {
-      return true;
-    }
-  }
-
-  pluralLabel(label, number) {
-    if (this.isPlural(number)) {
-      return label + 's';
-    } else {
-      return label;
-    }
-  }
-
   handleDateChange(date) {
     this.setState({
       expireDate: date,
@@ -144,17 +128,10 @@ class ExpiryHoursPicker extends React.Component {
           />
 
           <label htmlFor="relativeCheck">Relatively:</label>
-          <input type='text' min="0" max="10" name="years" maxLength={2} ref={(i) => {this.years = i;}} value={this.state.yearsValue} onChange={this.handleYearChange.bind(this)} autoComplete="off"/>
-          { this.pluralLabel.bind(this, 'Year', this.state.yearsValue)() }
-
-          <input type='text' min="0" max="999" name="months" maxLength={2} ref={(i) => {this.months = i;}} value={this.state.monthsValue} onChange={this.handleMonthChange.bind(this)} autoComplete="off"/>
-          { this.pluralLabel.bind(this, 'Month', this.state.monthsValue)() }
-
-          <input type='text' min="0" max="999" name="days" maxLength={2} ref={(i) => {this.days = i;}} value={this.state.daysValue} onChange={this.handleDayChange.bind(this)} autoComplete="off"/>
-          { this.pluralLabel.bind(this, 'Day', this.state.daysValue)() }
-
-          <input type='text' min="0" max="999" name="hours" maxLength={2} ref={(i) => {this.hours = i;}} value={this.state.hoursValue} onChange={this.handleHourChange.bind(this)} autoComplete="off"/>
-          { this.pluralLabel.bind(this, 'Hour', this.state.hoursValue)() } from now
+          <input type='text' min="0" max="10" name="years" maxLength={2} ref={(i) => {this.years = i;}} value={this.state.yearsValue} onChange={this.handleYearChange.bind(this)} autoComplete="off"/> years
+          <input type='text' min="0" max="999" name="months" maxLength={2} ref={(i) => {this.months = i;}} value={this.state.monthsValue} onChange={this.handleMonthChange.bind(this)} autoComplete="off"/> months
+          <input type='text' min="0" max="999" name="days" maxLength={2} ref={(i) => {this.days = i;}} value={this.state.daysValue} onChange={this.handleDayChange.bind(this)} autoComplete="off"/> days
+          <input type='text' min="0" max="999" name="hours" maxLength={2} ref={(i) => {this.hours = i;}} value={this.state.hoursValue} onChange={this.handleHourChange.bind(this)} autoComplete="off"/> hours from now
         </li>
         <li>
           <input type='radio'

--- a/src/styles/components/_cluster_details.sass
+++ b/src/styles/components/_cluster_details.sass
@@ -4,7 +4,7 @@
     line-height: 45px
 
   .upgrade-available
-    font-family: Roboto
+    font-family: Roboto, sans-serif
     color: $gold
     i
       color: $gold

--- a/src/styles/components/_create_key_pair.sass
+++ b/src/styles/components/_create_key_pair.sass
@@ -67,3 +67,6 @@
 
 .expiring
   color: $gold
+
+.react-datepicker
+  font-family: Roboto, sans-serif !important

--- a/src/styles/components/_expiry_hours_picker.sass
+++ b/src/styles/components/_expiry_hours_picker.sass
@@ -17,7 +17,7 @@
   margin-bottom: 10px
 
   input[type='text']
-    width: 50px
+    width: 35px
     text-align: center
     padding: 2px
     margin-left: 15px

--- a/src/styles/components/_expiry_hours_picker.sass
+++ b/src/styles/components/_expiry_hours_picker.sass
@@ -11,6 +11,7 @@
   label
     width: 70px
     display: inline-block
+    font-size: 16px
 
 .expiry-hours-picker--granular
   margin-bottom: 10px


### PR DESCRIPTION
The main change here is the removal of the dynamic behaviour of the relative time labels. This was causing the layout to change during input.

In addition, inputs field are a bit narrower, and labels are lower case (which works better for me as this is practically a sentence) plus some more adjustments.

Preview

![image](https://user-images.githubusercontent.com/273727/47858711-f2c7c980-ddec-11e8-924e-fcc13741f025.png)


![image](https://user-images.githubusercontent.com/273727/47858740-fc513180-ddec-11e8-83e5-88e62e65f546.png)
