### PR TITLE
Improve rendering of certificate orgs in key pairs table

### DIFF
--- a/src/components/cluster/detail/certificate_orgs_label.js
+++ b/src/components/cluster/detail/certificate_orgs_label.js
@@ -1,0 +1,30 @@
+'use strict';
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class CertificateOrgsLabel extends React.Component {
+  render() {
+    var orgs = this.props.value.split(',');
+    orgs.sort();
+    var orgLabels = [];
+    orgs.forEach(element => {
+      var classNames = 'orglabel';
+      if (element === 'system:masters') {
+        classNames += ' isadmin';
+      }
+      orgLabels.push(
+        <span className={classNames}>
+          <code>{element}</code>
+        </span>
+      );
+    });
+    return orgLabels;
+  }
+}
+
+CertificateOrgsLabel.propTypes = {
+  value: PropTypes.string,
+};
+
+export default CertificateOrgsLabel;

--- a/src/components/cluster/detail/certificate_orgs_label.js
+++ b/src/components/cluster/detail/certificate_orgs_label.js
@@ -5,6 +5,10 @@ import React from 'react';
 
 class CertificateOrgsLabel extends React.Component {
   render() {
+    if (this.props.value === '') {
+      return <span />;
+    }
+
     var orgs = this.props.value.split(',');
     orgs.sort();
     var orgLabels = [];

--- a/src/components/cluster/detail/certificate_orgs_label.js
+++ b/src/components/cluster/detail/certificate_orgs_label.js
@@ -17,11 +17,7 @@ class CertificateOrgsLabel extends React.Component {
       if (element === 'system:masters') {
         classNames += ' isadmin';
       }
-      orgLabels.push(
-        <span className={classNames}>
-          <code>{element}</code>
-        </span>
-      );
+      orgLabels.push(<span className={classNames}>{element}</span>);
     });
     return orgLabels;
   }

--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -9,6 +9,7 @@ import { relativeDate } from '../../../lib/helpers.js';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import BootstrapTable from 'react-bootstrap-table-next';
 import Button from '../../shared/button';
+import CertificateOrgsLabel from './certificate_orgs_label';
 import copy from 'copy-to-clipboard';
 import Copyable from '../../shared/copyable';
 import ExpiryHoursPicker from './expiry_hours_picker';
@@ -343,7 +344,7 @@ class ClusterKeyPairs extends React.Component {
   organizationFormatter(cell, row) {
     return (
       <Copyable copyText={row.certificate_organizations}>
-        <small>{row.certificate_organizations}</small>
+        <CertificateOrgsLabel value={row.certificate_organizations} />
       </Copyable>
     );
   }

--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -342,11 +342,14 @@ class ClusterKeyPairs extends React.Component {
   }
 
   organizationFormatter(cell, row) {
-    return (
-      <Copyable copyText={row.certificate_organizations}>
-        <CertificateOrgsLabel value={row.certificate_organizations} />
-      </Copyable>
-    );
+    if (row.certificate_organizations !== '') {
+      return (
+        <Copyable copyText={row.certificate_organizations}>
+          <CertificateOrgsLabel value={row.certificate_organizations} />
+        </Copyable>
+      );
+    }
+    return <span />;
   }
 
   render() {

--- a/src/styles/components/_cluster_details.sass
+++ b/src/styles/components/_cluster_details.sass
@@ -33,3 +33,10 @@
   .last-updated
     margin-left: 10px
 
+.cluster_key_pairs
+  .orglabel
+    margin-right: 2px
+  .orglabel.isadmin
+    code
+      background-color: #6f0316
+      color: #ccc

--- a/src/styles/components/_cluster_details.sass
+++ b/src/styles/components/_cluster_details.sass
@@ -36,7 +36,14 @@
 .cluster_key_pairs
   .orglabel
     margin-right: 2px
+    font-family: Inconsolata, monospace
+    font-size: 0.95em
+    font-weight: 400
+    border-radius: 3px
+    padding: 3px 5px
+    color: #c7c5bd
+    background-color: darken($darkblue, 5%)
+
   .orglabel.isadmin
-    code
-      background-color: #6f0316
-      color: #ccc
+    background-color: #4e272d
+    color: #ccc


### PR DESCRIPTION
- Splits multiple orgs, sorts them
- Highlights the cluster-admin org name `system:masters` (but not `systems:master` ;-))

### Before

![image](https://user-images.githubusercontent.com/273727/56038490-61149e80-5d32-11e9-9c4b-c941d8d8206a.png)

### After

![image](https://user-images.githubusercontent.com/273727/56038518-738ed800-5d32-11e9-974a-9c69944ff4e5.png)
