### PR TITLE
When nodes are not running yet, display 0 for resources

### DIFF
--- a/src/components/cluster_detail/cluster_detail_table.js
+++ b/src/components/cluster_detail/cluster_detail_table.js
@@ -290,7 +290,7 @@ class ClusterDetailTable extends React.Component {
                   <td>Worker nodes running</td>
                   <td className='value'>
                     {this.getNumberOfNodes() === null
-                      ? 'n/a'
+                      ? '0'
                       : this.getNumberOfNodes()}
                   </td>
                 </tr>
@@ -298,14 +298,14 @@ class ClusterDetailTable extends React.Component {
                 <tr>
                   <td>Total CPU cores in worker nodes</td>
                   <td className='value'>
-                    {this.getCpusTotal() === null ? 'n/a' : this.getCpusTotal()}
+                    {this.getCpusTotal() === null ? '0' : this.getCpusTotal()}
                   </td>
                 </tr>
                 <tr>
                   <td>Total RAM in worker nodes</td>
                   <td className='value'>
                     {this.getMemoryTotal() === null
-                      ? 'n/a'
+                      ? '0'
                       : this.getMemoryTotal()}{' '}
                     GB
                   </td>
@@ -315,7 +315,7 @@ class ClusterDetailTable extends React.Component {
                     <td>Total storage in worker nodes</td>
                     <td className='value'>
                       {this.getStorageTotal() === null
-                        ? 'n/a'
+                        ? '0'
                         : this.getStorageTotal()}{' '}
                       GB
                     </td>

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -141,12 +141,12 @@ class ClusterDashboardItem extends React.Component {
           </div>
           <div>
             <b>{this.getNumberOfNodes()}</b> nodes ·{' '}
-            <b>{memory ? memory : 'n/a'}</b> GB RAM ·{' '}
-            <b>{cpus ? cpus : 'n/a'}</b> CPUs
+            <b>{memory ? memory : '0'}</b> GB RAM · <b>{cpus ? cpus : '0'}</b>{' '}
+            CPUs
             {this.props.cluster.kvm ? (
               <span>
                 {' '}
-                · <b>{storage ? storage : 'n/a'}</b> GB storage
+                · <b>{storage ? storage : '0'}</b> GB storage
               </span>
             ) : (
               undefined


### PR DESCRIPTION
When there are no nodes running yet during cluster creation, display 0 instead
of n/a for CPUs, RAM and storage.