### PR TITLE
Don't show cluster apps when we don't have any release information.

### DIFF
--- a/src/components/cluster_detail/index.js
+++ b/src/components/cluster_detail/index.js
@@ -230,7 +230,11 @@ class ClusterDetail extends React.Component {
                         credentials={this.props.credentials}
                         release={this.props.release}
                       />
-                      <ClusterApps release={this.props.release} />
+
+                      {this.props.release && (
+                        <ClusterApps release={this.props.release} />
+                      )}
+
                       <ClusterKeyPairs cluster={this.props.cluster} />
 
                       <div className='row section cluster_delete col-12'>


### PR DESCRIPTION
ClusterApps fails if for some reason we do not have release information for the cluster.

This is a rare edge case, but worth to guard against.