### PR TITLE
Fix "empty password" is not valid anymore

### DIFF
--- a/src/lib/password_validation.js
+++ b/src/lib/password_validation.js
@@ -4,9 +4,7 @@ export function validatePassword(password) {
   var valid = false;
   var statusMessage = '';
 
-  if (password.length === 0) {
-    valid = true;
-  } else if (password.length < 8) {
+  if (password.length < 8) {
     statusMessage = 'password_too_short';
   } else if (/^[0-9]+$/.test(password)) {
     statusMessage = 'password_not_just_numbers';


### PR DESCRIPTION
I think it's related to Issue #234 
In "Sign up" screen if you leave the password field empty and hit TAB, "Next" button becomes active.
In "Set your new password" screen after you reset your password, if you leave both password fields empty and hit TAB, the status text change to "Perfect match" and submit button becomes active.