### PR TITLE
Use sorting of allowed instances array

### DIFF
--- a/src/components/create_cluster/aws_instance_type_selector.js
+++ b/src/components/create_cluster/aws_instance_type_selector.js
@@ -41,13 +41,11 @@ class AWSInstanceTypeSelector extends React.Component {
     }
 
     var availableInstanceTypes = [];
-    // Filter the list down to only the allowed instance types. Push the
-    // instance type into the list of allowed instance types, add the name to
-    // the object.
-    Object.keys(instanceTypes).forEach(function(key) {
-      if (props.allowedInstanceTypes.indexOf(key) !== -1) {
+    // Create a list of only the allowed instance types
+    props.allowedInstanceTypes.forEach(function(it) {
+      if (typeof instanceTypes[it] === 'object') {
         availableInstanceTypes.push(
-          Object.assign({}, instanceTypes[key], { name: key })
+          Object.assign({}, instanceTypes[it], { name: it })
         );
       }
     });

--- a/src/components/create_cluster/vm_size_selector.js
+++ b/src/components/create_cluster/vm_size_selector.js
@@ -54,11 +54,10 @@ class VMSizeSelector extends React.Component {
     }
 
     var availableVMSizes = [];
-    // Filter the list down to only the allowed vm sizes.
-    // Push the instance type into the list of allowed vm sizes
-    Object.keys(vmSizes).forEach(function(key) {
-      if (props.allowedVMSizes.indexOf(key) !== -1) {
-        availableVMSizes.push(vmSizes[key]);
+    // Create a list of only the allowed VM sizes.
+    props.allowedVMSizes.forEach(function(vs) {
+      if (typeof vmSizes[vs] === 'object') {
+        availableVMSizes.push(vmSizes[vs]);
       }
     });
 


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/5305

This makes use of the sorting of the allowed instance types/VM sizes array to sort the selection table.