### PR TITLE
Improve scaling dialog warnings

### DIFF
--- a/src/components/cluster/detail/certificate_orgs_label.js
+++ b/src/components/cluster/detail/certificate_orgs_label.js
@@ -17,7 +17,11 @@ class CertificateOrgsLabel extends React.Component {
       if (element === 'system:masters') {
         classNames += ' isadmin';
       }
-      orgLabels.push(<span className={classNames}>{element}</span>);
+      orgLabels.push(
+        <span key={element} className={classNames}>
+          {element}
+        </span>
+      );
     });
     return orgLabels;
   }

--- a/src/components/cluster/detail/scale_cluster_modal.js
+++ b/src/components/cluster/detail/scale_cluster_modal.js
@@ -97,16 +97,6 @@ class ScaleClusterModal extends React.Component {
     });
   };
 
-  getCurrentDesiredCapacity = () => {
-    if (
-      Object.keys(this.props.cluster).includes('status') &&
-      this.props.cluster.status != null
-    ) {
-      return this.props.cluster.status.cluster.scaling.desiredCapacity;
-    }
-    return 0;
-  };
-
   submit = () => {
     this.setState(
       {
@@ -153,19 +143,19 @@ class ScaleClusterModal extends React.Component {
       return this.state.scaling.min - this.props.cluster.scaling.min;
     }
 
-    if (this.getCurrentDesiredCapacity() < this.state.scaling.min) {
-      return this.state.scaling.min - this.getCurrentDesiredCapacity;
+    if (this.props.workerNodesDesired < this.state.scaling.min) {
+      return this.state.scaling.min - this.props.workerNodesDesired;
     }
 
-    if (this.getCurrentDesiredCapacity() > this.state.scaling.max) {
-      return this.state.scaling.max - this.getCurrentDesiredCapacity();
+    if (this.props.workerNodesDesired > this.state.scaling.max) {
+      return this.state.scaling.max - this.props.workerNodesDesired;
     }
 
     if (
       this.state.scaling.min == this.state.scaling.max &&
-      this.getCurrentDesiredCapacity() < this.state.scaling.max
+      this.props.workerNodesDesired < this.state.scaling.max
     ) {
-      return this.getCurrentDesiredCapacity() - this.state.scaling.max;
+      return this.props.workerNodesDesired - this.state.scaling.max;
     }
 
     return 0;
@@ -191,8 +181,8 @@ class ScaleClusterModal extends React.Component {
         this.props.cluster.release_version
       )
     ) {
-      if (this.state.scaling.min > this.getCurrentDesiredCapacity()) {
-        workerDelta = this.state.scaling.min - this.getCurrentDesiredCapacity();
+      if (this.state.scaling.min > this.props.workerNodesDesired) {
+        workerDelta = this.state.scaling.min - this.props.workerNodesDesired;
         return {
           title: `Increase minimum number of nodes by ${workerDelta} worker node${this.pluralize(
             workerDelta
@@ -202,8 +192,10 @@ class ScaleClusterModal extends React.Component {
         };
       }
 
-      if (this.state.scaling.max < this.getCurrentDesiredCapacity()) {
-        workerDelta = this.getCurrentDesiredCapacity() - this.state.scaling.max;
+      if (this.state.scaling.max < this.props.workerNodesDesired) {
+        workerDelta = Math.abs(
+          this.props.workerNodesDesired - this.state.scaling.max
+        );
         return {
           title: `Remove ${Math.abs(workerDelta)} worker node${this.pluralize(
             workerDelta

--- a/src/components/cluster/detail/scale_cluster_modal.js
+++ b/src/components/cluster/detail/scale_cluster_modal.js
@@ -3,6 +3,7 @@
 import * as clusterActions from '../../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import {
   FlashMessage,
   messageTTL,
@@ -17,6 +18,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 class ScaleClusterModal extends React.Component {
+  rollupAnimationDuration = 500;
+
   constructor(props) {
     super(props);
 
@@ -270,34 +273,55 @@ class ScaleClusterModal extends React.Component {
         )
       ) {
         warnings.push(
-          <p key='node-removal'>
-            <i className='fa fa-warning' /> The cluster currently has{' '}
-            {this.props.workerNodesRunning} worker nodes running. By setting the
-            maximum lower than that, you enforce the removal of{' '}
-            {diff === 1 ? 'one node' : diff + ' nodes'}. This could result in
-            unscheduled workloads.
-          </p>
+          <CSSTransition
+            key={1}
+            classNames='rollup'
+            enter={true}
+            exit={true}
+            timeout={this.rollupAnimationDuration}
+          >
+            <p key='node-removal'>
+              <i className='fa fa-warning' /> The cluster currently has{' '}
+              {this.props.workerNodesRunning} worker nodes running. By setting
+              the maximum lower than that, you enforce the removal of{' '}
+              {diff === 1 ? 'one node' : diff + ' nodes'}. This could result in
+              unscheduled workloads.
+            </p>
+          </CSSTransition>
         );
       } else {
         warnings.push(
-          <p key='node-removal'>
-            <i className='fa fa-warning' /> You are about to enforce the removal
-            of {diff === 1 ? 'one node' : diff + ' nodes'}. Please make sure the
-            cluster has enough capacity to schedule all workloads.
-          </p>
+          <CSSTransition
+            key={2}
+            classNames='rollup'
+            timeout={this.rollupAnimationDuration}
+          >
+            <p key='node-removal'>
+              <i className='fa fa-warning' /> You are about to enforce the
+              removal of {diff === 1 ? 'one node' : diff + ' nodes'}. Please
+              make sure the cluster has enough capacity to schedule all
+              workloads.
+            </p>
+          </CSSTransition>
         );
       }
     }
 
     if (this.state.scaling.min < 3) {
       warnings.push(
-        <p key='unsupported'>
-          <i className='fa fa-warning' /> With less than 3 worker nodes, the
-          cluster does not fall under the Giant Swarm{' '}
-          <abbr title='Service Level Agreement'>SLA</abbr>. Giant Swarm staff
-          will not be alerted in case of problems and will not provide proactive
-          support.
-        </p>
+        <CSSTransition
+          key={3}
+          classNames='rollup'
+          timeout={this.rollupAnimationDuration}
+        >
+          <p key='unsupported'>
+            <i className='fa fa-warning' /> With less than 3 worker nodes, the
+            cluster does not fall under the Giant Swarm{' '}
+            <abbr title='Service Level Agreement'>SLA</abbr>. Giant Swarm staff
+            will not be alerted in case of problems and will not provide
+            proactive support.
+          </p>
+        </CSSTransition>
       );
     }
 
@@ -322,7 +346,7 @@ class ScaleClusterModal extends React.Component {
             onChange={this.updateScaling}
           />
         </div>
-        {warnings}
+        <TransitionGroup>{warnings}</TransitionGroup>
       </BootstrapModal.Body>
     );
     var footer = (

--- a/src/components/shared/node_count_selector.js
+++ b/src/components/shared/node_count_selector.js
@@ -112,7 +112,11 @@ class NodeCountSelector extends React.Component {
           </div>
           <div className='row'>
             <div className='col-12'>
-              <p>To disable autoscaling, set both numbers to the same value.</p>
+              <p>
+                {this.state.scaling.min === this.state.scaling.max
+                  ? 'To enable autoscaling, set minimum and maximum to different values.'
+                  : 'To disable autoscaling, set both numbers to the same value.'}
+              </p>
             </div>
           </div>
         </form>

--- a/src/styles/transitions/_slide.sass
+++ b/src/styles/transitions/_slide.sass
@@ -47,3 +47,22 @@ $slide-curve: ease-out
 .slide-right-leave.slide-right-leave-active
   opacity: 0
 
+
+// rollup is an animation where an element grows from zero to full height on entry
+// and shrinks the same way on removal.
+
+.rollup-enter
+  max-height: 0px
+
+.rollup-enter-active
+  max-height: 500px
+  overflow-y: hidden
+  transition: max-height .5s ease-in-out
+
+.rollup-exit
+  max-height: 500px
+
+.rollup-exit-active
+  max-height: 0px
+  overflow-y: hidden
+  transition: max-height .5s ease-in-out


### PR DESCRIPTION
Our warnings regarding scaling down needed improvements in several ways.

- Scenario: changing form pinned to 3 to min2/max3. The warnings indicated that worker nodes would be removed, which would in fact only happen if the autoscaler decides so. Accordingly, the submit button showed `Remove 1 node` when in fact only the scaling limits would be changed.
- We were lacking the info that a cluster with less than 3 nodes is not supported.
- We were showing some info regarding possible data loss that can be taken as general

This PR brings changes:

- Changed the logic regarding which warning appears in what situation, so that only warnings appear which apply to the situation
- change design of warnings, to prevent it from looking like an error message
- Simplify submit button working to make it shorter
- The label `To disable autoscaling, set both numbers to the same value.` changes to `To enable autoscaling, set minimum and maximum to different values.` when size is pinned.

### Before (AWS)

![image](https://user-images.githubusercontent.com/273727/56129520-9f080180-5f82-11e9-925a-00100dfc2461.png)


### Preview AWS autoscaling

![x20VvfLWnx](https://user-images.githubusercontent.com/273727/56129486-80a20600-5f82-11e9-8ce4-d1a36d241f90.gif)
