### PR TITLE
Expose the InputField type property as HTML attribute

### DIFF
--- a/src/components/shared/input_field.js
+++ b/src/components/shared/input_field.js
@@ -118,6 +118,7 @@ class InputField extends React.Component {
           ref={i => {
             this.input = i;
           }}
+          type={this.props.type}
           id={this.props.name}
           value={this.state.value}
           onBlur={this.onBlur}
@@ -143,6 +144,7 @@ InputField.propTypes = {
   label: PropTypes.string,
   value: PropTypes.string,
   readOnly: PropTypes.bool,
+  type: PropTypes.stringm,
 };
 
 export default InputField;

--- a/src/styles/components/_form.sass
+++ b/src/styles/components/_form.sass
@@ -5,7 +5,7 @@ form
     color: #ccc
     margin-bottom: 10px
 
-  textarea, input[type='text'], input[type='email'], input[type='password']
+  textarea, input[type='text'], input[type='email'], input[type='password'], .textfield input
     box-sizing: border-box
     width: 100%
     background-color: #32526a

--- a/src/styles/components/_form.sass
+++ b/src/styles/components/_form.sass
@@ -5,7 +5,7 @@ form
     color: #ccc
     margin-bottom: 10px
 
-  textarea, input[type='text'], input[type='email'], input[type='password'], .textfield input
+  textarea, input[type='text'], input[type='email'], input[type='password']
     box-sizing: border-box
     width: 100%
     background-color: #32526a


### PR DESCRIPTION
This PR fixes the problem that the AWS EC2 instance type input field and the Azure VM size input field did not carry a `type=text` HTML attribute.

As a consequence, they were rendered like this:

![image](https://user-images.githubusercontent.com/273727/53878114-4e0fff80-400b-11e9-995c-27ebf7e2d46b.png)