### PR TITLE
Change scaling modal title, remove cluster name

### DIFF
--- a/src/components/cluster/detail/scale_cluster_modal.js
+++ b/src/components/cluster/detail/scale_cluster_modal.js
@@ -263,9 +263,8 @@ class ScaleClusterModal extends React.Component {
       <BootstrapModal show={this.state.modalVisible} onHide={this.close}>
         <BootstrapModal.Header closeButton>
           <BootstrapModal.Title>
-            Scale workers on:{' '}
-            <ClusterIDLabel clusterID={this.props.cluster.id} />{' '}
-            <strong>{this.props.cluster.name}</strong>
+            Edit scaling settings for{' '}
+            <ClusterIDLabel clusterID={this.props.cluster.id} />
           </BootstrapModal.Title>
         </BootstrapModal.Header>
         {!this.state.error ? (


### PR DESCRIPTION
This changes the title of the scaling modal to `Edit scaling settings for <id>` to better match the situation we have since the introduction of autoscaling.

The cluster name is removed, since we are in the context of that cluster anyway and the name does not fit in some situations.

### Before

![image](https://user-images.githubusercontent.com/273727/56041757-c0c27800-5d39-11e9-85f1-cfbf571642cd.png)

### After

![image](https://user-images.githubusercontent.com/273727/56041767-c7e98600-5d39-11e9-844d-950c76752280.png)
