### PR TITLE
Attempt fetching an index.yaml using cors anywhere if it fails.

### DIFF
--- a/src/actions/catalogActions.js
+++ b/src/actions/catalogActions.js
@@ -5,8 +5,20 @@ import yaml from 'js-yaml';
 // loadCatalog takes a catalog object and tries to load further data.
 function loadCatalogIndex(catalog) {
   return fetch(catalog.spec.storage.URL + 'index.yaml', { mode: 'cors' })
+    .catch(() => {
+      console.log(`Fetch error for ${catalog.spec.storage.URL}, attempting with cors anywhere.`);
+      return fetch('https://cors-anywhere.herokuapp.com/' + catalog.spec.storage.URL + 'index.yaml', { mode: 'cors' });
+    })
+    .catch((error) => {
+      console.error('Fetch error: ', error);
+      throw error;
+    })
     .then(response => {
-      return response.text();
+      if (response.status === 200) {
+        return response.text();
+      } else {
+        throw `Could not fetch index.yaml at ${catalog.spec.storage.URL}`;
+      }
     })
     .then(body => {
       let rawCatalog = yaml.safeLoad(body);
@@ -14,7 +26,7 @@ function loadCatalogIndex(catalog) {
       return catalog;
     })
     .catch(error => {
-      console.error(error);
+      console.error('YAML error: ', error);
       throw error;
     });
 }

--- a/src/actions/catalogActions.js
+++ b/src/actions/catalogActions.js
@@ -6,10 +6,19 @@ import yaml from 'js-yaml';
 function loadCatalogIndex(catalog) {
   return fetch(catalog.spec.storage.URL + 'index.yaml', { mode: 'cors' })
     .catch(() => {
-      console.log(`Fetch error for ${catalog.spec.storage.URL}, attempting with cors anywhere.`);
-      return fetch('https://cors-anywhere.herokuapp.com/' + catalog.spec.storage.URL + 'index.yaml', { mode: 'cors' });
+      console.log(
+        `Fetch error for ${
+          catalog.spec.storage.URL
+        }, attempting with cors anywhere.`
+      );
+      return fetch(
+        'https://cors-anywhere.herokuapp.com/' +
+          catalog.spec.storage.URL +
+          'index.yaml',
+        { mode: 'cors' }
+      );
     })
-    .catch((error) => {
+    .catch(error => {
       console.error('Fetch error: ', error);
       throw error;
     })

--- a/src/components/app_catalog/catalogs/index.js
+++ b/src/components/app_catalog/catalogs/index.js
@@ -54,12 +54,6 @@ class Catalogs extends React.Component {
               </div>
             </React.Fragment>
           )}
-          <p className='well'>
-            <b>Preview Limitations:</b>
-            <br />
-            During the preview you&apos;ll only be able to browse apps.
-            Installing apps is coming soon!
-          </p>
         </React.Fragment>
       </DocumentTitle>
     );


### PR DESCRIPTION
This is a lil workaround while we do not cache and serve the index.yamls ourself.

fyi @puja108 
