### PR TITLE
Add icons to buttons on cluster details page

### DIFF
--- a/src/components/cluster_detail/index.js
+++ b/src/components/cluster_detail/index.js
@@ -208,11 +208,11 @@ class ClusterDetail extends React.Component {
                         <div className='col-5'>
                           <div className='pull-right btn-group'>
                             <Button onClick={this.accessCluster}>
-                              GET STARTED
+                              <i className='fa fa-start' /> GET STARTED
                             </Button>
                             {this.canClusterScale() ? (
                               <Button onClick={this.showScalingModal}>
-                                SCALE
+                                <i className='fa fa-scale' /> SCALE
                               </Button>
                             ) : (
                               undefined
@@ -220,7 +220,7 @@ class ClusterDetail extends React.Component {
 
                             {this.canClusterUpgrade() ? (
                               <Button onClick={this.showUpgradeModal}>
-                                UPGRADE
+                                <i className='fa fa-version-upgrade' /> UPGRADE
                               </Button>
                             ) : (
                               undefined


### PR DESCRIPTION
### Preview

![image](https://user-images.githubusercontent.com/273727/53178439-2627a180-35f2-11e9-8676-d7171f9d3706.png)

and as it's not visible in the screenshot:

![image](https://user-images.githubusercontent.com/273727/53178494-3ccdf880-35f2-11e9-8b20-8d294e934d9b.png)

