### PR TITLE
Upgrade nginx to 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.13-alpine
+FROM nginx:1.14-alpine
 
 ADD dist /www
 


### PR DESCRIPTION
This closes some security vulnerabilities by upgrading from NGINX 1.13 to 1.14.

![image](https://user-images.githubusercontent.com/273727/50169895-dcb78f00-02ee-11e9-9e90-1033651b07ad.png)

