### PR TITLE
Added CPU and RAM to list items

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -143,6 +143,9 @@ class Home extends React.Component {
                       <ClusterDashboardItem
                         animate={true}
                         cluster={cluster}
+                        isNodePool={this.props.nodePoolsClusters.includes(
+                          cluster.id
+                        )}
                         key={cluster.id}
                         selectedOrganization={this.props.selectedOrganization}
                       />
@@ -178,6 +181,7 @@ Home.propTypes = {
   selectedOrganization: PropTypes.string,
   organizations: PropTypes.object,
   errorLoadingClusters: PropTypes.bool,
+  nodePoolsClusters: PropTypes.array,
 };
 
 function mapStateToProps(state) {
@@ -185,6 +189,7 @@ function mapStateToProps(state) {
   var organizations = state.entities.organizations.items;
   var allClusters = state.entities.clusters.items;
   var errorLoadingClusters = state.entities.clusters.errorLoading;
+  const nodePoolsClusters = state.entities.clusters.nodePoolsClusters;
 
   var clusters = [];
   if (selectedOrganization) {
@@ -198,6 +203,7 @@ function mapStateToProps(state) {
     organizations: organizations,
     errorLoadingClusters: errorLoadingClusters,
     selectedOrganization: selectedOrganization,
+    nodePoolsClusters,
   };
 }
 


### PR DESCRIPTION
Here I am computing the value for RAM (and CPUs) doing the following: RAM amount * number of NPs of the cluster * number of nodes that each NP has.

Is that correct @marians ?

And I am using the `nodePools` array in store instead of `window.config.environment` and cluster id