### PR TITLE
Fix node count selector, clean up scaling modal

### DIFF
--- a/src/components/cluster/detail/scale_cluster_modal.js
+++ b/src/components/cluster/detail/scale_cluster_modal.js
@@ -69,7 +69,14 @@ class ScaleClusterModal extends React.Component {
     });
   };
 
-  isScalingAutomatic(provider, releaseVer) {
+  /**
+   * Returns true if autoscaling of worker nodes is possible in this
+   * tenant cluster.
+   *
+   * @param String Provider identifier (aws, azure, kvm)
+   * @param String Semantic release version number
+   */
+  supportsAutoscaling(provider, releaseVer) {
     if (provider != 'aws') {
       return false;
     }
@@ -136,7 +143,7 @@ class ScaleClusterModal extends React.Component {
 
   workerDelta = () => {
     if (
-      !this.isScalingAutomatic(
+      !this.supportsAutoscaling(
         this.props.provider,
         this.props.cluster.release_version
       )
@@ -179,7 +186,7 @@ class ScaleClusterModal extends React.Component {
     var pluralizeWorkers = this.pluralize(workerDelta);
 
     if (
-      this.isScalingAutomatic(
+      this.supportsAutoscaling(
         this.props.provider,
         this.props.cluster.release_version
       )
@@ -273,7 +280,7 @@ class ScaleClusterModal extends React.Component {
               <p>How many workers would you like your cluster to have?</p>
               <div className='row section'>
                 <NodeCountSelector
-                  autoscalingEnabled={this.isScalingAutomatic(
+                  autoscalingEnabled={this.supportsAutoscaling(
                     this.props.provider,
                     this.props.cluster.release_version
                   )}

--- a/src/components/cluster/new/view.js
+++ b/src/components/cluster/new/view.js
@@ -514,15 +514,20 @@ class CreateCluster extends React.Component {
             })()}
 
             <div className='row section'>
-              <NodeCountSelector
-                autoscalingEnabled={this.isScalingAutomatic(
-                  this.props.provider,
-                  this.state.releaseVersion
-                )}
-                scaling={this.state.scaling}
-                readOnly={false}
-                onChange={this.updateScaling}
-              />
+              <div className='col-3'>
+                <h3 className='table-label'>Node Count</h3>
+              </div>
+              <div className='col-9'>
+                <NodeCountSelector
+                  autoscalingEnabled={this.isScalingAutomatic(
+                    this.props.provider,
+                    this.state.releaseVersion
+                  )}
+                  scaling={this.state.scaling}
+                  readOnly={false}
+                  onChange={this.updateScaling}
+                />
+              </div>
             </div>
 
             <ProviderCredentials

--- a/src/components/shared/node_count_selector.js
+++ b/src/components/shared/node_count_selector.js
@@ -112,7 +112,7 @@ class NodeCountSelector extends React.Component {
           </div>
           <div className='row'>
             <div className='col-12'>
-              <p>To disable autoscaling, set both numbers to the same value</p>
+              <p>To disable autoscaling, set both numbers to the same value.</p>
             </div>
           </div>
         </form>

--- a/src/components/shared/node_count_selector.js
+++ b/src/components/shared/node_count_selector.js
@@ -79,75 +79,62 @@ class NodeCountSelector extends React.Component {
   render() {
     if (this.props.autoscalingEnabled === true) {
       return (
-        <div>
-          <div className='col-3'>
-            <h3 className='table-label'>Node Count</h3>
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+          }}
+        >
+          <div className='row'>
+            <div className='col-6'>
+              <label>Minimum</label>
+              <NumberPicker
+                label=''
+                stepSize={1}
+                value={this.state.scaling.min}
+                min={1}
+                max={this.state.scaling.max}
+                onChange={this.updateScalingMin}
+                readOnly={false}
+              />
+            </div>
+            <div className='col-6'>
+              <label>Maximum</label>
+              <NumberPicker
+                label=''
+                stepSize={1}
+                value={this.state.scaling.max}
+                min={this.state.scaling.min}
+                max={99} // TODO
+                onChange={this.updateScalingMax}
+                readOnly={false}
+              />
+            </div>
           </div>
-          <div className='col-9'>
-            <form
-              onSubmit={e => {
-                e.preventDefault();
-              }}
-            >
-              <div>
-                <p>
-                  To disable autoscaling, set both numbers to the same value
-                </p>
-                <div className='col-6'>
-                  <label>Minimum</label>
-                  <NumberPicker
-                    label=''
-                    stepSize={1}
-                    value={this.state.scaling.min}
-                    min={1}
-                    max={this.state.scaling.max}
-                    onChange={this.updateScalingMin}
-                    readOnly={false}
-                  />
-                </div>
-                <div className='col-6'>
-                  <label>Maximum</label>
-                  <NumberPicker
-                    label=''
-                    stepSize={1}
-                    value={this.state.scaling.max}
-                    min={this.state.scaling.min}
-                    max={99} // TODO
-                    onChange={this.updateScalingMax}
-                    readOnly={false}
-                  />
-                </div>
-              </div>
-            </form>
+          <div className='row'>
+            <div className='col-12'>
+              <p>To disable autoscaling, set both numbers to the same value</p>
+            </div>
           </div>
-        </div>
+        </form>
       );
     } else {
       return (
-        <div>
-          <div className='col-3'>
-            <h3 className='table-label'>Node Count</h3>
-          </div>
-          <div className='col-9'>
+        <div className='row'>
+          <div className='col-12'>
             <form
               onSubmit={e => {
                 e.preventDefault();
               }}
             >
-              <div>
-                <div className='col-3'>
-                  <label>Number of nodes</label>
-                  <NumberPicker
-                    label=''
-                    stepSize={1}
-                    value={this.state.scaling.max}
-                    min={1}
-                    max={99} // TODO
-                    onChange={this.updateNodeCount}
-                    readOnly={false}
-                  />
-                </div>
-              </div>
+              <NumberPicker
+                label=''
+                stepSize={1}
+                value={this.state.scaling.max}
+                min={1}
+                max={99} // TODO
+                onChange={this.updateNodeCount}
+                readOnly={false}
+              />
             </form>
           </div>
         </div>


### PR DESCRIPTION
This removes the `Node Count` column from the `NodeCountSelector` component, as it should not appear in the scaling modal.

In the case of manual scaling, the extra `Number of nodes` label above the number picker is removed.

### Autoscaling before

![image](https://user-images.githubusercontent.com/273727/56045972-8d381b80-5d42-11e9-9579-ebc1fee8348a.png)

### Autoscaling after

![image](https://user-images.githubusercontent.com/273727/56046002-9d4ffb00-5d42-11e9-8f12-89d1a47b51b5.png)

### Manual scaling before

![image](https://user-images.githubusercontent.com/273727/56046094-ca041280-5d42-11e9-9db6-27d31778accb.png)

### Manual scaling after

![image](https://user-images.githubusercontent.com/273727/56046180-f9b31a80-5d42-11e9-9671-9379d8abea77.png)
