### PR TITLE
Add azure vm size descriptions

### DIFF
--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -19,49 +19,45 @@ import { Breadcrumb } from 'react-breadcrumbs';
 import cmp from 'semver-compare';
 
 class CreateCluster extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      availabilityZones: 1,
-      releaseVersion: '',
-      clusterName: 'My cluster',
-      workerCount: 3,
-      syncWorkers: true,
-      workers: [
-        {
-          id: 1,
-          cpu: 1,
-          memory: 1,
-          storage: 10,
-          instanceType: 'm3.large',
-          vmSize: 'Standard_D2s_v3',
-          valid: true,
-        },
-        {
-          id: 2,
-          cpu: 1,
-          memory: 1,
-          storage: 10,
-          instanceType: 'm3.large',
-          vmSize: 'Standard_D2s_v3',
-          valid: true,
-        },
-        {
-          id: 3,
-          cpu: 1,
-          memory: 1,
-          storage: 10,
-          instanceType: 'm3.large',
-          vmSize: 'Standard_D2s_v3',
-          valid: true,
-        },
-      ],
-      submitting: false,
-      valid: false, // Start off invalid now since we're not sure we have a valid release yet, the release endpoint could be malfunctioning.
-      error: false,
-    };
-  }
+  state = {
+    availabilityZones: 1,
+    releaseVersion: '',
+    clusterName: 'My cluster',
+    workerCount: 3,
+    syncWorkers: true,
+    workers: [
+      {
+        id: 1,
+        cpu: 1,
+        memory: 1,
+        storage: 10,
+        instanceType: 'm3.large',
+        vmSize: 'Standard_D2s_v3',
+        valid: true,
+      },
+      {
+        id: 2,
+        cpu: 1,
+        memory: 1,
+        storage: 10,
+        instanceType: 'm3.large',
+        vmSize: 'Standard_D2s_v3',
+        valid: true,
+      },
+      {
+        id: 3,
+        cpu: 1,
+        memory: 1,
+        storage: 10,
+        instanceType: 'm3.large',
+        vmSize: 'Standard_D2s_v3',
+        valid: true,
+      },
+    ],
+    submitting: false,
+    valid: false, // Start off invalid now since we're not sure we have a valid release yet, the release endpoint could be malfunctioning.
+    error: false,
+  };
 
   updateAvailabilityZones = n => {
     this.setState({

--- a/src/components/create_cluster/new_azure_worker.js
+++ b/src/components/create_cluster/new_azure_worker.js
@@ -184,7 +184,7 @@ class NewAzureWorker extends React.Component {
         <BootstrapModal
           show={this.state.modalVisible}
           onHide={this.closeModal}
-          className='new-cluster--instance-type-selector-modal'
+          className='new-cluster--instance-type-selector-modal azure'
         >
           <BootstrapModal.Header closeButton>
             <BootstrapModal.Title>Select a VM Size</BootstrapModal.Title>
@@ -195,6 +195,7 @@ class NewAzureWorker extends React.Component {
                 <tr>
                   <th />
                   <th>Name</th>
+                  <th>Description</th>
                   <th className='numeric'>CPU Cores</th>
                   <th className='numeric'>Memory</th>
                 </tr>
@@ -214,6 +215,9 @@ class NewAzureWorker extends React.Component {
                         />
                       </td>
                       <td>{vmSize.name}</td>
+                      <td className='description'>
+                        {vmSize.description}
+                      </td>
                       <td className='numeric'>{vmSize.numberOfCores}</td>
                       <td className='numeric'>
                         {(vmSize.memoryInMb / 1000).toFixed(2)} GB

--- a/src/components/create_cluster/new_azure_worker.js
+++ b/src/components/create_cluster/new_azure_worker.js
@@ -10,12 +10,13 @@ class NewAzureWorker extends React.Component {
   constructor(props) {
     super(props);
 
-    // devInstanceTypes are placeholder instance types for the dev environment.
+    // devVMSizes are placeholder VM sizes for the dev environment.
     // In the dev environment window.config.azureCapabilitiesJson is not set to anything.
     // It would normally be set by the value in the installations repo.
     var devVMSizes = {
       Standard_A2_v2: {
         additionalProperties: {},
+        description: 'This is some description',
         maxDataDiskCount: 4,
         memoryInMb: 4294.967296,
         name: 'Standard_A2_v2',
@@ -25,6 +26,7 @@ class NewAzureWorker extends React.Component {
       },
       Standard_A4_v2: {
         additionalProperties: {},
+        description: 'Here is a longer description that might be too long for the field',
         maxDataDiskCount: 8,
         memoryInMb: 8589.934592,
         name: 'Standard_A4_v2',
@@ -34,6 +36,7 @@ class NewAzureWorker extends React.Component {
       },
       Standard_A8_v2: {
         additionalProperties: {},
+        description: 'Another VM size description text',
         maxDataDiskCount: 16,
         memoryInMb: 17179.869184,
         name: 'Standard_A8_v2',

--- a/src/components/create_cluster/new_azure_worker.js
+++ b/src/components/create_cluster/new_azure_worker.js
@@ -26,7 +26,8 @@ class NewAzureWorker extends React.Component {
       },
       Standard_A4_v2: {
         additionalProperties: {},
-        description: 'Here is a longer description that might be too long for the field',
+        description:
+          'Here is a longer description that might be too long for the field',
         maxDataDiskCount: 8,
         memoryInMb: 8589.934592,
         name: 'Standard_A4_v2',
@@ -215,9 +216,7 @@ class NewAzureWorker extends React.Component {
                         />
                       </td>
                       <td>{vmSize.name}</td>
-                      <td className='description'>
-                        {vmSize.description}
-                      </td>
+                      <td className='description'>{vmSize.description}</td>
                       <td className='numeric'>{vmSize.numberOfCores}</td>
                       <td className='numeric'>
                         {(vmSize.memoryInMb / 1000).toFixed(2)} GB

--- a/src/styles/components/_create_cluster.sass
+++ b/src/styles/components/_create_cluster.sass
@@ -199,7 +199,7 @@
       width: 138px
 
       &:first-child
-        width: 50px
+        width: 30px
 
 .new-cluster--instance-type-selector-table
   margin-bottom: -10px
@@ -216,10 +216,14 @@
     display: block
 
   tbody td, thead th
-    width: 184px
+    padding-top: 10px
+    padding-bottom: 10px
+    padding-left: 0px
+    padding-right: 5px
+    width: 148px
 
     &:first-child
-      width: 50px
+      width: 30px
 
   tbody
     height: 300px


### PR DESCRIPTION
This adds a description column to the Azure VM size selection dialog

## Preview

### Azure

![image](https://user-images.githubusercontent.com/273727/49148678-45bb7080-f308-11e8-84fa-a7c964778408.png)

### AWS

Only confirming that the CSS still works for AWS

![image](https://user-images.githubusercontent.com/273727/49148764-8adfa280-f308-11e8-8dc0-55f289e066ad.png)

