### PR TITLE
Remove notice regarding moved content

### DIFF
--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -301,16 +301,6 @@ class ClusterDetailView extends React.Component {
                         workerNodesDesired={this.getDesiredNumberOfNodes()}
                       />
 
-                      <div className='row section col-12'>
-                        <h3 className='table-label'>
-                          Key Pairs and Managed Services are gone?
-                        </h3>
-                        <p>
-                          No, we just moved them into separate tabs above to
-                          clean up a bit.
-                        </p>
-                      </div>
-
                       <div className='row section cluster_delete col-12'>
                         <div className='row'>
                           <h3 className='table-label'>Delete This Cluster</h3>


### PR DESCRIPTION
This PR removes the following notice:

![image](https://user-images.githubusercontent.com/273727/59333205-20b4ab00-8cf8-11e9-97f7-11bf77ca0a05.png)
