### PR TITLE
Guards against an edge case where scaling is not present yet.

### DIFF
--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -128,8 +128,12 @@ export default function clusterReducer(
           items[cluster.id],
           ensureMetricKeysAreAvailable(cluster)
         );
+
+        // Guard against API that returns null for certain values when they are
+        // empty.
         items[cluster.id].nodes = items[cluster.id].nodes || [];
         items[cluster.id].keyPairs = items[cluster.id].keyPairs || [];
+        items[cluster.id].scaling = items[cluster.id].scaling || {};
       });
 
       return {


### PR DESCRIPTION
Noticed this while testing some of the auto scaling branches. This guards against a race condition where scaling is not present yet (or empty) and thus omitted from the API response. Happa still tries to reach into it (`cluster.scaling.min`), which raises errors when `scaling` is null.