### PR TITLE
Remove use of deprecated componentWillReceiveProps

### DIFF
--- a/src/components/home/bar_chart.js
+++ b/src/components/home/bar_chart.js
@@ -39,7 +39,7 @@ class BarChart extends React.Component {
   componentDidUpdate(prevProps) {
     if (this.props.percentage !== prevProps.percentage) {
       this.setState({
-        percentage: this.props.percentage
+        percentage: this.props.percentage,
       });
     }
   }

--- a/src/components/home/bar_chart.js
+++ b/src/components/home/bar_chart.js
@@ -36,10 +36,12 @@ class BarChart extends React.Component {
     }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState({
-      percentage: nextProps.percentage,
-    });
+  componentDidUpdate(prevProps) {
+    if (this.props.percentage !== prevProps.percentage) {
+      this.setState({
+        percentage: this.props.percentage
+      });
+    }
   }
 
   cappedPercentage() {

--- a/src/components/shared/input_field.js
+++ b/src/components/shared/input_field.js
@@ -11,7 +11,7 @@ var doneTypingInterval = 250; // ms
 // A subcomponent that emits 'onChange' when the user has stopped typing
 // after 250 ms or after leaving the field
 //
-// And shows a error message if a supplied validation function returns fails
+// And shows an error message if a supplied validation function returns fails
 
 class InputField extends React.Component {
   constructor(props) {
@@ -24,20 +24,21 @@ class InputField extends React.Component {
     };
   }
 
-  UNSAFE_componentWillReceiveProps(props) {
-    if (props.value != this.state.value) {
-      var validation = this.props.validate(props.value);
-      this.setState({
-        value: props.value,
-        valid: validation.valid,
-        validationError: validation.validationError,
-      });
-    }
-  }
-
   componentDidMount() {
     if (this.props.autofocus) {
       this.input.focus();
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.props.value != this.state.value) {
+      var validation = this.props.validate(this.props.value);
+
+      this.setState({
+        value: this.props.value,
+        valid: validation.valid,
+        validationError: validation.validationError,
+      });
     }
   }
 

--- a/src/components/signup/index.js
+++ b/src/components/signup/index.js
@@ -8,7 +8,7 @@ import TermsOfService from './terms_of_service';
 import * as userActions from '../../actions/userActions';
 import { flashAdd } from '../../actions/flashMessageActions';
 import { bindActionCreators } from 'redux';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { validatePassword } from '../../lib/password_validation';
 import { push } from 'connected-react-router';
@@ -17,24 +17,24 @@ import Button from '../button';
 // TODO: Figure out a way to make the test suite know about our standard
 // 'window.config' object. Or change the way these config params are passed
 // in. Or change the way these components get at these supporting libraries.
-window.config = window.config || {passageEndpoint: 'http://localhost:5000'};
+window.config = window.config || { passageEndpoint: 'http://localhost:5000' };
 // EndTODO
-var passage = new Passage({endpoint: window.config.passageEndpoint});
+var passage = new Passage({ endpoint: window.config.passageEndpoint });
 
 export class SignUp extends React.Component {
   state = {
     statusMessage: 'verify_started',
     checkInviteStatus: 'started',
     email: undefined,
-    passwordField: {value: '', valid: false},
-    passwordConfirmationField: {value: '', valid: false},
-    termsOfServiceField: {value: false, valid: false},
+    passwordField: { value: '', valid: false },
+    passwordConfirmationField: { value: '', valid: false },
+    termsOfServiceField: { value: false, valid: false },
     formValid: undefined,
     submitting: false,
     buttonText: ['', 'Next', 'Next', 'Create your account now'],
     formSteps: ['', 'passwordGroup', 'passwordConfirmationGroup', 'TOSGroup'],
     currentStep: 0,
-    advancable: false
+    advancable: false,
   };
 
   resetForm() {
@@ -42,40 +42,44 @@ export class SignUp extends React.Component {
       statusMessage: 'verify_started',
       checkInviteStatus: 'started',
       email: undefined,
-      passwordField: {value: '', valid: false},
-      passwordConfirmationField: {value: '', valid: false},
-      termsOfServiceField: {value: false, valid: false},
+      passwordField: { value: '', valid: false },
+      passwordConfirmationField: { value: '', valid: false },
+      termsOfServiceField: { value: false, valid: false },
       formValid: undefined,
       submitting: false,
       buttonText: ['', 'Next', 'Next', 'Create your account now'],
       formSteps: ['', 'passwordGroup', 'passwordConfirmationGroup', 'TOSGroup'],
       currentStep: 0,
-      advancable: false
+      advancable: false,
     });
   }
 
-  componentDidMount(){
+  componentDidMount() {
     var token = this.props.match.params.token;
 
-    passage.checkInvite({token})
+    passage
+      .checkInvite({ token })
       .then(data => {
         this.setState({
           email: data.email,
           statusMessage: 'verify_completed',
-          checkInviteStatus: 'completed'
+          checkInviteStatus: 'completed',
         });
 
-        setTimeout(function() {
-          this.setState({
-            statusMessage: 'enter_password',
-          });
+        setTimeout(
+          function() {
+            this.setState({
+              statusMessage: 'enter_password',
+            });
 
-          this.advanceForm();
-        }.bind(this), 800);
+            this.advanceForm();
+          }.bind(this),
+          800
+        );
       })
       .catch(error => {
         this.setState({
-          checkInviteStatus: 'failed'
+          checkInviteStatus: 'failed',
         });
 
         var statusMessage = 'verify_failed';
@@ -85,7 +89,7 @@ export class SignUp extends React.Component {
         }
 
         this.setState({
-          statusMessage: statusMessage
+          statusMessage: statusMessage,
         });
       });
   }
@@ -100,64 +104,70 @@ export class SignUp extends React.Component {
   advanceForm() {
     var nextStep = this.state.currentStep + 1;
 
-    this.setState({
-      currentStep: nextStep
-    }, () => {
-      if (nextStep === 1) {
-        this.password.focus();
-      } else if (nextStep === 2) {
-        this.passwordConfirmation.focus();
-      } else if (nextStep === 3) {
-        this.setState({
-          statusMessage: 'tos_intro'
-        });
+    this.setState(
+      {
+        currentStep: nextStep,
+      },
+      () => {
+        if (nextStep === 1) {
+          this.password.focus();
+        } else if (nextStep === 2) {
+          this.passwordConfirmation.focus();
+        } else if (nextStep === 3) {
+          this.setState({
+            statusMessage: 'tos_intro',
+          });
 
-        this.passwordConfirmation.blur();
+          this.passwordConfirmation.blur();
+        }
       }
-    });
+    );
   }
 
   accountCreated() {
     // Delay a bit so the user sees the DONE message
     // and then transition to the getting started guide
     //
-    this.props.dispatch(flashAdd({
-      message: 'Account created! Welcome to Giant Swarm.',
-      class: 'success'
-    }));
+    this.props.dispatch(
+      flashAdd({
+        message: 'Account created! Welcome to Giant Swarm.',
+        class: 'success',
+      })
+    );
 
     setTimeout(() => {
       this.props.dispatch(push('/'));
     }, 1000);
   }
 
-  handleSubmit = (e) => {
+  handleSubmit = e => {
     e.preventDefault();
 
-    if(this.state.formValid) {
+    if (this.state.formValid) {
       this.setState({
         statusMessage: 'create_account_starting',
         submitting: true,
       });
 
-      passage.createAccount({
-        inviteToken: this.props.match.params.token,
-        password: this.state.passwordField.value
-      })
-        .then((data) => {
+      passage
+        .createAccount({
+          inviteToken: this.props.match.params.token,
+          password: this.state.passwordField.value,
+        })
+        .then(data => {
           var userData = {
             username: data.username,
             email: data.email,
-            auth:{
-              'scheme':'giantswarm',
-              'token': data.token
-            }
+            auth: {
+              scheme: 'giantswarm',
+              token: data.token,
+            },
           };
 
           this.props.actions.loginSuccess(userData);
 
           this.setState({
-            statusMessage: 'create_account_completed'
+            statusMessage: 'create_account_completed',
           });
 
           this.accountCreated();
@@ -165,15 +175,15 @@ export class SignUp extends React.Component {
         .catch(() => {
           this.setState({
             statusMessage: 'create_account_failed',
-            submitting: false
+            submitting: false,
           });
         });
     } else {
       this.advanceForm();
     }
-  }
+  };
 
-  tosChanged = (e) => {
+  tosChanged = e => {
     var checked = e.target.checked;
 
     var statusMessage = this.state.statusMessage;
@@ -183,8 +193,8 @@ export class SignUp extends React.Component {
       advancable: false,
       termsOfServiceField: {
         valid: false,
-        value: checked
-      }
+        value: checked,
+      },
     });
 
     var termsOfServiceFieldValid = false;
@@ -200,64 +210,69 @@ export class SignUp extends React.Component {
       statusMessage = 'tos_not_accepted';
     }
 
-    this.setState({
-      termsOfServiceField: {
-        valid: termsOfServiceFieldValid,
-        value: termsOfServiceFieldValue
+    this.setState(
+      {
+        termsOfServiceField: {
+          valid: termsOfServiceFieldValid,
+          value: termsOfServiceFieldValue,
+        },
+        statusMessage: statusMessage,
       },
-      statusMessage: statusMessage
-    }, () => {
-      this.validateForm();
-    });
-  }
+      () => {
+        this.validateForm();
+      }
+    );
+  };
 
-  passwordEditingStarted = (password) => {
+  passwordEditingStarted = password => {
     this.setState({
       formValid: false,
       advancable: false,
       passwordField: {
         value: password,
-        valid: false
-      }
+        valid: false,
+      },
     });
-  }
+  };
 
-  passwordEditingCompleted = (password) => {
+  passwordEditingCompleted = password => {
     var validationResult = validatePassword(password);
 
     this.setState({
       statusMessage: validationResult.statusMessage,
       passwordField: {
         value: password,
-        valid: validationResult.valid
-      }
+        valid: validationResult.valid,
+      },
     });
 
     this.validateForm();
-  }
+  };
 
-  passwordConfirmationEditingStarted = (confirmation) => {
+  passwordConfirmationEditingStarted = confirmation => {
     this.setState({
       formValid: false,
       advancable: false,
       passwordConfirmationField: {
         valid: false,
-        value: confirmation
-      }
+        value: confirmation,
+      },
     });
 
     if (this.state.passwordField.valid) {
       if (this.state.passwordField.value === confirmation) {
-
-        this.setState({
-          passwordConfirmationField: {
-            valid: true,
-            value: confirmation
+        this.setState(
+          {
+            passwordConfirmationField: {
+              valid: true,
+              value: confirmation,
+            },
+            statusMessage: 'password_confirmation_ok',
           },
-          statusMessage: 'password_confirmation_ok'
-        }, () => {
-          this.validateForm();
-        });
+          () => {
+            this.validateForm();
+          }
+        );
 
         if (this.state.currentStep === 1) {
           // If we're on the first step, the confirmation field isn't even visible
@@ -267,9 +282,9 @@ export class SignUp extends React.Component {
         }
       }
     }
-  }
+  };
 
-  passwordConfirmationEditingCompleted = (passwordConfirmation) => {
+  passwordConfirmationEditingCompleted = passwordConfirmation => {
     var statusMessage = this.state.statusMessage;
     var valid = this.state.passwordConfirmationField.valid;
 
@@ -278,8 +293,8 @@ export class SignUp extends React.Component {
       advancable: false,
       passwordConfirmationField: {
         valid: false,
-        value: passwordConfirmation
-      }
+        value: passwordConfirmation,
+      },
     });
 
     if (this.state.passwordField.valid) {
@@ -295,13 +310,13 @@ export class SignUp extends React.Component {
         statusMessage: statusMessage,
         passwordConfirmationField: {
           valid: valid,
-          value: passwordConfirmation
-        }
+          value: passwordConfirmation,
+        },
       });
 
       this.validateForm();
     }
-  }
+  };
 
   validateForm() {
     var advancable = false;
@@ -310,15 +325,28 @@ export class SignUp extends React.Component {
 
     if (this.state.currentStep === 1 && this.state.passwordField.valid) {
       advancable = true;
-    } else if (this.state.currentStep === 2 && this.state.passwordField.valid && this.state.passwordConfirmationField.valid) {
+    } else if (
+      this.state.currentStep === 2 &&
+      this.state.passwordField.valid &&
+      this.state.passwordConfirmationField.valid
+    ) {
       advancable = true;
-    } else if (this.state.currentStep === 3 && this.state.passwordField.valid && this.state.passwordConfirmationField.valid && this.state.termsOfServiceField.valid) {
+    } else if (
+      this.state.currentStep === 3 &&
+      this.state.passwordField.valid &&
+      this.state.passwordConfirmationField.valid &&
+      this.state.termsOfServiceField.valid
+    ) {
       advancable = true;
     } else {
       advancable = false;
     }
 
-    if (this.state.passwordField.valid && this.state.passwordConfirmationField.valid && this.state.termsOfServiceField.valid) {
+    if (
+      this.state.passwordField.valid &&
+      this.state.passwordConfirmationField.valid &&
+      this.state.termsOfServiceField.valid
+    ) {
       formValid = true;
       statusMessage = 'all_good';
     } else {
@@ -328,31 +356,53 @@ export class SignUp extends React.Component {
     this.setState({
       advancable: advancable,
       formValid: formValid,
-      statusMessage: statusMessage
+      statusMessage: statusMessage,
     });
   }
 
   render() {
     return (
       <div className='signup--container col-6'>
-        <h1 ref={(t) => {this.title = t;}}>Create Your Giant Swarm Account</h1>
+        <h1
+          ref={t => {
+            this.title = t;
+          }}
+        >
+          Create Your Giant Swarm Account
+        </h1>
 
-
-        <form ref={(f) => {this.signupForm = f;}} onSubmit={this.handleSubmit} className={'step-' + this.state.currentStep} >
+        <form
+          ref={f => {
+            this.signupForm = f;
+          }}
+          onSubmit={this.handleSubmit}
+          className={'step-' + this.state.currentStep}
+        >
           <div id='passwordGroup'>
-            <p className='subtitle'>This is your personal Giant Swarm account for the email address {this.state.email}!</p>
+            <p className='subtitle'>
+              This is your personal Giant Swarm account for the email address{' '}
+              {this.state.email}!
+            </p>
 
-            <PasswordField ref={(p) => {this.password = p;}}
-                           label='Set a password'
-                           onStartTyping={this.passwordEditingStarted}
-                           onChange={this.passwordEditingCompleted} />
+            <PasswordField
+              ref={p => {
+                this.password = p;
+              }}
+              label='Set a password'
+              onStartTyping={this.passwordEditingStarted}
+              onChange={this.passwordEditingCompleted}
+            />
           </div>
 
           <div id='passwordConfirmationGroup'>
-            <PasswordField ref={(f) => {this.passwordConfirmation = f;}}
-                           label='Password, once again'
-                           onStartTyping={this.passwordConfirmationEditingStarted}
-                           onChange={this.passwordConfirmationEditingCompleted} />
+            <PasswordField
+              ref={f => {
+                this.passwordConfirmation = f;
+              }}
+              label='Password, once again'
+              onStartTyping={this.passwordConfirmationEditingStarted}
+              onChange={this.passwordConfirmationEditingCompleted}
+            />
           </div>
 
           <div id='TOSGroup'>
@@ -360,27 +410,35 @@ export class SignUp extends React.Component {
 
             <div className='checkbox'>
               <label htmlFor='tosAccept'>
-                <input type='checkbox' ref={(i) => {this.tosAccept = i;}} id='tosAccept' onChange={this.tosChanged} />
+                <input
+                  type='checkbox'
+                  ref={i => {
+                    this.tosAccept = i;
+                  }}
+                  id='tosAccept'
+                  onChange={this.tosChanged}
+                />
                 I accept the terms of service
               </label>
             </div>
           </div>
 
           <StatusMessage status={this.state.statusMessage} />
-            { this.state.buttonText[this.state.currentStep] != '' ?
-              <Button type='submit'
-                    bsStyle='primary'
-                    bsSize='large'
-                    disabled={ (! this.state.advancable) || this.state.submitting }
-                    loading={this.state.submitting}
-                    onClick={this.logIn}>{this.state.buttonText[this.state.currentStep]}</Button>
-              :
-              ''
-            }
+          {this.state.buttonText[this.state.currentStep] != '' ? (
+            <Button
+              type='submit'
+              bsStyle='primary'
+              bsSize='large'
+              disabled={!this.state.advancable || this.state.submitting}
+              loading={this.state.submitting}
+              onClick={this.logIn}
+            >
+              {this.state.buttonText[this.state.currentStep]}
+            </Button>
+          ) : (
+            ''
+          )}
         </form>
-
-
-
       </div>
     );
   }
@@ -389,14 +447,17 @@ export class SignUp extends React.Component {
 SignUp.propTypes = {
   match: PropTypes.object,
   dispatch: PropTypes.func,
-  actions: PropTypes.object
+  actions: PropTypes.object,
 };
 
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(userActions, dispatch),
-    dispatch: dispatch
+    dispatch: dispatch,
   };
 }
 
-export default connect(null, mapDispatchToProps)(SignUp);
+export default connect(
+  null,
+  mapDispatchToProps
+)(SignUp);

--- a/src/components/signup/index.js
+++ b/src/components/signup/index.js
@@ -8,7 +8,7 @@ import TermsOfService from './terms_of_service';
 import * as userActions from '../../actions/userActions';
 import { flashAdd } from '../../actions/flashMessageActions';
 import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import { validatePassword } from '../../lib/password_validation';
 import { push } from 'connected-react-router';
@@ -17,73 +17,65 @@ import Button from '../button';
 // TODO: Figure out a way to make the test suite know about our standard
 // 'window.config' object. Or change the way these config params are passed
 // in. Or change the way these components get at these supporting libraries.
-window.config = window.config || { passageEndpoint: 'http://localhost:5000' };
+window.config = window.config || {passageEndpoint: 'http://localhost:5000'};
 // EndTODO
-var passage = new Passage({ endpoint: window.config.passageEndpoint });
+var passage = new Passage({endpoint: window.config.passageEndpoint});
 
 export class SignUp extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      statusMessage: 'verify_started',
-      checkInviteStatus: 'started',
-      email: undefined,
-      passwordField: { value: '', valid: false },
-      passwordConfirmationField: { value: '', valid: false },
-      termsOfServiceField: { value: false, valid: false },
-      formValid: undefined,
-      submitting: false,
-      buttonText: ['', 'Next', 'Next', 'Create your account now'],
-      formSteps: ['', 'passwordGroup', 'passwordConfirmationGroup', 'TOSGroup'],
-      currentStep: 0,
-      advancable: false,
-    };
-  }
+  state = {
+    statusMessage: 'verify_started',
+    checkInviteStatus: 'started',
+    email: undefined,
+    passwordField: {value: '', valid: false},
+    passwordConfirmationField: {value: '', valid: false},
+    termsOfServiceField: {value: false, valid: false},
+    formValid: undefined,
+    submitting: false,
+    buttonText: ['', 'Next', 'Next', 'Create your account now'],
+    formSteps: ['', 'passwordGroup', 'passwordConfirmationGroup', 'TOSGroup'],
+    currentStep: 0,
+    advancable: false
+  };
 
   resetForm() {
     this.setState({
       statusMessage: 'verify_started',
       checkInviteStatus: 'started',
       email: undefined,
-      passwordField: { value: '', valid: false },
-      passwordConfirmationField: { value: '', valid: false },
-      termsOfServiceField: { value: false, valid: false },
+      passwordField: {value: '', valid: false},
+      passwordConfirmationField: {value: '', valid: false},
+      termsOfServiceField: {value: false, valid: false},
       formValid: undefined,
       submitting: false,
       buttonText: ['', 'Next', 'Next', 'Create your account now'],
       formSteps: ['', 'passwordGroup', 'passwordConfirmationGroup', 'TOSGroup'],
       currentStep: 0,
-      advancable: false,
+      advancable: false
     });
   }
 
-  componentDidMount() {
+  componentDidMount(){
     var token = this.props.match.params.token;
 
-    passage
-      .checkInvite({ token })
+    passage.checkInvite({token})
       .then(data => {
         this.setState({
           email: data.email,
           statusMessage: 'verify_completed',
-          checkInviteStatus: 'completed',
+          checkInviteStatus: 'completed'
         });
 
-        setTimeout(
-          function() {
-            this.setState({
-              statusMessage: 'enter_password',
-            });
+        setTimeout(function() {
+          this.setState({
+            statusMessage: 'enter_password',
+          });
 
-            this.advanceForm();
-          }.bind(this),
-          800
-        );
+          this.advanceForm();
+        }.bind(this), 800);
       })
       .catch(error => {
         this.setState({
-          checkInviteStatus: 'failed',
+          checkInviteStatus: 'failed'
         });
 
         var statusMessage = 'verify_failed';
@@ -93,12 +85,12 @@ export class SignUp extends React.Component {
         }
 
         this.setState({
-          statusMessage: statusMessage,
+          statusMessage: statusMessage
         });
       });
   }
 
-  UNSAFE_componentWillReceiveProps() {
+  componentDidUpdate() {
     this.resetForm();
     this.componentDidMount();
   }
@@ -106,70 +98,64 @@ export class SignUp extends React.Component {
   advanceForm() {
     var nextStep = this.state.currentStep + 1;
 
-    this.setState(
-      {
-        currentStep: nextStep,
-      },
-      () => {
-        if (nextStep === 1) {
-          this.password.focus();
-        } else if (nextStep === 2) {
-          this.passwordConfirmation.focus();
-        } else if (nextStep === 3) {
-          this.setState({
-            statusMessage: 'tos_intro',
-          });
+    this.setState({
+      currentStep: nextStep
+    }, () => {
+      if (nextStep === 1) {
+        this.password.focus();
+      } else if (nextStep === 2) {
+        this.passwordConfirmation.focus();
+      } else if (nextStep === 3) {
+        this.setState({
+          statusMessage: 'tos_intro'
+        });
 
-          this.passwordConfirmation.blur();
-        }
+        this.passwordConfirmation.blur();
       }
-    );
+    });
   }
 
   accountCreated() {
     // Delay a bit so the user sees the DONE message
     // and then transition to the getting started guide
     //
-    this.props.dispatch(
-      flashAdd({
-        message: 'Account created! Welcome to Giant Swarm.',
-        class: 'success',
-      })
-    );
+    this.props.dispatch(flashAdd({
+      message: 'Account created! Welcome to Giant Swarm.',
+      class: 'success'
+    }));
 
     setTimeout(() => {
       this.props.dispatch(push('/'));
     }, 1000);
   }
 
-  handleSubmit = e => {
+  handleSubmit = (e) => {
     e.preventDefault();
 
-    if (this.state.formValid) {
+    if(this.state.formValid) {
       this.setState({
         statusMessage: 'create_account_starting',
         submitting: true,
       });
 
-      passage
-        .createAccount({
-          inviteToken: this.props.match.params.token,
-          password: this.state.passwordField.value,
-        })
-        .then(data => {
+      passage.createAccount({
+        inviteToken: this.props.match.params.token,
+        password: this.state.passwordField.value
+      })
+        .then((data) => {
           var userData = {
             username: data.username,
             email: data.email,
-            auth: {
-              scheme: 'giantswarm',
-              token: data.token,
-            },
+            auth:{
+              'scheme':'giantswarm',
+              'token': data.token
+            }
           };
 
           this.props.actions.loginSuccess(userData);
 
           this.setState({
-            statusMessage: 'create_account_completed',
+            statusMessage: 'create_account_completed'
           });
 
           this.accountCreated();
@@ -177,15 +163,15 @@ export class SignUp extends React.Component {
         .catch(() => {
           this.setState({
             statusMessage: 'create_account_failed',
-            submitting: false,
+            submitting: false
           });
         });
     } else {
       this.advanceForm();
     }
-  };
+  }
 
-  tosChanged = e => {
+  tosChanged = (e) => {
     var checked = e.target.checked;
 
     var statusMessage = this.state.statusMessage;
@@ -195,8 +181,8 @@ export class SignUp extends React.Component {
       advancable: false,
       termsOfServiceField: {
         valid: false,
-        value: checked,
-      },
+        value: checked
+      }
     });
 
     var termsOfServiceFieldValid = false;
@@ -212,69 +198,64 @@ export class SignUp extends React.Component {
       statusMessage = 'tos_not_accepted';
     }
 
-    this.setState(
-      {
-        termsOfServiceField: {
-          valid: termsOfServiceFieldValid,
-          value: termsOfServiceFieldValue,
-        },
-        statusMessage: statusMessage,
+    this.setState({
+      termsOfServiceField: {
+        valid: termsOfServiceFieldValid,
+        value: termsOfServiceFieldValue
       },
-      () => {
-        this.validateForm();
-      }
-    );
-  };
+      statusMessage: statusMessage
+    }, () => {
+      this.validateForm();
+    });
+  }
 
-  passwordEditingStarted = password => {
+  passwordEditingStarted = (password) => {
     this.setState({
       formValid: false,
       advancable: false,
       passwordField: {
         value: password,
-        valid: false,
-      },
+        valid: false
+      }
     });
-  };
+  }
 
-  passwordEditingCompleted = password => {
+  passwordEditingCompleted = (password) => {
     var validationResult = validatePassword(password);
 
     this.setState({
       statusMessage: validationResult.statusMessage,
       passwordField: {
         value: password,
-        valid: validationResult.valid,
-      },
+        valid: validationResult.valid
+      }
     });
 
     this.validateForm();
-  };
+  }
 
-  passwordConfirmationEditingStarted = confirmation => {
+  passwordConfirmationEditingStarted = (confirmation) => {
     this.setState({
       formValid: false,
       advancable: false,
       passwordConfirmationField: {
         valid: false,
-        value: confirmation,
-      },
+        value: confirmation
+      }
     });
 
     if (this.state.passwordField.valid) {
       if (this.state.passwordField.value === confirmation) {
-        this.setState(
-          {
-            passwordConfirmationField: {
-              valid: true,
-              value: confirmation,
-            },
-            statusMessage: 'password_confirmation_ok',
+
+        this.setState({
+          passwordConfirmationField: {
+            valid: true,
+            value: confirmation
           },
-          () => {
-            this.validateForm();
-          }
-        );
+          statusMessage: 'password_confirmation_ok'
+        }, () => {
+          this.validateForm();
+        });
 
         if (this.state.currentStep === 1) {
           // If we're on the first step, the confirmation field isn't even visible
@@ -284,9 +265,9 @@ export class SignUp extends React.Component {
         }
       }
     }
-  };
+  }
 
-  passwordConfirmationEditingCompleted = passwordConfirmation => {
+  passwordConfirmationEditingCompleted = (passwordConfirmation) => {
     var statusMessage = this.state.statusMessage;
     var valid = this.state.passwordConfirmationField.valid;
 
@@ -295,8 +276,8 @@ export class SignUp extends React.Component {
       advancable: false,
       passwordConfirmationField: {
         valid: false,
-        value: passwordConfirmation,
-      },
+        value: passwordConfirmation
+      }
     });
 
     if (this.state.passwordField.valid) {
@@ -312,13 +293,13 @@ export class SignUp extends React.Component {
         statusMessage: statusMessage,
         passwordConfirmationField: {
           valid: valid,
-          value: passwordConfirmation,
-        },
+          value: passwordConfirmation
+        }
       });
 
       this.validateForm();
     }
-  };
+  }
 
   validateForm() {
     var advancable = false;
@@ -327,28 +308,15 @@ export class SignUp extends React.Component {
 
     if (this.state.currentStep === 1 && this.state.passwordField.valid) {
       advancable = true;
-    } else if (
-      this.state.currentStep === 2 &&
-      this.state.passwordField.valid &&
-      this.state.passwordConfirmationField.valid
-    ) {
+    } else if (this.state.currentStep === 2 && this.state.passwordField.valid && this.state.passwordConfirmationField.valid) {
       advancable = true;
-    } else if (
-      this.state.currentStep === 3 &&
-      this.state.passwordField.valid &&
-      this.state.passwordConfirmationField.valid &&
-      this.state.termsOfServiceField.valid
-    ) {
+    } else if (this.state.currentStep === 3 && this.state.passwordField.valid && this.state.passwordConfirmationField.valid && this.state.termsOfServiceField.valid) {
       advancable = true;
     } else {
       advancable = false;
     }
 
-    if (
-      this.state.passwordField.valid &&
-      this.state.passwordConfirmationField.valid &&
-      this.state.termsOfServiceField.valid
-    ) {
+    if (this.state.passwordField.valid && this.state.passwordConfirmationField.valid && this.state.termsOfServiceField.valid) {
       formValid = true;
       statusMessage = 'all_good';
     } else {
@@ -358,53 +326,31 @@ export class SignUp extends React.Component {
     this.setState({
       advancable: advancable,
       formValid: formValid,
-      statusMessage: statusMessage,
+      statusMessage: statusMessage
     });
   }
 
   render() {
     return (
       <div className='signup--container col-6'>
-        <h1
-          ref={t => {
-            this.title = t;
-          }}
-        >
-          Create Your Giant Swarm Account
-        </h1>
+        <h1 ref={(t) => {this.title = t;}}>Create Your Giant Swarm Account</h1>
 
-        <form
-          ref={f => {
-            this.signupForm = f;
-          }}
-          onSubmit={this.handleSubmit}
-          className={'step-' + this.state.currentStep}
-        >
+
+        <form ref={(f) => {this.signupForm = f;}} onSubmit={this.handleSubmit} className={'step-' + this.state.currentStep} >
           <div id='passwordGroup'>
-            <p className='subtitle'>
-              This is your personal Giant Swarm account for the email address{' '}
-              {this.state.email}!
-            </p>
+            <p className='subtitle'>This is your personal Giant Swarm account for the email address {this.state.email}!</p>
 
-            <PasswordField
-              ref={p => {
-                this.password = p;
-              }}
-              label='Set a password'
-              onStartTyping={this.passwordEditingStarted}
-              onChange={this.passwordEditingCompleted}
-            />
+            <PasswordField ref={(p) => {this.password = p;}}
+                           label='Set a password'
+                           onStartTyping={this.passwordEditingStarted}
+                           onChange={this.passwordEditingCompleted} />
           </div>
 
           <div id='passwordConfirmationGroup'>
-            <PasswordField
-              ref={f => {
-                this.passwordConfirmation = f;
-              }}
-              label='Password, once again'
-              onStartTyping={this.passwordConfirmationEditingStarted}
-              onChange={this.passwordConfirmationEditingCompleted}
-            />
+            <PasswordField ref={(f) => {this.passwordConfirmation = f;}}
+                           label='Password, once again'
+                           onStartTyping={this.passwordConfirmationEditingStarted}
+                           onChange={this.passwordConfirmationEditingCompleted} />
           </div>
 
           <div id='TOSGroup'>
@@ -412,35 +358,27 @@ export class SignUp extends React.Component {
 
             <div className='checkbox'>
               <label htmlFor='tosAccept'>
-                <input
-                  type='checkbox'
-                  ref={i => {
-                    this.tosAccept = i;
-                  }}
-                  id='tosAccept'
-                  onChange={this.tosChanged}
-                />
+                <input type='checkbox' ref={(i) => {this.tosAccept = i;}} id='tosAccept' onChange={this.tosChanged} />
                 I accept the terms of service
               </label>
             </div>
           </div>
 
           <StatusMessage status={this.state.statusMessage} />
-          {this.state.buttonText[this.state.currentStep] != '' ? (
-            <Button
-              type='submit'
-              bsStyle='primary'
-              bsSize='large'
-              disabled={!this.state.advancable || this.state.submitting}
-              loading={this.state.submitting}
-              onClick={this.logIn}
-            >
-              {this.state.buttonText[this.state.currentStep]}
-            </Button>
-          ) : (
-            ''
-          )}
+            { this.state.buttonText[this.state.currentStep] != '' ?
+              <Button type='submit'
+                    bsStyle='primary'
+                    bsSize='large'
+                    disabled={ (! this.state.advancable) || this.state.submitting }
+                    loading={this.state.submitting}
+                    onClick={this.logIn}>{this.state.buttonText[this.state.currentStep]}</Button>
+              :
+              ''
+            }
         </form>
+
+
+
       </div>
     );
   }
@@ -449,17 +387,14 @@ export class SignUp extends React.Component {
 SignUp.propTypes = {
   match: PropTypes.object,
   dispatch: PropTypes.func,
-  actions: PropTypes.object,
+  actions: PropTypes.object
 };
 
 function mapDispatchToProps(dispatch) {
   return {
     actions: bindActionCreators(userActions, dispatch),
-    dispatch: dispatch,
+    dispatch: dispatch
   };
 }
 
-export default connect(
-  null,
-  mapDispatchToProps
-)(SignUp);
+export default connect(null, mapDispatchToProps)(SignUp);

--- a/src/components/signup/index.js
+++ b/src/components/signup/index.js
@@ -90,9 +90,11 @@ export class SignUp extends React.Component {
       });
   }
 
-  componentDidUpdate() {
-    this.resetForm();
-    this.componentDidMount();
+  componentDidUpdate(prevProps) {
+    if (prevProps.match.params.token != this.props.match.params.token) {
+      this.resetForm();
+      this.componentDidMount();
+    }
   }
 
   advanceForm() {


### PR DESCRIPTION
Setting eslint to the right React version yields complaints about us using `componentWillReceiveProps`, which is deprecated since 16.3.0.

Details: https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops

This replaces the former usage of `componentWillReceiveProps` in the following components:

- `InputField`, used in cluster creation to set worker machine/instance type, for both Azure and AWS.
- `SignUp`, which is the signup form.
- `BarChart` which is not in use.