### PR TITLE
Load app catalogs individually

### DIFF
--- a/src/actions/catalogActions.js
+++ b/src/actions/catalogActions.js
@@ -63,6 +63,7 @@ export function catalogsLoad() {
         catalogs = Array.from(catalogs);
 
         catalogs.forEach(catalog => {
+          catalog.isFetchingIndex = true;
           catalogsDict[catalog.metadata.name] = catalog;
         });
 

--- a/src/components/app_catalog/app_list/index.js
+++ b/src/components/app_catalog/app_list/index.js
@@ -37,15 +37,15 @@ class AppList extends React.Component {
               <i aria-hidden='true' className='fa fa-chevron-left' />
               Back to all catalogs
             </Link>
-            <br/>
-            <br/>
+            <br />
+            <br />
             <Loading loading={this.props.catalog.isFetchingIndex}>
               <AppListInner {...this.props} />
             </Loading>
           </React.Fragment>
         </DocumentTitle>
       </Breadcrumb>
-    )
+    );
   }
 }
 
@@ -154,67 +154,65 @@ class AppListInner extends React.Component {
 
   render() {
     return (
-        <React.Fragment>
-            <h1>
-              {this.props.catalog.spec.title}
-              <form>
-                <div className='input-with-icon'>
-                  <i className='fa fa-search' />
-                  <input
-                    onChange={this.updateSearchQuery}
-                    type='text'
-                    value={this.state.searchQuery}
-                  />
-                  {this.state.searchQuery !== '' ? (
-                    <a className='clearQuery' onClick={this.resetFilters}>
-                      <i className='fa fa-close' />
-                    </a>
-                  ) : (
-                    undefined
-                  )}
-                </div>
-              </form>
-            </h1>
-            <div className='app-catalog-overview'>
-              <div className='apps' style={{ justifyContent: 'flex-start' }}>
-                {(() => {
-                  var apps = this.filterApps(
-                    this.props.catalog.apps,
-                    this.filter()
-                  );
-                  if (apps.length === 0) {
-                    return (
-                      <div className='emptystate'>
-                        No apps matched your search query: &quot;
-                        {this.state.searchQuery}&quot;
-                      </div>
-                    );
-                  } else {
-                    return (
-                      <React.Fragment>
-                        {apps.map(appVersions => {
-                          const key = `${appVersions[0].repoName}/${appVersions[0].name}`;
-                          return (
-                            <AppContainer
-                              appVersions={appVersions}
-                              catalog={this.props.catalog}
-                              iconErrors={this.state.iconErrors}
-                              imgError={this.imgError}
-                              key={key}
-                              ref={ref =>
-                                (this.appRefs[appVersions[0].name] = ref)
-                              }
-                              searchQuery={this.state.searchQuery}
-                            />
-                          );
-                        })}
-                      </React.Fragment>
-                    );
-                  }
-                })()}
-              </div>
+      <React.Fragment>
+        <h1>
+          {this.props.catalog.spec.title}
+          <form>
+            <div className='input-with-icon'>
+              <i className='fa fa-search' />
+              <input
+                onChange={this.updateSearchQuery}
+                type='text'
+                value={this.state.searchQuery}
+              />
+              {this.state.searchQuery !== '' ? (
+                <a className='clearQuery' onClick={this.resetFilters}>
+                  <i className='fa fa-close' />
+                </a>
+              ) : (
+                undefined
+              )}
             </div>
-          </React.Fragment>
+          </form>
+        </h1>
+        <div className='app-catalog-overview'>
+          <div className='apps' style={{ justifyContent: 'flex-start' }}>
+            {(() => {
+              var apps = this.filterApps(
+                this.props.catalog.apps,
+                this.filter()
+              );
+              if (apps.length === 0) {
+                return (
+                  <div className='emptystate'>
+                    No apps matched your search query: &quot;
+                    {this.state.searchQuery}&quot;
+                  </div>
+                );
+              } else {
+                return (
+                  <React.Fragment>
+                    {apps.map(appVersions => {
+                      const key = `${appVersions[0].repoName}/${appVersions[0].name}`;
+                      return (
+                        <AppContainer
+                          appVersions={appVersions}
+                          catalog={this.props.catalog}
+                          iconErrors={this.state.iconErrors}
+                          imgError={this.imgError}
+                          key={key}
+                          ref={ref => (this.appRefs[appVersions[0].name] = ref)}
+                          searchQuery={this.state.searchQuery}
+                        />
+                      );
+                    })}
+                  </React.Fragment>
+                );
+              }
+            })()}
+          </div>
+        </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/app_catalog/app_list/index.js
+++ b/src/components/app_catalog/app_list/index.js
@@ -8,7 +8,48 @@ import lunr from 'lunr';
 import PropTypes from 'prop-types';
 import React from 'react';
 
+function Loading(props) {
+  if (props.loading) {
+    return (
+      <div className='app-loading'>
+        <div className='app-loading-contents'>
+          <img className='loader' src='/images/loader_oval_light.svg' />
+        </div>
+      </div>
+    );
+  } else {
+    return props.children;
+  }
+}
+
 class AppList extends React.Component {
+  render() {
+    return (
+      <Breadcrumb
+        data={{
+          title: this.props.catalog.metadata.name.toUpperCase(),
+          pathname: this.props.match.url,
+        }}
+      >
+        <DocumentTitle title={'Apps | Giant Swarm '}>
+          <React.Fragment>
+            <Link to={'/app-catalogs/'}>
+              <i aria-hidden='true' className='fa fa-chevron-left' />
+              Back to all catalogs
+            </Link>
+            <br/>
+            <br/>
+            <Loading loading={this.props.catalog.isFetchingIndex}>
+              <AppListInner {...this.props} />
+            </Loading>
+          </React.Fragment>
+        </DocumentTitle>
+      </Breadcrumb>
+    )
+  }
+}
+
+class AppListInner extends React.Component {
   // Contains refs to all the app-container divs in dom so that we can
   // scroll to them if needed.
   appRefs = {};
@@ -113,20 +154,7 @@ class AppList extends React.Component {
 
   render() {
     return (
-      <Breadcrumb
-        data={{
-          title: this.props.catalog.metadata.name.toUpperCase(),
-          pathname: this.props.match.url,
-        }}
-      >
-        <DocumentTitle title={'Apps | Giant Swarm '}>
-          <React.Fragment>
-            <Link to={'/app-catalogs/'}>
-              <i aria-hidden='true' className='fa fa-chevron-left' />
-              Back to all catalogs
-            </Link>
-            <br />
-            <br />
+        <React.Fragment>
             <h1>
               {this.props.catalog.spec.title}
               <form>
@@ -187,13 +215,19 @@ class AppList extends React.Component {
               </div>
             </div>
           </React.Fragment>
-        </DocumentTitle>
-      </Breadcrumb>
     );
   }
 }
 
 AppList.propTypes = {
+  catalog: PropTypes.object,
+  dispatch: PropTypes.func,
+  location: PropTypes.object,
+  loading: PropTypes.bool,
+  match: PropTypes.object,
+};
+
+AppListInner.propTypes = {
   catalog: PropTypes.object,
   dispatch: PropTypes.func,
   location: PropTypes.object,

--- a/src/components/app_catalog/catalogs/index.js
+++ b/src/components/app_catalog/catalogs/index.js
@@ -40,12 +40,15 @@ class Catalogs extends React.Component {
                       <div className='app-catalog--description'>
                         <h3>
                           {this.props.catalogs.items[catalogName].spec.title}
-                          {
-                            this.props.catalogs.items[catalogName].isFetchingIndex ?
-                            <img className='loader' src='/images/loader_oval_light.svg' />
-                            :
+                          {this.props.catalogs.items[catalogName]
+                            .isFetchingIndex ? (
+                            <img
+                              className='loader'
+                              src='/images/loader_oval_light.svg'
+                            />
+                          ) : (
                             undefined
-                          }
+                          )}
                         </h3>
                         <ReactMarkdown>
                           {

--- a/src/components/app_catalog/catalogs/index.js
+++ b/src/components/app_catalog/catalogs/index.js
@@ -40,6 +40,12 @@ class Catalogs extends React.Component {
                       <div className='app-catalog--description'>
                         <h3>
                           {this.props.catalogs.items[catalogName].spec.title}
+                          {
+                            this.props.catalogs.items[catalogName].isFetchingIndex ?
+                            <img className='loader' src='/images/loader_oval_light.svg' />
+                            :
+                            undefined
+                          }
                         </h3>
                         <ReactMarkdown>
                           {

--- a/src/components/app_catalog/index.js
+++ b/src/components/app_catalog/index.js
@@ -40,23 +40,23 @@ class CatalogIndex extends React.Component {
         }}
       >
         <div className='app-catalog'>
-            <Switch>
-              <Route
-                exact
-                path={`${this.props.match.path}`}
-                render={() => <Catalogs {...this.props} />}
-              />
-              <Route
-                component={AppList}
-                exact
-                path={`${this.props.match.path}/:repo`}
-              />
-              <Route
-                component={Detail}
-                exact
-                path={`${this.props.match.path}/:repo/:app`}
-              />
-            </Switch>
+          <Switch>
+            <Route
+              exact
+              path={`${this.props.match.path}`}
+              render={() => <Catalogs {...this.props} />}
+            />
+            <Route
+              component={AppList}
+              exact
+              path={`${this.props.match.path}/:repo`}
+            />
+            <Route
+              component={Detail}
+              exact
+              path={`${this.props.match.path}/:repo/:app`}
+            />
+          </Switch>
         </div>
       </Breadcrumb>
     );

--- a/src/components/app_catalog/index.js
+++ b/src/components/app_catalog/index.js
@@ -10,10 +10,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 class CatalogIndex extends React.Component {
-  state = {
-    loading: true,
-  };
-
   componentDidMount() {
     this.props
       .dispatch(catalogsLoad())
@@ -23,11 +19,6 @@ class CatalogIndex extends React.Component {
         });
 
         return Promise.all(promises);
-      })
-      .then(() => {
-        this.setState({
-          loading: false,
-        });
       })
       .catch(error => {
         new FlashMessage(
@@ -49,7 +40,6 @@ class CatalogIndex extends React.Component {
         }}
       >
         <div className='app-catalog'>
-          <Loading loading={this.state.loading}>
             <Switch>
               <Route
                 exact
@@ -67,24 +57,9 @@ class CatalogIndex extends React.Component {
                 path={`${this.props.match.path}/:repo/:app`}
               />
             </Switch>
-          </Loading>
         </div>
       </Breadcrumb>
     );
-  }
-}
-
-function Loading(props) {
-  if (props.loading) {
-    return (
-      <div className='app-loading'>
-        <div className='app-loading-contents'>
-          <img className='loader' src='/images/loader_oval_light.svg' />
-        </div>
-      </div>
-    );
-  } else {
-    return props.children;
   }
 }
 

--- a/src/styles/components/_app_catalog.sass
+++ b/src/styles/components/_app_catalog.sass
@@ -86,6 +86,11 @@
     margin-bottom: 0px
     margin-top: 10px
 
+  img.loader
+    height: 20px
+    margin: 0px 10px
+    display: inline
+
 .app-catalog--repo
   flex: 0 0
   margin-bottom: 15px


### PR DESCRIPTION
This shows all the app catalogs and allows people to visit app catalogs that have loaded before other ones, instead of blocking the whole feature while all app catalogs load.