### PR TITLE
Check for zero workers when extracting worker instance details

### DIFF
--- a/src/components/cluster_detail/cluster_detail_table.js
+++ b/src/components/cluster_detail/cluster_detail_table.js
@@ -55,7 +55,7 @@ class ClusterDetailTable extends React.Component {
 
   getMemoryTotal() {
     var workers = this.getNumberOfNodes();
-    if (workers === null || !this.props.cluster.workers) {
+    if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     var m = workers * this.props.cluster.workers[0].memory.size_gb;
@@ -64,7 +64,7 @@ class ClusterDetailTable extends React.Component {
 
   getStorageTotal() {
     var workers = this.getNumberOfNodes();
-    if (workers === null || !this.props.cluster.workers) {
+    if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     var s = workers * this.props.cluster.workers[0].storage.size_gb;
@@ -73,7 +73,7 @@ class ClusterDetailTable extends React.Component {
 
   getCpusTotal() {
     var workers = this.getNumberOfNodes();
-    if (workers === null || !this.props.cluster.workers) {
+    if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     return workers * this.props.cluster.workers[0].cpu.cores;

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -17,7 +17,7 @@ class ClusterDashboardItem extends React.Component {
 
   getMemoryTotal() {
     var workers = this.getNumberOfNodes();
-    if (workers === null || !this.props.cluster.workers) {
+    if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     var m = workers * this.props.cluster.workers[0].memory.size_gb;
@@ -26,7 +26,7 @@ class ClusterDashboardItem extends React.Component {
 
   getStorageTotal() {
     var workers = this.getNumberOfNodes();
-    if (workers === null || !this.props.cluster.workers) {
+    if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     var s = workers * this.props.cluster.workers[0].storage.size_gb;
@@ -35,7 +35,7 @@ class ClusterDashboardItem extends React.Component {
 
   getCpusTotal() {
     var workers = this.getNumberOfNodes();
-    if (workers === null || !this.props.cluster.workers) {
+    if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     return workers * this.props.cluster.workers[0].cpu.cores;


### PR DESCRIPTION
When extracting number of CPU cores, amount of RAM or storage space, check for
zero workers before performing actual calculation.

This fixes inconsistence in cluster details when cluster is being created and
there are no nodes running yet.