### PR TITLE
Add the app=happa label to all resources.

### DIFF
--- a/helm/happa-chart/templates/certs-secret.yaml
+++ b/helm/happa-chart/templates/certs-secret.yaml
@@ -4,6 +4,8 @@ type: Opaque
 metadata:
   name: happa-certs-secret
   namespace: giantswarm
+  labels:
+    app: happa
 data:
   tls.crt: {{ .Values.Installation.V1.Secret.Certificate.GiantSwarm.CrtPem | b64enc | quote }}
   tls.key: {{ .Values.Installation.V1.Secret.Certificate.GiantSwarm.KeyPem | b64enc | quote }}

--- a/helm/happa-chart/templates/configmap.yaml
+++ b/helm/happa-chart/templates/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: happa-configmap
   namespace: giantswarm
+  labels:
+    app: happa
 data:
   passage-endpoint: {{ .Values.Installation.V1.GiantSwarm.Passage.Address }}
   api-endpoint: {{ .Values.Installation.V1.GiantSwarm.API.Address }}

--- a/helm/happa-chart/templates/nginx-config.yaml
+++ b/helm/happa-chart/templates/nginx-config.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: happa-nginx-config
   namespace: giantswarm
+  labels:
+    app: happa
 
 data:
   nginx.conf: |

--- a/helm/happa-chart/templates/pull-secret.yml
+++ b/helm/happa-chart/templates/pull-secret.yml
@@ -4,5 +4,7 @@ type: kubernetes.io/dockerconfigjson
 metadata:
   name: happa-pull-secret
   namespace: giantswarm
+  labels:
+    app: happa
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}


### PR DESCRIPTION
A bit random, just something I noticed.

I feel like the `app` label has no purpose unless all resources belonging to happa have it set.

This lets us do `kubectl get -l app=happa all` and see all the things related to Happa.