### PR TITLE
improves number picker style

### DIFF
--- a/src/styles/components/_form.sass
+++ b/src/styles/components/_form.sass
@@ -5,7 +5,7 @@ form
     color: #ccc
     margin-bottom: 10px
 
-  input, textarea, .form-group input
+  input:not([type='number']), textarea, .form-group input:not([type='number'])
     box-sizing: border-box
     width: 100%
     background-color: #32526a

--- a/src/styles/components/_number_picker.sass
+++ b/src/styles/components/_number_picker.sass
@@ -41,22 +41,31 @@
     background-color: darken(#3b5f7b, 6%)
     color: #aaa
 
-.number-picker--control-increase
+.number-picker .number-picker--control-increase
   display: inline-block
   right: 0px
   border-top-right-radius: 5px
   border-bottom-right-radius: 5px
 
-.number-picker--control-decrease
+.number-picker .number-picker--control-decrease
   display: inline-block
   left: 0px
   border-top-left-radius: 5px
   border-bottom-left-radius: 5px
 
-.number-picker--value input
+.number-picker .number-picker--value input
   display: inline-block
   background-color: inherit
   border: none
   text-align: center
   width: 100%
-  padding-left: 10px
+  height: 100%;
+  outline: none;
+
+.number-picker .number-picker--value input:focus
+  outline: none;
+
+.number-picker .number-picker--value input[type=number]::-webkit-inner-spin-button,
+.number-picker .number-picker--value input[type=number]::-webkit-outer-spin-button
+  -webkit-appearance: none;
+  margin: 0;


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/pull/2206. Note that this PR is based on [`feature-auto-scaling`](https://github.com/giantswarm/happa/pull/424). I noticed the number picker's input field is not aligned in height and the padding was confused with other input fields. Also the border outline on focus was wrong. I couldn't make the on focus border really useful so I took the shortcut and dropped it completely. Below are screenshots of before and after. 

<img width="245" alt="screenshot 2018-12-13 at 13 44 11" src="https://user-images.githubusercontent.com/552769/49941570-31b86700-fee3-11e8-8c9f-c5d055df5378.png">

<img width="222" alt="screenshot 2018-12-13 at 14 24 14" src="https://user-images.githubusercontent.com/552769/49941571-34b35780-fee3-11e8-9704-ea02020866b2.png">
