### PR TITLE
Resume Scale button for non-auto-scaling clusters

### DIFF
--- a/src/components/cluster_detail/scale_cluster_modal.js
+++ b/src/components/cluster_detail/scale_cluster_modal.js
@@ -131,6 +131,17 @@ class ScaleClusterModal extends React.Component {
   };
 
   workerDelta = () => {
+    if (
+      !this.isScalingAutomatic(
+        this.props.provider,
+        this.props.cluster.release_version
+      )
+    ) {
+      // On non-auto-scaling clusters scaling.min == scaling.max so comparing
+      // only min between props and current state works.
+      return this.state.scaling.min - this.props.cluster.scaling.min;
+    }
+
     if (this.getCurrentDesiredCapacity() < this.state.scaling.min) {
       return this.state.scaling.min - this.getCurrentDesiredCapacity;
     }


### PR DESCRIPTION
Due to way how non-auto-scaling clusters adjust number of worker nodes,
auto-scaling changes broke function that calculates differences between
existing number of workers and desired scaling value.

Fix this calculation for non-auto-scaling clusters by simply comparing minimum
number of nodes.