### PR TITLE
Fix worker node counting

### DIFF
--- a/src/components/cluster_detail/cluster_detail_table.js
+++ b/src/components/cluster_detail/cluster_detail_table.js
@@ -47,7 +47,7 @@ class ClusterDetailTable extends React.Component {
       var workers = 0;
       nodes.forEach(node => {
         if (Object.keys(node).includes('labels')) {
-          if (node.labels['role'] === 'worker') {
+          if (node.labels['role'] != 'master') {
             workers++;
           }
         }

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -61,7 +61,7 @@ class ClusterDashboardItem extends React.Component {
       var workers = 0;
       nodes.forEach(node => {
         if (Object.keys(node).includes('labels')) {
-          if (node.labels['role'] === 'worker') {
+          if (node.labels['role'] != 'master') {
             workers++;
           }
         }


### PR DESCRIPTION
Initially I thought there is role=worker label for worker nodes just like there
is role=master label for master nodes. In earlier PRs I got noted that there
isn't such label (even though I checked this before creating this
implementation).

It turns out that by default k8s doesn't assign worker nodes the role label and
therefore it is actually missing in our tenant clusters. On control plane we
set this label manually as part of a node configuration so that's how I saw it
there.

I changed the code to count all nodes except masters as workers.