### PR TITLE
Set default values

### DIFF
--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -441,7 +441,7 @@ class CreateCluster extends React.Component {
                         <br />
 
                         <NumberPicker
-                          label='Memory'
+                          label='Memory (GB)'
                           unit='GB'
                           stepSize={1}
                           value={this.state.kvm.memorySize.value}
@@ -452,7 +452,7 @@ class CreateCluster extends React.Component {
                         <br />
 
                         <NumberPicker
-                          label='Storage'
+                          label='Storage (GB)'
                           unit='GB'
                           stepSize={10}
                           value={this.state.kvm.diskSize.value}
@@ -586,11 +586,24 @@ function mapStateToProps(state) {
   var maxAvailabilityZones = state.app.info.general.availability_zones.max;
   var selectedOrganization = state.app.selectedOrganization;
   var provider = state.app.info.general.provider;
-  var defaultInstanceType = 'm3.large'; // TODO
-  var defaultVMSize = 'Standard_A2_v2'; // TODO
+
+  var defaultInstanceType;
+  if (state.app.info.workers.instance_type && state.app.info.workers.instance_type.default) {
+    defaultInstanceType = state.app.info.workers.instance_type.default;
+  } else {
+    defaultInstanceType = 'm3.large';
+  }
+
+  var defaultVMSize;
+  if (state.app.info.workers.vm_size && state.app.info.workers.vm_size.default) {
+    defaultVMSize = state.app.info.workers.vm_size.default;
+  } else {
+    defaultVMSize = 'Standard_D2s_v3';
+  }
+
   var defaultCPUCores = 1; // TODO
   var defaultMemorySize = 1; // TODO
-  var defaultDiskSize = 1; // TODO
+  var defaultDiskSize = 20; // TODO
 
   var allowedInstanceTypes = [];
   if (provider === 'aws') {

--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -588,14 +588,20 @@ function mapStateToProps(state) {
   var provider = state.app.info.general.provider;
 
   var defaultInstanceType;
-  if (state.app.info.workers.instance_type && state.app.info.workers.instance_type.default) {
+  if (
+    state.app.info.workers.instance_type &&
+    state.app.info.workers.instance_type.default
+  ) {
     defaultInstanceType = state.app.info.workers.instance_type.default;
   } else {
     defaultInstanceType = 'm3.large';
   }
 
   var defaultVMSize;
-  if (state.app.info.workers.vm_size && state.app.info.workers.vm_size.default) {
+  if (
+    state.app.info.workers.vm_size &&
+    state.app.info.workers.vm_size.default
+  ) {
     defaultVMSize = state.app.info.workers.vm_size.default;
   } else {
     defaultVMSize = 'Standard_D2s_v3';


### PR DESCRIPTION
Set default values from the info endpoint.

For KVM,  we don't have default values for cpu, memory and storage from the api info endpoint, so setting them to what they always were in Happa.

