### PR TITLE
Fix initial org create

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -88,7 +88,10 @@ export function auth0Login(authResult) {
   return function(dispatch) {
     return new Promise(function(resolve) {
       let isAdmin = false;
-      if (authResult.idTokenPayload['https://giantswarm.io/groups'] === 'api-admin') {
+      if (
+        authResult.idTokenPayload['https://giantswarm.io/groups'] ===
+        'api-admin'
+      ) {
         isAdmin = true;
       }
 

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -62,6 +62,7 @@ export function refreshUserInfo() {
             scheme: getState().app.loggedInUser.auth.scheme,
             token: getState().app.loggedInUser.auth.token,
           },
+          isAdmin: getState().app.loggedInUser.isAdmin,
         };
 
         dispatch({
@@ -86,12 +87,18 @@ export function refreshUserInfo() {
 export function auth0Login(authResult) {
   return function(dispatch) {
     return new Promise(function(resolve) {
+      let isAdmin = false;
+      if (authResult.idTokenPayload['https://giantswarm.io/groups'] === 'api-admin') {
+        isAdmin = true;
+      }
+
       var userData = {
         email: authResult.idTokenPayload.email,
         auth: {
           scheme: 'Bearer',
           token: authResult.accessToken,
         },
+        isAdmin: isAdmin,
       };
 
       resolve(dispatch(loginSuccess(userData)));

--- a/src/reducers/appReducer.js
+++ b/src/reducers/appReducer.js
@@ -124,18 +124,11 @@ export default function appReducer(
 
     case types.ORGANIZATIONS_LOAD_SUCCESS:
       // Organizations have been loaded.
-
-      // Determine if the user should be considered an admin.
-      var isAdmin = false;
-
       var organizations = Object.entries(action.organizations).map(
         ([, o]) => o.id
       );
-      if (organizations.indexOf('giantswarm') != -1) {
-        isAdmin = true;
-      }
 
-      var loggedInUser = Object.assign({}, state.loggedInUser, { isAdmin });
+      var loggedInUser = Object.assign({}, state.loggedInUser);
 
       // Deterimine what organization should be selected.
       var selectedOrganization = determineSelectedOrganization(


### PR DESCRIPTION
Theres a problem creating orgs as an admin when the cluster has no orgs yet.

As an admin, happa has to create the org without trying to add you to it at the same time. 

And, it already has code that does that. However, the way it knows you are an admin is if you are in the giantswarm org, which doesn’t exist yet.

This adjusts Happa's logic so that it determines whether or not you are an admin from a claim in the JWT token. This claim is only given to us admins. (And so far only us admins can even use SSO, but anyways this is better than simply granting `isAdmin` to all auth0 logins, since in the future we might have other users also making use of the SSO login route)

BTW, this has nothing to do with being an 'admin' on the API. In other words, if someone were to edit their localstorage and set isAdmin to `true`, that wouldn't mean that they can suddenly access the admin only api endpoints. They _would_ see the `Users` link in the main navigation, but no full list of users would load.

It is only changing how happa decides whether or not the person logged in is an admin to be more in line with how the API does it too.

Alternatively we could change the API to return `isAdmin: true|false` for the `/v4/user` call, but that is something we want to avoid cementing into the API, and instead want to keep the door open for a more role based permission model.

