### PR TITLE
Add version tag icon, restructure cluster overview info

### DIFF
--- a/src/components/cluster_detail/cluster_detail_table.js
+++ b/src/components/cluster_detail/cluster_detail_table.js
@@ -237,6 +237,7 @@ class ClusterDetailTable extends React.Component {
                     <td>Release version</td>
                     <td className='value code'>
                       <a onClick={this.showReleaseDetails}>
+                        <i className='fa fa-version-tag' />{' '}
                         {this.props.cluster.release_version}{' '}
                         {(() => {
                           var kubernetes = _.find(

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -124,29 +124,25 @@ class ClusterDashboardItem extends React.Component {
           </div>
 
           <div>
-            Organization: <b>{this.props.selectedOrganization}</b> · Created{' '}
-            <b>{relativeDate(this.props.cluster.create_date)}</b> ·
-            {this.props.cluster.release_version &&
-            this.props.cluster.release_version !== '' ? (
-              <span>
-                {' '}
-                Release Version <b>{this.props.cluster.release_version}</b>
-              </span>
-            ) : (
-              <span>
-                {' '}
-                Kubernetes <b>{this.props.cluster.kubernetes_version}</b>
-              </span>
-            )}
+            <i className='fa fa-version-tag' title='Release version' />{' '}
+            {this.props.cluster.release_version}
+            {' · Kubernetes '}
+            {this.props.cluster.kubernetes_version
+              ? this.props.cluster.kubernetes_version
+              : 'n/a'}
+            {' · Created '}
+            {relativeDate(this.props.cluster.create_date)}
           </div>
           <div>
-            <b>{this.getNumberOfNodes()}</b> nodes ·{' '}
-            <b>{memory ? memory : '0'}</b> GB RAM · <b>{cpus ? cpus : '0'}</b>{' '}
-            CPUs
+            {this.getNumberOfNodes()} nodes
+            {' · '}
+            {cpus ? cpus : '0'} CPU cores
+            {' · '}
+            {memory ? memory : '0'} GB RAM
             {this.props.cluster.kvm ? (
               <span>
-                {' '}
-                · <b>{storage ? storage : '0'}</b> GB storage
+                {' · '}
+                {storage ? storage : '0'} GB storage
               </span>
             ) : (
               undefined


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/5410

Changes

- Remove organization name from cluster details in list
- Remove bold formatting of data vs. label
- Replace `Release version` with icon
- Re-order info

### Preview

![image](https://user-images.githubusercontent.com/273727/53109277-dafd8800-3538-11e9-8a18-94674facd977.png)

![image](https://user-images.githubusercontent.com/273727/53109300-e5b81d00-3538-11e9-9de9-08a3aa74bb55.png)
