### PR TITLE
Add eslint emotion plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,11 @@
     "es6": true
   },
   "rules": {
+    "emotion/import-from-emotion": "error",
+    "emotion/jsx-import": "error",
+    "emotion/no-vanilla": "error",
+    "emotion/styled-import": "error",
+    "emotion/syntax-preference": [1, "string"],
     "strict": 2,
     "no-underscore-dangle": 0,
     "quotes": [1, "single", {"allowTemplateLiterals": true}],
@@ -34,6 +39,7 @@
     "plugin:react/recommended"
   ],
   "plugins": [
+    "emotion",
     "react",
     "sort-imports-es6-autofix"
   ],

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "enzyme-adapter-react-16": "^1.13.2",
     "eslint": "5.16.0",
     "eslint-loader": "2.1.2",
+    "eslint-plugin-emotion": "10.0.14",
     "eslint-plugin-react": "7.13.0",
     "eslint-plugin-sort-imports-es6-autofix": "0.4.0",
     "file-loader": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,6 +3656,11 @@ eslint-loader@2.1.2:
     object-hash "^1.1.4"
     rimraf "^2.6.1"
 
+eslint-plugin-emotion@10.0.14:
+  version "10.0.14"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-emotion/-/eslint-plugin-emotion-10.0.14.tgz#c643ff2f34f85ae77a65b2056915e939cf7e8129"
+  integrity sha512-kI0hTPA5oo7MAc2YcdF1JcT36TZ1Ci0S5sbA9aojZ3leEPyCH34YBB76/8NQ3/9gybqrekIEuEhr8MP6JZf95Q==
+
 eslint-plugin-react@7.13.0:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"


### PR DESCRIPTION
To merged into #600 

Adds checks regarding eslint (no CSS syntax checks though)

`emotion/syntax-preference` is about the string syntax being preferred and yields a warning of object syntax is used.

The other rules are checking imports.