### PR TITLE
Add plus icon to Create/Add buttons

### DIFF
--- a/src/components/cluster_detail/key_pairs.js
+++ b/src/components/cluster_detail/key_pairs.js
@@ -302,7 +302,7 @@ class ClusterKeyPairs extends React.Component {
                       bsStyle='default'
                       className='small'
                     >
-                      Create Key Pair
+                      <i className='fa fa-add-circle' /> Create Key Pair
                     </Button>
                   </div>
                 );
@@ -403,7 +403,7 @@ class ClusterKeyPairs extends React.Component {
                       bsStyle='default'
                       className='small'
                     >
-                      Create Key Pair
+                      <i className='fa fa-add-circle' /> Create Key Pair
                     </Button>
                   </div>
                 );

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -67,7 +67,7 @@ class Home extends React.Component {
               <div className='well launch-new-cluster'>
                 <Link to='new-cluster'>
                   <Button type='button' bsStyle='primary'>
-                    Launch New Cluster
+                    <i className='fa fa-add-circle' /> Launch New Cluster
                   </Button>
                 </Link>
                 {this.props.clusters.length === 0

--- a/src/components/organizations/detail.js
+++ b/src/components/organizations/detail.js
@@ -179,7 +179,7 @@ class OrganizationDetail extends React.Component {
                       />
                     )}
                     <Button onClick={this.addMember} bsStyle='default'>
-                      Add Member
+                      <i className='fa fa-add-circle' /> Add Member
                     </Button>
                   </div>
                 </div>

--- a/src/components/organizations/detail.js
+++ b/src/components/organizations/detail.js
@@ -154,7 +154,9 @@ class OrganizationDetail extends React.Component {
                       />
                     )}
                     <Link to='/new-cluster'>
-                      <Button bsStyle='default'>Create Cluster</Button>
+                      <Button bsStyle='default'>
+                        <i className='fa fa-add-circle' /> Create Cluster
+                      </Button>
                     </Link>
                   </div>
                 </div>

--- a/src/components/organizations/index.js
+++ b/src/components/organizations/index.js
@@ -67,7 +67,7 @@ class Organizations extends React.Component {
                       bsStyle='default'
                       onClick={this.createOrganization.bind(this)}
                     >
-                      Create New Organization
+                      <i className='fa fa-add-circle' /> Create New Organization
                     </Button>
                   </div>
                 );

--- a/src/components/organizations/index.js
+++ b/src/components/organizations/index.js
@@ -116,7 +116,7 @@ class Organizations extends React.Component {
                       bsStyle='default'
                       onClick={this.createOrganization.bind(this)}
                     >
-                      Create New Organization
+                      <i className='fa fa-add-circle' /> Create New Organization
                     </Button>
                   </div>
                 );

--- a/src/components/users/index.js
+++ b/src/components/users/index.js
@@ -330,7 +330,7 @@ class Users extends React.Component {
               <div className='col-5'>
                 <div className='pull-right btn-group'>
                   <Button onClick={this.inviteUser.bind(this)}>
-                    INVITE USER
+                    <i className='fa fa-add-circle' /> INVITE USER
                   </Button>
                 </div>
               </div>

--- a/src/styles/components/_button.sass
+++ b/src/styles/components/_button.sass
@@ -118,3 +118,7 @@ td
     top: -2px
     margin-left: 5px
     padding: 0px 15px
+
+button
+  i.fa
+    padding-right: 0.3em


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/5410

This adds a + icon to all create/add buttons I could find.

### Preview

![image](https://user-images.githubusercontent.com/273727/53107403-3ded2000-3535-11e9-879c-d786f463a0fc.png)

![image](https://user-images.githubusercontent.com/273727/53107423-46ddf180-3535-11e9-8dcf-c5f71f065344.png)

![image](https://user-images.githubusercontent.com/273727/53107451-55c4a400-3535-11e9-8777-86e76f7fefce.png)

![image](https://user-images.githubusercontent.com/273727/53107464-5b21ee80-3535-11e9-8c04-b98b42bbe8c1.png)

![image](https://user-images.githubusercontent.com/273727/53107573-8c9aba00-3535-11e9-9d28-0fab8130571d.png)

![image](https://user-images.githubusercontent.com/273727/53107586-94f2f500-3535-11e9-93db-a6df0b1dd003.png)


FYI: The `Set Credentials` button doesn't get the icon. I feel that's not right, as it's not about adding potentially multiple things. User can either set them or not set them.

![image](https://user-images.githubusercontent.com/273727/53107550-83115200-3535-11e9-8e96-22c75dfe472a.png)
