### PR TITLE
Fix 'Users' disappearing in nav after token refresh.

### DIFF
--- a/src/reducers/appReducer.js
+++ b/src/reducers/appReducer.js
@@ -102,7 +102,7 @@ export default function appReducer(
       defaultClientAuth.apiKeyPrefix = action.userData.auth.scheme;
 
       return Object.assign({}, state, {
-        loggedInUser: action.userData,
+        loggedInUser: Object.assign({}, state.loggedInUser, action.userData),
       });
 
     case types.LOGIN_ERROR:


### PR DESCRIPTION
I noticed the "Users" link in the navigation would sometimes appear and disappear. 

This is because on re-acquiring the auth token, we'd overwrite the user object instead of merge the existing user object with the new user data. The user object contained information about whether or not the user was an admin, which is determined when happa loads the list of organisations. 

This commit ensures that information is retained when a refreshed token is acquired. 

(Only relevant for giant swarm 'admins' that can see the global user list to begin with)