### PR TITLE
Dynamic truncation for the key pairs table

### DIFF
--- a/src/components/organizations/cluster_key_pairs.js
+++ b/src/components/organizations/cluster_key_pairs.js
@@ -218,7 +218,7 @@ class ClusterKeyPairs extends React.Component {
         </div>
 
         <div className='row'>
-          <div className='col-9'>
+          <div className='col-12'>
             <p>Key pairs consist of an RSA private key and certificate, signed by the certificate authority (CA) belonging to this cluster. They are used for access to the cluster via the Kubernetes API.</p>
           </div>
         </div>

--- a/src/components/organizations/cluster_key_pairs.js
+++ b/src/components/organizations/cluster_key_pairs.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Button from '../button';
 import * as clusterActions from '../../actions/clusterActions';
-import { relativeDate, truncate } from '../../lib/helpers.js';
+import { relativeDate } from '../../lib/helpers.js';
 import {OverlayTrigger, Tooltip} from 'react-bootstrap/lib';
 import ExpiryHoursPicker from './expiry_hours_picker';
 import { makeKubeConfigTextFile, dedent } from '../../lib/helpers';
@@ -245,12 +245,12 @@ class ClusterKeyPairs extends React.Component {
                   <table>
                     <thead>
                       <tr>
-                        <th>ID</th>
-                        <th>Description</th>
-                        <th>Created</th>
-                        <th>Expires</th>
-                        <th>Common Name (CN)</th>
-                        <th>Organization (O)</th>
+                        <th className='hidden-xs'>ID</th>
+                        <th className='hidden-xs'>Description</th>
+                        <th className='hidden-xs'>Created</th>
+                        <th className='hidden-xs'>Expires</th>
+                        <th className=''>Common Name (CN)</th>
+                        <th className=''>Organization (O)</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -264,22 +264,28 @@ class ClusterKeyPairs extends React.Component {
                           }
 
                           return <tr key={keyPair.id}>
-                            <td className="code">
-                              <OverlayTrigger placement="top" overlay={
-                                  <Tooltip id="tooltip">{keyPair.id}</Tooltip>
-                                }>
-                                <span>{truncate(keyPair.id.replace(/:/g, ''), 9)}</span>
+                            <td className='code truncate hidden-xs col-sm-2'>
+                              <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip">{keyPair.id}</Tooltip>}>
+                                <span>{keyPair.id.replace(/:/g, '')}</span>
                               </OverlayTrigger>
                             </td>
-                            <td>{keyPair.description}</td>
-                            <td>{relativeDate(keyPair.create_date)}</td>
-                            <td className={expiryClass}>{relativeDate(keyPair.expire_date)}</td>
-                            <td className="code">
+                            <td className='truncate hidden-xs col-sm-4'>
+                              <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip">{keyPair.description}</Tooltip>}>
+                                <span>{keyPair.description}</span>
+                              </OverlayTrigger>
+                            </td>
+                            <td className='truncate hidden-xs col-sm-1'>{relativeDate(keyPair.create_date)}</td>
+                            <td className={`${expiryClass} truncate hidden-xs col-sm-1`}>{relativeDate(keyPair.expire_date)}</td>
+                            <td className='code truncate col-xs-3'>
                               <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip">{keyPair.common_name}</Tooltip>}>
-                                <span>{truncate(keyPair.common_name, 24)}</span>
+                                <span>{keyPair.common_name}</span>
                               </OverlayTrigger>
                             </td>
-                            <td className="code">{keyPair.certificate_organizations}</td>
+                            <td className='code truncate col-xs-1'>
+                              <OverlayTrigger placement="top" overlay={<Tooltip id="tooltip">{keyPair.certificate_organizations}</Tooltip>}>
+                                <span>{keyPair.certificate_organizations}</span>
+                              </OverlayTrigger>
+                            </td>
                           </tr>;
                         })
                       }

--- a/src/styles/components/_table.sass
+++ b/src/styles/components/_table.sass
@@ -41,6 +41,12 @@ table
   td
     padding: 10px
     color: #ccc
+  
+    &.truncate
+      max-width: 0
+      white-space: nowrap
+      overflow: hidden
+      text-overflow: ellipsis
 
   td.centered, th.centered
     text-align: center


### PR DESCRIPTION
The key pairs table with the static truncation didn't really use the available space for the best usability.

This PR makes the truncation dynamic, to let the table use the entire column width. In addition, some columns are hidden entirely in smaller viewports, to be able to render a recognizable table as such.

## Preview

![screen-recording-2018-11-06-at-14 10](https://user-images.githubusercontent.com/273727/48066973-59732b80-e1cf-11e8-9361-e35aedbfd3cf.gif)
