### PR TITLE
Give user some feedback if startup requests fail, and why.

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -53,22 +53,26 @@ class Layout extends React.Component {
         .catch(error => {
           if (error.status === 401) {
             this.props.flashActions.flashAdd({
-              message: 'Please log in again, your previously saved credentials appear to be invalid.',
+              message:
+                'Please log in again, your previously saved credentials appear to be invalid.',
               class: 'warning',
             });
 
             this.props.dispatch(push('/login'));
           } else {
             this.props.flashActions.flashAdd({
-              message: (<div>
-                <strong>
-                  Something went wrong while trying to load user and organization information.
-                </strong>
-                <br />
-                {error.body
-                  ? error.body.status_text
-                  : 'Perhaps our servers are down, please try again later or contact support: support@giantswarm.io'}
-              </div>),
+              message: (
+                <div>
+                  <strong>
+                    Something went wrong while trying to load user and
+                    organization information.
+                  </strong>
+                  <br />
+                  {error.body
+                    ? error.body.status_text
+                    : 'Perhaps our servers are down, please try again later or contact support: support@giantswarm.io'}
+                </div>
+              ),
               class: 'warning',
             });
           }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -41,6 +41,9 @@ class Layout extends React.Component {
       defaultClientAuth.apiKeyPrefix = this.props.user.auth.scheme;
       defaultClientAuth.apiKey = this.props.user.auth.token;
 
+      // This is the first component that loads,
+      // and refreshUserInfo and the subsequent organisationsLoad() are the
+      // first calls happa makes to the API.
       this.props.actions
         .refreshUserInfo()
         .then(() => {
@@ -48,6 +51,28 @@ class Layout extends React.Component {
           return null;
         })
         .catch(error => {
+          if (error.status === 401) {
+            this.props.flashActions.flashAdd({
+              message: 'Please log in again, your previously saved credentials appear to be invalid.',
+              class: 'warning',
+            });
+
+            this.props.dispatch(push('/login'));
+          } else {
+            this.props.flashActions.flashAdd({
+              message: (<div>
+                <strong>
+                  Something went wrong while trying to load user and organization information.
+                </strong>
+                <br />
+                {error.body
+                  ? error.body.status_text
+                  : 'Perhaps our servers are down, please try again later or contact support: support@giantswarm.io'}
+              </div>),
+              class: 'warning',
+            });
+          }
+
           throw error;
         });
     } else {
@@ -64,6 +89,7 @@ class Layout extends React.Component {
       return (
         <DocumentTitle title='Loading | Giant Swarm '>
           <div className='app-loading'>
+            <FlashMessages />
             <div className='app-loading-contents'>
               <img className='loader' src='/images/loader_oval_light.svg' />
             </div>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -68,9 +68,8 @@ class Layout extends React.Component {
                     organization information.
                   </strong>
                   <br />
-                  {error.body
-                    ? error.body.status_text
-                    : 'Perhaps our servers are down, please try again later or contact support: support@giantswarm.io'}
+                  Please try again later or contact support:
+                  support@giantswarm.io
                 </div>
               ),
               class: 'warning',


### PR DESCRIPTION
This will give people some feedback if happa encounters an error while starting up.

If the API returns a 500 error, or is simply not reachable, a flash message will appear above the spinner.

If the API returns a 401 error, Happa will redirect to the login page and show an error message asking the user to log in again.

<img width="1332" alt="screenshot 2018-11-27 at 15 07 34" src="https://user-images.githubusercontent.com/455309/49064646-88bd0b80-f256-11e8-9c38-27b0153e3b4b.png">

<img width="1353" alt="screenshot 2018-11-27 at 15 08 30" src="https://user-images.githubusercontent.com/455309/49064648-89ee3880-f256-11e8-8866-fb4d4e1e6170.png">
