### PR TITLE
Remove useless `use strict`.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "es6": true
   },
   "rules": {
+    "strict": 2,
     "no-underscore-dangle": 0,
     "quotes": [1, "single", {"allowTemplateLiterals": true}],
     "semi": [1, "always"],

--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -32,7 +32,7 @@
  * NOUN can also represent the nesting of resources.
  */
 
-'use strict';
+
 
 // Clusters
 export const CLUSTER_LOAD_DETAILS = 'CLUSTER_LOAD_DETAILS';

--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -32,8 +32,6 @@
  * NOUN can also represent the nesting of resources.
  */
 
-
-
 // Clusters
 export const CLUSTER_LOAD_DETAILS = 'CLUSTER_LOAD_DETAILS';
 export const CLUSTER_LOAD_DETAILS_SUCCESS = 'CLUSTER_LOAD_DETAILS_SUCCESS';

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -1,5 +1,3 @@
-
-
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from '../lib/flash_message';
 import { modalHide } from './modalActions';

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from '../lib/flash_message';

--- a/src/actions/forgotPasswordActions.js
+++ b/src/actions/forgotPasswordActions.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from './actionTypes';
 import Passage from '../lib/passage_client';

--- a/src/actions/forgotPasswordActions.js
+++ b/src/actions/forgotPasswordActions.js
@@ -1,5 +1,3 @@
-
-
 import * as types from './actionTypes';
 import Passage from '../lib/passage_client';
 

--- a/src/actions/invitationActions.js
+++ b/src/actions/invitationActions.js
@@ -1,5 +1,3 @@
-
-
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from '../lib/flash_message';
 import _ from 'underscore';

--- a/src/actions/invitationActions.js
+++ b/src/actions/invitationActions.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from '../lib/flash_message';

--- a/src/actions/modalActions.js
+++ b/src/actions/modalActions.js
@@ -1,5 +1,3 @@
-
-
 import * as types from './actionTypes';
 
 export function modalHide() {

--- a/src/actions/modalActions.js
+++ b/src/actions/modalActions.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from './actionTypes';
 

--- a/src/actions/organizationActions.js
+++ b/src/actions/organizationActions.js
@@ -1,5 +1,3 @@
-
-
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from '../lib/flash_message';
 import { modalHide } from './modalActions';

--- a/src/actions/organizationActions.js
+++ b/src/actions/organizationActions.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from '../lib/flash_message';

--- a/src/actions/releaseActions.js
+++ b/src/actions/releaseActions.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from './actionTypes';
 import GiantSwarmV4 from 'giantswarm-v4';

--- a/src/actions/releaseActions.js
+++ b/src/actions/releaseActions.js
@@ -1,5 +1,3 @@
-
-
 import * as types from './actionTypes';
 import GiantSwarmV4 from 'giantswarm-v4';
 

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -1,5 +1,3 @@
-
-
 import * as types from './actionTypes';
 import { Base64 } from 'js-base64';
 import {

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from './actionTypes';
 import { Base64 } from 'js-base64';

--- a/src/components/account_settings/change_email_form.js
+++ b/src/components/account_settings/change_email_form.js
@@ -1,5 +1,3 @@
-
-
 import Button from '../shared/button';
 import GiantSwarmV4 from 'giantswarm-v4';
 import PropTypes from 'prop-types';

--- a/src/components/account_settings/change_email_form.js
+++ b/src/components/account_settings/change_email_form.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import Button from '../shared/button';
 import GiantSwarmV4 from 'giantswarm-v4';

--- a/src/components/account_settings/change_password_form.js
+++ b/src/components/account_settings/change_password_form.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Base64 } from 'js-base64';
 import { validatePassword } from '../../lib/password_validation';

--- a/src/components/account_settings/change_password_form.js
+++ b/src/components/account_settings/change_password_form.js
@@ -1,5 +1,3 @@
-
-
 import { Base64 } from 'js-base64';
 import { validatePassword } from '../../lib/password_validation';
 import Button from '../shared/button';

--- a/src/components/account_settings/index.js
+++ b/src/components/account_settings/index.js
@@ -1,5 +1,3 @@
-
-
 import * as UserActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import { Breadcrumb } from 'react-breadcrumbs';

--- a/src/components/account_settings/index.js
+++ b/src/components/account_settings/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as UserActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import 'babel-polyfill';
 import { ConnectedRouter } from 'connected-react-router';

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,5 +1,3 @@
-
-
 import 'babel-polyfill';
 import { ConnectedRouter } from 'connected-react-router';
 import { Provider } from 'react-redux';

--- a/src/components/auth/admin.js
+++ b/src/components/auth/admin.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/auth/admin.js
+++ b/src/components/auth/admin.js
@@ -1,5 +1,3 @@
-
-
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import { clearQueues } from '../../lib/flash_message';

--- a/src/components/auth/login.js
+++ b/src/components/auth/login.js
@@ -1,5 +1,3 @@
-
-
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import {

--- a/src/components/auth/login.js
+++ b/src/components/auth/login.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/auth/logout.js
+++ b/src/components/auth/logout.js
@@ -1,5 +1,3 @@
-
-
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/auth/logout.js
+++ b/src/components/auth/logout.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/auth/oauth_callback.js
+++ b/src/components/auth/oauth_callback.js
@@ -1,5 +1,3 @@
-
-
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/auth/oauth_callback.js
+++ b/src/components/auth/oauth_callback.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/cluster/detail/cluster_apps.js
+++ b/src/components/cluster/detail/cluster_apps.js
@@ -1,5 +1,3 @@
-
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/src/components/cluster/detail/cluster_apps.js
+++ b/src/components/cluster/detail/cluster_apps.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/cluster/detail/cluster_detail_table.js
+++ b/src/components/cluster/detail/cluster_detail_table.js
@@ -1,5 +1,3 @@
-
-
 import { relativeDate } from '../../../lib/helpers.js';
 import _ from 'underscore';
 import AWSAccountID from '../../shared/aws_account_id';

--- a/src/components/cluster/detail/cluster_detail_table.js
+++ b/src/components/cluster/detail/cluster_detail_table.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { relativeDate } from '../../../lib/helpers.js';
 import _ from 'underscore';

--- a/src/components/cluster/detail/expiry_hours_picker.js
+++ b/src/components/cluster/detail/expiry_hours_picker.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import DatePicker from 'react-datepicker';
 import moment from 'moment';

--- a/src/components/cluster/detail/expiry_hours_picker.js
+++ b/src/components/cluster/detail/expiry_hours_picker.js
@@ -1,5 +1,3 @@
-
-
 import DatePicker from 'react-datepicker';
 import moment from 'moment';
 import PropTypes from 'prop-types';

--- a/src/components/cluster/detail/index.js
+++ b/src/components/cluster/detail/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';

--- a/src/components/cluster/detail/index.js
+++ b/src/components/cluster/detail/index.js
@@ -1,5 +1,3 @@
-
-
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';

--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../../actions/clusterActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/cluster/detail/scale_cluster_modal.js
+++ b/src/components/cluster/detail/scale_cluster_modal.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/cluster/detail/scale_cluster_modal.js
+++ b/src/components/cluster/detail/scale_cluster_modal.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../../actions/clusterActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/cluster/detail/upgrade_cluster_modal.js
+++ b/src/components/cluster/detail/upgrade_cluster_modal.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/cluster/detail/upgrade_cluster_modal.js
+++ b/src/components/cluster/detail/upgrade_cluster_modal.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../../actions/clusterActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../../actions/clusterActions';
 import * as releaseActions from '../../../actions/releaseActions';

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../../actions/clusterActions';
 import * as releaseActions from '../../../actions/releaseActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/cluster/index.js
+++ b/src/components/cluster/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';

--- a/src/components/cluster/index.js
+++ b/src/components/cluster/index.js
@@ -1,5 +1,3 @@
-
-
 import { connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import ClusterDetail from './detail/';

--- a/src/components/cluster/new/aws_instance_type_selector.js
+++ b/src/components/cluster/new/aws_instance_type_selector.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from '../../shared/button';

--- a/src/components/cluster/new/aws_instance_type_selector.js
+++ b/src/components/cluster/new/aws_instance_type_selector.js
@@ -1,5 +1,3 @@
-
-
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from '../../shared/button';
 import InputField from '../../shared/input_field';

--- a/src/components/cluster/new/azure_vm_size_selector.js
+++ b/src/components/cluster/new/azure_vm_size_selector.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from '../../shared/button';

--- a/src/components/cluster/new/azure_vm_size_selector.js
+++ b/src/components/cluster/new/azure_vm_size_selector.js
@@ -1,5 +1,3 @@
-
-
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from '../../shared/button';
 import InputField from '../../shared/input_field';

--- a/src/components/cluster/new/index.js
+++ b/src/components/cluster/new/index.js
@@ -1,5 +1,3 @@
-
-
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';

--- a/src/components/cluster/new/index.js
+++ b/src/components/cluster/new/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';

--- a/src/components/cluster/new/provider_credentials.js
+++ b/src/components/cluster/new/provider_credentials.js
@@ -1,5 +1,3 @@
-
-
 import { connect } from 'react-redux';
 import { organizationCredentialsLoad } from '../../../actions/organizationActions';
 import AWSAccountID from '../../shared/aws_account_id';

--- a/src/components/cluster/new/provider_credentials.js
+++ b/src/components/cluster/new/provider_credentials.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { connect } from 'react-redux';
 import { organizationCredentialsLoad } from '../../../actions/organizationActions';

--- a/src/components/cluster/new/release_selector.js
+++ b/src/components/cluster/new/release_selector.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { connect } from 'react-redux';
 import {

--- a/src/components/cluster/new/release_selector.js
+++ b/src/components/cluster/new/release_selector.js
@@ -1,5 +1,3 @@
-
-
 import { connect } from 'react-redux';
 import {
   FlashMessage,

--- a/src/components/cluster/new/view.js
+++ b/src/components/cluster/new/view.js
@@ -1,5 +1,3 @@
-
-
 import { Breadcrumb } from 'react-breadcrumbs';
 import { clusterCreate } from '../../../actions/clusterActions';
 import { connect } from 'react-redux';

--- a/src/components/cluster/new/view.js
+++ b/src/components/cluster/new/view.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Breadcrumb } from 'react-breadcrumbs';
 import { clusterCreate } from '../../../actions/clusterActions';

--- a/src/components/forgot_password/index.js
+++ b/src/components/forgot_password/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as forgotPasswordActions from '../../actions/forgotPasswordActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/forgot_password/index.js
+++ b/src/components/forgot_password/index.js
@@ -1,5 +1,3 @@
-
-
 import * as forgotPasswordActions from '../../actions/forgotPasswordActions';
 import { bindActionCreators } from 'redux';
 import {

--- a/src/components/forgot_password/set_password.js
+++ b/src/components/forgot_password/set_password.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as forgotPasswordActions from '../../actions/forgotPasswordActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/forgot_password/set_password.js
+++ b/src/components/forgot_password/set_password.js
@@ -1,5 +1,3 @@
-
-
 import * as forgotPasswordActions from '../../actions/forgotPasswordActions';
 import { bindActionCreators } from 'redux';
 import {

--- a/src/components/getting-started/0_overview.js
+++ b/src/components/getting-started/0_overview.js
@@ -1,5 +1,3 @@
-
-
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/getting-started/0_overview.js
+++ b/src/components/getting-started/0_overview.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';

--- a/src/components/getting-started/1_configure_kubectl.js
+++ b/src/components/getting-started/1_configure_kubectl.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { Breadcrumb } from 'react-breadcrumbs';

--- a/src/components/getting-started/1_configure_kubectl.js
+++ b/src/components/getting-started/1_configure_kubectl.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/getting-started/1_configure_kubectl_alternative.js
+++ b/src/components/getting-started/1_configure_kubectl_alternative.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { CodeBlock, Prompt } from './codeblock';

--- a/src/components/getting-started/1_configure_kubectl_alternative.js
+++ b/src/components/getting-started/1_configure_kubectl_alternative.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/getting-started/2_simple_example.js
+++ b/src/components/getting-started/2_simple_example.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { Breadcrumb } from 'react-breadcrumbs';

--- a/src/components/getting-started/2_simple_example.js
+++ b/src/components/getting-started/2_simple_example.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/getting-started/3_next_steps.js
+++ b/src/components/getting-started/3_next_steps.js
@@ -1,5 +1,3 @@
-
-
 import { Breadcrumb } from 'react-breadcrumbs';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';

--- a/src/components/getting-started/3_next_steps.js
+++ b/src/components/getting-started/3_next_steps.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Breadcrumb } from 'react-breadcrumbs';
 import { Link } from 'react-router-dom';

--- a/src/components/getting-started/codeblock.js
+++ b/src/components/getting-started/codeblock.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as Helpers from '../../lib/helpers';
 import copy from 'copy-to-clipboard';

--- a/src/components/getting-started/codeblock.js
+++ b/src/components/getting-started/codeblock.js
@@ -1,5 +1,3 @@
-
-
 import * as Helpers from '../../lib/helpers';
 import copy from 'copy-to-clipboard';
 import Line from './line';

--- a/src/components/getting-started/fileblock.js
+++ b/src/components/getting-started/fileblock.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as Helpers from '../../lib/helpers';
 import copy from 'copy-to-clipboard';

--- a/src/components/getting-started/fileblock.js
+++ b/src/components/getting-started/fileblock.js
@@ -1,5 +1,3 @@
-
-
 import * as Helpers from '../../lib/helpers';
 import copy from 'copy-to-clipboard';
 import Line from './line';

--- a/src/components/getting-started/index.js
+++ b/src/components/getting-started/index.js
@@ -1,5 +1,3 @@
-
-
 import { Breadcrumb } from 'react-breadcrumbs';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import DocumentTitle from 'react-document-title';

--- a/src/components/getting-started/index.js
+++ b/src/components/getting-started/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Breadcrumb } from 'react-breadcrumbs';
 import { Redirect, Route, Switch } from 'react-router-dom';

--- a/src/components/getting-started/line.js
+++ b/src/components/getting-started/line.js
@@ -1,5 +1,3 @@
-
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/src/components/getting-started/line.js
+++ b/src/components/getting-started/line.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/home/cluster_empty_state.js
+++ b/src/components/home/cluster_empty_state.js
@@ -1,5 +1,3 @@
-
-
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/home/cluster_empty_state.js
+++ b/src/components/home/cluster_empty_state.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -1,5 +1,3 @@
-
-
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as clusterActions from '../../actions/clusterActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,5 +1,3 @@
-
-
 import * as UserActions from '../actions/userActions';
 import { bindActionCreators } from 'redux';
 import { Breadcrumb } from 'react-breadcrumbs';

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as UserActions from '../actions/userActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { clusterDeleteConfirmed } from '../../actions/clusterActions';
 import { connect } from 'react-redux';

--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -1,5 +1,3 @@
-
-
 import { clusterDeleteConfirmed } from '../../actions/clusterActions';
 import { connect } from 'react-redux';
 import { modalHide } from '../../actions/modalActions';

--- a/src/components/modals/release_details_modal.js
+++ b/src/components/modals/release_details_modal.js
@@ -1,5 +1,3 @@
-
-
 import { relativeDate } from '../../lib/helpers.js';
 import _ from 'underscore';
 import BootstrapModal from 'react-bootstrap/lib/Modal';

--- a/src/components/modals/release_details_modal.js
+++ b/src/components/modals/release_details_modal.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { relativeDate } from '../../lib/helpers.js';
 import _ from 'underscore';

--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Breadcrumbs } from 'react-breadcrumbs';
 import { connect } from 'react-redux';

--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -1,5 +1,3 @@
-
-
 import { Breadcrumbs } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';

--- a/src/components/organizations/detail/credentials.js
+++ b/src/components/organizations/detail/credentials.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { connect } from 'react-redux';
 import {

--- a/src/components/organizations/detail/credentials.js
+++ b/src/components/organizations/detail/credentials.js
@@ -1,5 +1,3 @@
-
-
 import { connect } from 'react-redux';
 import {
   organizationCredentialsLoad,

--- a/src/components/organizations/detail/index.js
+++ b/src/components/organizations/detail/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';

--- a/src/components/organizations/detail/index.js
+++ b/src/components/organizations/detail/index.js
@@ -1,5 +1,3 @@
-
-
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';

--- a/src/components/organizations/detail/view.js
+++ b/src/components/organizations/detail/view.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as OrganizationActions from '../../../actions/organizationActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/organizations/detail/view.js
+++ b/src/components/organizations/detail/view.js
@@ -1,5 +1,3 @@
-
-
 import * as OrganizationActions from '../../../actions/organizationActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/organizations/index.js
+++ b/src/components/organizations/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';

--- a/src/components/organizations/index.js
+++ b/src/components/organizations/index.js
@@ -1,5 +1,3 @@
-
-
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';

--- a/src/components/organizations/list/index.js
+++ b/src/components/organizations/list/index.js
@@ -1,5 +1,3 @@
-
-
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';

--- a/src/components/organizations/list/index.js
+++ b/src/components/organizations/list/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';

--- a/src/components/organizations/list/organization_row.js
+++ b/src/components/organizations/list/organization_row.js
@@ -1,5 +1,3 @@
-
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/src/components/organizations/list/organization_row.js
+++ b/src/components/organizations/list/organization_row.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/organizations/list/view.js
+++ b/src/components/organizations/list/view.js
@@ -1,5 +1,3 @@
-
-
 import { clustersForOrg } from '../../../lib/helpers';
 import { connect } from 'react-redux';
 import {

--- a/src/components/organizations/list/view.js
+++ b/src/components/organizations/list/view.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { clustersForOrg } from '../../../lib/helpers';
 import { connect } from 'react-redux';

--- a/src/components/shared/aws_account_id.js
+++ b/src/components/shared/aws_account_id.js
@@ -1,5 +1,3 @@
-
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/src/components/shared/aws_account_id.js
+++ b/src/components/shared/aws_account_id.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/shared/button.js
+++ b/src/components/shared/button.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import BsButton from 'react-bootstrap/lib/Button';
 import PropTypes from 'prop-types';

--- a/src/components/shared/button.js
+++ b/src/components/shared/button.js
@@ -1,5 +1,3 @@
-
-
 import BsButton from 'react-bootstrap/lib/Button';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/shared/cluster_id_label.js
+++ b/src/components/shared/cluster_id_label.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import ColorHash from 'color-hash';
 import copy from 'copy-to-clipboard';

--- a/src/components/shared/cluster_id_label.js
+++ b/src/components/shared/cluster_id_label.js
@@ -1,5 +1,3 @@
-
-
 import ColorHash from 'color-hash';
 import copy from 'copy-to-clipboard';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';

--- a/src/components/shared/cluster_name.js
+++ b/src/components/shared/cluster_name.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { clusterPatch } from '../../actions/clusterActions';
 import { FlashMessage, messageTTL, messageType } from '../../lib/flash_message';

--- a/src/components/shared/cluster_name.js
+++ b/src/components/shared/cluster_name.js
@@ -1,5 +1,3 @@
-
-
 import { clusterPatch } from '../../actions/clusterActions';
 import { FlashMessage, messageTTL, messageType } from '../../lib/flash_message';
 import Button from '../shared/button';

--- a/src/components/shared/copyable.js
+++ b/src/components/shared/copyable.js
@@ -1,5 +1,3 @@
-
-
 import copy from 'copy-to-clipboard';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import PropTypes from 'prop-types';

--- a/src/components/shared/copyable.js
+++ b/src/components/shared/copyable.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import copy from 'copy-to-clipboard';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';

--- a/src/components/shared/email_field.js
+++ b/src/components/shared/email_field.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/shared/email_field.js
+++ b/src/components/shared/email_field.js
@@ -1,5 +1,3 @@
-
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/components/shared/input_field.js
+++ b/src/components/shared/input_field.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/shared/input_field.js
+++ b/src/components/shared/input_field.js
@@ -1,5 +1,3 @@
-
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/components/shared/node_count_selector.js
+++ b/src/components/shared/node_count_selector.js
@@ -1,5 +1,3 @@
-
-
 import { connect } from 'react-redux';
 import NumberPicker from './number_picker.js';
 import PropTypes from 'prop-types';

--- a/src/components/shared/node_count_selector.js
+++ b/src/components/shared/node_count_selector.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { connect } from 'react-redux';
 import NumberPicker from './number_picker.js';

--- a/src/components/shared/number_picker.js
+++ b/src/components/shared/number_picker.js
@@ -1,5 +1,3 @@
-
-
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/shared/number_picker.js
+++ b/src/components/shared/number_picker.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/src/components/shared/refreshable_label.js
+++ b/src/components/shared/refreshable_label.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import _ from 'underscore';
 import PropTypes from 'prop-types';

--- a/src/components/shared/refreshable_label.js
+++ b/src/components/shared/refreshable_label.js
@@ -1,5 +1,3 @@
-
-
 import _ from 'underscore';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/signup/index.js
+++ b/src/components/signup/index.js
@@ -1,5 +1,3 @@
-
-
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/src/components/signup/index.js
+++ b/src/components/signup/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as userActions from '../../actions/userActions';
 import { bindActionCreators } from 'redux';

--- a/src/components/signup/password_field.js
+++ b/src/components/signup/password_field.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/signup/password_field.js
+++ b/src/components/signup/password_field.js
@@ -1,5 +1,3 @@
-
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/components/signup/status_message.js
+++ b/src/components/signup/status_message.js
@@ -1,5 +1,3 @@
-
-
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/src/components/signup/status_message.js
+++ b/src/components/signup/status_message.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/signup/terms_of_service.js
+++ b/src/components/signup/terms_of_service.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import React from 'react';
 

--- a/src/components/signup/terms_of_service.js
+++ b/src/components/signup/terms_of_service.js
@@ -1,5 +1,3 @@
-
-
 import React from 'react';
 
 class TermsOfService extends React.Component {

--- a/src/components/users/index.js
+++ b/src/components/users/index.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';

--- a/src/components/users/index.js
+++ b/src/components/users/index.js
@@ -1,5 +1,3 @@
-
-
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import {

--- a/src/lib/api_status_client.js
+++ b/src/lib/api_status_client.js
@@ -1,5 +1,3 @@
-
-
 var request = require('superagent-bluebird-promise');
 var helpers = require('./helpers');
 

--- a/src/lib/api_status_client.js
+++ b/src/lib/api_status_client.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 var request = require('superagent-bluebird-promise');
 var helpers = require('./helpers');

--- a/src/lib/flash_message.js
+++ b/src/lib/flash_message.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import Noty from 'noty';
 

--- a/src/lib/flash_message.js
+++ b/src/lib/flash_message.js
@@ -1,5 +1,3 @@
-
-
 import Noty from 'noty';
 
 // messageType affects the visual markup to distinguish severity

--- a/src/lib/giantswarm_v4_client_wrapper.js
+++ b/src/lib/giantswarm_v4_client_wrapper.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 // A wrapper for the GiantSwarm V4 JS Client
 // It initializes the client with the right end point.

--- a/src/lib/giantswarm_v4_client_wrapper.js
+++ b/src/lib/giantswarm_v4_client_wrapper.js
@@ -1,5 +1,3 @@
-
-
 // A wrapper for the GiantSwarm V4 JS Client
 // It initializes the client with the right end point.
 

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import _ from 'underscore';
 import moment from 'moment';

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,5 +1,3 @@
-
-
 import _ from 'underscore';
 import moment from 'moment';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';

--- a/src/lib/page_visibility_tracker.js
+++ b/src/lib/page_visibility_tracker.js
@@ -1,5 +1,3 @@
-
-
 class PageVisibilityTracker {
   constructor() {
     // client-independent tracking of visibility change

--- a/src/lib/page_visibility_tracker.js
+++ b/src/lib/page_visibility_tracker.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 class PageVisibilityTracker {
   constructor() {

--- a/src/lib/passage_client.js
+++ b/src/lib/passage_client.js
@@ -1,5 +1,3 @@
-
-
 var request = require('superagent-bluebird-promise');
 var helpers = require('./helpers');
 

--- a/src/lib/passage_client.js
+++ b/src/lib/passage_client.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 var request = require('superagent-bluebird-promise');
 var helpers = require('./helpers');

--- a/src/lib/password_validation.js
+++ b/src/lib/password_validation.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 export function validatePassword(password) {
   var valid = false;

--- a/src/lib/password_validation.js
+++ b/src/lib/password_validation.js
@@ -1,5 +1,3 @@
-
-
 export function validatePassword(password) {
   var valid = false;
   var statusMessage = '';

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 //
 // A wrapper around platform.js that returns just:

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -1,5 +1,3 @@
-
-
 //
 // A wrapper around platform.js that returns just:
 // 'Windows', 'Mac', 'Linux', or 'Unknown'

--- a/src/reducers/appReducer.js
+++ b/src/reducers/appReducer.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from '../actions/actionTypes';
 import GiantSwarmV4 from 'giantswarm-v4';

--- a/src/reducers/appReducer.js
+++ b/src/reducers/appReducer.js
@@ -1,5 +1,3 @@
-
-
 import * as types from '../actions/actionTypes';
 import GiantSwarmV4 from 'giantswarm-v4';
 

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from '../actions/actionTypes';
 import _ from 'underscore';

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -1,5 +1,3 @@
-
-
 import * as types from '../actions/actionTypes';
 import _ from 'underscore';
 import moment from 'moment';

--- a/src/reducers/credentialReducer.js
+++ b/src/reducers/credentialReducer.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from '../actions/actionTypes';
 

--- a/src/reducers/credentialReducer.js
+++ b/src/reducers/credentialReducer.js
@@ -1,5 +1,3 @@
-
-
 import * as types from '../actions/actionTypes';
 
 export default function credentialReducer(

--- a/src/reducers/invitationReducer.js
+++ b/src/reducers/invitationReducer.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from '../actions/actionTypes';
 

--- a/src/reducers/invitationReducer.js
+++ b/src/reducers/invitationReducer.js
@@ -1,5 +1,3 @@
-
-
 import * as types from '../actions/actionTypes';
 
 export default function invitationReducer(

--- a/src/reducers/modalReducer.js
+++ b/src/reducers/modalReducer.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from '../actions/actionTypes';
 

--- a/src/reducers/modalReducer.js
+++ b/src/reducers/modalReducer.js
@@ -1,5 +1,3 @@
-
-
 import * as types from '../actions/actionTypes';
 
 export default function modalReducer(

--- a/src/reducers/organizationReducer.js
+++ b/src/reducers/organizationReducer.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from '../actions/actionTypes';
 

--- a/src/reducers/organizationReducer.js
+++ b/src/reducers/organizationReducer.js
@@ -1,5 +1,3 @@
-
-
 import * as types from '../actions/actionTypes';
 
 /**

--- a/src/reducers/releaseReducer.js
+++ b/src/reducers/releaseReducer.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from '../actions/actionTypes';
 import _ from 'underscore';

--- a/src/reducers/releaseReducer.js
+++ b/src/reducers/releaseReducer.js
@@ -1,5 +1,3 @@
-
-
 import * as types from '../actions/actionTypes';
 import _ from 'underscore';
 

--- a/src/reducers/userReducer.js
+++ b/src/reducers/userReducer.js
@@ -1,5 +1,3 @@
-
-
 import * as types from '../actions/actionTypes';
 
 export default function userReducer(

--- a/src/reducers/userReducer.js
+++ b/src/reducers/userReducer.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import * as types from '../actions/actionTypes';
 

--- a/src/stores/configureStore.js
+++ b/src/stores/configureStore.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { applyMiddleware, compose, createStore } from 'redux';
 import { routerMiddleware } from 'connected-react-router';

--- a/src/stores/configureStore.js
+++ b/src/stores/configureStore.js
@@ -1,5 +1,3 @@
-
-
 import { applyMiddleware, compose, createStore } from 'redux';
 import { routerMiddleware } from 'connected-react-router';
 import history from './history';

--- a/src/stores/history.js
+++ b/src/stores/history.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import { createBrowserHistory } from 'history';
 

--- a/src/stores/history.js
+++ b/src/stores/history.js
@@ -1,5 +1,3 @@
-
-
 import { createBrowserHistory } from 'history';
 
 const history = createBrowserHistory();


### PR DESCRIPTION
Adds a linting rule to warn us when we have a useless `'use strict';` in our code.
And removes all the cases where it was not needed.