### PR TITLE
Auto-refresh cluster list on home screen

### DIFF
--- a/src/components/cluster/detail/cluster_detail_table.js
+++ b/src/components/cluster/detail/cluster_detail_table.js
@@ -11,10 +11,6 @@ import RefreshableLabel from '../../shared/refreshable_label';
 import ReleaseDetailsModal from '../../modals/release_details_modal';
 
 class ClusterDetailTable extends React.Component {
-  state = {
-    modifiedPropsPaths: [],
-  };
-
   componentDidMount = () => {
     this.registerRefreshInterval();
   };

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -89,7 +89,7 @@ class ClusterDetailView extends React.Component {
   };
 
   handleVisibilityChange = () => {
-    if (this.visibilityTracker.isVisible()) {
+    if (!this.visibilityTracker.isVisible()) {
       this.props.clearInterval(this.loadDataInterval);
     } else {
       this.refreshClusterData();

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -19,6 +19,7 @@ import ClusterKeyPairs from './key_pairs';
 import ClusterName from '../../shared/cluster_name';
 import cmp from 'semver-compare';
 import DocumentTitle from 'react-document-title';
+import PageVisibilityTracker from '../../../lib/page_visibility_tracker';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactTimeout from 'react-timeout';
@@ -61,47 +62,18 @@ class ClusterDetailView extends React.Component {
           });
         });
     }
