### PR TITLE
Adjust width of availability zone label (minor)

### DIFF
--- a/src/components/UI/availability_zones_label.js
+++ b/src/components/UI/availability_zones_label.js
@@ -14,7 +14,7 @@ const Wrapper = styled.abbr`
   color: #333;
   padding: 2px;
   display: inline-block;
-  width: 1.7em;
+  width: 1.6em;
   text-align: center;
   margin-left: 4px;
   margin-right: 4px;


### PR DESCRIPTION
This turns an oval into a circle.