### PR TITLE
Move dev instance types into dev cofiguration.

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -15,7 +15,7 @@ if [ -n "$INGRESS_BASE_DOMAIN" ]; then
 fi
 
 if [ -n "$AWS_CAPABILITIES_JSON" ]; then
-  sed -i "s|awsCapabilitiesJSON: ''|awsCapabilitiesJSON: '$AWS_CAPABILITIES_JSON'|" /www/index.html
+  sed -i "s|awsCapabilitiesJSON: .*|awsCapabilitiesJSON: '$AWS_CAPABILITIES_JSON'|" /www/index.html
 fi
 
 if [ -n "$AZURE_CAPABILITIES_JSON" ]; then

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,29 +3,29 @@
 # This script replaces some placeholders in index.html with values from the
 # environment. It is used for Happa's production deployment.
 if [ -n "$API_ENDPOINT" ]; then
-  sed -i "s|apiEndpoint: 'http://localhost:8000'|apiEndpoint: '$API_ENDPOINT'|" /www/index.html
+  sed -i "s|apiEndpoint: .*|apiEndpoint: '$API_ENDPOINT',|" /www/index.html
 fi
 
 if [ -n "$PASSAGE_ENDPOINT" ]; then
-  sed -i "s|passageEndpoint: 'http://localhost:5001'|passageEndpoint: '$PASSAGE_ENDPOINT'|" /www/index.html
+  sed -i "s|passageEndpoint: .*|passageEndpoint: '$PASSAGE_ENDPOINT',|" /www/index.html
 fi
 
 if [ -n "$INGRESS_BASE_DOMAIN" ]; then
-  sed -i "s|ingressBaseDomain: 'k8s.sample.io'|ingressBaseDomain: '$INGRESS_BASE_DOMAIN'|" /www/index.html
+  sed -i "s|ingressBaseDomain: .*|ingressBaseDomain: '$INGRESS_BASE_DOMAIN',|" /www/index.html
 fi
 
 if [ -n "$AWS_CAPABILITIES_JSON" ]; then
-  sed -i "s|awsCapabilitiesJSON: .*|awsCapabilitiesJSON: '$AWS_CAPABILITIES_JSON'|" /www/index.html
+  sed -i "s|awsCapabilitiesJSON: .*|awsCapabilitiesJSON: '$AWS_CAPABILITIES_JSON',|" /www/index.html
 fi
 
 if [ -n "$AZURE_CAPABILITIES_JSON" ]; then
-  sed -i "s|azureCapabilitiesJSON: ''|azureCapabilitiesJSON: '$AZURE_CAPABILITIES_JSON'|" /www/index.html
+  sed -i "s|azureCapabilitiesJSON: .*|azureCapabilitiesJSON: '$AZURE_CAPABILITIES_JSON',|" /www/index.html
 fi
 
 if [ -n "$ENVIRONMENT" ]; then
-  sed -i "s|environment: 'development'|environment: '$ENVIRONMENT'|" /www/index.html
+  sed -i "s|environment: .*|environment: '$ENVIRONMENT',|" /www/index.html
 else
-  sed -i "s|environment: 'development'|environment: 'docker-container'|" /www/index.html
+  sed -i "s|environment: .*|environment: 'docker-container',|" /www/index.html
 fi
 
 # This sets the VERSION placeholder in the footer to the version specified in the

--- a/src/components/cluster/new/aws_instance_type_selector.js
+++ b/src/components/cluster/new/aws_instance_type_selector.js
@@ -10,32 +10,8 @@ class AWSInstanceTypeSelector extends React.Component {
   constructor(props) {
     super(props);
 
-    // devInstanceTypes are placeholder instance types for the dev environment.
-    // In the dev environment window.config.awsCapabilitiesJson is not set to anything.
-    // It would normally be set by the value in the installations repo.
-    var devInstanceTypes = {
-      'm3.large': {
-        description: 'M3 General Purpose Large',
-        memory_size_gb: '7.5',
-        cpu_cores: '2',
-        storage_size_gb: '32',
-      },
-      'm3.xlarge': {
-        description: 'M3 General Purpose Extra Large',
-        memory_size_gb: '15',
-        cpu_cores: '4',
-        storage_size_gb: '80',
-      },
-      'm3.2xlarge': {
-        description: 'M3 General Purpose Double Extra Large',
-        memory_size_gb: '30',
-        cpu_cores: '8',
-        storage_size_gb: '160',
-      },
-    };
+    var instanceTypes = {};
 
-    // Use devInstanceTypes unless there is something set for window.config.awsCapabilitiesJSON
-    var instanceTypes = devInstanceTypes;
     if (window.config.awsCapabilitiesJSON != '') {
       instanceTypes = JSON.parse(window.config.awsCapabilitiesJSON);
     }

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@
     passageEndpoint: 'http://localhost:5001',
     environment: 'development',
     ingressBaseDomain: 'k8s.sample.io',
-    awsCapabilitiesJSON: '',
+    awsCapabilitiesJSON: '{"m3.large":{"description":"M3 General Purpose Large","memory_size_gb":7.5,"cpu_cores":2,"storage_size_gb":32},"m3.xlarge":{"description":"M3 General Purpose Extra Large","memory_size_gb":15,"cpu_cores":4,"storage_size_gb":80},"m3.2xlarge":{"description":"M3 General Purpose Double Extra Large","memory_size_gb":30,"cpu_cores":8,"storage_size_gb":160}}',
     azureCapabilitiesJSON: '',
   };
   window.config = config;


### PR DESCRIPTION
Instead of having these devInstanceTypes in the source code, I move it to the dev configuration. This lets us avoid repeating checking wether or not instance types set and substituting in the dev values.

(Currently the cluster detail table is broken in dev, and this fixes it.)

Why I didn't do this in the first place? Not sure. I probably didn't think of the `.*` for the replacement in `start.sh`