### PR TITLE
Cluster reducer with spread operator

### DIFF
--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -24,7 +24,7 @@ export default function clusterReducer(
   state = { lastUpdated: null, isFetching: false, items: {} },
   action = undefined
 ) {
-  var items;
+  let items = { ...state.items };
 
   switch (action.type) {
     case types.CLUSTERS_LOAD_SUCCESS:
@@ -32,7 +32,6 @@ export default function clusterReducer(
       var prevClusterIDs = Object.keys(state.items).sort();
 
       // use existing state's items and update it
-      items = Object.assign({}, state.items);
 
       var newClusterIDs = _.map(_.toArray(action.clusters), item => {
         return item.id;
@@ -71,8 +70,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_DETAILS_SUCCESS:
-      items = Object.assign({}, state.items);
-
       items[action.cluster.id] = Object.assign(
         {},
         items[action.cluster.id],
@@ -97,8 +94,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_DETAILS_ERROR:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         errorLoading: true,
       });
@@ -110,8 +105,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_STATUS_SUCCESS:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         status: action.status,
       });
@@ -125,8 +118,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_STATUS_NOT_FOUND:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         status: null,
       });
@@ -138,8 +129,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_STATUS_ERROR:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         errorLoading: true,
       });
@@ -151,8 +140,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_APPS:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         isFetchingApps: true,
       });
@@ -164,8 +151,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_APPS_SUCCESS:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         isFetchingApps: false,
 
@@ -182,8 +167,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_APPS_ERROR:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         isFetchingApps: false,
       });
@@ -195,8 +178,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_KEY_PAIRS:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         isFetchingKeyPairs: true,
       });
@@ -208,8 +189,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_KEY_PAIRS_SUCCESS:
-      items = Object.assign({}, state.items);
-
       // Add expire_date to keyPairs based on ttl_hours
       var keyPairs = Object.entries(action.keyPairs).map(([, keyPair]) => {
         keyPair.expire_date = moment(keyPair.create_date)
@@ -230,8 +209,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_LOAD_KEY_PAIRS_ERROR:
-      items = Object.assign({}, state.items);
-
       items[action.clusterId] = Object.assign({}, items[action.clusterId], {
         isFetchingKeyPairs: false,
       });
@@ -243,8 +220,6 @@ export default function clusterReducer(
       };
 
     case types.CLUSTER_DELETE_SUCCESS:
-      items = Object.assign({}, state.items);
-
       delete items[action.clusterId];
 
       return {

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -56,17 +56,16 @@ export default function clusterReducer(
       });
 
       return {
+        ...state,
         lastUpdated: Date.now(),
-        isFetching: false,
-        items: items,
+        items,
       };
 
     case types.CLUSTERS_LOAD_ERROR:
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
+        ...state,
         errorLoading: true,
-        items: items,
+        items,
       };
 
     case types.CLUSTER_LOAD_DETAILS_SUCCESS:
@@ -88,9 +87,8 @@ export default function clusterReducer(
       }
 
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
-        items: items,
+        ...state,
+        items,
       };
 
     case types.CLUSTER_LOAD_DETAILS_ERROR:
@@ -99,9 +97,8 @@ export default function clusterReducer(
       });
 
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
-        items: items,
+        ...state,
+        items,
       };
 
     case types.CLUSTER_LOAD_STATUS_SUCCESS:
@@ -112,9 +109,8 @@ export default function clusterReducer(
       items[action.clusterId].status.lastUpdated = Date.now();
 
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
-        items: items,
+        ...state,
+        items,
       };
 
     case types.CLUSTER_LOAD_STATUS_NOT_FOUND:
@@ -123,9 +119,8 @@ export default function clusterReducer(
       });
 
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
-        items: items,
+        ...state,
+        items,
       };
 
     case types.CLUSTER_LOAD_STATUS_ERROR:
@@ -134,9 +129,8 @@ export default function clusterReducer(
       });
 
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
-        items: items,
+        ...state,
+        items,
       };
 
     case types.CLUSTER_LOAD_APPS:
@@ -145,9 +139,9 @@ export default function clusterReducer(
       });
 
       return {
+        ...state,
         lastUpdated: Date.now(),
-        isFetching: false,
-        items: items,
+        items,
       };
 
     case types.CLUSTER_LOAD_APPS_SUCCESS:
@@ -161,9 +155,9 @@ export default function clusterReducer(
       });
 
       return {
+        ...state,
         lastUpdated: Date.now(),
-        isFetching: false,
-        items: items,
+        items,
       };
 
     case types.CLUSTER_LOAD_APPS_ERROR:
@@ -172,9 +166,9 @@ export default function clusterReducer(
       });
 
       return {
+        ...state,
         lastUpdated: Date.now(),
-        isFetching: false,
-        items: items,
+        items,
       };
 
     case types.CLUSTER_LOAD_KEY_PAIRS:
@@ -183,9 +177,8 @@ export default function clusterReducer(
       });
 
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
-        items: items,
+        ...state,
+        items,
       };
 
     case types.CLUSTER_LOAD_KEY_PAIRS_SUCCESS:
@@ -203,9 +196,8 @@ export default function clusterReducer(
       });
 
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
-        items: items,
+        ...state,
+        items,
       };
 
     case types.CLUSTER_LOAD_KEY_PAIRS_ERROR:
@@ -214,18 +206,17 @@ export default function clusterReducer(
       });
 
       return {
-        lastUpdated: state.lastUpdated,
-        isFetching: false,
-        items: items,
+        ...state,
+        items,
       };
 
     case types.CLUSTER_DELETE_SUCCESS:
       delete items[action.clusterId];
 
       return {
+        ...state,
         lastUpdated: Date.now(),
-        isFetching: false,
-        items: items,
+        items,
       };
 
     default:


### PR DESCRIPTION
Minor refactor: I saw that inside every `case` we were overwriting state. I decided to refactor in a way that the state is modified, but never overwritten.

I also had simplified this:

`{ items: items }`

To this:

`{ items }`

But no real change here, it is the exact same thing with ES6 syntax.

Also I have removed state `isFetching: false` from returns because I haven't found a single `isFetching: true`, then we can remove them safely (?). I am wondering if we really need this property here...

If you are ok with this I will do the same in the other reducers