### PR TITLE
Fix cluster duplicates.

### DIFF
--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -34,7 +34,7 @@ export default function clusterReducer(
       var prevClusterIDs = Object.keys(state.items).sort();
 
       // use existing state's items and update it
-      items = Object.assign({}, state.items, action.clusters);
+      items = Object.assign({}, state.items);
 
       var newClusterIDs = _.map(_.toArray(action.clusters), item => {
         return item.id;


### PR DESCRIPTION
Clusters were showing up twice in the organization list.

This is because of a mistake in the recently introduced merging code.

In the `clusters load success`  reducer, we were merging `action.clusters` which is an array of clusters into the `entites.items` object, which is supposed to be a dictionary of cluster id's to cluster objects:

`items = Object.assign({}, state.items, action.clusters);`