### PR TITLE
Adjust table layout for users and keypairs

### DIFF
--- a/src/styles/components/_cluster_details.sass
+++ b/src/styles/components/_cluster_details.sass
@@ -51,3 +51,6 @@
   .orglabel.isadmin
     background-color: #4e272d
     color: #ccc
+
+  .react-bootstrap-table table
+    table-layout: auto

--- a/src/styles/components/_users_table.sass
+++ b/src/styles/components/_users_table.sass
@@ -1,5 +1,5 @@
 .users-table
-  .react-bootstrap-table table.table
+  .react-bootstrap-table table
     table-layout: auto
 
   .status

--- a/src/styles/components/_users_table.sass
+++ b/src/styles/components/_users_table.sass
@@ -1,5 +1,6 @@
 .users-table
-
+  .react-bootstrap-table table.table
+    table-layout: auto
 
   .status
     width: 90px


### PR DESCRIPTION
This allows the fields grow/shrink in size, which was probably the case before, but once I added the bootstrap-table styles in https://github.com/giantswarm/happa/pull/542#issuecomment-478230923, `table-layout: fixed` came with it.

Before:
<img width="1003" alt="Screenshot 2019-04-26 at 7 48 32 AM" src="https://user-images.githubusercontent.com/455309/56775024-cc14a980-67f7-11e9-90a0-103a8172eb8c.png">

After:
<img width="983" alt="Screenshot 2019-04-26 at 7 48 20 AM" src="https://user-images.githubusercontent.com/455309/56775026-cd45d680-67f7-11e9-87b5-c5ec223b1bce.png">
