### PR TITLE
Show duration statistics on cluster creation page

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "connected-react-router": "6.4.0",
     "copy-to-clipboard": "3.2.0",
     "deep-diff": "1.0.2",
-    "giantswarm-v4": "git+https://github.com/giantswarm/giantswarm-js-client.git#master",
+    "giantswarm-v4": "git+https://github.com/giantswarm/giantswarm-js-client.git#add-info-stats",
     "history": "^4.7.2",
     "immutable": "3.8.2",
     "js-base64": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "connected-react-router": "6.4.0",
     "copy-to-clipboard": "3.2.0",
     "deep-diff": "1.0.2",
-    "giantswarm-v4": "git+https://github.com/giantswarm/giantswarm-js-client.git#add-info-stats",
+    "giantswarm-v4": "git+https://github.com/giantswarm/giantswarm-js-client.git#master",
     "history": "^4.7.2",
     "immutable": "3.8.2",
     "js-base64": "2.5.1",

--- a/src/components/cluster/new/cluster_creation_duration.js
+++ b/src/components/cluster/new/cluster_creation_duration.js
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class ClusterCreationDuration extends React.Component {
+  render() {
+    let minutes = 0;
+
+    if (this.props.stats.p75) {
+      minutes = Math.round(this.props.stats.p75 / 60.0);
+    }
+
+    if (minutes > 0) {
+      return (
+        <p>
+          Most clusters are up within {minutes} minutes once this form has been
+          submitted.
+        </p>
+      );
+    }
+
+    return <p>Clusters usually take between 10 and 30 minutes to come up.</p>;
+  }
+}
+
+ClusterCreationDuration.propTypes = {
+  stats: PropTypes.object,
+};
+
+export default ClusterCreationDuration;

--- a/src/components/cluster/new/view.js
+++ b/src/components/cluster/new/view.js
@@ -5,6 +5,7 @@ import { push } from 'connected-react-router';
 import AWSInstanceTypeSelector from './aws_instance_type_selector.js';
 import AzureVMSizeSelector from './azure_vm_size_selector.js';
 import Button from '../../shared/button';
+import ClusterCreationDuration from './cluster_creation_duration';
 import cmp from 'semver-compare';
 import DocumentTitle from 'react-document-title';
 import NodeCountSelector from '../../shared/node_count_selector.js';
@@ -530,10 +531,10 @@ class CreateCluster extends React.Component {
 
             <div className='row section new-cluster--launch'>
               <div className='col-12'>
-                <p>
-                  Create this cluster now and it will be available for you to
-                  use as soon as possible.
-                </p>
+                <ClusterCreationDuration
+                  stats={this.props.clusterCreationStats}
+                />
+
                 {this.state.error ? this.errorState() : undefined}
                 <Button
                   type='button'
@@ -568,6 +569,7 @@ CreateCluster.propTypes = {
   defaultMemorySize: PropTypes.number,
   defaultDiskSize: PropTypes.number,
   match: PropTypes.object,
+  clusterCreationStats: PropTypes.object,
 };
 
 function mapStateToProps(state) {
@@ -575,6 +577,7 @@ function mapStateToProps(state) {
   var maxAvailabilityZones = state.app.info.general.availability_zones.max;
   var selectedOrganization = state.app.selectedOrganization;
   var provider = state.app.info.general.provider;
+  var clusterCreationStats = state.app.info.stats.cluster_creation_duration;
 
   var defaultInstanceType;
   if (
@@ -622,6 +625,7 @@ function mapStateToProps(state) {
     defaultMemorySize,
     defaultDiskSize,
     selectedOrganization,
+    clusterCreationStats,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,9 +4378,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-"giantswarm-v4@git+https://github.com/giantswarm/giantswarm-js-client.git#add-info-stats":
+"giantswarm-v4@git+https://github.com/giantswarm/giantswarm-js-client.git#master":
   version "4.0.0"
-  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#9506144c7cd5987958691f313b0aabeb8a405476"
+  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#7b02299dd0f085ba3e4cd6788c0f52dad5a3cc81"
   dependencies:
     superagent "3.8.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,9 +4378,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-"giantswarm-v4@git+https://github.com/giantswarm/giantswarm-js-client.git#master":
+"giantswarm-v4@git+https://github.com/giantswarm/giantswarm-js-client.git#add-info-stats":
   version "4.0.0"
-  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#f50529d9805720e99b9cbd36d372afa3b4eeec33"
+  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#9506144c7cd5987958691f313b0aabeb8a405476"
   dependencies:
     superagent "3.8.3"
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6005

This adds some info regarding the actual cluster creation duration to the creation page. The info is coming from the statistics provided via the API's info endpoint.

### Preview

![image](https://user-images.githubusercontent.com/273727/58895158-9f578a00-86f3-11e9-8d86-cd77514640a5.png)

### TODO

- [x] revert JS client branch to master before merging
