### PR TITLE
Add lighthouse audits to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,28 +53,12 @@ jobs:
           CURL_OUTPUT=$(curl -s -k https://localhost:8000)
           echo "${CURL_OUTPUT}" | grep Happa
 
-          if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
-            docker run --rm \
-              -v $PWD:/workdir \
-              -w /workdir \
-              -v $PWD:/out \
-              -v $PWD/dev-shm:/dev/shm \
-              -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \
-              --network host \
-              quay.io/giantswarm/lighthouse:alternative-gh-reporter \
-              lighthouse-github-reporter run \
-                --urls https://localhost:8000 \
-                --prId $(basename $CIRCLE_PULL_REQUEST) \
-                --reporterUserName taylorbot \
-                --noiseLevel low \
-                --owner $CIRCLE_PROJECT_USERNAME \
-                --repository $CIRCLE_PROJECT_REPONAME \
-                --pwa 60 \
-                --performance 100 \
-                --accessibility 50 \
-                --bestPractices 60 \
-                --seo 0
-          fi
+          docker run --rm \
+            -v $PWD:/out \
+            -v $PWD/dev-shm:/dev/shm \
+            --link testcontainer:testcontainer \
+            quay.io/giantswarm/lighthouse:add-ci-runner \
+              ci-run.sh https://testcontainer:8000/
 
           docker kill testcontainer
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
               -v $PWD/dev-shm:/dev/shm \
               -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \
               quay.io/giantswarm/lighthouse \
-              lighthouse-github-reporter \
-                -u https://localhost:8000 \
+              lighthouse-github-reporter run \
+                --urls https://localhost:8000 \
                 --prId $(basename $CIRCLE_PULL_REQUEST) \
                 --reporterUserName taylorbot \
                 --noiseLevel low \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
 
           if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
             docker run --rm \
+              -w $PWD \
               -v $PWD:/out \
               -v $PWD/dev-shm:/dev/shm \
               -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,23 +53,25 @@ jobs:
           CURL_OUTPUT=$(curl -s -k https://localhost:8000)
           echo "${CURL_OUTPUT}" | grep Happa
 
-          docker run --rm \
-            -v $PWD:/out \
-            -v $PWD/dev-shm:/dev/shm \
-            -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \
-            quay.io/giantswarm/lighthouse \
-            lighthouse-github-reporter \
-              --urls https://localhost:8000 \
-              --prId $CIRCLE_PR_NUMBER \
-              --reporterUserName taylorbot \
-              --noiseLevel low \
-              --owner $CIRCLE_PROJECT_USERNAME \
-              --repository $CIRCLE_PROJECT_REPONAME \
-              --pwa 60 \
-              --performance 100 \
-              --accessibility 50 \
-              --bestPractices 60 \
-              --seo 0
+          if [ "$CIRCLE_PR_NUMBER" != "" ]; then
+            docker run --rm \
+              -v $PWD:/out \
+              -v $PWD/dev-shm:/dev/shm \
+              -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \
+              quay.io/giantswarm/lighthouse \
+              lighthouse-github-reporter \
+                -u https://localhost:8000 \
+                --prId $CIRCLE_PR_NUMBER \
+                --reporterUserName taylorbot \
+                --noiseLevel low \
+                --owner $CIRCLE_PROJECT_USERNAME \
+                --repository $CIRCLE_PROJECT_REPONAME \
+                --pwa 60 \
+                --performance 100 \
+                --accessibility 50 \
+                --bestPractices 60 \
+                --seo 0
+          fi
 
           docker kill testcontainer
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,8 @@ jobs:
 
           if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
             docker run --rm \
-              -w $PWD \
+              -v $PWD:/workdir \
+              -w /workdir \
               -v $PWD:/out \
               -v $PWD/dev-shm:/dev/shm \
               -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
               -v $PWD:/out \
               -v $PWD/dev-shm:/dev/shm \
               -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \
-              --network container:testcontainer \
+              --network host \
               quay.io/giantswarm/lighthouse:alternative-gh-reporter \
               lighthouse-github-reporter run \
                 --urls https://localhost:8000 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
               -v $PWD/dev-shm:/dev/shm \
               -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \
               --network container:testcontainer \
-              quay.io/giantswarm/lighthouse \
+              quay.io/giantswarm/lighthouse:alternative-gh-reporter \
               lighthouse-github-reporter run \
                 --urls https://localhost:8000 \
                 --prId $(basename $CIRCLE_PULL_REQUEST) \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,25 @@ jobs:
           docker run --name testcontainer -p 8000:8000 -d quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
           CURL_OUTPUT=$(curl -s -k https://localhost:8000)
           echo "${CURL_OUTPUT}" | grep Happa
+
+          docker run --rm \
+            -v $PWD:/out \
+            -v $PWD/dev-shm:/dev/shm \
+            -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \
+            quay.io/giantswarm/lighthouse \
+            lighthouse-github-reporter \
+              --urls https://localhost:8000 \
+              --prId $CIRCLE_PR_NUMBER \
+              --reporterUserName taylorbot \
+              --noiseLevel low \
+              --owner $CIRCLE_PROJECT_USERNAME \
+              --repository $CIRCLE_PROJECT_REPONAME \
+              --pwa 60 \
+              --performance 100 \
+              --accessibility 50 \
+              --bestPractices 60 \
+              --seo 0
+
           docker kill testcontainer
 
     - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           CURL_OUTPUT=$(curl -s -k https://localhost:8000)
           echo "${CURL_OUTPUT}" | grep Happa
 
-          if [ "$CIRCLE_PR_NUMBER" != "" ]; then
+          if [ "$CIRCLE_PULL_REQUEST" != "" ]; then
             docker run --rm \
               -v $PWD:/out \
               -v $PWD/dev-shm:/dev/shm \
@@ -61,7 +61,7 @@ jobs:
               quay.io/giantswarm/lighthouse \
               lighthouse-github-reporter \
                 -u https://localhost:8000 \
-                --prId $CIRCLE_PR_NUMBER \
+                --prId $(basename $CIRCLE_PULL_REQUEST) \
                 --reporterUserName taylorbot \
                 --noiseLevel low \
                 --owner $CIRCLE_PROJECT_USERNAME \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
               -v $PWD:/out \
               -v $PWD/dev-shm:/dev/shm \
               -e GH_USER_AUTH_TOKEN=${RELEASE_TOKEN} \
+              --network container:testcontainer \
               quay.io/giantswarm/lighthouse \
               lighthouse-github-reporter run \
                 --urls https://localhost:8000 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,20 +47,21 @@ jobs:
         command: ./architect build
 
     - run:
-        name: Test the image we just built
+        name: Launch container for tests
         command: |
           docker run --name testcontainer -p 8000:8000 -d quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
           CURL_OUTPUT=$(curl -s -k https://localhost:8000)
           echo "${CURL_OUTPUT}" | grep Happa
 
+    - run:
+        name: Lighthouse audits
+        command: |
           docker run --rm \
             -v $PWD:/out \
             -v $PWD/dev-shm:/dev/shm \
             --link testcontainer:testcontainer \
             quay.io/giantswarm/lighthouse:add-ci-runner \
               ci-run.sh https://testcontainer:8000/
-
-          docker kill testcontainer
 
     - deploy:
         name: Deploy with architect (master only)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4874

This adds a step `Lighthouse audits` to CI with this result:

```
RESULTS FOR URL https://testcontainer:8000/

-----------------------------
SELECTED AUDITS

first-contentful-paint: 4651.8055
first-meaningful-paint: 4801.8055
speed-index: 4651.8055
interactive: 4952.027
first-cpu-idle: 4801.8055
estimated-input-latency: 34.800000000000004
render-blocking-resources: 1005
uses-responsive-images: 0
unminified-css: 0
unminified-javascript: 0
unused-css-rules: 0
uses-optimized-images: 0
total-byte-weight: 529967
dom-size: 54

-----------------------------
SCORING

accessibility: 0.58
best-practices: 0.93
performance: 0.64
pwa: 0.44
seo: 0.6
```

The output currently depends on https://github.com/giantswarm/lighthouse/blob/3074344773ec009b1e9f73a8c7b507c922a4969c/ci-run.sh

This does not yet set any thresholds for CI to fail. That could be done in a next step.