### PR TITLE
Add a label that does some expectation management depending on the catalog type.

### DIFF
--- a/src/components/UI/__tests__/catalog_type_label.js
+++ b/src/components/UI/__tests__/catalog_type_label.js
@@ -1,0 +1,49 @@
+import 'jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+import React from 'react';
+import CatalogTypeLabel from 'UI/catalog_type_label';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(<CatalogTypeLabel />, div);
+});
+
+it('shows a more serious warning for the community catalog type', () => {
+  const div = document.createElement('div');
+  const { container } = render(
+    <CatalogTypeLabel catalogType='community' />,
+    div
+  );
+
+  expect(container.querySelector('i')).toHaveAttribute(
+    'class',
+    'fa fa-warning'
+  );
+});
+
+it('shows a less serious warning for the incubator catalog type', () => {
+  const div = document.createElement('div');
+  const { container } = render(
+    <CatalogTypeLabel catalogType='incubator' />,
+    div
+  );
+
+  expect(container.querySelector('i')).toHaveAttribute('class', 'fa fa-info');
+});
+
+it('shows a less serious warning for the test catalog type', () => {
+  const div = document.createElement('div');
+  const { container } = render(
+    <CatalogTypeLabel catalogType='incubator' />,
+    div
+  );
+
+  expect(container.querySelector('i')).toHaveAttribute('class', 'fa fa-info');
+});
+
+it('renders nothing for unknown catalog types', () => {
+  const div = document.createElement('div');
+  const { container } = render(<CatalogTypeLabel catalogType='yolo' />, div);
+
+  expect(container).toBeEmpty();
+});

--- a/src/components/UI/catalog_type_label.js
+++ b/src/components/UI/catalog_type_label.js
@@ -1,0 +1,74 @@
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from '@emotion/styled';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+
+const Wrapper = styled.div`
+  font-size: 12px;
+  display: inline-block;
+  margin-bottom: 15px;
+
+  span {
+    background-color: #1e4156;
+    padding: 4px 6px;
+    border-radius: 4px;
+    margin-right: 5px;
+  }
+
+  .fa {
+    font-size: 16px;
+    position: relative;
+    top: 1px;
+  }
+`;
+
+/**
+ * CatalogTypeLabel shows some information about a catalog depending on its type.
+ */
+const CatalogTypeLabel = props => {
+  var icon;
+  var message;
+
+  switch (props.catalogType) {
+    case 'community':
+      icon = 'warning';
+      message =
+        'Apps from this catalog will not work on your cluster without some alterations to the security settings.';
+      break;
+    case 'incubator':
+      icon = 'info';
+      message =
+        'These apps are a work in progress, but are made to work with your cluster. Feedback is appreciated!';
+      break;
+    case 'test':
+      icon = 'info';
+      message =
+        "We're still getting these apps ready. They might not work at all.";
+      break;
+    default:
+      icon = '';
+      message = '';
+  }
+
+  return (
+    <>
+      <Wrapper>
+        <OverlayTrigger
+          overlay={<Tooltip id='tooltip'>{message}</Tooltip>}
+          placement='top'
+        >
+          <div>
+            <span>{props.catalogType}</span> <i className={`fa fa-${icon}`} />
+          </div>
+        </OverlayTrigger>
+      </Wrapper>
+    </>
+  );
+};
+
+CatalogTypeLabel.propTypes = {
+  catalogType: PropTypes.string,
+};
+
+export default CatalogTypeLabel;

--- a/src/components/UI/catalog_type_label.js
+++ b/src/components/UI/catalog_type_label.js
@@ -27,8 +27,15 @@ const Wrapper = styled.div`
  * CatalogTypeLabel shows some information about a catalog depending on its type.
  */
 const CatalogTypeLabel = props => {
-  var icon;
-  var message;
+  let icon;
+  let message;
+
+  let validCatalogTypes = ['community', 'incubator', 'test'];
+
+  // Early return if we're dealing with a unknown catalog type.
+  if (!validCatalogTypes.includes(props.catalogType)) {
+    return null;
+  }
 
   switch (props.catalogType) {
     case 'community':

--- a/src/components/app_catalog/catalogs/index.js
+++ b/src/components/app_catalog/catalogs/index.js
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import Button from 'UI/button';
+import CatalogTypeLabel from 'UI/catalog_type_label';
 import DocumentTitle from 'react-document-title';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -42,6 +43,12 @@ class Catalogs extends React.Component {
                         <h3>
                           {this.props.catalogs.items[catalogName].spec.title}
                         </h3>
+                        <CatalogTypeLabel
+                          catalogType={
+                            this.props.catalogs.items[catalogName].metadata
+                              .labels['application.giantswarm.io/catalog-type']
+                          }
+                        />
                         <ReactMarkdown>
                           {
                             this.props.catalogs.items[catalogName].spec

--- a/src/styles/components/_app_catalog.sass
+++ b/src/styles/components/_app_catalog.sass
@@ -90,6 +90,7 @@
   .app-catalog--description
     flex: 1
     padding-left: 14px
+    line-height: 12px
 
     h3
       margin-bottom: 0px


### PR DESCRIPTION
This adds a label to the catalog listing, which on hover, gives a bit of expectation management for the `incubator`, `test` and `community` catalog types.

The `test` type of catalog should by the way never appear on customer installations, but I decided to cover that case anyways.

<img width="1516" alt="Screenshot 2019-08-02 at 4 47 47 PM" src="https://user-images.githubusercontent.com/455309/62357295-5716e580-b545-11e9-8490-676c7dd8a237.png">

I will also add a warning on app installation when someone is about to install a community app, but that will be in a different PR.
