### PR TITLE
Version constraint for app installation features

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -9,9 +9,6 @@ import GiantSwarmV4 from 'giantswarm-v4';
 // enhanceWithCapabilities enhances a list of clusters with the capabilities they support based on
 // their release version and provider.
 function enhanceWithCapabilities(clusters, provider) {
-  console.log(clusters);
-  console.log(provider);
-
   clusters = clusters.map((c) => {
     c.capabilities = computeCapabilities(c, provider);
     return c;

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -3,7 +3,41 @@ import { FlashMessage, messageTTL, messageType } from '../lib/flash_message';
 import { modalHide } from './modalActions';
 import { push } from 'connected-react-router';
 import APIClusterStatusClient from '../lib/api_status_client';
+import cmp from 'semver-compare';
 import GiantSwarmV4 from 'giantswarm-v4';
+
+// enhanceWithCapabilities enhances a list of clusters with the capabilities they support based on
+// their release version and provider.
+function enhanceWithCapabilities(clusters, provider) {
+  console.log(clusters);
+  console.log(provider);
+
+  clusters = clusters.map((c) => {
+    c.capabilities = computeCapabilities(c, provider);
+    return c;
+  });
+
+  return clusters;
+}
+
+// computeCapabilities takes a cluster object and provider and returns a
+// capabilities object with the features that this cluster supports.
+function computeCapabilities(cluster, provider) {
+  let capabilities = {};
+  let releaseVer = cluster.release_version;
+
+  // Installing Apps
+  // Must be AWS or KVM and larger than 8.1.0
+  // or any provider and larger than 8.2.0
+  if (
+    (cmp(releaseVer, '8.0.99') === 1) && ((provider === 'aws' || provider === 'kvm')) ||
+    (cmp(releaseVer, '8.1.99') === 1)
+  ) {
+    capabilities.canInstallApps = true;
+  }
+
+  return capabilities;
+}
 
 /**
  * Performs the getClusters API call and dispatches the clustersLoadSuccess
@@ -19,9 +53,10 @@ export function clustersLoad() {
 
     return clustersApi
       .getClusters(scheme + ' ' + token)
-      .then(data => {
-        dispatch(clustersLoadSuccess(data));
-        return data;
+      .then(clusters => {
+        clusters = enhanceWithCapabilities(clusters, getState().app.info.general.provider);
+        dispatch(clustersLoadSuccess(clusters));
+        return clusters;
       })
       .catch(error => {
         console.error(error);

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -9,7 +9,7 @@ import GiantSwarmV4 from 'giantswarm-v4';
 // enhanceWithCapabilities enhances a list of clusters with the capabilities they support based on
 // their release version and provider.
 function enhanceWithCapabilities(clusters, provider) {
-  clusters = clusters.map((c) => {
+  clusters = clusters.map(c => {
     c.capabilities = computeCapabilities(c, provider);
     return c;
   });
@@ -27,8 +27,9 @@ function computeCapabilities(cluster, provider) {
   // Must be AWS or KVM and larger than 8.1.0
   // or any provider and larger than 8.2.0
   if (
-    (cmp(releaseVer, '8.0.99') === 1) && ((provider === 'aws' || provider === 'kvm')) ||
-    (cmp(releaseVer, '8.1.99') === 1)
+    (cmp(releaseVer, '8.0.99') === 1 &&
+      (provider === 'aws' || provider === 'kvm')) ||
+    cmp(releaseVer, '8.1.99') === 1
   ) {
     capabilities.canInstallApps = true;
   }
@@ -51,7 +52,10 @@ export function clustersLoad() {
     return clustersApi
       .getClusters(scheme + ' ' + token)
       .then(clusters => {
-        clusters = enhanceWithCapabilities(clusters, getState().app.info.general.provider);
+        clusters = enhanceWithCapabilities(
+          clusters,
+          getState().app.info.general.provider
+        );
         dispatch(clustersLoadSuccess(clusters));
         return clusters;
       })

--- a/src/components/app_catalog/detail/cluster_picker.js
+++ b/src/components/app_catalog/detail/cluster_picker.js
@@ -62,7 +62,8 @@ const ClusterPicker = props => {
       <ClusterList>
         {props.clusters.length === 0 && (
           <NoSearchResults>
-            No clusters matched your search query: &quot;{props.query}&quot;
+            No clusters matched your search query: &quot;{props.query}&quot; <br/>
+            <small>Perhaps you have no clusters that support app installation.</small>
           </NoSearchResults>
         )}
 

--- a/src/components/app_catalog/detail/cluster_picker.js
+++ b/src/components/app_catalog/detail/cluster_picker.js
@@ -62,8 +62,11 @@ const ClusterPicker = props => {
       <ClusterList>
         {props.clusters.length === 0 && (
           <NoSearchResults>
-            No clusters matched your search query: &quot;{props.query}&quot; <br/>
-            <small>Perhaps you have no clusters that support app installation.</small>
+            No clusters matched your search query: &quot;{props.query}&quot;{' '}
+            <br />
+            <small>
+              Perhaps you have no clusters that support app installation.
+            </small>
           </NoSearchResults>
         )}
 

--- a/src/components/app_catalog/detail/install_app_modal.js
+++ b/src/components/app_catalog/detail/install_app_modal.js
@@ -205,7 +205,7 @@ const InstallAppModal = props => {
                 visible={visible}
               >
                 <ClusterPicker
-                  clusters={clusters}
+                  clusters={clusters.filter(c => c.capabilities.canInstallApps)}
                   onChangeQuery={setQuery}
                   onSelectCluster={onSelectCluster}
                   query={query}
@@ -277,6 +277,7 @@ function mapStateToProps(state) {
       id: clusterID,
       name: state.entities.clusters.items[clusterID].name,
       owner: state.entities.clusters.items[clusterID].owner,
+      capabilities: state.entities.clusters.items[clusterID].capabilities,
     };
   });
 

--- a/src/components/cluster/detail/view.js
+++ b/src/components/cluster/detail/view.js
@@ -335,7 +335,8 @@ class ClusterDetailView extends React.Component {
                         installedApps={this.props.cluster.apps}
                         release={this.props.release}
                         showInstalledAppsBlock={
-                          Object.keys(this.props.catalogs.items).length > 0
+                          Object.keys(this.props.catalogs.items).length > 0 &&
+                          this.props.cluster.capabilities.canInstallApps
                         }
                       />
                     ) : (


### PR DESCRIPTION
This ensures we don't show app installation related features for clusters that don't support it.