### PR TITLE
Make parts of the keypair table copyable.

### DIFF
--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -374,34 +374,16 @@ class ClusterKeyPairs extends React.Component {
                                 </td>
                                 <td className='code truncate'>
                                   <Copyable copyText={keyPair.common_name}>
-                                    <OverlayTrigger
-                                      placement='top'
-                                      overlay={
-                                        <Tooltip id='tooltip'>
-                                          {keyPair.common_name}
-                                        </Tooltip>
-                                      }
-                                    >
-                                      <small>{keyPair.common_name}</small>
-                                    </OverlayTrigger>
+                                    <small>{keyPair.common_name}</small>
                                   </Copyable>
                                 </td>
                                 <td className='code truncate'>
                                   <Copyable
                                     copyText={keyPair.certificate_organizations}
                                   >
-                                    <OverlayTrigger
-                                      placement='top'
-                                      overlay={
-                                        <Tooltip id='tooltip'>
-                                          {keyPair.certificate_organizations}
-                                        </Tooltip>
-                                      }
-                                    >
-                                      <small>
-                                        {keyPair.certificate_organizations}
-                                      </small>
-                                    </OverlayTrigger>
+                                    <small>
+                                      {keyPair.certificate_organizations}
+                                    </small>
                                   </Copyable>
                                 </td>
                               </tr>

--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -10,6 +10,7 @@ import _ from 'underscore';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from '../../shared/button';
 import copy from 'copy-to-clipboard';
+import Copyable from '../../shared/copyable';
 import ExpiryHoursPicker from './expiry_hours_picker';
 import moment from 'moment';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
@@ -314,7 +315,6 @@ class ClusterKeyPairs extends React.Component {
                     <table>
                       <thead>
                         <tr>
-                          <th className='hidden-xs'>ID</th>
                           <th className='hidden-xs'>Description</th>
                           <th className='hidden-xs'>Created</th>
                           <th className='hidden-xs'>Expires</th>
@@ -337,18 +337,6 @@ class ClusterKeyPairs extends React.Component {
 
                             return (
                               <tr key={keyPair.id}>
-                                <td className='code truncate hidden-xs col-sm-2'>
-                                  <OverlayTrigger
-                                    placement='top'
-                                    overlay={
-                                      <Tooltip id='tooltip'>
-                                        {keyPair.id}
-                                      </Tooltip>
-                                    }
-                                  >
-                                    <span>{keyPair.id.replace(/:/g, '')}</span>
-                                  </OverlayTrigger>
-                                </td>
                                 <td className='truncate hidden-xs col-sm-4'>
                                   <OverlayTrigger
                                     placement='top'
@@ -360,40 +348,55 @@ class ClusterKeyPairs extends React.Component {
                                   >
                                     <span>{keyPair.description}</span>
                                   </OverlayTrigger>
+                                  <Copyable copyText={keyPair.id}>
+                                    <small>
+                                      ID: {keyPair.id.replace(/:/g, '')}
+                                    </small>
+                                  </Copyable>
                                 </td>
                                 <td className='truncate hidden-xs col-sm-1'>
-                                  {relativeDate(keyPair.create_date)}
+                                  <small>
+                                    {relativeDate(keyPair.create_date)}
+                                  </small>
                                 </td>
                                 <td
                                   className={`${expiryClass} truncate hidden-xs col-sm-1`}
                                 >
-                                  {relativeDate(keyPair.expire_date)}
+                                  <small>
+                                    {relativeDate(keyPair.expire_date)}
+                                  </small>
                                 </td>
                                 <td className='code truncate col-xs-3'>
-                                  <OverlayTrigger
-                                    placement='top'
-                                    overlay={
-                                      <Tooltip id='tooltip'>
-                                        {keyPair.common_name}
-                                      </Tooltip>
-                                    }
-                                  >
-                                    <span>{keyPair.common_name}</span>
-                                  </OverlayTrigger>
+                                  <Copyable copyText={keyPair.common_name}>
+                                    <OverlayTrigger
+                                      placement='top'
+                                      overlay={
+                                        <Tooltip id='tooltip'>
+                                          {keyPair.common_name}
+                                        </Tooltip>
+                                      }
+                                    >
+                                      <small>{keyPair.common_name}</small>
+                                    </OverlayTrigger>
+                                  </Copyable>
                                 </td>
                                 <td className='code truncate col-xs-1'>
-                                  <OverlayTrigger
-                                    placement='top'
-                                    overlay={
-                                      <Tooltip id='tooltip'>
-                                        {keyPair.certificate_organizations}
-                                      </Tooltip>
-                                    }
+                                  <Copyable
+                                    copyText={keyPair.certificate_organizations}
                                   >
-                                    <span>
-                                      {keyPair.certificate_organizations}
-                                    </span>
-                                  </OverlayTrigger>
+                                    <OverlayTrigger
+                                      placement='top'
+                                      overlay={
+                                        <Tooltip id='tooltip'>
+                                          {keyPair.certificate_organizations}
+                                        </Tooltip>
+                                      }
+                                    >
+                                      <small>
+                                        {keyPair.certificate_organizations}
+                                      </small>
+                                    </OverlayTrigger>
+                                  </Copyable>
                                 </td>
                               </tr>
                             );

--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -346,7 +346,9 @@ class ClusterKeyPairs extends React.Component {
                                       </Tooltip>
                                     }
                                   >
-                                    <span>{keyPair.description}</span>
+                                    <div style={{ overflow: 'hidden' }}>
+                                      <span>{keyPair.description}</span>
+                                    </div>
                                   </OverlayTrigger>
                                   <Copyable copyText={keyPair.id}>
                                     <small>

--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -337,7 +337,7 @@ class ClusterKeyPairs extends React.Component {
 
                             return (
                               <tr key={keyPair.id}>
-                                <td className='truncate hidden-xs col-sm-4'>
+                                <td className='truncate hidden-xs'>
                                   <OverlayTrigger
                                     placement='top'
                                     overlay={
@@ -354,19 +354,23 @@ class ClusterKeyPairs extends React.Component {
                                     </small>
                                   </Copyable>
                                 </td>
-                                <td className='truncate hidden-xs col-sm-1'>
+                                <td
+                                  className='truncate hidden-xs'
+                                  style={{ width: '120px' }}
+                                >
                                   <small>
                                     {relativeDate(keyPair.create_date)}
                                   </small>
                                 </td>
                                 <td
-                                  className={`${expiryClass} truncate hidden-xs col-sm-1`}
+                                  className={`${expiryClass} truncate hidden-xs`}
+                                  style={{ width: '120px' }}
                                 >
                                   <small>
                                     {relativeDate(keyPair.expire_date)}
                                   </small>
                                 </td>
-                                <td className='code truncate col-xs-3'>
+                                <td className='code truncate'>
                                   <Copyable copyText={keyPair.common_name}>
                                     <OverlayTrigger
                                       placement='top'
@@ -380,7 +384,7 @@ class ClusterKeyPairs extends React.Component {
                                     </OverlayTrigger>
                                   </Copyable>
                                 </td>
-                                <td className='code truncate col-xs-1'>
+                                <td className='code truncate'>
                                   <Copyable
                                     copyText={keyPair.certificate_organizations}
                                   >

--- a/src/components/shared/copyable.js
+++ b/src/components/shared/copyable.js
@@ -11,6 +11,13 @@ class Copyable extends React.Component {
     copied: false,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.copyToClipboard = this.copyToClipboard.bind(this);
+    this.mouseLeave = this.mouseLeave.bind(this);
+  }
+
   copyToClipboard(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -31,8 +38,8 @@ class Copyable extends React.Component {
     return (
       <div
         className='copyable'
-        onClick={this.copyToClipboard.bind(this)}
-        onMouseLeave={this.mouseLeave.bind(this)}
+        onClick={this.copyToClipboard}
+        onMouseLeave={this.mouseLeave}
         style={{ cursor: 'pointer' }}
       >
         <div className='copyable-content'>{this.props.children}</div>

--- a/src/components/shared/copyable.js
+++ b/src/components/shared/copyable.js
@@ -1,0 +1,62 @@
+'use strict';
+
+import copy from 'copy-to-clipboard';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+
+class Copyable extends React.Component {
+  state = {
+    copied: false,
+  };
+
+  copyToClipboard(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    copy(this.props.copyText);
+
+    this.setState({
+      copied: true,
+    });
+  }
+
+  mouseLeave() {
+    this.setState({
+      copied: false,
+    });
+  }
+
+  render() {
+    return (
+      <div
+        className='copyable'
+        onClick={this.copyToClipboard.bind(this)}
+        onMouseLeave={this.mouseLeave.bind(this)}
+        style={{ cursor: 'pointer' }}
+      >
+        <div className='copyable-content'>{this.props.children}</div>
+
+        <div className='copyable-tooltip'>
+          {this.state.copied ? (
+            <i className='fa fa-done' aria-hidden='true' />
+          ) : (
+            <OverlayTrigger
+              placement='top'
+              overlay={<Tooltip id='tooltip'>Copy to clipboard.</Tooltip>}
+            >
+              <i className='fa fa-content-copy' aria-hidden='true' />
+            </OverlayTrigger>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+Copyable.propTypes = {
+  children: PropTypes.object,
+  copyText: PropTypes.string,
+};
+
+export default Copyable;

--- a/src/components/shared/copyable.js
+++ b/src/components/shared/copyable.js
@@ -11,14 +11,7 @@ class Copyable extends React.Component {
     copied: false,
   };
 
-  constructor(props) {
-    super(props);
-
-    this.copyToClipboard = this.copyToClipboard.bind(this);
-    this.mouseLeave = this.mouseLeave.bind(this);
-  }
-
-  copyToClipboard(e) {
+  copyToClipboard = e => {
     e.preventDefault();
     e.stopPropagation();
     copy(this.props.copyText);
@@ -26,13 +19,13 @@ class Copyable extends React.Component {
     this.setState({
       copied: true,
     });
-  }
+  };
 
-  mouseLeave() {
+  mouseLeave = () => {
     this.setState({
       copied: false,
     });
-  }
+  };
 
   render() {
     return (

--- a/src/styles/app.sass
+++ b/src/styles/app.sass
@@ -17,6 +17,7 @@
 @import components/component_slider
 @import components/configure_containers
 @import components/copy_link
+@import components/copyable
 @import components/create_cluster
 @import components/create_key_pair
 @import components/domain_list

--- a/src/styles/components/_copyable.sass
+++ b/src/styles/components/_copyable.sass
@@ -3,7 +3,7 @@
   position: relative
   overflow: inherit
   text-overflow: inherit
-  display: block
+  display: inherit
 
   .copyable-content
     position: relative
@@ -21,3 +21,15 @@
     position: absolute
     display: inline-block
     opacity: 0
+
+.truncate
+  .copyable
+    display: inline-block
+    max-width: 100%
+
+  .copyable-content
+    display: block
+    small
+      text-overflow: ellipsis
+      display: inline-block
+      width: 100%

--- a/src/styles/components/_copyable.sass
+++ b/src/styles/components/_copyable.sass
@@ -1,0 +1,21 @@
+.copyable
+  padding-right: 20px
+  position: relative
+  overflow: inherit
+  text-overflow: inherit
+
+  .copyable-content
+    position: relative
+    overflow: inherit
+    text-overflow: inherit
+
+  &:hover
+    .copyable-tooltip
+      opacity: 0.7
+
+  .copyable-tooltip
+    top: 0px
+    right: 0px
+    position: absolute
+    display: inline-block
+    opacity: 0

--- a/src/styles/components/_copyable.sass
+++ b/src/styles/components/_copyable.sass
@@ -3,11 +3,13 @@
   position: relative
   overflow: inherit
   text-overflow: inherit
+  display: block
 
   .copyable-content
     position: relative
     overflow: inherit
     text-overflow: inherit
+    display: inherit
 
   &:hover
     .copyable-tooltip


### PR DESCRIPTION
This introduces a wrapper component called 'Copyable' and applies it to some elements in the keypair table.

It is a helper to allow us to make certain pieces of text quickly copyable to the clipboard.

See the behaviour in this gif:
![copy](https://user-images.githubusercontent.com/455309/55129684-fa4c8e00-5152-11e9-8374-fb21e04dc4a9.gif)

As you can see, you can click anywhere on the element, not just on the copyable indicator icon that appears on hover.

I made a change to the keypair table as well, combining the description and ID field in one column to allow for a bit more breathing room, and made most elements `small`er

Related: https://github.com/giantswarm/giantswarm/issues/2903
