### PR TITLE
Add NodeCountSelector component for cluster creation

### DIFF
--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -176,7 +176,7 @@ class CreateCluster extends React.Component {
 
     // In order to have support for automatic scaling and therefore for scaling
     // limits, provider must be AWS and cluster release >= 6.1.0.
-    return (cmp(releaseVer, '6.1.0') === 1);
+    return cmp(releaseVer, '6.1.0') === 1;
   }
 
   selectRelease = releaseVersion => {
@@ -486,7 +486,10 @@ class CreateCluster extends React.Component {
 
             <div className='row section'>
               <NodeCountSelector
-                autoscalingEnabled={this.isScalingAutomatic(this.props.provider, this.state.releaseVersion)}
+                autoscalingEnabled={this.isScalingAutomatic(
+                  this.props.provider,
+                  this.state.releaseVersion
+                )}
                 scaling={this.state.scaling}
                 readOnly={false}
                 onChange={this.UpdateScaling}

--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -174,6 +174,8 @@ class CreateCluster extends React.Component {
       return false;
     }
 
+    // In order to have support for automatic scaling and therefore for scaling
+    // limits, provider must be AWS and cluster release >= 6.1.0.
     return (cmp(releaseVer, '6.1.0') === 1);
   }
 

--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import DocumentTitle from 'react-document-title';
 import Button from '../button';
 import { clusterCreate } from '../../actions/clusterActions';
+import NodeCountSelector from './node_count_selector.js';
 import NumberPicker from './number_picker.js';
 import AWSInstanceTypeSelector from './aws_instance_type_selector.js';
 import VMSizeSelector from './vm_size_selector.js';
@@ -27,6 +28,7 @@ class CreateCluster extends React.Component {
       releaseVersion: '',
       clusterName: 'My cluster',
       scaling: {
+        automatic: false,
         min: 3,
         minValid: true,
         max: 3,
@@ -73,24 +75,13 @@ class CreateCluster extends React.Component {
     });
   };
 
-  updateScalingMin = numberPicker => {
+  updateScaling = nodeCountSelector => {
     this.setState({
       scaling: {
-        min: numberPicker.value,
-        minValid: numberPicker.valid,
-        max: this.state.scaling.max,
-        maxValid: this.state.scaling.maxValid,
-      },
-    });
-  };
-
-  updateScalingMax = numberPicker => {
-    this.setState({
-      scaling: {
-        min: this.state.scaling.min,
-        minValid: this.state.scaling.minValid,
-        max: numberPicker.value,
-        maxValid: numberPicker.valid,
+        min: nodeCountSelector.scaling.min,
+        minValid: nodeCountSelector.scaling.minValid,
+        max: nodeCountSelector.scaling.max,
+        maxValid: nodeCountSelector.scaling.maxValid,
       },
     });
   };
@@ -176,6 +167,14 @@ class CreateCluster extends React.Component {
 
   componentDidMount() {
     this.cluster_name.select();
+  }
+
+  isScalingAutomatic(provider, releaseVer) {
+    if (provider != 'aws') {
+      return false;
+    }
+
+    return (cmp(releaseVer, '6.1.0') === 1);
   }
 
   selectRelease = releaseVersion => {
@@ -484,46 +483,12 @@ class CreateCluster extends React.Component {
             })()}
 
             <div className='row section'>
-              <div className='col-3'>
-                <h3 className='table-label'>Node Count</h3>
-              </div>
-              <div className='col-9'>
-                <form
-                  onSubmit={e => {
-                    e.preventDefault();
-                  }}
-                >
-                  <div>
-                    <p>
-                      To disable autoscaling, set both numbers to the same value
-                    </p>
-                    <div className='col-3'>
-                      <p>Minimum</p>
-                      <NumberPicker
-                        label=''
-                        stepSize={1}
-                        value={this.state.scaling.min}
-                        min={1}
-                        max={this.state.scaling.max}
-                        onChange={this.updateScalingMin}
-                        readOnly={false}
-                      />
-                    </div>
-                    <div className='col-3'>
-                      <p>Maximum</p>
-                      <NumberPicker
-                        label=''
-                        stepSize={1}
-                        value={this.state.scaling.max}
-                        min={this.state.scaling.min}
-                        max={99} // TODO
-                        onChange={this.updateScalingMax}
-                        readOnly={false}
-                      />
-                    </div>
-                  </div>
-                </form>
-              </div>
+              <NodeCountSelector
+                autoscalingEnabled={this.isScalingAutomatic(this.props.provider, this.state.releaseVersion)}
+                scaling={this.state.scaling}
+                readOnly={false}
+                onChange={this.UpdateScaling}
+              />
             </div>
 
             <div className='row section'>

--- a/src/components/create_cluster/node_count_selector.js
+++ b/src/components/create_cluster/node_count_selector.js
@@ -1,0 +1,165 @@
+'use strict';
+
+import React from 'react';
+import { connect } from 'react-redux';
+import NumberPicker from './number_picker.js';
+import PropTypes from 'prop-types';
+
+// NodeCountSelector is a component that allows a user to pick a number of
+// nodes by incrementing / decrementing a node count value or adjusting min and
+// max values for scaling limits.
+//
+// State explanation:
+//
+// autoscalingEnabled - Boolean whether cluster supports autoscaling or not.
+//                      This is used to determine whether only number of nodes
+//                      is displayed of if there is pickers for min/max values.
+//
+// scaling - The current value of the input field[s].
+//
+
+class NodeCountSelector extends React.Component {
+  state = {
+    autoscalingEnabled: this.props.autoscalingEnabled,
+    scaling: this.props.scaling,
+  };
+
+  updateScalingMin = numberPicker => {
+    this.setState({
+      scaling: {
+        automatic: this.state.scaling.automatic,
+        min: numberPicker.value,
+        minValid: numberPicker.valid,
+        max: this.state.scaling.max,
+        maxValid: this.state.scaling.maxValid,
+      },
+    });
+  };
+
+  updateScalingMax = numberPicker => {
+    this.setState({
+      scaling: {
+        automatic: this.state.scaling.automatic,
+        min: this.state.scaling.min,
+        minValid: this.state.scaling.minValid,
+        max: numberPicker.value,
+        maxValid: numberPicker.valid,
+      },
+    });
+  };
+
+  updateNodeCount = numberPicker => {
+    this.setState({
+      scaling: {
+        automatic: false,
+        min: numberPicker.value,
+        minValid: numberPicker.valid,
+        max: numberPicker.value,
+        maxValid: numberPicker.valid,
+      },
+    });
+  }
+
+  handleFocus = event => {
+    event.target.select();
+  };
+
+  render() {
+    if (this.props.autoscalingEnabled === true) {
+      return (
+        <div>
+          <div className='col-3'>
+            <h3 className='table-label'>Node Count</h3>
+          </div>
+          <div className='col-9'>
+            <form
+              onSubmit={e => {
+                e.preventDefault();
+              }}
+            >
+              <div>
+                <p>
+                  To disable autoscaling, set both numbers to the same value
+                </p>
+                <div className='col-3'>
+                  <p>Minimum</p>
+                  <NumberPicker
+                    label=''
+                    stepSize={1}
+                    value={this.state.scaling.min}
+                    min={1}
+                    max={this.state.scaling.max}
+                    onChange={this.updateScalingMin}
+                    readOnly={false}
+                  />
+                </div>
+                <div className='col-3'>
+                  <p>Maximum</p>
+                  <NumberPicker
+                    label=''
+                    stepSize={1}
+                    value={this.state.scaling.max}
+                    min={this.state.scaling.min}
+                    max={99} // TODO
+                    onChange={this.updateScalingMax}
+                    readOnly={false}
+                  />
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <div className='col-3'>
+            <h3 className='table-label'>Node Count</h3>
+          </div>
+          <div className='col-9'>
+            <form
+              onSubmit={e => {
+                e.preventDefault();
+              }}
+            >
+              <div>
+                <div className='col-3'>
+                  <p>Number of nodes</p>
+                  <NumberPicker
+                    label=''
+                    stepSize={1}
+                    value={this.state.scaling.max}
+                    min={1}
+                    max={99} // TODO
+                    onChange={this.updateNodeCount}
+                    readOnly={false}
+                  />
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+NodeCountSelector.propTypes = {
+  autoscalingEnabled: PropTypes.bool,
+  onChange: PropTypes.func,
+  readOnly: PropTypes.bool,
+  scaling: PropTypes.object,
+};
+
+function mapStateToProps() {
+  return {};
+}
+
+function mapDispatchToProps() {
+  return {};
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NodeCountSelector);

--- a/src/components/create_cluster/node_count_selector.js
+++ b/src/components/create_cluster/node_count_selector.js
@@ -55,7 +55,7 @@ class NodeCountSelector extends React.Component {
         maxValid: numberPicker.valid,
       },
     });
-  }
+  };
 
   handleFocus = event => {
     event.target.select();

--- a/src/components/create_cluster/node_count_selector.js
+++ b/src/components/create_cluster/node_count_selector.js
@@ -79,7 +79,7 @@ class NodeCountSelector extends React.Component {
                   To disable autoscaling, set both numbers to the same value
                 </p>
                 <div className='col-3'>
-                  <p>Minimum</p>
+                  <label>Minimum</label>
                   <NumberPicker
                     label=''
                     stepSize={1}
@@ -91,7 +91,7 @@ class NodeCountSelector extends React.Component {
                   />
                 </div>
                 <div className='col-3'>
-                  <p>Maximum</p>
+                  <label>Maximum</label>
                   <NumberPicker
                     label=''
                     stepSize={1}
@@ -121,7 +121,7 @@ class NodeCountSelector extends React.Component {
             >
               <div>
                 <div className='col-3'>
-                  <p>Number of nodes</p>
+                  <label>Number of nodes</label>
                   <NumberPicker
                     label=''
                     stepSize={1}

--- a/src/components/create_cluster/node_count_selector.js
+++ b/src/components/create_cluster/node_count_selector.js
@@ -27,7 +27,6 @@ class NodeCountSelector extends React.Component {
   updateScalingMin = numberPicker => {
     this.setState({
       scaling: {
-        automatic: this.state.scaling.automatic,
         min: numberPicker.value,
         minValid: numberPicker.valid,
         max: this.state.scaling.max,
@@ -39,7 +38,6 @@ class NodeCountSelector extends React.Component {
   updateScalingMax = numberPicker => {
     this.setState({
       scaling: {
-        automatic: this.state.scaling.automatic,
         min: this.state.scaling.min,
         minValid: this.state.scaling.minValid,
         max: numberPicker.value,
@@ -51,7 +49,6 @@ class NodeCountSelector extends React.Component {
   updateNodeCount = numberPicker => {
     this.setState({
       scaling: {
-        automatic: false,
         min: numberPicker.value,
         minValid: numberPicker.valid,
         max: numberPicker.value,


### PR DESCRIPTION
NodeCountSelector provides number picker[s] and related labels for node
count selection and appropriate logic to provide either single node
count or min/max values for scaling limits.

This is also now wired for cluster creation view and there is a function
that decides based on provider and release version whether cluster
supports automatic scaling limits or just a static node count.

**NOTE:** This is just a change for cluster creation. I still need to do changes for existing cluster details page & scaling view.

**NOTE2:** Please, have a critical eagle eye on reasonability / code style of this change. :smile: 

Towards https://github.com/giantswarm/giantswarm/pull/2206