### PR TITLE
Fix kubernetes n/a

### DIFF
--- a/src/components/create_cluster/release_selector.js
+++ b/src/components/create_cluster/release_selector.js
@@ -181,7 +181,7 @@ class ReleaseSelector extends React.Component {
 
           {kubernetes ? (
             <div>
-              <p>This releases contains:</p>
+              <p>This release contains:</p>
               <div className='release-selector-modal--component contrast'>
                 <span className='release-selector-modal--component--name'>
                   kubernetes

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -134,10 +134,6 @@ class ClusterDashboardItem extends React.Component {
           <div>
             <i className='fa fa-version-tag' title='Release version' />{' '}
             {this.props.cluster.release_version}
-            {' · Kubernetes '}
-            {this.props.cluster.kubernetes_version
-              ? this.props.cluster.kubernetes_version
-              : 'n/a'}
             {' · Created '}
             {relativeDate(this.props.cluster.create_date)}
           </div>


### PR DESCRIPTION
Don't show `kubernetes n/a` on the cluster overview screen for all clusters.

We deprecated the `kubernetes_version` field, so there will never be anything in it.

I have some refactoring in mind for moving the setting of various information that components might want to display or act on further up to the actions. Allowing components to do less work to get the data they need. Part of that could be extracting the kubernetes version from the release information of a cluster and adding it to the cluster object so that Happa can display it easily in a place like this.

That's a bit of a refactoring in though, so for now I'd like to remove this `n/a` as it might be confusing for users.

