### PR TITLE
Refactor and fix style issues.

### DIFF
--- a/src/components/cluster_detail/index.js
+++ b/src/components/cluster_detail/index.js
@@ -529,7 +529,6 @@ class ClusterDetail extends React.Component {
                         this.scaleClusterModal = s;
                       }}
                       cluster={this.props.cluster}
-                      user={this.props.user}
                     />
 
                     {this.props.targetRelease ? (

--- a/src/components/cluster_detail/scale_cluster_modal.js
+++ b/src/components/cluster_detail/scale_cluster_modal.js
@@ -253,8 +253,6 @@ class ScaleClusterModal extends React.Component {
 
 ScaleClusterModal.propTypes = {
   cluster: PropTypes.object,
-  giantSwarm: PropTypes.func,
-  user: PropTypes.object,
   clusterActions: PropTypes.object,
   flashActions: PropTypes.object,
 };

--- a/src/components/cluster_detail/upgrade_cluster_modal.js
+++ b/src/components/cluster_detail/upgrade_cluster_modal.js
@@ -315,10 +315,8 @@ UpgradeClusterModal.propTypes = {
   cluster: PropTypes.object,
   clusterActions: PropTypes.object,
   flashActions: PropTypes.object,
-  giantSwarm: PropTypes.func,
   release: PropTypes.object,
   targetRelease: PropTypes.object,
-  user: PropTypes.object,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -67,7 +67,7 @@ class ClusterDashboardItem extends React.Component {
     var storage = this.getStorageTotal();
     var cpus = this.getCpusTotal();
     return (
-      <div className='cluster-dashboard-item row well'>
+      <div className='cluster-dashboard-item well'>
         <div className='cluster-dashboard-item--label'>
           <Link
             to={
@@ -81,7 +81,7 @@ class ClusterDashboardItem extends React.Component {
           </Link>
         </div>
 
-        <div className='col-8'>
+        <div className='cluster-dashboard-item--content'>
           <div className='cluster-dashboard-item--title'>
             <Link
               to={
@@ -135,8 +135,8 @@ class ClusterDashboardItem extends React.Component {
           </div>
         </div>
 
-        <div className='col-3 pull-right'>
-          <ButtonGroup className='pull-right'>
+        <div className='cluster-dashboard-item--buttons'>
+          <ButtonGroup>
             <Button onClick={this.goToClusterDetails.bind(this)}>
               Details
             </Button>

--- a/src/styles/components/_cluster_dashboard.sass
+++ b/src/styles/components/_cluster_dashboard.sass
@@ -1,6 +1,18 @@
 .cluster-dashboard-item
+  display: flex
+
   b
     font-weight: 400
+
+.cluster-dashboard-item--content
+  flex: 1;
+  padding-right: 15px
+
+.cluster-dashboard-item--label
+  flex: 0 0 90px;
+
+.cluster-dashboard-item--buttons
+  flex: 0 0 162px;
 
 .cluster-dashboard
   position: relative
@@ -30,8 +42,6 @@
 
 .cluster-dashboard-item--label
   font-size: 1.2em
-  float: left
-  margin-right: 7px
 
 .cluster-dashboard-item--title
   font-size: 1.2em

--- a/src/styles/components/_create_cluster.sass
+++ b/src/styles/components/_create_cluster.sass
@@ -8,10 +8,15 @@
   .checkbox
     margin-bottom: 0px
 
+.col-4.new-cluster--worker
+  min-height: 203px
+
+.col-4.new-cluster--worker:nth-child(3n+0)
+  margin-right: 0px
+
 .new-cluster--worker
   border-radius: 5px
   background-color: #244d65
-  min-height: 203px
   margin-bottom: 25px
   padding: 10px 16px
   font-weight: 400

--- a/src/styles/vendor/_simple-grid.scss
+++ b/src/styles/vendor/_simple-grid.scss
@@ -99,7 +99,7 @@ li {
 
 // grid
 
-$width: 96%;
+$width: 100%;
 $gutter: 4%;
 $breakpoint-small: 540px;
 $breakpoint-med: 825px;


### PR DESCRIPTION
I fixed a couple things as I was clicking around in Happa:

- There are some unused props in the modals of the cluster detail screen.

- The screen doesn't line up correctly with the menu on the right side on some screens, like the cluster detail screen.

- The create workers screen was not aligning well, as the min height for those elements was getting superseded by a css declaration with higher specificity from the simple-grid 'framework'

<img width="1232" alt="screenshot 2019-01-15 at 18 33 10" src="https://user-images.githubusercontent.com/455309/51175441-598d5700-18f5-11e9-8051-722e1a97c3e8.png">
