### PR TITLE
aligns div widths in cluster details view

### DIFF
--- a/src/components/organizations/cluster_detail.js
+++ b/src/components/organizations/cluster_detail.js
@@ -490,29 +490,25 @@ class ClusterDetail extends React.Component {
 
                     <ClusterKeyPairs cluster={this.props.cluster} />
 
-                    <div className='row section cluster_delete'>
+                    <div className='row section cluster_delete col-12'>
                       <div className='row'>
-                        <div className='col-12'>
-                          <h3 className='table-label'>Delete This Cluster</h3>
-                        </div>
+                        <h3 className='table-label'>Delete This Cluster</h3>
                       </div>
                       <div className='row'>
-                        <div className='col-9'>
-                          <p>
-                            All workloads on this cluster will be terminated.
-                            Data stored on the worker nodes will be lost. There
-                            is no way to undo this action.
-                          </p>
-                          <Button
-                            bsStyle='danger'
-                            onClick={this.showDeleteClusterModal.bind(
-                              this,
-                              this.props.cluster
-                            )}
-                          >
-                            Delete Cluster
-                          </Button>
-                        </div>
+                        <p>
+                          All workloads on this cluster will be terminated. Data
+                          stored on the worker nodes will be lost. There is no
+                          way to undo this action.
+                        </p>
+                        <Button
+                          bsStyle='danger'
+                          onClick={this.showDeleteClusterModal.bind(
+                            this,
+                            this.props.cluster
+                          )}
+                        >
+                          Delete Cluster
+                        </Button>
                       </div>
                     </div>
                     <ScaleClusterModal

--- a/src/components/organizations/cluster_key_pairs.js
+++ b/src/components/organizations/cluster_key_pairs.js
@@ -226,21 +226,17 @@ class ClusterKeyPairs extends React.Component {
 
   render() {
     return (
-      <div className='row section cluster_key_pairs'>
+      <div className='row section cluster_key_pairs col-12'>
         <div className='row'>
-          <div className='col-12'>
-            <h3 className='table-label'>Key Pairs</h3>
-          </div>
+          <h3 className='table-label'>Key Pairs</h3>
         </div>
 
         <div className='row'>
-          <div className='col-12'>
-            <p>
-              Key pairs consist of an RSA private key and certificate, signed by
-              the certificate authority (CA) belonging to this cluster. They are
-              used for access to the cluster via the Kubernetes API.
-            </p>
-          </div>
+          <p>
+            Key pairs consist of an RSA private key and certificate, signed by
+            the certificate authority (CA) belonging to this cluster. They are
+            used for access to the cluster via the Kubernetes API.
+          </p>
         </div>
 
         <div className='row'>


### PR DESCRIPTION
Without the change the last two boxes appear to be wider then the others. 

<img width="1913" alt="screen shot 2018-11-27 at 15 23 18" src="https://user-images.githubusercontent.com/552769/49088079-c7ec5c00-f258-11e8-8892-59e85664fbab.png">

With the change the alignment is fixed. Note that the padding on the right side is off regardless. I do not intend to fix this here. 

<img width="1920" alt="screen shot 2018-11-27 at 15 23 03" src="https://user-images.githubusercontent.com/552769/49088082-cc187980-f258-11e8-81b7-bc2b8f64f7e3.png">
