### PR TITLE
Calculate total CPUs/RAM/Storage by running nodes

### DIFF
--- a/src/components/cluster_detail/cluster_detail_table.js
+++ b/src/components/cluster_detail/cluster_detail_table.js
@@ -76,7 +76,7 @@ class ClusterDetailTable extends React.Component {
     if (workers === null || !this.props.cluster.workers) {
       return null;
     }
-    return (workers * this.props.cluster.workers[0].cpu.cores);
+    return workers * this.props.cluster.workers[0].cpu.cores;
   }
 
   render() {

--- a/src/components/cluster_detail/cluster_detail_table.js
+++ b/src/components/cluster_detail/cluster_detail_table.js
@@ -23,17 +23,6 @@ class ClusterDetailTable extends React.Component {
     return null;
   }
 
-  getMemoryTotal() {
-    if (!this.props.cluster.workers) {
-      return null;
-    }
-    var m = 0.0;
-    for (var i = 0; i < this.props.cluster.workers.length; i++) {
-      m += this.props.cluster.workers[i].memory.size_gb;
-    }
-    return m.toFixed(2);
-  }
-
   getNumberOfNodes() {
     if (
       Object.keys(this.props.cluster).includes('status') &&
@@ -64,26 +53,30 @@ class ClusterDetailTable extends React.Component {
     return null;
   }
 
-  getStorageTotal() {
-    if (!this.props.cluster.workers) {
+  getMemoryTotal() {
+    var workers = this.getNumberOfNodes();
+    if (workers === null || !this.props.cluster.workers) {
       return null;
     }
-    var s = 0.0;
-    for (var i = 0; i < this.props.cluster.workers.length; i++) {
-      s += this.props.cluster.workers[i].storage.size_gb;
+    var m = workers * this.props.cluster.workers[0].memory.size_gb;
+    return m.toFixed(2);
+  }
+
+  getStorageTotal() {
+    var workers = this.getNumberOfNodes();
+    if (workers === null || !this.props.cluster.workers) {
+      return null;
     }
+    var s = workers * this.props.cluster.workers[0].storage.size_gb;
     return s.toFixed(2);
   }
 
   getCpusTotal() {
-    if (!this.props.cluster.workers) {
+    var workers = this.getNumberOfNodes();
+    if (workers === null || !this.props.cluster.workers) {
       return null;
     }
-    var c = 0;
-    for (var i = 0; i < this.props.cluster.workers.length; i++) {
-      c += this.props.cluster.workers[i].cpu.cores;
-    }
-    return c;
+    return (workers * this.props.cluster.workers[0].cpu.cores);
   }
 
   render() {

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -38,7 +38,7 @@ class ClusterDashboardItem extends React.Component {
     if (workers === null || !this.props.cluster.workers) {
       return null;
     }
-    return (workers * this.props.cluster.workers[0].cpu.cores);
+    return workers * this.props.cluster.workers[0].cpu.cores;
   }
 
   getNumberOfNodes() {

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -16,36 +16,29 @@ class ClusterDashboardItem extends React.Component {
   }
 
   getMemoryTotal() {
-    if (!this.props.cluster.workers) {
+    var workers = this.getNumberOfNodes();
+    if (workers === null || !this.props.cluster.workers) {
       return null;
     }
-    var m = 0.0;
-    for (var i = 0; i < this.props.cluster.workers.length; i++) {
-      m += this.props.cluster.workers[i].memory.size_gb;
-    }
+    var m = workers * this.props.cluster.workers[0].memory.size_gb;
     return m.toFixed(2);
   }
 
   getStorageTotal() {
-    if (!this.props.cluster.workers) {
+    var workers = this.getNumberOfNodes();
+    if (workers === null || !this.props.cluster.workers) {
       return null;
     }
-    var s = 0.0;
-    for (var i = 0; i < this.props.cluster.workers.length; i++) {
-      s += this.props.cluster.workers[i].storage.size_gb;
-    }
+    var s = workers * this.props.cluster.workers[0].storage.size_gb;
     return s.toFixed(2);
   }
 
   getCpusTotal() {
-    if (!this.props.cluster.workers) {
+    var workers = this.getNumberOfNodes();
+    if (workers === null || !this.props.cluster.workers) {
       return null;
     }
-    var c = 0;
-    for (var i = 0; i < this.props.cluster.workers.length; i++) {
-      c += this.props.cluster.workers[i].cpu.cores;
-    }
-    return c;
+    return (workers * this.props.cluster.workers[0].cpu.cores);
   }
 
   getNumberOfNodes() {


### PR DESCRIPTION
When number of nodes changes, calculate total amount of CPU cores, RAM and
storage space by number of running nodes, not by scaling limits.