### PR TITLE
Make cluster name editable

### DIFF
--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -227,7 +227,7 @@ class ClusterDetailView extends React.Component {
             <div>
               <div className='cluster-details'>
                 <div className='row'>
-                  <div className='col-7'>
+                  <div className='col-sm-12 col-md-7 col-9'>
                     <h1>
                       <ClusterIDLabel
                         clusterID={this.props.cluster.id}
@@ -250,8 +250,31 @@ class ClusterDetailView extends React.Component {
                       )}
                     </h1>
                   </div>
-                  <div className='col-5'>
-                    <div className='pull-right btn-group'>
+                  <div className='col-sm-12 col-md-5 col-3'>
+                    <div
+                      className='btn-group visible-xs-block visible-sm-block visible-md-block'
+                      style={{ marginTop: 10 }}
+                    >
+                      <Button onClick={this.accessCluster}>
+                        <i className='fa fa-start' /> GET STARTED
+                      </Button>
+                      {this.canClusterScale() ? (
+                        <Button onClick={this.showScalingModal}>
+                          <i className='fa fa-scale' /> SCALE
+                        </Button>
+                      ) : (
+                        undefined
+                      )}
+
+                      {this.canClusterUpgrade() ? (
+                        <Button onClick={this.showUpgradeModal}>
+                          <i className='fa fa-version-upgrade' /> UPGRADE
+                        </Button>
+                      ) : (
+                        undefined
+                      )}
+                    </div>
+                    <div className='pull-right btn-group visible-lg-block'>
                       <Button onClick={this.accessCluster}>
                         <i className='fa fa-start' /> GET STARTED
                       </Button>

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -16,6 +16,7 @@ import ClusterApps from './cluster_apps';
 import ClusterDetailTable from './cluster_detail_table';
 import ClusterIDLabel from '../../shared/cluster_id_label';
 import ClusterKeyPairs from './key_pairs';
+import ClusterName from '../../shared/cluster_name';
 import cmp from 'semver-compare';
 import DocumentTitle from 'react-document-title';
 import PropTypes from 'prop-types';
