### PR TITLE
Don't show tab 2 as the first tab.

### DIFF
--- a/src/components/cluster/detail/tabs.js
+++ b/src/components/cluster/detail/tabs.js
@@ -1,0 +1,17 @@
+import BootstrapTabs from 'react-bootstrap/lib/Tabs';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const Tabs = props => {
+  return (
+    <BootstrapTabs animation={false} defaultActiveKey={1} id='tabs'>
+      {props.children}
+    </BootstrapTabs>
+  );
+};
+
+Tabs.propTypes = {
+  children: PropTypes.node,
+};
+
+export default Tabs;

--- a/src/components/cluster/detail/tabs.test.js
+++ b/src/components/cluster/detail/tabs.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Tab from 'react-bootstrap/lib/Tab';
+import { mount } from 'enzyme';
+
+import Tabs from './tabs';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Tabs />, div);
+});
+
+it('renders only the first tab', () => {
+  const tabs = mount(
+    <Tabs>
+      <Tab eventKey={1} title='first'>
+        <h1>First Tab</h1>
+      </Tab>
+      <Tab eventKey={2} title='second'>
+        <h1>Second Tab</h1>
+      </Tab>
+      <Tab eventKey={3} title='third'>
+        <h1>Third Tab</h1>
+      </Tab>
+    </Tabs>
+  );
+
+  expect(tabs.find('#tabs-pane-1').hasClass('active')).toEqual(true);
+
+  expect(tabs.find('#tabs-pane-2').hasClass('active')).toEqual(false);
+
+  expect(tabs.find('#tabs-pane-3').hasClass('active')).toEqual(false);
+});

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -23,7 +23,7 @@ import React from 'react';
 import ReactTimeout from 'react-timeout';
 import ScaleClusterModal from './scale_cluster_modal';
 import Tab from 'react-bootstrap/lib/Tab';
-import Tabs from 'react-bootstrap/lib/Tabs';
+import Tabs from './tabs';
 import UpgradeClusterModal from './upgrade_cluster_modal';
 
 class ClusterDetailView extends React.Component {
@@ -293,7 +293,7 @@ class ClusterDetailView extends React.Component {
               </div>
               <div className='row'>
                 <div className='col-12'>
-                  <Tabs animation={false} defaultActiveKey={1} id='tabs'>
+                  <Tabs>
                     <Tab eventKey={1} title='General'>
                       <ClusterDetailTable
                         canClusterUpgrade={this.canClusterUpgrade()}

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -293,7 +293,7 @@ class ClusterDetailView extends React.Component {
               </div>
               <div className='row'>
                 <div className='col-12'>
-                  <Tabs animation={false} defaultActiveKey={2} id='tabs'>
+                  <Tabs animation={false} defaultActiveKey={1} id='tabs'>
                     <Tab eventKey={1} title='General'>
                       <ClusterDetailTable
                         canClusterUpgrade={this.canClusterUpgrade()}


### PR DESCRIPTION
I made a mistake and committed this, which I had set to `2` to more quickly test some changes I was making to the keypair table.

I'm gonna try to write a test so I don't make that same mistake again.