### PR TITLE
Add dropdown button for AWS region selection in cluster creation

### DIFF
--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -156,6 +156,7 @@ class CreateCluster extends React.Component {
           },
           name: this.state.clusterName,
           owner: this.props.selectedOrganization,
+          region: this.state.aws.region,
           release_version: this.state.releaseVersion,
           workers: workers,
         })

--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -455,13 +455,14 @@ class CreateCluster extends React.Component {
               switch (this.props.provider) {
                 case 'aws':
                   return (
-                    <div>
-                      <p>
-                        Select AWS Region for your cluster.
-                      </p>
+                  <div>
+                    <div className='row section'>
                       <div className='col-3'>
-                         <div className='textfield'>
-                            <label>Region:</label>
+                        <h3 className='table-label'>AWS Region</h3>
+                      </div>
+                      <div className='col-9'>
+                         <div className='col-6'>
+                            <p>Select AWS Region for your cluster.</p>
                             <DropdownButton
                               id='region'
                               className='outline'
@@ -481,6 +482,7 @@ class CreateCluster extends React.Component {
                             </DropdownButton>
                           </div>
                       </div>
+                    </div>
                     <div className='row section'>
                       <div className='col-3'>
                         <h3 className='table-label'>Instance Type</h3>

--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -27,7 +27,6 @@ class CreateCluster extends React.Component {
         value: 1,
         valid: true,
       },
-      region: 'eu-central-1',
       releaseVersion: '',
       clusterName: 'My cluster',
       scaling: {
@@ -45,6 +44,7 @@ class CreateCluster extends React.Component {
           valid: true,
           value: props.defaultInstanceType,
         },
+        region: 'eu-central-1',
       },
       azure: {
         vmSize: {
@@ -464,7 +464,7 @@ class CreateCluster extends React.Component {
                             <DropdownButton
                               id='region'
                               className='outline'
-                              title={this.state.region}
+                              title={this.state.aws.region}
                             >
                               {this.getAvailableRegions().map(region => (
                                 <MenuItem

--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -4,6 +4,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import DocumentTitle from 'react-document-title';
 import Button from '../shared/button';
+import MenuItem from 'react-bootstrap/lib/MenuItem';
+import DropdownButton from 'react-bootstrap/lib/DropdownButton';
 import { clusterCreate } from '../../actions/clusterActions';
 import NodeCountSelector from '../shared/node_count_selector.js';
 import NumberPicker from '../shared/number_picker.js';
@@ -25,6 +27,7 @@ class CreateCluster extends React.Component {
         value: 1,
         valid: true,
       },
+      region: 'eu-central-1',
       releaseVersion: '',
       clusterName: 'My cluster',
       scaling: {
@@ -197,6 +200,31 @@ class CreateCluster extends React.Component {
     });
   };
 
+  getAvailableRegions() {
+      var regions = [
+          'us-east-1',
+          'us-east-2',
+          'us-west-1',
+          'us-west-2',
+          'ap-south-1',
+          'ap-northeast-1',
+          'ap-northeast-2',
+          'ap-northeast-3',
+          'ap-southeast-1',
+          'ap-southeast-2',
+          'ca-central-1',
+          'eu-central-1',
+          'eu-west-1',
+          'eu-west-2',
+          'eu-west-3',
+          'eu-north-1',
+          'sa-east-1',
+          'us-gov-east-1',
+          'us-gov-west-1',
+      ];
+      return regions;
+  }
+
   errorState() {
     return (
       <div className='new-cluster-error flash-messages--flash-message flash-messages--danger'>
@@ -213,6 +241,16 @@ class CreateCluster extends React.Component {
       </div>
     );
   }
+
+  updateAWSRegion = value => {
+    console.log(value);
+    this.setState({
+        aws: {
+            instanceType: this.state.aws.instanceType,
+            region: value,
+        }
+    });
+  };
 
   updateAWSInstanceType = value => {
     this.setState({
@@ -416,6 +454,32 @@ class CreateCluster extends React.Component {
               switch (this.props.provider) {
                 case 'aws':
                   return (
+                    <div>
+                      <p>
+                        Select AWS Region for your cluster.
+                      </p>
+                      <div className='col-3'>
+                         <div className='textfield'>
+                            <label>Region:</label>
+                            <DropdownButton
+                              id='region'
+                              className='outline'
+                              title={this.state.region}
+                            >
+                              {this.getAvailableRegions().map(region => (
+                                <MenuItem
+                                  key={region}
+                                  onClick={this.updateAWSRegion.bind(
+                                    this,
+                                    region
+                                  )}
+                                >
+                                  {region}
+                                </MenuItem>
+                              ))}
+                            </DropdownButton>
+                          </div>
+                      </div>
                     <div className='row section'>
                       <div className='col-3'>
                         <h3 className='table-label'>Instance Type</h3>
@@ -430,6 +494,7 @@ class CreateCluster extends React.Component {
                         />
                       </div>
                     </div>
+                  </div>
                   );
                 case 'kvm':
                   return (

--- a/src/components/create_cluster/index.js
+++ b/src/components/create_cluster/index.js
@@ -202,28 +202,28 @@ class CreateCluster extends React.Component {
   };
 
   getAvailableRegions() {
-      var regions = [
-          'us-east-1',
-          'us-east-2',
-          'us-west-1',
-          'us-west-2',
-          'ap-south-1',
-          'ap-northeast-1',
-          'ap-northeast-2',
-          'ap-northeast-3',
-          'ap-southeast-1',
-          'ap-southeast-2',
-          'ca-central-1',
-          'eu-central-1',
-          'eu-west-1',
-          'eu-west-2',
-          'eu-west-3',
-          'eu-north-1',
-          'sa-east-1',
-          'us-gov-east-1',
-          'us-gov-west-1',
-      ];
-      return regions;
+    var regions = [
+      'us-east-1',
+      'us-east-2',
+      'us-west-1',
+      'us-west-2',
+      'ap-south-1',
+      'ap-northeast-1',
+      'ap-northeast-2',
+      'ap-northeast-3',
+      'ap-southeast-1',
+      'ap-southeast-2',
+      'ca-central-1',
+      'eu-central-1',
+      'eu-west-1',
+      'eu-west-2',
+      'eu-west-3',
+      'eu-north-1',
+      'sa-east-1',
+      'us-gov-east-1',
+      'us-gov-west-1',
+    ];
+    return regions;
   }
 
   errorState() {
@@ -246,10 +246,10 @@ class CreateCluster extends React.Component {
   updateAWSRegion = value => {
     console.log(value);
     this.setState({
-        aws: {
-            instanceType: this.state.aws.instanceType,
-            region: value,
-        }
+      aws: {
+        instanceType: this.state.aws.instanceType,
+        region: value,
+      },
     });
   };
 
@@ -455,13 +455,13 @@ class CreateCluster extends React.Component {
               switch (this.props.provider) {
                 case 'aws':
                   return (
-                  <div>
-                    <div className='row section'>
-                      <div className='col-3'>
-                        <h3 className='table-label'>AWS Region</h3>
-                      </div>
-                      <div className='col-9'>
-                         <div className='col-6'>
+                    <div>
+                      <div className='row section'>
+                        <div className='col-3'>
+                          <h3 className='table-label'>AWS Region</h3>
+                        </div>
+                        <div className='col-9'>
+                          <div className='col-6'>
                             <p>Select AWS Region for your cluster.</p>
                             <DropdownButton
                               id='region'
@@ -481,23 +481,25 @@ class CreateCluster extends React.Component {
                               ))}
                             </DropdownButton>
                           </div>
+                        </div>
+                      </div>
+                      <div className='row section'>
+                        <div className='col-3'>
+                          <h3 className='table-label'>Instance Type</h3>
+                        </div>
+                        <div className='col-9'>
+                          <p>Select the instance type for your worker nodes.</p>
+                          <AWSInstanceTypeSelector
+                            allowedInstanceTypes={
+                              this.props.allowedInstanceTypes
+                            }
+                            value={this.state.aws.instanceType.value}
+                            readOnly={false}
+                            onChange={this.updateAWSInstanceType}
+                          />
+                        </div>
                       </div>
                     </div>
-                    <div className='row section'>
-                      <div className='col-3'>
-                        <h3 className='table-label'>Instance Type</h3>
-                      </div>
-                      <div className='col-9'>
-                        <p>Select the instance type for your worker nodes.</p>
-                        <AWSInstanceTypeSelector
-                          allowedInstanceTypes={this.props.allowedInstanceTypes}
-                          value={this.state.aws.instanceType.value}
-                          readOnly={false}
-                          onChange={this.updateAWSInstanceType}
-                        />
-                      </div>
-                    </div>
-                  </div>
                   );
                 case 'kvm':
                   return (

--- a/src/components/create_cluster/release_selector.js
+++ b/src/components/create_cluster/release_selector.js
@@ -250,8 +250,8 @@ function mapStateToProps(state) {
   var provider = state.app.info.general.provider;
   var releases = Object.assign({}, state.entities.releases.items);
 
-  var activeSortedReleases = _.filter(releases, release => release.active);
-  activeSortedReleases = activeSortedReleases.map(release => release.version);
+  //var activeSortedReleases = _.filter(releases, release => release.active);
+  var activeSortedReleases = _.map(releases, release => release.version); //activeSortedReleases.map(release => release.version);
   activeSortedReleases.sort(cmp).reverse();
 
   return {


### PR DESCRIPTION
There is now an upcoming support for inter-region clusters in aws-operator and
to use that one needs to be able to specify the region the cluster should be
created in. Therefore add a dropdown selection for this region.