### PR TITLE
Add age condition for showing Get Started button

### DIFF
--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -9,6 +9,7 @@ import { relativeDate } from '../../lib/helpers.js';
 import Button from '../shared/button';
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import ClusterIDLabel from '../shared/cluster_id_label';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -86,6 +87,15 @@ class ClusterDashboardItem extends React.Component {
     var memory = this.getMemoryTotal();
     var storage = this.getStorageTotal();
     var cpus = this.getCpusTotal();
+
+    var age = Math.abs(
+      moment(this.props.cluster.create_date)
+        .utc()
+        .diff(moment().utc()) / 1000
+    );
+
+    var younger_than_thirty_days = age < 30 * 24 * 60 * 60;
+
     return (
       <div className='cluster-dashboard-item well'>
         <div className='cluster-dashboard-item--label'>
@@ -144,12 +154,16 @@ class ClusterDashboardItem extends React.Component {
         </div>
 
         <div className='cluster-dashboard-item--buttons'>
-          <ButtonGroup>
-            <Button onClick={this.accessCluster.bind(this)}>
-              <i className='fa fa-start' />
-              Get Started
-            </Button>
-          </ButtonGroup>
+          {younger_than_thirty_days ? (
+            <ButtonGroup>
+              <Button onClick={this.accessCluster.bind(this)}>
+                <i className='fa fa-start' />
+                Get Started
+              </Button>
+            </ButtonGroup>
+          ) : (
+            ''
+          )}
         </div>
       </div>
     );

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -71,6 +71,19 @@ class ClusterDashboardItem extends React.Component {
     return 0;
   }
 
+  /**
+   * Returns true if the cluster is younger than 30 days
+   */
+  clusterYoungerThan30Days() {
+    var age = Math.abs(
+      moment(this.props.cluster.create_date)
+        .utc()
+        .diff(moment().utc()) / 1000
+    );
+
+    return age < 30 * 24 * 60 * 60;
+  }
+
   accessCluster() {
     this.props.dispatch(
       push(
@@ -87,14 +100,6 @@ class ClusterDashboardItem extends React.Component {
     var memory = this.getMemoryTotal();
     var storage = this.getStorageTotal();
     var cpus = this.getCpusTotal();
-
-    var age = Math.abs(
-      moment(this.props.cluster.create_date)
-        .utc()
-        .diff(moment().utc()) / 1000
-    );
-
-    var younger_than_thirty_days = age < 30 * 24 * 60 * 60;
 
     return (
       <div className='cluster-dashboard-item well'>
@@ -154,7 +159,7 @@ class ClusterDashboardItem extends React.Component {
         </div>
 
         <div className='cluster-dashboard-item--buttons'>
-          {younger_than_thirty_days ? (
+          {this.clusterYoungerThan30Days() ? (
             <ButtonGroup>
               <Button onClick={this.accessCluster.bind(this)}>
                 <i className='fa fa-start' />


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/5410

This hides the `Get Started` button in the cluster overview if the cluster is older than 30 days.

Preview

![image](https://user-images.githubusercontent.com/273727/54033679-40967900-41b5-11e9-9c03-55bee65acda1.png)
