### PR TITLE
Also compute capabilities on cluster load details.

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -309,6 +309,7 @@ export function clusterLoadDetails(clusterId) {
         return dispatch(clusterLoadStatus(clusterId));
       })
       .then(() => {
+        cluster.capabilities = computeCapabilities(cluster);
         dispatch(clusterLoadDetailsSuccess(cluster));
         return cluster;
       })

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -309,7 +309,10 @@ export function clusterLoadDetails(clusterId) {
         return dispatch(clusterLoadStatus(clusterId));
       })
       .then(() => {
-        cluster.capabilities = computeCapabilities(cluster, getState().app.info.general.provider);
+        cluster.capabilities = computeCapabilities(
+          cluster,
+          getState().app.info.general.provider
+        );
         dispatch(clusterLoadDetailsSuccess(cluster));
         return cluster;
       })

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -309,7 +309,7 @@ export function clusterLoadDetails(clusterId) {
         return dispatch(clusterLoadStatus(clusterId));
       })
       .then(() => {
-        cluster.capabilities = computeCapabilities(cluster);
+        cluster.capabilities = computeCapabilities(cluster, getState().app.info.general.provider);
         dispatch(clusterLoadDetailsSuccess(cluster));
         return cluster;
       })


### PR DESCRIPTION
When creating a cluster, a new cluster is added to the state without loading all clusters.

I was only computing the capabilities on the clusters load action, and not on the singular cluster load details action.