### PR TITLE
Only allow giantswarm.io emails to be invited to the giantswarm org.

### DIFF
--- a/src/components/users/index.js
+++ b/src/components/users/index.js
@@ -181,9 +181,10 @@ class Users extends React.Component {
     // Don't allow adding non @giantswarm.io emails to the giantswarm org
     // since we know there is a serverside validation against that as well.
     if (invitationForm.organization === 'giantswarm') {
-      if (! isGiantSwarmEmail(invitationForm.email)) {
+      if (!isGiantSwarmEmail(invitationForm.email)) {
         invitationForm.valid = false;
-        invitationForm.error = 'Only @giantswarm.io domains may be invited to the giantswarm organization.';
+        invitationForm.error =
+          'Only @giantswarm.io domains may be invited to the giantswarm organization.';
       }
     }
 
@@ -564,13 +565,13 @@ class Users extends React.Component {
                               </label>
                             </div>
                           </div>
-                          { this.state.invitationForm.error !== '' ?
+                          {this.state.invitationForm.error !== '' ? (
                             <div className='flash-messages--flash-message flash-messages--danger'>
                               {this.state.invitationForm.error}
                             </div>
-                            :
+                          ) : (
                             undefined
-                          }
+                          )}
                         </form>
                       </BootstrapModal.Body>
                       <BootstrapModal.Footer>
@@ -578,7 +579,7 @@ class Users extends React.Component {
                           type='submit'
                           bsStyle='primary'
                           loading={this.state.modal.loading}
-                          disabled={! this.state.invitationForm.valid}
+                          disabled={!this.state.invitationForm.valid}
                           onClick={this.confirmInviteUser.bind(this)}
                         >
                           {this.state.modal.loading

--- a/src/components/users/index.js
+++ b/src/components/users/index.js
@@ -39,8 +39,10 @@ class Users extends React.Component {
       },
       invitationForm: {
         email: '',
+        error: '',
         organization: props.organizations,
         sendEmail: true,
+        valid: true,
       },
     };
   }
@@ -123,8 +125,10 @@ class Users extends React.Component {
       },
       invitationForm: {
         email: '',
+        error: '',
         organization: this.props.selectedOrganization,
         sendEmail: true,
+        valid: true,
       },
     });
   }
@@ -163,9 +167,27 @@ class Users extends React.Component {
 
     invitationForm.email = e.target.value;
 
+    invitationForm = this.validateInvitationForm(invitationForm);
+
     this.setState({
       invitationForm: invitationForm,
     });
+  }
+
+  validateInvitationForm(invitationForm) {
+    invitationForm.valid = true;
+    invitationForm.error = '';
+
+    // Don't allow adding non @giantswarm.io emails to the giantswarm org
+    // since we know there is a serverside validation against that as well.
+    if (invitationForm.organization === 'giantswarm') {
+      if (! isGiantSwarmEmail(invitationForm.email)) {
+        invitationForm.valid = false;
+        invitationForm.error = 'Only @giantswarm.io domains may be invited to the giantswarm organization.';
+      }
+    }
+
+    return invitationForm;
   }
 
   handleSendEmailChange(e) {
@@ -182,6 +204,8 @@ class Users extends React.Component {
     var invitationForm = Object.assign({}, this.state.invitationForm);
 
     invitationForm.organization = orgId;
+
+    invitationForm = this.validateInvitationForm(invitationForm);
 
     this.setState({
       invitationForm: invitationForm,
@@ -540,6 +564,13 @@ class Users extends React.Component {
                               </label>
                             </div>
                           </div>
+                          { this.state.invitationForm.error !== '' ?
+                            <div className='flash-messages--flash-message flash-messages--danger'>
+                              {this.state.invitationForm.error}
+                            </div>
+                            :
+                            undefined
+                          }
                         </form>
                       </BootstrapModal.Body>
                       <BootstrapModal.Footer>
@@ -547,6 +578,7 @@ class Users extends React.Component {
                           type='submit'
                           bsStyle='primary'
                           loading={this.state.modal.loading}
+                          disabled={! this.state.invitationForm.valid}
                           onClick={this.confirmInviteUser.bind(this)}
                         >
                           {this.state.modal.loading
@@ -758,6 +790,19 @@ function isExpired(timestamp) {
   }
 
   return false;
+}
+
+function isGiantSwarmEmail(email) {
+  if (email && typeof email === 'string') {
+    var domain = email.split('@')[1];
+    if (domain === 'giantswarm.io') {
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
 }
 
 function mapStateToProps(state) {


### PR DESCRIPTION
This PR adds some clientside validation to help us remember that only giantswarm.io emails may be invited to the giantswarm organization.

Related to: https://github.com/giantswarm/giantswarm/issues/4296

![giantswarmonly](https://user-images.githubusercontent.com/455309/51097746-63359280-1801-11e9-869f-fe1876497820.gif)
