### PR TITLE
Merge clusters into state to avoid flapping of cluster info

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -33,7 +33,7 @@ export function clustersLoad() {
 }
 
 /**
- * Takes a clusterId and loads details for that cluster
+ * Loads details for a cluster.
  *
  * @param {String} clusterId Cluster ID
  */

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -7,11 +7,10 @@ import { push } from 'connected-react-router';
 import APIClusterStatusClient from '../lib/api_status_client';
 import GiantSwarmV4 from 'giantswarm-v4';
 
-// clustersLoad
-// -----------------
-// Performs the getClusters API call and dispatches the clustersLoadSuccess
-// action.
-//
+/**
+ * Performs the getClusters API call and dispatches the clustersLoadSuccess
+ * action.
+ */
 export function clustersLoad() {
   return function(dispatch, getState) {
     var token = getState().app.loggedInUser.auth.token;
@@ -33,10 +32,11 @@ export function clustersLoad() {
   };
 }
 
-// clusterLoadDetails
-// =============================================================
-// Takes a clusterId and loads details for that cluster
-
+/**
+ * Takes a clusterId and loads details for that cluster
+ *
+ * @param {String} clusterId Cluster ID
+ */
 export function clusterLoadDetails(clusterId) {
   return function(dispatch, getState) {
     var token = getState().app.loggedInUser.auth.token;
@@ -76,10 +76,11 @@ export function clusterLoadDetails(clusterId) {
   };
 }
 
-// clusterLoadStatus
-// =============================================================
-// Takes a clusterId and loads status for that cluster.
-
+/**
+ * Takes a clusterId and loads status for that cluster.
+ *
+ * @param {String} clusterId Cluster ID
+ */
 export function clusterLoadStatus(clusterId) {
   return function(dispatch, getState) {
     var token = getState().app.loggedInUser.auth.token;
@@ -120,11 +121,12 @@ export function clusterLoadStatus(clusterId) {
   };
 }
 
-// clusterCreate
-// ==============================================================
-// Takes a cluster object and tries to create it. Dispatches CLUSTER_CREATE_SUCCESS
-// on success or CLUSTER_CREATE_ERROR on error.
-
+/**
+ * Takes a cluster object and tries to create it. Dispatches CLUSTER_CREATE_SUCCESS
+ * on success or CLUSTER_CREATE_ERROR on error.
+ *
+ * @param {Object} cluster Cluster definition object
+ */
 export function clusterCreate(cluster) {
   return function(dispatch, getState) {
     var token = getState().app.loggedInUser.auth.token;
@@ -170,14 +172,12 @@ export function clusterCreate(cluster) {
   };
 }
 
-// clusterDeleteConfirmed
-// ==============================================================
-// Takes a cluster object and deletes that cluster. Dispatches CLUSTER_DELETE_SUCCESS
-// on success or CLUSTER_DELETE_ERROR on error.
-//
-// required param:
-//  cluster: {id: "string", owner: "string"}
-
+/**
+ * Takes a cluster object and deletes that cluster. Dispatches CLUSTER_DELETE_SUCCESS
+ * on success or CLUSTER_DELETE_ERROR on error.
+ *
+ * @param {Object} cluster Cluster definition object, containing ID and owner
+ */
 export function clusterDeleteConfirmed(cluster) {
   return function(dispatch, getState) {
     var token = getState().app.loggedInUser.auth.token;
@@ -225,12 +225,13 @@ export function clusterDeleteConfirmed(cluster) {
   };
 }
 
-// clusterLoadKeyPairs
-// ==============================================================
-// Takes a clusterId and loads its key pairs.
-// dispatches CLUSTER_LOAD_KEY_PAIRS_SUCCESS on success or CLUSTER_LOAD_KEY_PAIRS_ERROR
-// on error.
-
+/**
+ * Takes a clusterId and loads its key pairs.
+ * dispatches CLUSTER_LOAD_KEY_PAIRS_SUCCESS on success or CLUSTER_LOAD_KEY_PAIRS_ERROR
+ * on error.
+ *
+ * @param {String} clusterId Cluster ID
+ */
 export function clusterLoadKeyPairs(clusterId) {
   return function(dispatch, getState) {
     var token = getState().app.loggedInUser.auth.token;
@@ -349,12 +350,13 @@ export function clustersLoadError(error) {
   };
 }
 
-// clusterPatch
-// ==============================================================
-// Takes a cluster object and tries to patch it.
-// dispatches CLUSTER_PATCH_SUCCESS on success or CLUSTER_PATCH_ERROR
-// on error.
-
+/**
+ * Takes a cluster object and tries to patch it.
+ * Dispatches CLUSTER_PATCH_SUCCESS on success or CLUSTER_PATCH_ERROR
+ * on error.
+ *
+ * @param {Object} cluster Cluster modification object
+ */
 export function clusterPatch(cluster) {
   return function(dispatch, getState) {
     var token = getState().app.loggedInUser.auth.token;
@@ -391,12 +393,14 @@ export function clusterPatch(cluster) {
   };
 }
 
-// clusterCreateKeyPair
-// ==============================================================
-// Creates a keypair for a cluster.
-// dispatches CLUSTER_CREATE_KEYPAIR_SUCCESS on success or CLUSTER_CREATE_KEYPAIR_ERROR
-// on error.
-
+/**
+ * Creates a keypair for a cluster.
+ * Dispatches CLUSTER_CREATE_KEYPAIR_SUCCESS on success or CLUSTER_CREATE_KEYPAIR_ERROR
+ * on error.
+ *
+ * @param {String} clusterId Cluster ID
+ * @param {Object} keypair   Key pair object
+ */
 export function clusterCreateKeyPair(clusterId, keypair) {
   return function(dispatch, getState) {
     var token = getState().app.loggedInUser.auth.token;

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -4,52 +4,6 @@ import * as types from '../actions/actionTypes';
 import _ from 'underscore';
 import moment from 'moment';
 
-var metricKeys = [
-  'cpu_cores',
-  'cpu_used',
-  'ram_available',
-  'ram_used',
-  'pod_count',
-  'container_count',
-  'node_storage_limit',
-  'node_storage_used',
-  'network_traffic_incoming',
-  'network_traffic_outgoing',
-];
-
-// ensureMetricKeysAreAvailable
-// ----------------------------
-// Make sure that expected metrics keys are present on cluster and nodes
-// since Desmotes will omit them if they are not found in Prometheus
-var ensureMetricKeysAreAvailable = function(clusterDetails) {
-  clusterDetails.metrics = clusterDetails.metrics || {};
-  for (var metricKey of metricKeys) {
-    clusterDetails.metrics[metricKey] = Object.assign(
-      {},
-      {
-        value: 0,
-        unit: 'unknown',
-        timestamp: 0,
-      },
-      clusterDetails.metrics[metricKey]
-    );
-    for (var node in clusterDetails.nodes) {
-      if (clusterDetails.nodes.hasOwnProperty(node)) {
-        clusterDetails.nodes[node][metricKey] = Object.assign(
-          {},
-          {
-            value: 0,
-            unit: 'unknown',
-            timestamp: 0,
-          },
-          clusterDetails.nodes[node][metricKey]
-        );
-      }
-    }
-  }
-
-  return clusterDetails;
-};
 
 // ensureWorkersHaveAWSkey
 // -----------------------

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -34,7 +34,7 @@ export default function clusterReducer(
       var prevClusterIDs = Object.keys(state.items).sort();
 
       // use existing state's items and update it
-      items = Object.assign(state.items, action.clusters);
+      items = Object.assign({}, state.items, action.clusters);
 
       var newClusterIDs = _.map(_.toArray(action.clusters), item => {
         return item.id;
@@ -73,9 +73,10 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_DETAILS_SUCCESS:
-      items = Object.assign(state.items, {});
+      items = Object.assign({}, state.items);
 
       items[action.cluster.id] = Object.assign(
+        {},
         items[action.cluster.id],
         ensureWorkersHaveAWSkey(action.cluster)
       );


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5671 mostly

This seems to improve the situation.

Improvable: When values get first loaded, items highlight once, which they shouldn't ideally. But that's not the point of the fix.

Another thing I noticed, but couldn't explain when it happened:

![image](https://user-images.githubusercontent.com/273727/55032209-a9348100-5010-11e9-9e8d-dafbf8e904d1.png)

Probably passed a bad value to `moment()`.