### PR TITLE
Group release changelog by component, add capabilities for longer and MD-formatted changelog entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-document-title": "2.0.3",
     "react-dom": "16.8.6",
     "react-gravatar": "2.6.3",
+    "react-markdown": "^4.1.0",
     "react-redux": "6.0.1",
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",

--- a/src/components/UI/component_changelog.js
+++ b/src/components/UI/component_changelog.js
@@ -1,0 +1,57 @@
+//import { css } from '@emotion/core';
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import styled from '@emotion/styled';
+
+/**
+ * Displays changes for one component. Expects the context of a <dl>.
+ */
+
+const Wrapper = styled.div`
+  margin-bottom: 10px;
+`;
+
+const ComponentName = styled.dt`
+  margin-bottom: 5px;
+`;
+
+const ChangeItems = styled.dd`
+  margin-left: 20px;
+  p {
+    margin-block-start: 6px;
+    margin-block-end: 6px;
+    line-height: 1.4;
+  }
+  p:first-of-type {
+    text-indent: -14px;
+  }
+  p:first-of-type::before {
+    content: '•';
+    padding-right: 8px;
+  }
+`;
+
+const ComponentChangelog = props => {
+  const { name, changes } = props;
+
+  return (
+    <Wrapper>
+      <ComponentName>{name}</ComponentName>
+      {changes.map((change, index) => {
+        return (
+          <ChangeItems key={index}>
+            <ReactMarkdown>{change}</ReactMarkdown>
+          </ChangeItems>
+        );
+      })}
+    </Wrapper>
+  );
+};
+
+ComponentChangelog.propTypes = {
+  name: PropTypes.string.isRequired,
+  changes: PropTypes.array.isRequired,
+};
+
+export default ComponentChangelog;

