### PR TITLE
Sort changes by component name

### DIFF
--- a/src/components/cluster/detail/upgrade_cluster_modal.js
+++ b/src/components/cluster/detail/upgrade_cluster_modal.js
@@ -113,13 +113,15 @@ class UpgradeClusterModal extends React.Component {
           <b>Changes</b>
         </p>
         <ul>
-          {this.props.targetRelease.changelog.map((changelog, i) => {
-            return (
-              <li key={changelog.component + i}>
-                <b>{changelog.component}:</b> {changelog.description}
-              </li>
-            );
-          })}
+          {_.sortBy(this.props.targetRelease.changelog, 'component').map(
+            (changelog, i) => {
+              return (
+                <li key={changelog.component + i}>
+                  <b>{changelog.component}:</b> {changelog.description}
+                </li>
+              );
+            }
+          )}
         </ul>
       </div>
     );

--- a/src/components/modals/release_details_modal.js
+++ b/src/components/modals/release_details_modal.js
@@ -80,13 +80,15 @@ class ReleaseDetailsModal extends React.Component {
                 </div>
                 <p>Changes</p>
                 <ul>
-                  {release.changelog.map((changelog, i) => {
-                    return (
-                      <li key={changelog.component + i}>
-                        <b>{changelog.component}:</b> {changelog.description}
-                      </li>
-                    );
-                  })}
+                  {_.sortBy(release.changelog, 'component').map(
+                    (changelog, i) => {
+                      return (
+                        <li key={changelog.component + i}>
+                          <b>{changelog.component}:</b> {changelog.description}
+                        </li>
+                      );
+                    }
+                  )}
                 </ul>
               </div>
             );


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6400

This sorts component changes by component name.

## Before

![image](https://user-images.githubusercontent.com/273727/60722471-52084b80-9f31-11e9-8ffd-d56317dfc156.png)

## After

![image](https://user-images.githubusercontent.com/273727/60722456-4452c600-9f31-11e9-8783-a95482fe3222.png)
