### PR TITLE
Access this.props.cluster.release_version

### DIFF
--- a/src/components/cluster_detail/cluster_detail_table.js
+++ b/src/components/cluster_detail/cluster_detail_table.js
@@ -19,7 +19,7 @@ class ClusterDetailTable extends React.Component {
     // only available on AWS starting from release 6.3.0 onwards.
     if (
       this.props.provider != 'aws' ||
-      cmp(this.props.release.version, '6.2.0') != 1
+      cmp(this.props.cluster.release_version, '6.2.0') != 1
     ) {
       return null;
     }


### PR DESCRIPTION
Fixes the problem described in https://gigantic.slack.com/archives/C7865GLSY/p1549538483080800