### PR TITLE
Add a footer with version number. Adjust release process.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ workflows:
           filters:
             branches:
               only:
-                - versioning
+                - master
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,26 @@
 version: 2
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build
+      - deploy-to-all:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+            branches:
+              ignore: /.*/
+      - deploy-to-testing:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - versioning
+
 jobs:
   build:
     machine: true
@@ -34,7 +56,7 @@ jobs:
           fi
 
     - run:
-        name: Valdiate code style using prettier
+        name: Validate code style using prettier
         command: |
           make validate-prettier
 
@@ -93,14 +115,29 @@ jobs:
               --github-issue $(basename ${CIRCLE_PULL_REQUEST})
           fi
 
-    - deploy:
-        name: Deploy with architect (master only)
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            ./architect deploy
-          fi
-
     - save_cache:
         key: v1-npm-deps-{{ checksum "yarn.lock" }}
         paths:
           - ./node_modules
+
+  deploy-to-testing:
+    machine: true
+    steps:
+    - checkout
+    - deploy:
+        name: Deploy with architect to testing envs
+        command: |
+          wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+          chmod +x ./architect
+          ./architect deploy --group=testing
+
+  deploy-to-all:
+    machine: true
+    steps:
+    - checkout
+    - deploy:
+        name: Deploy with architect to all envs
+        command: |
+          wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+          chmod +x ./architect
+          ./architect deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
           fi
 
           docker run --name happa-branch -p 8000:8000 -d quay.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+          sleep 2
           CURL_OUTPUT=$(curl -s -k https://localhost:8000)
           echo "${CURL_OUTPUT}" | grep Happa
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,17 @@ jobs:
         command: make dist
 
     - run:
+        name: Create VERSION file
+        command: |
+          tag=$(git tag --points-at HEAD)
+          if [ -z "$tag" ]
+          then
+            git rev-parse HEAD | cut -c-5 > VERSION
+          else
+            git tag --points-at HEAD | tr '\n' ' ' > VERSION
+          fi
+
+    - run:
         name: Build Docker image
         command: ./architect build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN rm -r /etc/nginx/conf.d
 RUN mkdir -p /etc/nginx/config
 ADD nginx.conf /etc/nginx/config
 
+ADD VERSION /
 ADD scripts/start.sh /
 
 # Test certifiates will be overwritten in production by configmap

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.14-alpine
 
-RUN apk add jq
+RUN apk --no-cache add jq
 
 ADD dist /www
 ADD package.json /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM nginx:1.14-alpine
 
+RUN apk add jq
+
 ADD dist /www
+ADD package.json /
 
 RUN rm -r /etc/nginx/conf.d
 RUN mkdir -p /etc/nginx/config

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ There are no automated tests for Happa at the moment.
 Deploying
 ---------
 
-This project is continuously deployed to our installations using CircleCI.
+Commits to the master branch are continuously deployed to Giant Swarm test installations.
+Tagged releases are continuously deployed to all installations.
 
 Building / Running locally
 --------------------------
@@ -199,3 +200,7 @@ To add a pre-commit hook, save the above as a file called `pre-commit` in the
 `.git/hooks` folder.
 
 Make sure it has has `0755` as the permission.
+
+### Publishing a Release
+
+See [docs/Release.md](https://github.com/giantswarm/happa/blob/master/docs/Release.md)

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -1,7 +1,6 @@
 # How to publish a release
 
-TL;DR: Releasing involves bumping the version in package.json and running a
-script that will create and push a tag to the GitHub repository. Our CI takes
+TL;DR: Releasing involves pushing a tag to the GitHub repository. Our CI takes
 over from there and auto deploys the release to our installations.
 
 ## Prerequisites
@@ -15,8 +14,7 @@ CircleCI must be set up with certain environment variables:
 
 ## Create and push a new release
 
-All you have to do is edit package.json and set the `version` key to the new
-version you want to release. After that run `scripts/release.sh`
+All you have to do is push a tag. CI will take care of it from there.
 
 Follow CircleCI's progress in https://circleci.com/gh/giantswarm/happa/.
 

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -1,0 +1,28 @@
+# How to publish a release
+
+TL;DR: Releasing involves bumping the version in package.json and running a
+script that will create and push a tag to the GitHub repository. Our CI takes
+over from there and auto deploys the release to our installations.
+
+## Prerequisites
+
+CircleCI must be set up with certain environment variables:
+
+- `RELEASE_TOKEN` - A GitHub token with the permission to write to repositories
+  - [giantswarm/happa](https://github.com/giantswarm/gsctl/)
+- `GITHUB_USER_EMAIL` - Email address of the github user owning the personal token above
+- `GITHUB_USER_NAME` - Username of the above github user
+
+## Create and push a new release
+
+All you have to do is edit package.json and set the `version` key to the new
+version you want to release. After that run `scripts/release.sh`
+
+Follow CircleCI's progress in https://circleci.com/gh/giantswarm/happa/.
+
+## Edit and publish the release
+
+Open the [release draft](https://github.com/giantswarm/happa/releases/) on Github.
+
+Edit the description to inform about what has changed since the last release.
+Save and publish the release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happa",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "",
   "repository": "",
   "private": true,

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -28,6 +28,8 @@ else
   sed -i "s|environment: 'development'|environment: 'docker-container'|" /www/index.html
 fi
 
+# This sets the VERSION placeholder in the footer to the version specified in package.json
+sed -i "s/VERSION/$(jq -r .version package.json)/g" /www/index.html
 
 echo ""
 echo "--- Starting Happa nginx server ---"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -28,8 +28,9 @@ else
   sed -i "s|environment: 'development'|environment: 'docker-container'|" /www/index.html
 fi
 
-# This sets the VERSION placeholder in the footer to the version specified in package.json
-sed -i "s/VERSION/$(jq -r .version package.json)/g" /www/index.html
+# This sets the VERSION placeholder in the footer to the version specified in the
+# VERSION file.
+sed -i "s/VERSION/$(cat VERSION |  tr '\n' ' ')/g" /www/index.html
 
 echo ""
 echo "--- Starting Happa nginx server ---"

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,12 @@
   window.config = config;
   </script>
 
+  <style>
+    footer {
+      display: none;
+    }
+  </style>
+
 </head>
 <body>
   <!--[if lt IE 8]>

--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,7 @@
 
   <div id="app"></div>
   <footer class="col-9">
-    Happa v0.1.31 - <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">View Release Notes</a> - <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/issues/new">Give Feedback</a>
+    Happa vVERSION - <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">View Release Notes</a> - <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/issues/new">Give Feedback</a>
   </footer>
   <script type="text/javascript" src="/vendor/modernizr.js"></script>
   <script type="text/javascript" src="/assets/app.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,7 @@
 
   <div id="app"></div>
   <footer class="col-9">
-    Happa vVERSION - <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">View Release Notes</a> - <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/issues/new">Give Feedback</a>
+    Happa vVERSION · <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">Release Notes</a>
   </footer>
   <script type="text/javascript" src="/vendor/modernizr.js"></script>
   <script type="text/javascript" src="/assets/app.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -42,6 +42,9 @@
   </noscript>
 
   <div id="app"></div>
+  <footer class="col-9">
+    Happa v0.1.31 - <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">View Release Notes</a> - <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/issues/new">Give Feedback</a>
+  </footer>
   <script type="text/javascript" src="/vendor/modernizr.js"></script>
   <script type="text/javascript" src="/assets/app.js"></script>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,7 @@
 
   <div id="app"></div>
   <footer class="col-9">
-    Happa vVERSION · <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">Release Notes</a>
+    Happa VERSION · <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">Release Notes</a>
   </footer>
   <script type="text/javascript" src="/vendor/modernizr.js"></script>
   <script type="text/javascript" src="/assets/app.js"></script>

--- a/src/styles/_base.sass
+++ b/src/styles/_base.sass
@@ -2,11 +2,33 @@
 $darkblue: #234a61
 $gold: #ddb03a
 
+
+// --- Sticky footer ---
+html
+	height: 100%
+
+body
+  display: flex
+  flex-direction: column
+
+#app
+	flex: 1 0 auto
+
+footer
+	flex-shrink: 0
+	margin: auto
+	font-size: 12px
+	color: #8FBCD6
+
+	a
+		color: #8FBCD6
+
+// --------------------
+
 html, body
 	background: $darkblue
 	padding-top: 60px
 	padding-bottom: 40px
-	height: auto
 
 h1
 	font-weight: 300

--- a/src/styles/_base.sass
+++ b/src/styles/_base.sass
@@ -10,15 +10,18 @@ html
 body
   display: flex
   flex-direction: column
+  min-height: 100vh
 
 #app
 	flex: 1 0 auto
+	padding-top: 120px
 
 footer
 	flex-shrink: 0
 	margin: auto
 	font-size: 12px
 	color: #8FBCD6
+	padding: 30px 0px 15px 0px
 
 	a
 		color: #8FBCD6
@@ -27,8 +30,6 @@ footer
 
 html, body
 	background: $darkblue
-	padding-top: 60px
-	padding-bottom: 40px
 
 h1
 	font-weight: 300


### PR DESCRIPTION
This adds a little footer to Happa with links to the github releases page.

<img width="1281" alt="screenshot 2019-02-22 at 01 36 36" src="https://user-images.githubusercontent.com/455309/53189374-4f701e00-3642-11e9-9279-c02ce29aaf04.png">

As for the actual release process, I'm thinking something like:

1. Bump the version in package.json
1. git commit -m "Release ${VERSION}"
1. git tag -a ${VERSION}
1. git push
1. CI takes over and makes the release draft

And we change our CI to only continuously deploy tags. Master can still be continuously deployed to our own Giant Swarm installations though.