### PR TITLE
Reset scroll position when navigating.

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -32,6 +32,10 @@ var appContainer = document.getElementById('app');
 
 const store = configureStore({});
 
+history.listen(() => {
+  window.scrollTo(0, 0);
+});
+
 render(
   <Provider store={store}>
     <ConnectedRouter history={history}>


### PR DESCRIPTION
I noticed this while working on the app catalog, but it is also present in `master`. 

The scroll position is not reset to the top of the page when navigating. This is only matters if you navigate between two pages that actually have some content to scroll for like when moving between the pages of the getting started guide for example.

It's a bit weird, because I never noticed this before, so at first I thought this is a regression in a library somewhere.. but I checked and it happens still all the way to our first tagged release (0.1.31)