### PR TITLE
Fix auth0 login error edge case.

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -48,8 +48,7 @@ class Layout extends React.Component {
       this.props.actions
         .refreshUserInfo()
         .then(() => {
-          this.props.dispatch(organizationsLoad());
-          return null;
+          return this.props.dispatch(organizationsLoad());
         })
         .catch(error => {
           if (error.status === 401) {
@@ -77,7 +76,7 @@ class Layout extends React.Component {
             });
           }
 
-          throw error;
+          console.error(error);
         });
     } else {
       this.props.dispatch(push('/login'));

--- a/src/lib/giantswarm_v4_client_wrapper.js
+++ b/src/lib/giantswarm_v4_client_wrapper.js
@@ -37,36 +37,35 @@ defaultClient.callApi = function callApi(
   // any call.
   if (defaultClientAuth.apiKeyPrefix === 'Bearer' && defaultClientAuth.apiKey) {
     if (isJwtExpired(defaultClientAuth.apiKey)) {
-      return new Promise(resolve => {
-        resolve(
-          auth0
-            .renewToken()
-            .then(result => {
-              // Update state with new token.
-              store.dispatch(auth0Login(result));
+      return auth0
+        .renewToken()
+        .then(result => {
+          // Update state with new token.
+          store.dispatch(auth0Login(result));
 
-              // Ensure the second attempt uses the new token.
-              headerParams['Authorization'] = 'Bearer ' + result.accessToken;
+          // Ensure the second attempt uses the new token.
+          headerParams['Authorization'] = 'Bearer ' + result.accessToken;
 
-              return origCallApi(
-                path,
-                httpMethod,
-                pathParams,
-                queryParams,
-                headerParams,
-                formParams,
-                bodyParam,
-                authNames,
-                contentTypes,
-                accepts,
-                returnType
-              );
-            })
-            .catch(err => {
-              throw err;
-            })
-        );
-      });
+          return origCallApi(
+            path,
+            httpMethod,
+            pathParams,
+            queryParams,
+            headerParams,
+            formParams,
+            bodyParam,
+            authNames,
+            contentTypes,
+            accepts,
+            returnType
+          );
+        })
+        .catch(err => {
+          err.status = 401; // Add 'status: 401' to the error object
+          // so the layout component can treat auth0
+          // login required errors correctly.
+          throw err;
+        });
     }
   }
 


### PR DESCRIPTION
When you have a bearer token, but you are not able to refresh it at auth0, happa would end up in a 'soft locked' state, showing just the "Something went wrong loading organizations" error message.

This is because the error from auth0 was not bubbling up correctly to the layout component which handles login error issues.