### PR TITLE
Some small style adjustments to app catalog index

### DIFF
--- a/src/components/UI/catalog_type_label.js
+++ b/src/components/UI/catalog_type_label.js
@@ -7,7 +7,7 @@ import Tooltip from 'react-bootstrap/lib/Tooltip';
 const Wrapper = styled.div`
   font-size: 12px;
   display: inline-block;
-  margin-bottom: 15px;
+  margin-bottom: 12px;
 
   span {
     background-color: #1e4156;

--- a/src/styles/components/_app_catalog.sass
+++ b/src/styles/components/_app_catalog.sass
@@ -98,6 +98,7 @@
 
     p
       max-width: 600px
+      font-size: 14px
 
   img
     flex-shrink: 0


### PR DESCRIPTION
I noticed I had messed up the font size. This sets it back to what it was, and adjust the space between the catalog type label and the text a bit.