### PR TITLE
Upgrade bootstrap to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "mainOutput": "main",
   "dependencies": {
     "auth0-js": "9.10.0",
-    "bootstrap": "3.4.0",
+    "bootstrap": "3.4.1",
     "color-hash": "latest",
     "connected-react-router": "6.3.0",
     "copy-to-clipboard": "3.0.8",


### PR DESCRIPTION
This updates bootsrap from 3.4.0, which has a security vulnerability, to 3.4.1.