### PR TITLE
Two GS JS client libraries: master and node pools

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "deep-diff": "1.0.2",
     "emotion-theming": "^10.0.10",
     "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git#master",
+    "giantswarm-v5": "git+https://github.com/giantswarm/giantswarm-js-client.git#node-pools",
     "history": "^4.7.2",
     "immutable": "3.8.2",
     "js-base64": "2.5.1",


### PR DESCRIPTION
I have added the node pools branch of the JS client library, so I can use it for development.

@marians we talk about about creating a `node-pools` branch in Happa to issue all Node Pools related PRs against it. But this way we will have a long-lived branch and when we will want to merge it with `master` probably we will have a bunch of conflicts, so maybe it would be a better approach to commit Node Pools PRs directly to `master`. 

My two open PRs go in this direction. WDYT?