### PR TITLE
After cluster creation, redirect to cluster details page

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -123,7 +123,7 @@ export function clusterLoadStatus(clusterId) {
 // clusterCreate
 // ==============================================================
 // Takes a cluster object and tries to create it. Dispatches CLUSTER_CREATE_SUCCESS
-// on success or CLUSTER_DELETE_ERROR on error.
+// on success or CLUSTER_CREATE_ERROR on error.
 
 export function clusterCreate(cluster) {
   return function(dispatch, getState) {

--- a/src/components/cluster/new/view.js
+++ b/src/components/cluster/new/view.js
@@ -157,9 +157,15 @@ class CreateCluster extends React.Component {
           workers: workers,
         })
       )
-      .then(() => {
+      .then(cluster => {
+        // after successful creation, redirect to cluster details
         this.props.dispatch(
-          push('/organizations/' + this.props.selectedOrganization)
+          push(
+            '/organizations/' +
+              this.props.selectedOrganization +
+              '/clusters/' +
+              cluster.id
+          )
         );
       })
       .catch(error => {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5555

So far, after cluster creation, the organization details page is shown. This changes this to show the cluster details page instead.