### PR TITLE
Refresh cluster details after successful scaling

### DIFF
--- a/src/components/cluster_detail/scale_cluster_modal.js
+++ b/src/components/cluster_detail/scale_cluster_modal.js
@@ -112,7 +112,7 @@ class ScaleClusterModal extends React.Component {
           .then(patchedCluster => {
             this.close();
 
-            this.props.clusterActions.clusterLoadDetailsSuccess(patchedCluster);
+            this.props.clusterActions.clusterLoadDetails(patchedCluster.id);
             this.props.flashActions.flashAdd({
               message: 'Successfully scaled cluster',
               class: 'success',


### PR DESCRIPTION
Once cluster scaling succeeds, cluster details should be refreshed to
correspond done changes. Load cluster state fom backend to get possible other
changes to cluster state (e.g. changes in desired number of workers).