### PR TITLE
Remove details button

### DIFF
--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -11,10 +11,6 @@ import PropTypes from 'prop-types';
 import { push } from 'connected-react-router';
 
 class ClusterDashboardItem extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   getMemoryTotal() {
     var workers = this.getNumberOfNodes();
     if (workers === null || workers === 0 || !this.props.cluster.workers) {

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -80,15 +80,6 @@ class ClusterDashboardItem extends React.Component {
     );
   }
 
-  goToClusterDetails() {
-    var url =
-      '/organizations/' +
-      this.props.selectedOrganization +
-      '/clusters/' +
-      this.props.cluster.id;
-    this.props.dispatch(push(url));
-  }
-
   render() {
     var memory = this.getMemoryTotal();
     var storage = this.getStorageTotal();
@@ -152,9 +143,6 @@ class ClusterDashboardItem extends React.Component {
 
         <div className='cluster-dashboard-item--buttons'>
           <ButtonGroup>
-            <Button onClick={this.goToClusterDetails.bind(this)}>
-              Details
-            </Button>
             <Button onClick={this.accessCluster.bind(this)}>
               <i className='fa fa-start' />
               Get Started


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/5410

This removes the details button, which is a redundancy to the linked cluster name