@@ -232,7 +233,11 @@ class ClusterDetailView extends React.Component {
                         clusterID={this.props.cluster.id}
                         copyEnabled
                       />{' '}
-                      {this.props.cluster.name}{' '}
+                      <ClusterName
+                        id={this.props.cluster.id}
+                        name={this.props.cluster.name}
+                        dispatchFunc={this.props.dispatch}
+                      />{' '}
                       {this.state.loading ? (
                         <img
                           className='loader'

--- a/src/components/shared/cluster_name.js
+++ b/src/components/shared/cluster_name.js
@@ -31,6 +31,13 @@ class ClusterName extends React.Component {
     this.setState({ editing: true });
   };
 
+  deactivateEditMode = () => {
+    this.setState({
+      editing: false,
+      name: this.props.name,
+    });
+  };
+
   handleChange = evt => {
     this.setState({ name: evt.target.value });
   };
@@ -108,7 +115,10 @@ class ClusterName extends React.Component {
             onKeyUp={this.handleKey}
             autoComplete='off'
           />
-          <Button type='submit'>OK</Button>
+          <div className='btn-group'>
+            <Button type='submit'>OK</Button>
+            <Button onClick={this.deactivateEditMode}>Cancel</Button>
+          </div>
         </form>
       );
     }

--- a/src/components/shared/cluster_name.js
+++ b/src/components/shared/cluster_name.js
@@ -19,27 +19,30 @@ class ClusterName extends React.Component {
     this.state = {
       // editing is true while the widget is in edit mode.
       editing: false,
-      // saving is true while the widget submits data, before the
-      // editing is confirmed.
-      error: null,
-      saving: false,
+      // name is a copy of the actual cluster name
       name: props.name,
+      // inputFieldValue is what the input field currently holds
+      inputFieldValue: props.name,
     };
   }
 
   activateEditMode = () => {
-    this.setState({ editing: true });
+    this.setState({
+      editing: true,
+      inputFieldValue: this.state.name,
+    });
   };
 
   deactivateEditMode = () => {
     this.setState({
       editing: false,
-      name: this.props.name,
+      // revert input
+      inputFieldValue: this.state.name,
     });
   };
 
   handleChange = evt => {
-    this.setState({ name: evt.target.value });
+    this.setState({ inputFieldValue: evt.target.value });
   };
 
   handleSubmit = evt => {
@@ -55,18 +58,17 @@ class ClusterName extends React.Component {
       return;
     }
 
-    console.debug('Form submitted and valid!');
     this.props
       .dispatchFunc(
         clusterPatch({
           id: this.props.id,
-          name: this.state.name,
+          name: this.state.inputFieldValue,
         })
       )
-      .then(successObject => {
-        console.debug('dispatch success', successObject);
+      .then(() => {
         this.setState({
           editing: false,
+          name: this.state.inputFieldValue,
         });
 
         new FlashMessage(
@@ -80,10 +82,7 @@ class ClusterName extends React.Component {
   handleKey = evt => {
     // 27 = Escape key
     if (evt.keyCode === 27) {
-      this.setState({
-        editing: false,
-        name: this.props.name, // revert name change
-      });
+      this.deactivateEditMode();
     }
   };
 
@@ -95,9 +94,6 @@ class ClusterName extends React.Component {
       };
     }
 
-    if (this.state.error !== null) {
-      this.setState({ error: null });
-    }
     return true;
   };
 
@@ -109,7 +105,7 @@ class ClusterName extends React.Component {
           <input
             type='text'
             name='cluster-name'
-            value={this.state.name}
+            value={this.state.inputFieldValue}
             autoFocus
             onChange={this.handleChange}
             onKeyUp={this.handleKey}

--- a/src/components/shared/cluster_name.js
+++ b/src/components/shared/cluster_name.js
@@ -1,0 +1,136 @@
+'use strict';
+
+import { clusterPatch } from '../../actions/clusterActions';
+import { FlashMessage, messageTTL, messageType } from '../../lib/flash_message';
+import Button from '../shared/button';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+
+/**
+ * ClusterName is a widget to display and edit a cluster name in the same
+ * place. It renders as inline-block.
+ */
+class ClusterName extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      // editing is true while the widget is in edit mode.
+      editing: false,
+      // saving is true while the widget submits data, before the
+      // editing is confirmed.
+      error: null,
+      saving: false,
+      name: props.name,
+    };
+  }
+
+  activateEditMode = () => {
+    this.setState({ editing: true });
+  };
+
+  handleChange = evt => {
+    this.setState({ name: evt.target.value });
+  };
+
+  handleSubmit = evt => {
+    evt.preventDefault();
+
+    var validate = this.validate();
+    if (typeof validate === 'object') {
+      new FlashMessage(
+        'Error: ' + validate.error,
+        messageType.ERROR,
+        messageTTL.MEDIUM
+      );
+      return;
+    }
+
+    console.debug('Form submitted and valid!');
+    this.props
+      .dispatchFunc(
+        clusterPatch({
+          id: this.props.id,
+          name: this.state.name,
+        })
+      )
+      .then(successObject => {
+        console.debug('dispatch success', successObject);
+        this.setState({
+          editing: false,
+        });
+
+        new FlashMessage(
+          'Cluster name changed',
+          messageType.SUCCESS,
+          messageTTL.SHORT
+        );
+      });
+  };
+
+  handleKey = evt => {
+    // 27 = Escape key
+    if (evt.keyCode === 27) {
+      this.setState({
+        editing: false,
+        name: this.props.name, // revert name change
+      });
+    }
+  };
+
+  validate = () => {
+    if (this.state.name.length < 3) {
+      return {
+        valid: false,
+        error: 'Please use a name with at least 3 characters',
+      };
+    }
+
+    if (this.state.error !== null) {
+      this.setState({ error: null });
+    }
+    return true;
+  };
+
+  render = () => {
+    if (this.state.editing) {
+      // edit mode
+      return (
+        <form className='form cluster-name' onSubmit={this.handleSubmit}>
+          <input
+            type='text'
+            name='cluster-name'
+            value={this.state.name}
+            autoFocus
+            onChange={this.handleChange}
+            onKeyUp={this.handleKey}
+            autoComplete='off'
+          />
+          <Button type='submit'>OK</Button>
+        </form>
+      );
+    }
+
+    // view mode
+    return (
+      <OverlayTrigger
+        placement='top'
+        overlay={<Tooltip id='tooltip'>Click to edit cluster name</Tooltip>}
+      >
+        <a className='cluster-name' onClick={this.activateEditMode}>
+          {this.state.name}
+        </a>
+      </OverlayTrigger>
+    );
+  };
+}
+
+ClusterName.propTypes = {
+  dispatchFunc: PropTypes.func,
+  id: PropTypes.string,
+  name: PropTypes.string,
+};
+
+export default ClusterName;

--- a/src/styles/components/_form.sass
+++ b/src/styles/components/_form.sass
@@ -55,3 +55,23 @@ form
       i
         margin-right: 8px
         color: #23c451
+
+// in-place editable cluster name form
+form.cluster-name
+  display: inline-block
+  width: 85%
+
+  input[type='text']
+    display: inline-block
+    padding: 0px 5px
+    width: 320px
+    margin-right: 5px
+    font-size: 85%
+  
+  .btn[type='submit']
+    display: inline
+  
+  a.cluster-name:hover
+    text-decoration: none
+    color: $gold
+

--- a/src/styles/components/_form.sass
+++ b/src/styles/components/_form.sass
@@ -59,7 +59,6 @@ form
 // in-place editable cluster name form
 form.cluster-name
   display: inline-block
-  width: 85%
 
   input[type='text']
     display: inline-block
@@ -71,7 +70,10 @@ form.cluster-name
   .btn[type='submit']
     display: inline
   
-  a.cluster-name:hover
-    text-decoration: none
-    color: $gold
-
+  .btn-group
+    float: none
+    margin-left: 4px
+  
+a.cluster-name:hover
+  text-decoration-style: dotted
+  color: #fff

--- a/src/styles/components/_form.sass
+++ b/src/styles/components/_form.sass
@@ -73,6 +73,7 @@ form.cluster-name
   .btn-group
     float: none
     margin-left: 4px
+    top: -2px
   
 a.cluster-name:hover
   text-decoration-style: dotted


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2046

This PR makes the cluster name editable from the cluster details page.

- Affects the cluster details page only
- Hovering the cluster name will change the style and reveal a tooltip `Click to edit name`
- A click reveals a form in place with an OK and edit button
- Form submission is possible by hitting Enter/Return or clicking the OK button
- Cancelling is possible via the ESC key and by clicking Cancel
- If the submission fails, an error will appear and the form will remain in edit mode
- In case of a successful change, a flash message appears (not visible in the preview below)

Depends on https://github.com/giantswarm/cluster-service/pull/369

Caveats

- On narrow viewports, the form may break into several lines.

### Preview

![efmGZmRWHa](https://user-images.githubusercontent.com/273727/54835343-3353b100-4cc2-11e9-8d4b-c221b753fb82.gif)
