### PR TITLE
Structure general cluster info

### DIFF
--- a/src/components/cluster/detail/cluster_detail_table.js
+++ b/src/components/cluster/detail/cluster_detail_table.js
@@ -222,9 +222,7 @@ class ClusterDetailTable extends React.Component {
             </RefreshableLabel>
 
             <span className='padding-left-10'>
-              <Button onClick={this.props.showScalingModal}>
-                <i className='fa fa-scale' /> SCALE
-              </Button>
+              <Button onClick={this.props.showScalingModal}>Edit</Button>
             </span>
           </td>
         </tr>

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -232,25 +232,11 @@ class ClusterDetailView extends React.Component {
                     <Button onClick={this.accessCluster}>
                       <i className='fa fa-start' /> GET STARTED
                     </Button>
-                    {this.canClusterScale() ? (
-                      <Button onClick={this.showScalingModal}>
-                        <i className='fa fa-scale' /> SCALE
-                      </Button>
-                    ) : (
-                      undefined
-                    )}
                   </div>
                   <div className='pull-right btn-group visible-lg-block'>
                     <Button onClick={this.accessCluster}>
                       <i className='fa fa-start' /> GET STARTED
                     </Button>
-                    {this.canClusterScale() ? (
-                      <Button onClick={this.showScalingModal}>
-                        <i className='fa fa-scale' /> SCALE
-                      </Button>
-                    ) : (
-                      undefined
-                    )}
                   </div>
                 </div>
               </div>

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -239,14 +239,6 @@ class ClusterDetailView extends React.Component {
                     ) : (
                       undefined
                     )}
-
-                    {this.canClusterUpgrade() ? (
-                      <Button onClick={this.showUpgradeModal}>
-                        <i className='fa fa-version-upgrade' /> UPGRADE
-                      </Button>
-                    ) : (
-                      undefined
-                    )}
                   </div>
                   <div className='pull-right btn-group visible-lg-block'>
                     <Button onClick={this.accessCluster}>
@@ -259,29 +251,17 @@ class ClusterDetailView extends React.Component {
                     ) : (
                       undefined
                     )}
-
-                    {this.canClusterUpgrade() ? (
-                      <Button onClick={this.showUpgradeModal}>
-                        <i className='fa fa-version-upgrade' /> UPGRADE
-                      </Button>
-                    ) : (
-                      undefined
-                    )}
                   </div>
                 </div>
               </div>
               <div className='row'>
                 <div className='col-12'>
-                  <Tabs
-                    justify
-                    animation={false}
-                    defaultActiveKey={1}
-                    id='tabs'
-                  >
+                  <Tabs animation={false} defaultActiveKey={1} id='tabs'>
                     <Tab eventKey={1} title='General'>
                       <ClusterDetailTable
                         canClusterUpgrade={this.canClusterUpgrade()}
                         showUpgradeModal={this.showUpgradeModal}
+                        showScalingModal={this.showScalingModal}
                         cluster={this.props.cluster}
                         provider={this.props.provider}
                         credentials={this.props.credentials}

--- a/src/styles/_base.sass
+++ b/src/styles/_base.sass
@@ -138,3 +138,10 @@ div.tooltip-inner
 	padding: 0px 4px
 	line-height: 1.25em
 	border-radius: 2px
+
+.padding-left-10
+	padding-left: 10px
+.padding-left-20
+	padding-left: 10px
+.padding-left-30
+	padding-left: 30px

--- a/src/styles/components/_table.sass
+++ b/src/styles/components/_table.sass
@@ -59,7 +59,6 @@ table
     color: #fff
 
   &.resource-details
-    margin-top: 20px
     border-bottom-color: #3a5f7b
 
   &.resource-details > tbody > tr > td

--- a/src/styles/components/_table.sass
+++ b/src/styles/components/_table.sass
@@ -70,6 +70,9 @@ table
 
     &.value
       font-weight: 400
+  
+  &.resource-details > tbody > tr:first-of-type > td
+    border-top-width: 0px
 
 
 .table-label

--- a/src/styles/components/_table.sass
+++ b/src/styles/components/_table.sass
@@ -62,6 +62,9 @@ table
     border-bottom-color: #3a5f7b
 
   &.resource-details > tbody > tr > td
+    padding-top: 12px
+    padding-bottom: 12px
+    padding-left: 2px
     border-top: 1px solid #3a5f7b
     color: #eee
 


### PR DESCRIPTION
This changes the cluster details page/tab in several ways:

- Remove SCALE button from top right, in a general attempt to get rid of those.
- Add vertical spacing to table rows to make table easier to read
- Remove top spacing and border form details table
- Regroup items to have the (unchangeable) VM size / instance type further in the top, above the dynamic details.

### Before

![image](https://user-images.githubusercontent.com/273727/56040810-88219f00-5d37-11e9-9686-d2fbe3c85daa.png)

### After

![image](https://user-images.githubusercontent.com/273727/56040826-940d6100-5d37-11e9-8cb4-21c9f0113886.png)