--- a/src/components/UI/style_guide.js
+++ b/src/components/UI/style_guide.js
@@ -63,11 +63,11 @@ const StyleGuide = () => {
           />
           <ComponentChangelog
             changes={[
-              `Here is a long component change description thatshows us how content breaking into several paragraphs works.
+              `Here is a long component change description that shows us how a changelog item consisting of several paragraphs would be rendered.
 
   Here is the second and last line of the markdown text.`,
             ]}
-            name='verylong-description'
+            name='multi-paragraph'
           />
           <ComponentChangelog
             changes={[

--- a/src/components/UI/style_guide.js
+++ b/src/components/UI/style_guide.js
@@ -1,3 +1,5 @@
+import ComponentChangelog from './component_changelog';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReleaseComponentLabel from './release_component_label';
 import styled from '@emotion/styled';
@@ -12,6 +14,26 @@ const Wrapper = styled.div`
   }
 `;
 
+const ExampleBox = styled.div`
+  max-width: 500px;
+  padding: 30px;
+  margin: 20px 0;
+  border: 1px dashed #999;
+`;
+
+const Header = props => {
+  const { name } = props;
+  return (
+    <h2 id={name}>
+      {name} <a href={`#${name}`}>¶</a>
+    </h2>
+  );
+};
+
+Header.propTypes = {
+  name: PropTypes.string,
+};
+
 const StyleGuide = () => {
   return (
     <Wrapper className='main col-9'>
@@ -19,14 +41,53 @@ const StyleGuide = () => {
 
       <hr />
 
-      <h2 id='ReleaseComponentLabel'>ReleaseComponentLabel</h2>
+      <Header name='ComponentChangelog' />
+
+      <p>Displays changes on a component in a release context.</p>
+
+      <ExampleBox>
+        <dl>
+          <ComponentChangelog
+            changes={[
+              'Fix update process node termination in http://example.com/.',
+            ]}
+            name='mycomponent'
+          />
+          <ComponentChangelog
+            changes={[
+              'Mount `/var/log` directory in an EBS Volume.',
+              'Use proper hostname annotation for nodes.',
+              'Update to 1.13.4 ([CVE-2019-1002100](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1002100)).',
+            ]}
+            name='kubernetes'
+          />
+          <ComponentChangelog
+            changes={[
+              `Here is a long component change description thatshows us how content breaking into several paragraphs works.
+
+  Here is the second and last line of the markdown text.`,
+            ]}
+            name='verylong-description'
+          />
+          <ComponentChangelog
+            changes={[
+              'This is a very long component change description that has only one purpose: to demonstrate how very long descriptions are handled in our user interfae. While being long, this description is only one paragraph.',
+            ]}
+            name='verylong-description'
+          />
+        </dl>
+      </ExampleBox>
+
+      <hr />
+
+      <Header name='ReleaseComponentLabel' />
 
       <p>
         Displays a release component&apos;s version number or the change of a
         version number in an upgrade.
       </p>
 
-      <div>
+      <ExampleBox>
         <ReleaseComponentLabel name='calico' version='3.1.5' />
         <ReleaseComponentLabel
           name='kubernetes'
@@ -35,7 +96,7 @@ const StyleGuide = () => {
         />
         <ReleaseComponentLabel isRemoved name='outphased' />
         <ReleaseComponentLabel isAdded name='newbie' version='0.0.1' />
-      </div>
+      </ExampleBox>
     </Wrapper>
   );
 };

--- a/src/components/cluster/detail/upgrade_cluster_modal.js
+++ b/src/components/cluster/detail/upgrade_cluster_modal.js
@@ -41,9 +41,10 @@ class UpgradeClusterModal extends React.Component {
   };
 
   changedComponents = () => {
+    const { release } = this.props;
     var currentComponents = {};
-    if (this.props.release && this.props.release.components) {
-      currentComponents = this.props.release.components;
+    if (release && release.components) {
+      currentComponents = release.components;
     }
 
     var components = {};
@@ -60,7 +61,7 @@ class UpgradeClusterModal extends React.Component {
 
     return (
       <div>
-        {this.props.release === undefined ? (
+        {release === undefined ? (
           <div className='flash-messages--flash-message flash-messages--info'>
             Could not get component information for release version{' '}
             {this.props.cluster.release_version}.<br />

--- a/src/components/cluster/detail/upgrade_cluster_modal.js
+++ b/src/components/cluster/detail/upgrade_cluster_modal.js
@@ -9,7 +9,7 @@ import {
 import _ from 'underscore';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from '../../UI/button';
-import ComponentChangelog from '../UI/component_changelog';
+import ComponentChangelog from '../../UI/component_changelog';
 import diff from 'deep-diff';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/cluster/detail/upgrade_cluster_modal.js
+++ b/src/components/cluster/detail/upgrade_cluster_modal.js
@@ -9,6 +9,7 @@ import {
 import _ from 'underscore';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from '../../UI/button';
+import ComponentChangelog from '../UI/component_changelog';
 import diff from 'deep-diff';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -58,6 +59,11 @@ class UpgradeClusterModal extends React.Component {
     });
 
     var changedComponents = diff.diff(components, targetComponents);
+
+    let changes = _.groupBy(this.props.targetRelease.changelog, item => {
+      return item.component;
+    });
+    let changedComponentNames = Object.keys(changes).sort();
 
     return (
       <div>
@@ -113,15 +119,19 @@ class UpgradeClusterModal extends React.Component {
         <p>
           <b>Changes</b>
         </p>
-        <ul>
-          {this.props.targetRelease.changelog.map((changelog, i) => {
+        <dl>
+          {changedComponentNames.map((componentName, index) => {
             return (
-              <li key={changelog.component + i}>
-                <b>{changelog.component}:</b> {changelog.description}
-              </li>
+              <ComponentChangelog
+                changes={changes[componentName].map(c => {
+                  return c.description;
+                })}
+                key={index}
+                name={componentName}
+              />
             );
           })}
-        </ul>
+        </dl>
       </div>
     );
   };

--- a/src/components/modals/release_details_modal.js
+++ b/src/components/modals/release_details_modal.js
@@ -2,9 +2,10 @@ import { relativeDate } from '../../lib/helpers.js';
 import _ from 'underscore';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from '../UI/button';
+import ComponentChangelog from '../UI/component_changelog';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReleaseComponentLabel from '../UI/release_component_label.js';
+import ReleaseComponentLabel from '../UI/release_component_label';
 
 class ReleaseDetailsModal extends React.Component {
   state = {
@@ -39,6 +40,13 @@ class ReleaseDetailsModal extends React.Component {
         </BootstrapModal.Header>
         <BootstrapModal.Body>
           {this.props.releases.map(release => {
+            // group changes by component
+            let changes = _.groupBy(release.changelog, item => {
+              return item.component;
+            });
+
+            let changedComponents = Object.keys(changes).sort();
+
             return (
               <div
                 className='release-selector-modal--release-details'
@@ -78,16 +86,22 @@ class ReleaseDetailsModal extends React.Component {
                     );
                   })}
                 </div>
+
                 <p>Changes</p>
-                <ul>
-                  {release.changelog.map((changelog, i) => {
+
+                <dl>
+                  {changedComponents.map((componentName, index) => {
                     return (
-                      <li key={changelog.component + i}>
-                        <b>{changelog.component}:</b> {changelog.description}
-                      </li>
+                      <ComponentChangelog
+                        changes={changes[componentName].map(c => {
+                          return c.description;
+                        })}
+                        key={index}
+                        name={componentName}
+                      />
                     );
                   })}
-                </ul>
+                </dl>
               </div>
             );
           })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,7 +3541,7 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
-domhandler@^2.3.0:
+domhandler@^2.3.0, domhandler@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
@@ -4949,6 +4949,17 @@ html-tags@^3.0.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.0.0.tgz#41f57708c9e6b7b46a00a22317d614c4a2bab166"
   integrity sha512-xiXEBjihaNI+VZ2mKEoI5ZPxqUsevTKM+aeeJ/W4KAg2deGE35minmCJMn51BvwJZmiHaeAxrb2LAS0yZJxuuA==
 
+html-to-react@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.3.4.tgz#647b3a54fdec73a6461864b129fb0d1eec7d4589"
+  integrity sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==
+  dependencies:
+    domhandler "^2.4.2"
+    escape-string-regexp "^1.0.5"
+    htmlparser2 "^3.10.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.26"
+
 htmlparser2@^3.10.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
@@ -5279,7 +5290,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.4, is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -6347,6 +6358,11 @@ lodash-es@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -6522,6 +6538,13 @@ md5@^2.1.0:
     charenc "~0.0.1"
     crypt "~0.0.1"
     is-buffer "~1.1.1"
+
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
+  dependencies:
+    unist-util-visit-parents "1.1.2"
 
 mdast-util-compact@^1.0.0:
   version "1.0.3"
@@ -8042,6 +8065,11 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
+ramda@^0.26:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 randomatic@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.1.tgz#b776efc59375984e36c537b2f51a1f0aff0da1ed"
@@ -8207,6 +8235,19 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-markdown@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.1.0.tgz#7fdf840ecbabc803f28156f7411c726b58f25a73"
+  integrity sha512-EOHsEAN+aoP8UVz7vTHx6Z63GJfhrO9KItKlfsiBtVVS9tmSWtUaBTw73+2SObrWiOiE2Cs9qUBL7ORsvVhOrA==
+  dependencies:
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
 
 react-onclickoutside@^6.7.1:
   version "6.8.0"
@@ -8564,6 +8605,27 @@ regjsparser@^0.6.0:
   integrity sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==
   dependencies:
     jsesc "~0.5.0"
+
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
 
 remark-parse@^6.0.0:
   version "6.0.3"
@@ -10028,6 +10090,18 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
 
+unified@^6.1.5:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
 unified@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-7.1.0.tgz#5032f1c1ee3364bd09da12e27fdd4a7553c7be13"
@@ -10095,6 +10169,11 @@ unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
   integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
 
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
+
 unist-util-visit-parents@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
@@ -10102,7 +10181,7 @@ unist-util-visit-parents@^2.0.0:
   dependencies:
     unist-util-is "^3.0.0"
 
-unist-util-visit@^1.1.0:
+unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
@@ -10276,6 +10355,16 @@ vfile-message@^1.0.0:
   integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
   dependencies:
     unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vfile@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6400

Goal of this PR is to group component changes in the release and upgrade dialog in a hierarchical way, with the component name as a sub-header and the changes in a list grouped together by component.

It introduces a new component which represents an items in a `<dl>` list. I wonder whether this is counterintuitive and whether there should be a component representing the entire list.

The component supports **Markdown** content, even multi paragraph, to allow for more advanced changelog entries.

### TODO

- [x] apply to upgrade dialog

### Preview

Example in dialog context, not using Markdown

![image](https://user-images.githubusercontent.com/273727/60729509-2b531080-9f43-11e9-8779-a96aee8ab196.png)

Markdown example from styleguide

![image](https://user-images.githubusercontent.com/273727/60729820-e4194f80-9f43-11e9-8c1f-283932bfc241.png)

