### PR TITLE
Faster admin login

### DIFF
--- a/src/components/auth/admin.js
+++ b/src/components/auth/admin.js
@@ -7,12 +7,41 @@ import { flashClearAll } from '../../actions/flashMessageActions';
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import Auth0 from '../../lib/auth0';
+import {isJwtExpired} from '../../lib/helpers';
 import PropTypes from 'prop-types';
+import { push } from 'connected-react-router';
 
 class AdminLogin extends React.Component {
   componentDidMount() {
     const auth0 = new Auth0();
-    auth0.login();
+
+    if (this.props.user && this.props.user.auth && this.props.user.auth.scheme === 'Bearer') {
+      if(isJwtExpired(this.props.user.auth.token)) {
+        // Token is expired. Try to renew it silently, and if that succeeds, redirect
+        // the user to the dashboard. Otherwise, send them to Auth0 to refresh the token that way.
+        auth0
+          .renewToken()
+          .then(result => {
+            // Update state with new token.
+            this.props.dispatch(userActions.auth0Login(result));
+
+            // Redirect to dashboard.
+            this.props.dispatch(push('/'));
+          })
+          .catch(() => {
+            // Unable to refresh token silently, so send the down the auth0
+            // flow.
+            auth0.login();
+          });
+      } else {
+        // Token isn't expired yet, so just redirect the user to the dashboard.
+        this.props.dispatch(push('/'));
+      }
+    } else {
+      // User doesn't have any previous token at all, send them to auth0 so
+      // they can get one.
+      auth0.login();
+    }
   }
 
   componentWillUnmount() {
@@ -30,7 +59,7 @@ class AdminLogin extends React.Component {
           </div>
 
           <img className='loader' src='/images/loader_oval_light.svg' />
-          <p>Redirecting you to our authentication provider.</p>
+          <p>Verifying credentials, and redirecting to our authentication provider if necessary.</p>
           <p>If nothing happens please let us know in #support.</p>
         </div>
       </div>
@@ -42,6 +71,7 @@ AdminLogin.propTypes = {
   dispatch: PropTypes.func,
   flashMessages: PropTypes.object,
   actions: PropTypes.object,
+  user: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/src/components/auth/admin.js
+++ b/src/components/auth/admin.js
@@ -7,7 +7,7 @@ import { flashClearAll } from '../../actions/flashMessageActions';
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import Auth0 from '../../lib/auth0';
-import {isJwtExpired} from '../../lib/helpers';
+import { isJwtExpired } from '../../lib/helpers';
 import PropTypes from 'prop-types';
 import { push } from 'connected-react-router';
 
@@ -15,8 +15,12 @@ class AdminLogin extends React.Component {
   componentDidMount() {
     const auth0 = new Auth0();
 
-    if (this.props.user && this.props.user.auth && this.props.user.auth.scheme === 'Bearer') {
-      if(isJwtExpired(this.props.user.auth.token)) {
+    if (
+      this.props.user &&
+      this.props.user.auth &&
+      this.props.user.auth.scheme === 'Bearer'
+    ) {
+      if (isJwtExpired(this.props.user.auth.token)) {
         // Token is expired. Try to renew it silently, and if that succeeds, redirect
         // the user to the dashboard. Otherwise, send them to Auth0 to refresh the token that way.
         auth0
@@ -59,7 +63,10 @@ class AdminLogin extends React.Component {
           </div>
 
           <img className='loader' src='/images/loader_oval_light.svg' />
-          <p>Verifying credentials, and redirecting to our authentication provider if necessary.</p>
+          <p>
+            Verifying credentials, and redirecting to our authentication
+            provider if necessary.
+          </p>
           <p>If nothing happens please let us know in #support.</p>
         </div>
       </div>
@@ -71,7 +78,7 @@ AdminLogin.propTypes = {
   dispatch: PropTypes.func,
   flashMessages: PropTypes.object,
   actions: PropTypes.object,
-  user: PropTypes.object
+  user: PropTypes.object,
 };
 
 function mapStateToProps(state) {

--- a/src/lib/giantswarm_v4_client_wrapper.js
+++ b/src/lib/giantswarm_v4_client_wrapper.js
@@ -7,7 +7,7 @@ import GiantSwarmV4 from 'giantswarm-v4';
 import Auth0 from '../lib/auth0';
 import configureStore from '../stores/configureStore';
 import { auth0Login } from '../actions/userActions';
-import {isJwtExpired} from '../lib/helpers';
+import { isJwtExpired } from '../lib/helpers';
 
 const auth0 = new Auth0();
 const store = configureStore({});

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -172,3 +172,15 @@ export function clustersForOrg(orgId, allClusters) {
 
   return clusters;
 }
+
+// isJwtExpired expired takes a JWT token and will return true if it is expired.
+export function isJwtExpired(token) {
+  var base64Url = token.split('.')[1];
+  var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  var parsedToken = JSON.parse(window.atob(base64));
+
+  var now = Math.round(Date.now() / 1000); // Browsers have millisecond precision, which we don't need.
+  var expire = parsedToken.exp;
+
+  return (now > expire);
+}

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -182,5 +182,5 @@ export function isJwtExpired(token) {
   var now = Math.round(Date.now() / 1000); // Browsers have millisecond precision, which we don't need.
   var expire = parsedToken.exp;
 
-  return (now > expire);
+  return now > expire;
 }


### PR DESCRIPTION
This makes the `/admin-login` page a bit smarter. If credentials already exist, it attempts to use them. And otherwise it will redirect to auth0 as before.