### PR TITLE
Fix member add notification

### DIFF
--- a/src/actions/organizationActions.js
+++ b/src/actions/organizationActions.js
@@ -298,7 +298,7 @@ export function organizationAddMemberConfirmed(orgId, email) {
             '</code> to organization <code>' +
             orgId +
             '</code>',
-          messageType.ERROR,
+          messageType.SUCCESS,
           messageTTL.MEDIUM
         );
 

--- a/src/lib/flash_message.js
+++ b/src/lib/flash_message.js
@@ -82,7 +82,7 @@ function escapeHTML(unsafe) {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
   safe = safe
-    .replace('&lt;code&gt;', '<code>')
-    .replace('&lt;/code&gt;', '</code>');
+    .replace(/&lt;code&gt;/g, '<code>')
+    .replace(/&lt;\/code&gt;/g, '</code>');
   return safe;
 }


### PR DESCRIPTION
reported by @jgsqware , we were using the `ERROR` type of flash message for a successful member adding.

Also noticed that only the first `<code> </code>` tag is whitelisted properly in our escapeHTML function. Fixed that as well.