+
+    this.visibilityTracker = new PageVisibilityTracker();
   }
 
   componentDidMount() {
     this.registerRefreshInterval();
-
-    if (typeof document.hidden !== 'undefined') {
-      // Opera 12.10 and Firefox 18 and later support
-      this.hidden = 'hidden';
-      this.visibilityChange = 'visibilitychange';
-    } else if (typeof document.msHidden !== 'undefined') {
-      this.hidden = 'msHidden';
-      this.visibilityChange = 'msvisibilitychange';
-    } else if (typeof document.webkitHidden !== 'undefined') {
-      this.hidden = 'webkitHidden';
-      this.visibilityChange = 'webkitvisibilitychange';
-    }
-
-    if (
-      typeof document.addEventListener === 'undefined' ||
-      this.hidden === undefined
-    ) {
-      console.log(
-        'This piece of code requires a browser that supports the Page Visibility API.'
-      );
-    } else {
-      // Handle page visibility change
-      document.addEventListener(
-        this.visibilityChange,
-        this.handleVisibilityChange,
-        false
-      );
-    }
+    this.visibilityTracker.addEventListener(this.handleVisibilityChange);
   }
 
   componentWillUnmount() {
     this.props.clearInterval(this.loadDataInterval);
-    document.removeEventListener(
-      this.visibilityChange,
-      this.handleVisibilityChange,
-      false
-    );
+    this.visibilityTracker.removeEventListener(this.handleVisibilityChange);
   }
 
   registerRefreshInterval = () => {
@@ -117,7 +89,7 @@ class ClusterDetailView extends React.Component {
   };
 
   handleVisibilityChange = () => {
-    if (document[this.hidden]) {
+    if (this.visibilityTracker.isVisible()) {
       this.props.clearInterval(this.loadDataInterval);
     } else {
       this.refreshClusterData();

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -93,14 +93,14 @@ class ClusterDetailView extends React.Component {
     }
   };
 
-  componentWillUnmount = () => {
+  componentWillUnmount() {
     window.clearInterval(this.loadDataInterval);
     document.removeEventListener(
       this.visibilityChange,
       this.handleVisibilityChange,
       false
     );
-  };
+  }
 
   registerRefreshInterval = () => {
     var refreshInterval = 30 * 1000; // 30 seconds

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -39,33 +39,33 @@ class ClusterDashboardItem extends React.Component {
     }, refreshInterval);
   };
 
-  getMemoryTotal = () => {
+  getMemoryTotal() {
     var workers = this.getNumberOfNodes();
     if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     var m = workers * this.props.cluster.workers[0].memory.size_gb;
     return m.toFixed(2);
-  };
+  }
 
-  getStorageTotal = () => {
+  getStorageTotal() {
     var workers = this.getNumberOfNodes();
     if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     var s = workers * this.props.cluster.workers[0].storage.size_gb;
     return s.toFixed(2);
-  };
+  }
 
-  getCpusTotal = () => {
+  getCpusTotal() {
     var workers = this.getNumberOfNodes();
     if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     return workers * this.props.cluster.workers[0].cpu.cores;
-  };
+  }
 
-  getNumberOfNodes = () => {
+  getNumberOfNodes() {
     if (
       Object.keys(this.props.cluster).includes('status') &&
       this.props.cluster.status != null
@@ -94,7 +94,7 @@ class ClusterDashboardItem extends React.Component {
     }
 
     return 0;
-  };
+  }
 
   /**
    * Returns true if the cluster is younger than 30 days

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -121,7 +121,6 @@ class ClusterDashboardItem extends React.Component {
   };
 
   render() {
-    console.debug('ClusterDashboardItem render() ', this.props.cluster.name);
     var memory = this.getMemoryTotal();
     var storage = this.getStorageTotal();
     var cpus = this.getCpusTotal();

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -12,6 +12,7 @@ import ClusterIDLabel from '../shared/cluster_id_label';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
+import RefreshableLabel from '../shared/refreshable_label';
 
 class ClusterDashboardItem extends React.Component {
   state = {
@@ -124,6 +125,7 @@ class ClusterDashboardItem extends React.Component {
     var memory = this.getMemoryTotal();
     var storage = this.getStorageTotal();
     var cpus = this.getCpusTotal();
+    var numNodes = this.getNumberOfNodes();
 
     return (
       <div className='cluster-dashboard-item well'>
@@ -150,31 +152,45 @@ class ClusterDashboardItem extends React.Component {
                 this.props.cluster.id
               }
             >
-              <span
-                className='cluster-dashboard-item--name'
-                style={{ fontWeight: 'bold' }}
-              >
-                {this.props.cluster.name}
-              </span>
+              <RefreshableLabel dataItems={[this.props.cluster.name]}>
+                <span
+                  className='cluster-dashboard-item--name'
+                  style={{ fontWeight: 'bold' }}
+                >
+                  {this.props.cluster.name}
+                </span>
+              </RefreshableLabel>
             </Link>
           </div>
 
           <div>
-            <i className='fa fa-version-tag' title='Release version' />{' '}
-            {this.props.cluster.release_version}
+            <RefreshableLabel dataItems={[this.props.cluster.release_version]}>
+              <span>
+                <i className='fa fa-version-tag' title='Release version' />{' '}
+                {this.props.cluster.release_version}
+              </span>
+            </RefreshableLabel>
             {' · Created '}
             {relativeDate(this.props.cluster.create_date)}
           </div>
           <div>
-            {this.getNumberOfNodes()} nodes
+            <RefreshableLabel dataItems={[numNodes]}>
+              <span>{numNodes} nodes</span>
+            </RefreshableLabel>
             {' · '}
-            {cpus ? cpus : '0'} CPU cores
+            <RefreshableLabel dataItems={[cpus]}>
+              <span>{cpus ? cpus : '0'} CPU cores</span>
+            </RefreshableLabel>
             {' · '}
-            {memory ? memory : '0'} GB RAM
+            <RefreshableLabel dataItems={[memory]}>
+              <span>{memory ? memory : '0'} GB RAM</span>
+            </RefreshableLabel>
             {this.props.cluster.kvm ? (
               <span>
                 {' · '}
-                {storage ? storage : '0'} GB storage
+                <RefreshableLabel dataItems={[storage]}>
+                  {storage ? storage : '0'} GB storage
+                </RefreshableLabel>
               </span>
             ) : (
               undefined

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -14,33 +14,57 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 class ClusterDashboardItem extends React.Component {
-  getMemoryTotal() {
+  state = {
+    enforceReRender: null,
+  };
+
+  componentDidMount() {
+    this.registerReRenderInterval();
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.reRenderInterval);
+  }
+
+  /**
+   * Activates periodic re-rendering to keep displayed info, like relative
+   * dates, fresh.
+   */
+  registerReRenderInterval = () => {
+    var refreshInterval = 10 * 1000; // 10 seconds
+    this.reRenderInterval = window.setInterval(() => {
+      // enforce re-rendering by state change
+      this.setState({ enforceReRender: Date.now() });
+    }, refreshInterval);
+  };
+
+  getMemoryTotal = () => {
     var workers = this.getNumberOfNodes();
     if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     var m = workers * this.props.cluster.workers[0].memory.size_gb;
     return m.toFixed(2);
-  }
+  };
 
-  getStorageTotal() {
+  getStorageTotal = () => {
     var workers = this.getNumberOfNodes();
     if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     var s = workers * this.props.cluster.workers[0].storage.size_gb;
     return s.toFixed(2);
-  }
+  };
 
-  getCpusTotal() {
+  getCpusTotal = () => {
     var workers = this.getNumberOfNodes();
     if (workers === null || workers === 0 || !this.props.cluster.workers) {
       return null;
     }
     return workers * this.props.cluster.workers[0].cpu.cores;
-  }
+  };
 
-  getNumberOfNodes() {
+  getNumberOfNodes = () => {
     if (
       Object.keys(this.props.cluster).includes('status') &&
       this.props.cluster.status != null
@@ -69,7 +93,7 @@ class ClusterDashboardItem extends React.Component {
     }
 
     return 0;
-  }
+  };
 
   /**
    * Returns true if the cluster is younger than 30 days
@@ -84,7 +108,7 @@ class ClusterDashboardItem extends React.Component {
     return age < 30 * 24 * 60 * 60;
   }
 
-  accessCluster() {
+  accessCluster = () => {
     this.props.dispatch(
       push(
         '/organizations/' +
@@ -94,9 +118,10 @@ class ClusterDashboardItem extends React.Component {
           '/getting-started/'
       )
     );
-  }
+  };
 
   render() {
+    console.debug('ClusterDashboardItem render() ', this.props.cluster.name);
     var memory = this.getMemoryTotal();
     var storage = this.getStorageTotal();
     var cpus = this.getCpusTotal();
@@ -161,7 +186,7 @@ class ClusterDashboardItem extends React.Component {
         <div className='cluster-dashboard-item--buttons'>
           {this.clusterYoungerThan30Days() ? (
             <ButtonGroup>
-              <Button onClick={this.accessCluster.bind(this)}>
+              <Button onClick={this.accessCluster}>
                 <i className='fa fa-start' />
                 Get Started
               </Button>

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -13,12 +13,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 class Home extends React.Component {
-  componentDidMount = () => {
+  componentDidMount() {
     this.registerRefreshInterval();
     this.fetchClusterDetails(this.props.clusters);
-  };
+  }
 
-  componentDidUpdate = prevProps => {
+  componentDidUpdate(prevProps) {
+    console.debug('componentDidUpdate: prevProps.clusters', prevProps.clusters);
+    console.debug(
+      'componentDidUpdate: this.props.clusters',
+      this.props.clusters
+    );
+
     // load cluster details if cluster list has changed
     if (
       !_.isEqual(
@@ -28,11 +34,11 @@ class Home extends React.Component {
     ) {
       this.fetchClusterDetails(this.props.clusters);
     }
-  };
+  }
 
-  componentWillUnmount = () => {
+  componentWillUnmount() {
     window.clearInterval(this.refreshInterval);
-  };
+  }
 
   /**
    * Load clusters list periodically
@@ -78,7 +84,8 @@ class Home extends React.Component {
     }
   };
 
-  render = () => {
+  render() {
+    console.debug('Home render()');
     return (
       <DocumentTitle title={this.title()}>
         {
@@ -127,7 +134,7 @@ class Home extends React.Component {
         }
       </DocumentTitle>
     );
-  };
+  }
 }
 
 Home.propTypes = {

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -68,10 +68,6 @@ class Home extends React.Component {
     }
   };
 
-  clustersSortedById = clusters => {
-    return _.sortBy(clusters, 'id');
-  };
-
   fetchClusterDetails = clusters => {
     return Promise.all(
       _.flatten(

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -13,11 +13,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 class Home extends React.Component {
-  componentDidMount() {
+  componentDidMount = () => {
+    this.registerRefreshInterval();
     this.fetchClusterDetails(this.props.clusters);
-  }
+  };
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate = prevProps => {
+    // load cluster details if cluster list has changed
     if (
       !_.isEqual(
         this.props.clusters.map(x => x.id),
@@ -26,17 +28,32 @@ class Home extends React.Component {
     ) {
       this.fetchClusterDetails(this.props.clusters);
     }
-  }
+  };
 
-  clustersSortedById(clusters) {
+  componentWillUnmount = () => {
+    window.clearInterval(this.refreshInterval);
+  };
+
+  /**
+   * Load clusters list periodically
+   */
+  registerRefreshInterval = () => {
+    var refreshIntervalDuration = 30 * 1000; // 30 seconds
+    this.refreshInterval = window.setInterval(
+      this.refreshClustersList,
+      refreshIntervalDuration
+    );
+  };
+
+  refreshClustersList = () => {
+    this.props.actions.clustersLoad();
+  };
+
+  clustersSortedById = clusters => {
     return _.sortBy(clusters, 'id');
-  }
+  };
 
-  clusterIds(clusters) {
-    return this.clustersSortedById(clusters).map(cluster => cluster.id);
-  }
-
-  fetchClusterDetails(clusters) {
+  fetchClusterDetails = clusters => {
     return Promise.all(
       _.flatten(
         clusters.map(cluster => {
@@ -44,9 +61,12 @@ class Home extends React.Component {
         })
       )
     );
-  }
+  };
 
-  title() {
+  /**
+   * Returns the string to use as the document.title
+   */
+  title = () => {
     if (this.props.selectedOrganization) {
       return (
         'Cluster Overview | ' +
@@ -56,9 +76,9 @@ class Home extends React.Component {
     } else {
       return 'Cluster Overview | Giant Swarm';
     }
-  }
+  };
 
-  render() {
+  render = () => {
     return (
       <DocumentTitle title={this.title()}>
         {
@@ -107,7 +127,7 @@ class Home extends React.Component {
         }
       </DocumentTitle>
     );
-  }
+  };
 }
 
 Home.propTypes = {

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -3,6 +3,7 @@
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { Link } from 'react-router-dom';
 import _ from 'underscore';
 import Button from '../shared/button';
@@ -117,19 +118,27 @@ class Home extends React.Component {
               />
             ) : null}
 
-            {_.sortBy(this.props.clusters, cluster => cluster.name).map(
-              cluster => {
-                return (
-                  <ClusterDashboardItem
-                    selectedOrganization={this.props.selectedOrganization}
-                    animate={true}
-                    key={cluster.id}
-                    cluster={cluster}
-                  />
-                );
-              },
-              cluster => cluster.id
-            )}
+            <TransitionGroup className='cluster-list'>
+              {_.sortBy(this.props.clusters, cluster => cluster.name).map(
+                cluster => {
+                  return (
+                    <CSSTransition
+                      key={cluster.id}
+                      timeout={500}
+                      classNames='cluster-list-item'
+                    >
+                      <ClusterDashboardItem
+                        selectedOrganization={this.props.selectedOrganization}
+                        animate={true}
+                        key={cluster.id}
+                        cluster={cluster}
+                      />
+                    </CSSTransition>
+                  );
+                },
+                cluster => cluster.id
+              )}
+            </TransitionGroup>
           </div>
         }
       </DocumentTitle>

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -80,6 +80,18 @@ class Home extends React.Component {
     }
   };
 
+  /**
+   * Returns the proper last updated info string based on available
+   * cluster and/or status information.
+   */
+  lastUpdatedLabel = () => {
+    var maxTimestamp = 0;
+    this.props.clusters.forEach(cluster => {
+      maxTimestamp = Math.max(maxTimestamp, cluster.lastUpdated);
+    });
+    return moment(maxTimestamp).fromNow();
+  };
+
   render() {
     return (
       <DocumentTitle title={this.title()}>
@@ -133,6 +145,18 @@ class Home extends React.Component {
                 cluster => cluster.id
               )}
             </TransitionGroup>
+
+            {this.props.clusters.length > 0 ? (
+              <p className='last-updated'>
+                <small>
+                  This table is auto-refreshing. Details last fetched{' '}
+                  <span className='last-updated-datestring'>
+                    {this.lastUpdatedLabel()}
+                  </span>
+                  . <span className='beta-tag'>BETA</span>
+                </small>
+              </p>
+            ) : null}
           </div>
         }
       </DocumentTitle>

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -10,6 +10,7 @@ import Button from '../shared/button';
 import ClusterDashboardItem from './cluster_dashboard_item';
 import ClusterEmptyState from './cluster_empty_state';
 import DocumentTitle from 'react-document-title';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -20,12 +21,6 @@ class Home extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    console.debug('componentDidUpdate: prevProps.clusters', prevProps.clusters);
-    console.debug(
-      'componentDidUpdate: this.props.clusters',
-      this.props.clusters
-    );
-
     // load cluster details if cluster list has changed
     if (
       !_.isEqual(
@@ -86,7 +81,6 @@ class Home extends React.Component {
   };
 
   render() {
-    console.debug('Home render()');
     return (
       <DocumentTitle title={this.title()}>
         {

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -68,7 +68,7 @@ class Home extends React.Component {
     }
   };
 
-  fetchClusterDetails = clusters => {
+  fetchClusterDetails(clusters) {
     return Promise.all(
       _.flatten(
         clusters.map(cluster => {
@@ -76,12 +76,12 @@ class Home extends React.Component {
         })
       )
     );
-  };
+  }
 
   /**
    * Returns the string to use as the document.title
    */
-  title = () => {
+  title() {
     if (this.props.selectedOrganization) {
       return (
         'Cluster Overview | ' +
@@ -91,7 +91,7 @@ class Home extends React.Component {
     } else {
       return 'Cluster Overview | Giant Swarm';
     }
-  };
+  }
 
   /**
    * Returns the proper last updated info string based on available

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -60,7 +60,7 @@ class Home extends React.Component {
   };
 
   handleVisibilityChange = () => {
-    if (this.visibilityTracker.isVisible()) {
+    if (!this.visibilityTracker.isVisible()) {
       this.props.clearInterval(this.refreshInterval);
     } else {
       this.refreshClustersList();

--- a/src/lib/page_visibility_tracker.js
+++ b/src/lib/page_visibility_tracker.js
@@ -1,0 +1,56 @@
+'use strict';
+
+class PageVisibilityTracker {
+  constructor() {
+    // client-independent tracking of visibility change
+    if (typeof document.hidden !== 'undefined') {
+      // Opera 12.10 and Firefox 18 and later support
+      this.hidden = 'hidden';
+      this.visibilityChange = 'visibilitychange';
+    } else if (typeof document.msHidden !== 'undefined') {
+      this.hidden = 'msHidden';
+      this.visibilityChange = 'msvisibilitychange';
+    } else if (typeof document.webkitHidden !== 'undefined') {
+      this.hidden = 'webkitHidden';
+      this.visibilityChange = 'webkitvisibilitychange';
+    }
+  }
+
+  /**
+   * Set a change handler function that will be called on every
+   * change of the page's visibility
+   *
+   * @param {change handler} func
+   */
+  addEventListener(func) {
+    if (
+      typeof document.addEventListener === 'undefined' ||
+      this.hidden === undefined
+    ) {
+      console.log(
+        'This piece of code requires a browser that supports the Page Visibility API.'
+      );
+    } else {
+      // Handle page visibility change
+      document.addEventListener(this.visibilityChange, func, false);
+    }
+  }
+
+  /**
+   * Remove the page visibility change handler
+   *
+   * @param {change handler} func
+   */
+  removeEventListener(func) {
+    document.removeEventListener(this.visibilityChange, func, false);
+  }
+
+  /**
+   * Return true if the page is visible
+   */
+  isVisible() {
+    return !document[this.hidden];
+  }
+}
+
+export default PageVisibilityTracker;

--- a/src/styles/_base.sass
+++ b/src/styles/_base.sass
@@ -111,3 +111,13 @@ div.tooltip-inner
 		color: #fff
 		opacity: 1.0
 		background-color: transparent
+
+.beta-tag
+	font-size: 0.9em
+	text-transform: uppercase
+	background-color: #ccc
+	color: $darkblue
+	display: inline-block
+	padding: 0px 4px
+	line-height: 1.25em
+	border-radius: 2px

--- a/src/styles/app.sass
+++ b/src/styles/app.sass
@@ -34,6 +34,7 @@
 @import components/number_picker
 @import components/platform_selector
 @import components/progress_button
+@import components/refreshable_label
 @import components/release_selector
 @import components/select_cluster
 @import components/signup

--- a/src/styles/components/_cluster_dashboard.sass
+++ b/src/styles/components/_cluster_dashboard.sass
@@ -1,5 +1,20 @@
+@keyframes expand
+  from
+    transform: scale(1, 0)
+    opacity: 0
+    background: #5470B0
+
+@keyframes slide-up
+    0%
+        opacity: 0
+        transform: translateY(20px)
+    100%
+        opacity: 1
+        transform: translateY(0)
+  
 .cluster-dashboard-item
   display: flex
+  animation: slide-up .3s ease-in-out
 
   b
     font-weight: 400

--- a/src/styles/components/_cluster_dashboard.sass
+++ b/src/styles/components/_cluster_dashboard.sass
@@ -11,10 +11,24 @@
     100%
         opacity: 1
         transform: translateY(0)
-  
+
+
+.cluster-list-item-enter
+  opacity: 0
+
+.cluster-list-item-enter-active
+  opacity: 1
+  transition: opacity 500ms ease-in
+
+.cluster-list-item-exit
+  opacity: 1
+
+.cluster-list-item-exit-active
+  opacity: 0
+  transition: opacity 500ms ease-in
+
 .cluster-dashboard-item
   display: flex
-  animation: slide-up .3s ease-in-out
 
   b
     font-weight: 400

--- a/src/styles/components/_cluster_details.sass
+++ b/src/styles/components/_cluster_details.sass
@@ -32,16 +32,4 @@
 
   .last-updated
     margin-left: 10px
-  
-  .refreshable-label
-    display: inline-block
-    line-height: 1.7
-    border-radius: 2px
-    margin-left: -5px
-    padding-left: 5px
-    padding-right: 5px
 
-    &.changed
-      animation-name: yellowfade
-      animation-duration: 2s
-      animation-timing-function: ease

--- a/src/styles/components/_cluster_details.sass
+++ b/src/styles/components/_cluster_details.sass
@@ -32,16 +32,6 @@
 
   .last-updated
     margin-left: 10px
-
-    .beta-tag
-      font-size: 0.9em
-      text-transform: uppercase
-      background-color: #ccc
-      color: $darkblue
-      display: inline-block
-      padding: 0px 4px
-      line-height: 1.25em
-      border-radius: 2px
   
   .refreshable-label
     display: inline-block

--- a/src/styles/components/_refreshable_label.sass
+++ b/src/styles/components/_refreshable_label.sass
@@ -1,0 +1,12 @@
+.refreshable-label
+  display: inline-block
+  line-height: 1.7
+  border-radius: 2px
+  margin-left: -5px
+  padding-left: 5px
+  padding-right: 5px
+
+  &.changed
+    animation-name: yellowfade
+    animation-duration: 2s
+    animation-timing-function: ease


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5446

This automatically refreshes the clusters list on the home screen. New data is loaded once every 30 seconds.

This includes some refactoring to make page visibility tracking re-usable.

### Preview

![home-auto-refresh](https://user-images.githubusercontent.com/273727/54913033-2917f980-4ef2-11e9-8ad8-c1cbc9125ec6.gif)

Preview needs some patience, as the animation is a minutes long. Use [this link](http://recordit.co/myotVpsRZh) to scrub and fast-forward.