### PR TITLE
Move azure dev vm sizes into config as well.

### DIFF
--- a/src/components/cluster/new/azure_vm_size_selector.js
+++ b/src/components/cluster/new/azure_vm_size_selector.js
@@ -10,45 +10,7 @@ class AzureVMSizeSelector extends React.Component {
   constructor(props) {
     super(props);
 
-    // devVMSizes are placeholder VM sizes for the dev environment.
-    // In the dev environment window.config.azureCapabilitiesJson is not set to anything.
-    // It would normally be set by the value in the installations repo.
-    var devVMSizes = {
-      Standard_A2_v2: {
-        additionalProperties: {},
-        description: 'This is some description',
-        maxDataDiskCount: 4,
-        memoryInMb: 4294.967296,
-        name: 'Standard_A2_v2',
-        numberOfCores: 2,
-        osDiskSizeInMb: 1047552,
-        resourceDiskSizeInMb: 21474.83648,
-      },
-      Standard_A4_v2: {
-        additionalProperties: {},
-        description:
-          'Here is a longer description that might be too long for the field',
-        maxDataDiskCount: 8,
-        memoryInMb: 8589.934592,
-        name: 'Standard_A4_v2',
-        numberOfCores: 4,
-        osDiskSizeInMb: 1047552,
-        resourceDiskSizeInMb: 42949.67296,
-      },
-      Standard_A8_v2: {
-        additionalProperties: {},
-        description: 'Another VM size description text',
-        maxDataDiskCount: 16,
-        memoryInMb: 17179.869184,
-        name: 'Standard_A8_v2',
-        numberOfCores: 8,
-        osDiskSizeInMb: 1047552,
-        resourceDiskSizeInMb: 85899.34592,
-      },
-    };
-
-    // Use devVMSizes unless there is something set for window.config.azureCapabilitiesJSON
-    var vmSizes = devVMSizes;
+    var vmSizes = {};
     if (window.config.azureCapabilitiesJSON != '') {
       vmSizes = JSON.parse(window.config.azureCapabilitiesJSON);
     }

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
     environment: 'development',
     ingressBaseDomain: 'k8s.sample.io',
     awsCapabilitiesJSON: '{"m3.large":{"description":"M3 General Purpose Large","memory_size_gb":7.5,"cpu_cores":2,"storage_size_gb":32},"m3.xlarge":{"description":"M3 General Purpose Extra Large","memory_size_gb":15,"cpu_cores":4,"storage_size_gb":80},"m3.2xlarge":{"description":"M3 General Purpose Double Extra Large","memory_size_gb":30,"cpu_cores":8,"storage_size_gb":160}}',
-    azureCapabilitiesJSON: '',
+    azureCapabilitiesJSON: '{"Standard_A2_v2":{"additionalProperties":{},"description":"This is some description","maxDataDiskCount":4,"memoryInMb":4294.967296,"name":"Standard_A2_v2","numberOfCores":2,"osDiskSizeInMb":1047552,"resourceDiskSizeInMb":21474.83648},"Standard_A4_v2":{"additionalProperties":{},"description":"Here is a longer description that might be too long for the field","maxDataDiskCount":8,"memoryInMb":8589.934592,"name":"Standard_A4_v2","numberOfCores":4,"osDiskSizeInMb":1047552,"resourceDiskSizeInMb":42949.67296},"Standard_A8_v2":{"additionalProperties":{},"description":"Another VM size description text","maxDataDiskCount":16,"memoryInMb":17179.869184,"name":"Standard_A8_v2","numberOfCores":8,"osDiskSizeInMb":1047552,"resourceDiskSizeInMb":85899.34592}}',
   };
   window.config = config;
   </script>


### PR DESCRIPTION
This moves the azure dev vm sizes into configuration instead of source code as well, like was done in pr #555 for aws instance types.
