### PR TITLE
Remove increment/decrement buttons for disabled input

### DIFF
--- a/src/styles/components/_number_picker.sass
+++ b/src/styles/components/_number_picker.sass
@@ -18,6 +18,11 @@
   position: relative
   margin-bottom: 5px
 
+  input:disabled
+    // to hide the increment/decrement buttons when disabled
+    -moz-appearance: textfield
+    background-color: #fff
+
 .number-picker--validation-error
   color: #fcc
 

--- a/src/styles/components/_number_picker.sass
+++ b/src/styles/components/_number_picker.sass
@@ -21,7 +21,6 @@
   input:disabled
     // to hide the increment/decrement buttons when disabled
     -moz-appearance: textfield
-    background-color: #fff
 
 .number-picker--validation-error
   color: #fcc


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5469

In Firefox, with the number picker being disabled, the input field would contain two tiny increment/decrement buttons.

![image](https://user-images.githubusercontent.com/273727/54031336-c2cf6f00-41ae-11e9-9ec6-9f7038411757.png)

This PR hides the buttons and aligns he appearance with Chrome.
