### PR TITLE
Refresh clusters list after deletion

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -203,6 +203,9 @@ export function clusterDeleteConfirmed(cluster) {
           messageType.INFO,
           messageTTL.SHORT
         );
+
+        // ensure refreshing of the clusters list
+        dispatch(clustersLoad());
       })
       .catch(error => {
         dispatch(modalHide());


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5596

Ensures that the clusters list is updated after deleting a cluster