### PR TITLE
Wire up a keypair detail modal.

### DIFF
--- a/src/components/cluster/detail/generic_modal.js
+++ b/src/components/cluster/detail/generic_modal.js
@@ -1,0 +1,33 @@
+import BootstrapModal from 'react-bootstrap/lib/Modal';
+import Button from '../../shared/button';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const GenericModal = props => {
+  return (
+    <BootstrapModal
+      className='create-key-pair-modal--success'
+      show={props.visible}
+      onHide={props.onClose}
+    >
+      <BootstrapModal.Header closeButton>
+        <BootstrapModal.Title>{props.title}</BootstrapModal.Title>
+      </BootstrapModal.Header>
+      <BootstrapModal.Body>{props.children}</BootstrapModal.Body>
+      <BootstrapModal.Footer>
+        <Button bsStyle='link' onClick={close}>
+          Close
+        </Button>
+      </BootstrapModal.Footer>
+    </BootstrapModal>
+  );
+};
+
+GenericModal.propTypes = {
+  children: PropTypes.node,
+  onClose: PropTypes.func,
+  title: PropTypes.node,
+  visible: PropTypes.bool,
+};
+
+export default GenericModal;

--- a/src/components/cluster/detail/key_pairs.js
+++ b/src/components/cluster/detail/key_pairs.js
@@ -7,6 +7,7 @@ import Button from '../../shared/button';
 import CertificateOrgsLabel from './certificate_orgs_label';
 import Copyable from '../../shared/copyable';
 import KeypairCreateModal from './key_pair_create_modal';
+import KeypairDetailModal from './generic_modal';
 import moment from 'moment';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import PropTypes from 'prop-types';
@@ -22,6 +23,12 @@ class ClusterKeyPairs extends React.Component {
     cn_prefix: '',
     cn_prefix_error: null,
     certificate_organizations: '',
+    keypairModal: {
+      visible: false,
+      keypair: {
+        id: '',
+      },
+    },
     modal: {
       visible: false,
       loading: false,
@@ -140,13 +147,17 @@ class ClusterKeyPairs extends React.Component {
     );
   }
 
-  commonNameFormatter(cell, row) {
+  commonNameFormatter = (cell, row) => {
     return (
-      <Copyable copyText={row.common_name}>
-        <small>{row.common_name}</small>
-      </Copyable>
+      <React.Fragment>
+        <Copyable copyText={row.common_name}>
+          <small>{row.common_name}</small>
+        </Copyable>
+        <br />
+        <Button onClick={this.showKeypairModal.bind(this, row)}>Details</Button>
+      </React.Fragment>
     );
-  }
+  };
 
   organizationFormatter(cell, row) {
     if (row.certificate_organizations !== '') {
@@ -158,6 +169,29 @@ class ClusterKeyPairs extends React.Component {
     }
     return <span />;
   }
+
+  bindShowModal = showFunc => {
+    this.showModal = showFunc;
+  };
+
+  showKeypairModal = row => {
+    this.setState({
+      keypairModal: {
+        visible: true,
+        keypair: {
+          id: row.id,
+        },
+      },
+    });
+  };
+
+  hideKeypairModal = () => {
+    this.setState({
+      keypairModal: {
+        visible: false,
+      },
+    });
+  };
 
   render() {
     return (
@@ -224,6 +258,16 @@ class ClusterKeyPairs extends React.Component {
               cluster={this.props.cluster}
               actions={this.props.actions}
             />
+
+            <KeypairDetailModal
+              visible={this.state.keypairModal.visible}
+              title='Key Pair Detail'
+              onClose={this.hideKeypairModal}
+            >
+              ID:
+              {this.state.keypairModal.keypair &&
+                this.state.keypairModal.keypair.id}
+            </KeypairDetailModal>
           </div>
         </div>
       </div>


### PR DESCRIPTION
@marians, this wires up a detail modal and adds a button to each row, placed hackishly in the `common name` column for now.

Feel free to take this PR as inspiration or continue from here.

I didn't manage to do what I wanted to do (which was to NOT have the visible state of the keypair tracked in the parent), so this is basically the same pattern we've done so far, except there is now this wrapped Bootstrap Modal (`generic_modal.js`) which makes it a bit less typing to get the structure of a basic modal up and running.