### PR TITLE
.eslintrc minor mods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,38 +18,18 @@
     "no-underscore-dangle": 0,
     "no-unused-vars": 1,
     "no-useless-escape": 0,
-    "quotes": [
-      1,
-      "single",
-      {
-        "allowTemplateLiterals": true
-      }
-    ],
-    "semi": [
-      1,
-      "always"
-    ],
+    "quotes": [1, "single", {"allowTemplateLiterals": true}],
+    "semi": [1, "always"],
     "react/button-has-type": 2,
-    "react/prefer-es6-class": [
-      1,
-      "always"
-    ],
+    "react/prefer-es6-class": [1, "always"],
     "react/no-find-dom-node": 0,
     "react/jsx-sort-props": 2,
     "strict": 2,
-    "sort-imports-es6-autofix/sort-imports-es6": [
-      2,
-      {
-        "ignoreCase": true,
-        "ignoreMemberSort": false,
-        "memberSyntaxSortOrder": [
-          "none",
-          "all",
-          "multiple",
-          "single"
-        ]
-      }
-    ]
+    "sort-imports-es6-autofix/sort-imports-es6": [2, {
+      "ignoreCase": true,
+      "ignoreMemberSort": false,
+      "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+    }]
   },
   "extends": [
     "eslint:recommended",
@@ -59,6 +39,7 @@
     "react",
     "sort-imports-es6-autofix"
   ],
+
   "settings": {
     "react": {
       "version": "16.5.2"

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,21 +14,42 @@
     "es6": true
   },
   "rules": {
-    "strict": 2,
+    "no-console": 0,
     "no-underscore-dangle": 0,
-    "quotes": [1, "single", {"allowTemplateLiterals": true}],
-    "semi": [1, "always"],
+    "no-unused-vars": 1,
+    "no-useless-escape": 0,
+    "quotes": [
+      1,
+      "single",
+      {
+        "allowTemplateLiterals": true
+      }
+    ],
+    "semi": [
+      1,
+      "always"
+    ],
     "react/button-has-type": 2,
-    "react/prefer-es6-class": [1, "always"],
+    "react/prefer-es6-class": [
+      1,
+      "always"
+    ],
     "react/no-find-dom-node": 0,
     "react/jsx-sort-props": 2,
-    "no-console": 0,
-    "no-useless-escape": "off",
-    "sort-imports-es6-autofix/sort-imports-es6": [2, {
-      "ignoreCase": true,
-      "ignoreMemberSort": false,
-      "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
-    }]
+    "strict": 2,
+    "sort-imports-es6-autofix/sort-imports-es6": [
+      2,
+      {
+        "ignoreCase": true,
+        "ignoreMemberSort": false,
+        "memberSyntaxSortOrder": [
+          "none",
+          "all",
+          "multiple",
+          "single"
+        ]
+      }
+    ]
   },
   "extends": [
     "eslint:recommended",
@@ -38,7 +59,6 @@
     "react",
     "sort-imports-es6-autofix"
   ],
-
   "settings": {
     "react": {
       "version": "16.5.2"


### PR DESCRIPTION
I have changed no-unused-vars error level from error to warning because when debugging I like to comment some parts of the code.

I also have sorted rules and favoured numbers instead of strings when defining levels of error.