### PR TITLE
Auto-refresh for cluster details 

### DIFF
--- a/src/components/cluster/detail/cluster_detail_table.js
+++ b/src/components/cluster/detail/cluster_detail_table.js
@@ -7,9 +7,14 @@ import cmp from 'semver-compare';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
+import RefreshableLabel from '../../shared/refreshable_label';
 import ReleaseDetailsModal from '../../modals/release_details_modal';
 
 class ClusterDetailTable extends React.Component {
+  state = {
+    modifiedPropsPaths: [],
+  };
+
   componentDidMount = () => {
     this.registerRefreshInterval();
   };
@@ -154,11 +159,21 @@ class ClusterDetailTable extends React.Component {
         <tr>
           <td>Worker node scaling</td>
           <td className='value'>
-            {this.props.cluster.scaling.min === this.props.cluster.scaling.max
-              ? `pinned at ${this.props.cluster.scaling.min}`
-              : `autoscaling between ${this.props.cluster.scaling.min} and ${
-                  this.props.cluster.scaling.max
-                }`}
+            <RefreshableLabel
+              dataItems={[
+                this.props.cluster.scaling.min,
+                this.props.cluster.scaling.max,
+              ]}
+            >
+              <span>
+                {this.props.cluster.scaling.min ===
+                this.props.cluster.scaling.max
+                  ? `pinned at ${this.props.cluster.scaling.min}`
+                  : `autoscaling between ${
+                      this.props.cluster.scaling.min
+                    } and ${this.props.cluster.scaling.max}`}
+              </span>
+            </RefreshableLabel>
           </td>
         </tr>
       );
@@ -169,12 +184,14 @@ class ClusterDetailTable extends React.Component {
       this.props.provider === 'aws' &&
       this.props.cluster.availability_zones
     ) {
+      var azs = this.props.cluster.availability_zones.map(az => {
+        return <code key={az}>{az}</code>;
+      });
+
       availabilityZonesOrNothing = (
         <tr>
           <td>Availablility zones</td>
-          <td className='value code'>
-            {this.props.cluster.availability_zones.join(', ')}
-          </td>
+          <td className='value'>{azs}</td>
         </tr>
       );
     }
@@ -185,7 +202,15 @@ class ClusterDetailTable extends React.Component {
       numberOfDesiredNodesOrNothing = (
         <tr>
           <td>Desired worker node count</td>
-          <td className='value'>{desiredNumberOfNodes}</td>
+          <td className='value'>
+            <RefreshableLabel
+              dataItems={[
+                this.props.cluster.status.cluster.scaling.desiredCapacity,
+              ]}
+            >
+              <span>{desiredNumberOfNodes}</span>
+            </RefreshableLabel>
+          </td>
         </tr>
       );
     }
@@ -267,34 +292,41 @@ class ClusterDetailTable extends React.Component {
                 {this.props.release ? (
                   <tr>
                     <td>Release version</td>
-                    <td className='value code'>
-                      <a onClick={this.showReleaseDetails}>
-                        <i className='fa fa-version-tag' />{' '}
-                        {this.props.cluster.release_version}{' '}
-                        {(() => {
-                          var kubernetes = _.find(
-                            this.props.release.components,
-                            component => component.name === 'kubernetes'
-                          );
-                          if (kubernetes) {
-                            return (
-                              <span>
-                                &mdash; includes Kubernetes {kubernetes.version}
-                              </span>
-                            );
-                          }
-                        })()}
-                      </a>{' '}
-                      {this.props.canClusterUpgrade ? (
-                        <a
-                          onClick={this.props.showUpgradeModal}
-                          className='upgrade-available'
-                        >
-                          <i className='fa fa-info' /> Upgrade available
-                        </a>
-                      ) : (
-                        undefined
-                      )}
+                    <td className='value'>
+                      <RefreshableLabel
+                        dataItems={[this.props.cluster.release_version]}
+                      >
+                        <span>
+                          <a onClick={this.showReleaseDetails}>
+                            <i className='fa fa-version-tag' />{' '}
+                            {this.props.cluster.release_version}{' '}
+                            {(() => {
+                              var kubernetes = _.find(
+                                this.props.release.components,
+                                component => component.name === 'kubernetes'
+                              );
+                              if (kubernetes) {
+                                return (
+                                  <span>
+                                    &mdash; includes Kubernetes{' '}
+                                    {kubernetes.version}
+                                  </span>
+                                );
+                              }
+                            })()}
+                          </a>{' '}
+                          {this.props.canClusterUpgrade ? (
+                            <a
+                              onClick={this.props.showUpgradeModal}
+                              className='upgrade-available'
+                            >
+                              <i className='fa fa-info' /> Upgrade available
+                            </a>
+                          ) : (
+                            undefined
+                          )}
+                        </span>
+                      </RefreshableLabel>
                     </td>
                   </tr>
                 ) : (
@@ -322,35 +354,61 @@ class ClusterDetailTable extends React.Component {
                 <tr>
                   <td>Worker nodes running</td>
                   <td className='value'>
-                    {this.getNumberOfNodes() === null
-                      ? '0'
-                      : this.getNumberOfNodes()}
+                    <RefreshableLabel
+                      dataItems={[this.props.cluster.workers.length]}
+                    >
+                      <span>
+                        {this.getNumberOfNodes() === null
+                          ? '0'
+                          : this.getNumberOfNodes()}
+                      </span>
+                    </RefreshableLabel>
                   </td>
                 </tr>
                 {instanceTypeOrVMSize}
                 <tr>
                   <td>Total CPU cores in worker nodes</td>
                   <td className='value'>
-                    {this.getCpusTotal() === null ? '0' : this.getCpusTotal()}
+                    <RefreshableLabel
+                      dataItems={[this.props.cluster.workers.length]}
+                    >
+                      <span>
+                        {this.getCpusTotal() === null
+                          ? '0'
+                          : this.getCpusTotal()}
+                      </span>
+                    </RefreshableLabel>
                   </td>
                 </tr>
                 <tr>
                   <td>Total RAM in worker nodes</td>
                   <td className='value'>
-                    {this.getMemoryTotal() === null
-                      ? '0'
-                      : this.getMemoryTotal()}{' '}
-                    GB
+                    <RefreshableLabel
+                      dataItems={[this.props.cluster.workers.length]}
+                    >
+                      <span>
+                        {this.getMemoryTotal() === null
+                          ? '0'
+                          : this.getMemoryTotal()}{' '}
+                        GB
+                      </span>
+                    </RefreshableLabel>
                   </td>
                 </tr>
                 {this.props.provider === 'kvm' ? (
                   <tr>
                     <td>Total storage in worker nodes</td>
                     <td className='value'>
-                      {this.getStorageTotal() === null
-                        ? '0'
-                        : this.getStorageTotal()}{' '}
-                      GB
+                      <RefreshableLabel
+                        dataItems={[this.props.cluster.workers.length]}
+                      >
+                        <span>
+                          {this.getStorageTotal() === null
+                            ? '0'
+                            : this.getStorageTotal()}{' '}
+                          GB
+                        </span>
+                      </RefreshableLabel>
                     </td>
                   </tr>
                 ) : (

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -80,7 +80,7 @@ class ClusterDetailView extends React.Component {
       typeof document.addEventListener === 'undefined' ||
       this.hidden === undefined
     ) {
-      console.debug(
+      console.log(
         'This piece of code requires a browser that supports the Page Visibility API.'
       );
     } else {
@@ -111,17 +111,13 @@ class ClusterDetailView extends React.Component {
   };
 
   refreshClusterData = () => {
-    console.debug('This is refreshClusterData', new Date());
-    // load new data
     this.props.clusterActions.clusterLoadDetails(this.props.cluster.id);
   };
 
   handleVisibilityChange = () => {
     if (document[this.hidden]) {
-      console.debug('Page just got hidden');
       window.clearInterval(this.loadDataInterval);
     } else {
-      console.debug('Page just got revealed');
       this.refreshClusterData();
       this.registerRefreshInterval();
     }

--- a/src/components/shared/refreshable_label.js
+++ b/src/components/shared/refreshable_label.js
@@ -42,11 +42,6 @@ class RefreshableLabel extends React.Component {
       prevState.dataItems !== this.state.dataItems
     ) {
       if (prevState.dataItems !== null) {
-        console.debug(
-          'RefreshableLabel detected dataItems change',
-          prevProps.dataItems,
-          this.props.dataItems
-        );
         this.setState({
           changed: true,
         });

--- a/src/components/shared/refreshable_label.js
+++ b/src/components/shared/refreshable_label.js
@@ -1,0 +1,80 @@
+'use strict';
+
+import _ from 'underscore';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * RefreshableLabel is an inline-block HTML container
+ * that is used to temporarily highlight its content.
+ *
+ * It is typically used to indicated that its content
+ * has changed. To detect a change, it provides a property
+ *
+ *   dataItems (Array)
+ *
+ * which is an array of arbitrary values. When this
+ * array changes, visual highlighting is triggered.
+ */
+class RefreshableLabel extends React.Component {
+  constructor(props) {
+    super();
+    this.state = {
+      dataItems: props.dataItems,
+      changed: false,
+    };
+  }
+
+  static getDerivedStateFromProps = (nextProps, prevState) => {
+    var d = _.difference(prevState.dataItems, nextProps.dataItems);
+    if (_.size(d) === 0) {
+      return null;
+    }
+
+    return {
+      dataItems: nextProps.dataItems,
+    };
+  };
+
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      prevState.dataItems !== null &&
+      prevState.dataItems !== this.state.dataItems
+    ) {
+      if (prevState.dataItems !== null) {
+        console.debug(
+          'RefreshableLabel detected dataItems change',
+          prevProps.dataItems,
+          this.props.dataItems
+        );
+        this.setState({
+          changed: true,
+        });
+
+        this.changeTimeout = window.setTimeout(() => {
+          this.setState({ changed: false });
+        }, 5000);
+      }
+    }
+  }
+
+  componentWillUnmount = () => {
+    window.clearTimeout(this.changeTimeout);
+  };
+
+  render = () => {
+    var className = 'refreshable-label';
+    if (this.state.changed) {
+      className += ' changed';
+    }
+
+    return <span className={className}>{this.props.children}</span>;
+  };
+}
+
+export default RefreshableLabel;
+
+RefreshableLabel.propTypes = {
+  children: PropTypes.object,
+  dataItems: PropTypes.array,
+};

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -68,7 +68,7 @@ var ensureWorkersHaveAWSkey = function(clusterDetails) {
 };
 
 export default function clusterReducer(
-  state = { lastUpdated: 0, isFetching: false, items: {} },
+  state = { lastUpdated: null, isFetching: false, items: {} },
   action = undefined
 ) {
   var items;
@@ -84,6 +84,8 @@ export default function clusterReducer(
           ensureMetricKeysAreAvailable(cluster)
         );
 
+        items[cluster.id].lastUpdated = Date.now();
+
         // Guard against API that returns null for certain values when they are
         // empty.
         items[cluster.id].nodes = items[cluster.id].nodes || [];
@@ -92,14 +94,14 @@ export default function clusterReducer(
       });
 
       return {
-        lastUpdated: state.lastUpdated,
+        lastUpdated: Date.now(),
         isFetching: false,
         items: items,
       };
 
     case types.CLUSTERS_LOAD_ERROR:
       return {
-        lastUpdated: Date.now(),
+        lastUpdated: state.lastUpdated,
         isFetching: false,
         errorLoading: true,
         items: items,
@@ -156,6 +158,8 @@ export default function clusterReducer(
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         status: action.status,
       });
+
+      items[action.clusterId].status.lastUpdated = Date.now();
 
       return {
         lastUpdated: state.lastUpdated,

--- a/src/styles/components/_cluster_details.sass
+++ b/src/styles/components/_cluster_details.sass
@@ -1,3 +1,9 @@
+@keyframes yellowfade
+    from
+      background: #e8d986
+    to
+      background: transparent
+  
 .cluster-details
   h1
     margin-bottom: 0px
@@ -36,3 +42,16 @@
       padding: 0px 4px
       line-height: 1.25em
       border-radius: 2px
+  
+  .refreshable-label
+    display: inline-block
+    line-height: 1.7
+    border-radius: 2px
+    margin-left: -5px
+    padding-left: 5px
+    padding-right: 5px
+
+    &.changed
+      animation-name: yellowfade
+      animation-duration: 2s
+      animation-timing-function: ease

--- a/src/styles/components/_cluster_details.sass
+++ b/src/styles/components/_cluster_details.sass
@@ -20,4 +20,19 @@
 
     dd
       margin-bottom: 5px
+  
+  .resource-details
+    margin-bottom: 7px
 
+  .last-updated
+    margin-left: 10px
+
+    .beta-tag
+      font-size: 0.9em
+      text-transform: uppercase
+      background-color: #ccc
+      color: $darkblue
+      display: inline-block
+      padding: 0px 4px
+      line-height: 1.25em
+      border-radius: 2px


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/5556

This lets the cluster details refresh automatically. A note is added showing that this is a new feature and when the information has been last refreshed.

### Preview

![image](https://user-images.githubusercontent.com/273727/54282573-934ca800-459c-11e9-84ff-5dbc7825bd1a.png)

### Details

- Loading of freshest data is done via `window.setInterval` every 30 seconds.
- the view component refreshes every 10 seconds, to update relative date strings like `a few seconds ago.`
- When the [page visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) indicates that the tab is invisible, the refresh interval function is unregistered. When the page is revealed again the freshest data gets pulled immediately and the interval function is registered again.
- The current implementation doesn't simplify any re-use of the refresh mechanism in other components.
- Cluster deletion (by somebody else) is not handled. The page will continue to show the latest cluster details, plus an error messages, mostly as it used to be before. The error message re-appears every 30 seconds.

### TODO

- [x] fix refresh interval not being stopped when page is hidden
- [x] temporary visual highlighting of elements when they change, if simple enough
- [x] test if SSO JWT is refreshed before use
- [x] remove console debugging code
- ~~react sensibly in case of a 404 error to the getCluster request~~