### PR TITLE
Add border-radius to all images.

### DIFF
--- a/src/styles/components/_cluster_apps.sass
+++ b/src/styles/components/_cluster_apps.sass
@@ -18,6 +18,7 @@
     float: left
     position: relative
     top: 3px
+    border-radius: 5px
 
   small
     font-size: 12px


### PR DESCRIPTION
Fixing what @xh3b4sd noticed. Not all the icons were correctly rounded.

Instead of fixing the actual image file, I apply a consistent border to all icons using css.

Result: 
<img width="978" alt="screenshot 2019-01-30 at 15 54 23" src="https://user-images.githubusercontent.com/455309/51966395-5a9eb680-24a7-11e9-9366-340abf660583.png">
