### PR TITLE
Refactor: shared functions in cluster view and list

### DIFF
--- a/src/components/cluster/detail/cluster_detail_table.js
+++ b/src/components/cluster/detail/cluster_detail_table.js
@@ -15,19 +15,20 @@ import RefreshableLabel from 'UI/refreshable_label';
 import ReleaseDetailsModal from '../../modals/release_details_modal';
 
 class ClusterDetailTable extends React.Component {
-  state = {
-    awsInstanceTypes: {},
-    azureVMSizes: {},
-  };
+  awsInstanceTypes = {};
+  azureVMSizes = {};
 
   componentDidMount() {
     this.registerRefreshInterval();
 
-    if (window.config.azureCapabilitiesJSON) {
-      const awsInstanceTypes = JSON.parse(window.config.awsCapabilitiesJSON);
-      const azureVMSizes = JSON.parse(window.config.azureCapabilitiesJSON);
-      this.setState({ awsInstanceTypes, azureVMSizes });
-    }
+    // TODO Store it in Redux store?
+    this.awsInstanceTypes = window.config.awsCapabilitiesJSON
+      ? JSON.parse(window.config.awsCapabilitiesJSON)
+      : {};
+
+    this.azureVMSizes = window.config.azureCapabilitiesJSON
+      ? JSON.parse(window.config.azureCapabilitiesJSON)
+      : {};
   }
 
   registerRefreshInterval = () => {
@@ -75,9 +76,9 @@ class ClusterDetailTable extends React.Component {
         workers &&
         workers.length > 0 &&
         typeof workers[0].aws.instance_type !== 'undefined' &&
-        this.state.awsInstanceTypes[workers[0].aws.instance_type]
+        this.awsInstanceTypes[workers[0].aws.instance_type]
       ) {
-        let t = this.state.awsInstanceTypes[workers[0].aws.instance_type];
+        let t = this.awsInstanceTypes[workers[0].aws.instance_type];
         details = (
           <span>
             &mdash; {t.cpu_cores} CPUs, {t.memory_size_gb.toFixed(0)} GB RAM
@@ -101,9 +102,9 @@ class ClusterDetailTable extends React.Component {
       if (
         workers &&
         typeof workers[0].azure.vm_size !== 'undefined' &&
-        this.state.azureVMSizes[workers[0].azure.vm_size]
+        this.azureVMSizes[workers[0].azure.vm_size]
       ) {
-        let t = this.state.azureVMSizes[workers[0].azure.vm_size];
+        let t = this.azureVMSizes[workers[0].azure.vm_size];
         details = (
           <span>
             &mdash; {t.numberOfCores} CPUs, {(t.memoryInMb / 1000.0).toFixed(1)}{' '}

--- a/src/components/cluster/detail/cluster_detail_table.js
+++ b/src/components/cluster/detail/cluster_detail_table.js
@@ -21,7 +21,6 @@ class ClusterDetailTable extends React.Component {
   componentDidMount() {
     this.registerRefreshInterval();
 
-    // TODO Store it in Redux store?
     this.awsInstanceTypes = window.config.awsCapabilitiesJSON
       ? JSON.parse(window.config.awsCapabilitiesJSON)
       : {};

--- a/src/components/cluster/detail/cluster_detail_view.js
+++ b/src/components/cluster/detail/cluster_detail_view.js
@@ -3,6 +3,10 @@ import * as releaseActions from 'actions/releaseActions';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
+import {
+  getNumberOfNodePoolsNodes,
+  getNumberOfNodes,
+} from 'utils/cluster_utils';
 import { organizationCredentialsLoad } from 'actions/organizationActions';
 import { push } from 'connected-react-router';
 import Button from 'UI/button';
@@ -170,49 +174,6 @@ class ClusterDetailView extends React.Component {
     }
   }
 
-  getNumberOfNodes() {
-    if (
-      Object.keys(this.props.cluster).includes('status') &&
-      this.props.cluster.status != null
-    ) {
-      var nodes = this.props.cluster.status.cluster.nodes;
-      if (nodes.length == 0) {
-        return 0;
-      }
-
-      var workers = 0;
-      nodes.forEach(node => {
-        if (Object.keys(node).includes('labels')) {
-          if (
-            node.labels['role'] != 'master' &&
-            node.labels['kubernetes.io/role'] != 'master'
-          ) {
-            workers++;
-          }
-        }
-      });
-
-      if (workers === 0) {
-        // No node labels available? Fallback to assumption that one of the
-        // nodes is master and rest are workers.
-        workers = nodes.length - 1;
-      }
-
-      return workers;
-    }
-    return null;
-  }
-
-  getNumberOfNodePoolsNodes = () => {
-    const { nodePools } = this.props.cluster;
-
-    if (!nodePools || nodePools.length === 0) return 0;
-
-    return nodePools.reduce((accumulator, current) => {
-      return accumulator + current.status.nodes;
-    }, 0);
-  };
-
   getDesiredNumberOfNodes() {
     // Desired number of nodes only makes sense with auto-scaling and that is
     // only available on AWS starting from release 6.3.0 onwards.
@@ -241,8 +202,20 @@ class ClusterDetailView extends React.Component {
   };
 
   render() {
+    const {
+      cluster,
+      credentials,
+      dispatch,
+      isNodePoolView,
+      provider,
+      release,
+      targetRelease,
+    } = this.props;
+
+    const { loading } = this.state;
+
     return (
-      <LoadingOverlay loading={this.state.loading}>
+      <LoadingOverlay loading={loading}>
         <DocumentTitle
           title={'Cluster Details | ' + this.clusterName() + ' | Giant Swarm'}
         >
@@ -250,16 +223,13 @@ class ClusterDetailView extends React.Component {
             <div className='row' style={{ marginBottom: '30px' }}>
               <div className='col-sm-12 col-md-7 col-9'>
                 <h1 style={{ marginLeft: '-10px' }}>
-                  <ClusterIDLabel
-                    clusterID={this.props.cluster.id}
-                    copyEnabled
-                  />{' '}
+                  <ClusterIDLabel clusterID={cluster.id} copyEnabled />{' '}
                   <ClusterName
-                    dispatchFunc={this.props.dispatch}
-                    id={this.props.cluster.id}
-                    name={this.props.cluster.name}
+                    dispatchFunc={dispatch}
+                    id={cluster.id}
+                    name={cluster.name}
                   />{' '}
-                  {this.state.loading ? (
+                  {loading ? (
                     <img
                       className='loader'
                       height='25px'
@@ -272,7 +242,7 @@ class ClusterDetailView extends React.Component {
                 </h1>
               </div>
               <div className='col-sm-12 col-md-5 col-3'>
-                {!this.props.isNodePoolView && (
+                {!isNodePoolView && (
                   <>
                     <div
                       className='btn-group visible-xs-block visible-sm-block visible-md-block'
@@ -295,30 +265,30 @@ class ClusterDetailView extends React.Component {
               <div className='col-12'>
                 <Tabs>
                   <Tab eventKey={1} title='General'>
-                    {this.props.isNodePoolView ? (
+                    {isNodePoolView ? (
                       <ClusterDetailNodePoolsTable
                         accessCluster={this.accessCluster}
                         canClusterUpgrade={this.canClusterUpgrade()}
-                        cluster={this.props.cluster}
-                        credentials={this.props.credentials}
-                        provider={this.props.provider}
-                        release={this.props.release}
+                        cluster={cluster}
+                        credentials={credentials}
+                        provider={provider}
+                        release={release}
                         showScalingModal={this.showScalingModal}
                         showUpgradeModal={this.showUpgradeModal}
                         workerNodesDesired={this.getDesiredNumberOfNodes()}
-                        workerNodesRunning={this.getNumberOfNodePoolsNodes()}
+                        workerNodesRunning={getNumberOfNodePoolsNodes(cluster)}
                       />
                     ) : (
                       <ClusterDetailTable
                         canClusterUpgrade={this.canClusterUpgrade()}
-                        cluster={this.props.cluster}
-                        credentials={this.props.credentials}
-                        provider={this.props.provider}
-                        release={this.props.release}
+                        cluster={cluster}
+                        credentials={credentials}
+                        provider={provider}
+                        release={release}
                         showScalingModal={this.showScalingModal}
                         showUpgradeModal={this.showUpgradeModal}
                         workerNodesDesired={this.getDesiredNumberOfNodes()}
-                        workerNodesRunning={this.getNumberOfNodes()}
+                        workerNodesRunning={getNumberOfNodes(cluster)}
                       />
                     )}
 
@@ -336,7 +306,7 @@ class ClusterDetailView extends React.Component {
                           bsStyle='danger'
                           onClick={this.showDeleteClusterModal.bind(
                             this,
-                            this.props.cluster
+                            cluster
                           )}
                         >
                           <i className='fa fa-delete' /> Delete Cluster
@@ -345,19 +315,19 @@ class ClusterDetailView extends React.Component {
                     </div>
                   </Tab>
                   <Tab eventKey={2} title='Key Pairs'>
-                    <ClusterKeyPairs cluster={this.props.cluster} />
+                    <ClusterKeyPairs cluster={cluster} />
                   </Tab>
                   <Tab eventKey={3} title='Apps'>
-                    {this.props.release ? (
+                    {release ? (
                       <ClusterApps
                         clusterId={this.props.clusterId}
-                        dispatch={this.props.dispatch}
+                        dispatch={dispatch}
                         errorLoading={this.state.errorLoadingApps}
-                        installedApps={this.props.cluster.apps}
-                        release={this.props.release}
+                        installedApps={cluster.apps}
+                        release={release}
                         showInstalledAppsBlock={
                           Object.keys(this.props.catalogs.items).length > 0 &&
-                          this.props.cluster.capabilities.canInstallApps
+                          cluster.capabilities.canInstallApps
                         }
                       />
                     ) : (
@@ -376,23 +346,23 @@ class ClusterDetailView extends React.Component {
             </div>
 
             <ScaleClusterModal
-              cluster={this.props.cluster}
-              provider={this.props.provider}
+              cluster={cluster}
+              provider={provider}
               ref={s => {
                 this.scaleClusterModal = s;
               }}
               workerNodesDesired={this.getDesiredNumberOfNodes()}
-              workerNodesRunning={this.getNumberOfNodes()}
+              workerNodesRunning={getNumberOfNodes(cluster)}
             />
 
-            {this.props.targetRelease ? (
+            {targetRelease ? (
               <UpgradeClusterModal
-                cluster={this.props.cluster}
+                cluster={cluster}
                 ref={s => {
                   this.upgradeClusterModal = s;
                 }}
-                release={this.props.release}
-                targetRelease={this.props.targetRelease}
+                release={release}
+                targetRelease={targetRelease}
               />
             ) : (
               undefined

--- a/src/components/cluster/detail/index.js
+++ b/src/components/cluster/detail/index.js
@@ -2,7 +2,7 @@ import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import _ from 'underscore';
-import ClusterDetailView from './view';
+import ClusterDetailView from './cluster_detail_view';
 import cmp from 'semver-compare';
 import GettingStarted from '../../getting-started';
 import PropTypes from 'prop-types';

--- a/src/utils/cluster_utils.js
+++ b/src/utils/cluster_utils.js
@@ -34,6 +34,7 @@ export function getNumberOfNodes(cluster) {
 
 export function getMemoryTotal(cluster) {
   var workers = getNumberOfNodes(cluster);
+
   if (workers === null || workers === 0 || !cluster.workers) {
     return null;
   }

--- a/src/utils/cluster_utils.js
+++ b/src/utils/cluster_utils.js
@@ -3,33 +3,34 @@
 
 // Regular clusters functions
 export function getNumberOfNodes(cluster) {
-  if (Object.keys(cluster).includes('status') && cluster.status != null) {
-    var nodes = cluster.status.cluster.nodes;
-    if (nodes.length == 0) {
-      return 0;
-    }
-
-    var workers = 0;
-    nodes.forEach(node => {
-      if (Object.keys(node).includes('labels')) {
-        if (
-          node.labels['role'] != 'master' &&
-          node.labels['kubernetes.io/role'] != 'master'
-        ) {
-          workers++;
-        }
-      }
-    });
-
-    if (workers === 0) {
-      // No node labels available? Fallback to assumption that one of the
-      // nodes is master and rest are workers.
-      workers = nodes.length - 1;
-    }
-
-    return workers;
+  if (
+    !cluster.status ||
+    !cluster.status.nodes ||
+    cluster.status.cluster.nodes.length === 0
+  ) {
+    return 0;
   }
-  return null;
+
+  const nodes = cluster.status.cluster.nodes;
+
+  let workers = nodes.reduce((accumulator, node) => {
+    if (
+      node.labels &&
+      node.labels['role'] !== 'master' &&
+      node.labels['kubernetes.io/role'] !== 'master'
+    ) {
+      accumulator++;
+    }
+    return accumulator;
+  }, 0);
+
+  if (workers === 0) {
+    // No node labels available? Fallback to assumption that one of the
+    // nodes is master and rest are workers.
+    workers = nodes.length - 1;
+  }
+
+  return workers;
 }
 
 export function getMemoryTotal(cluster) {

--- a/src/utils/cluster_utils.js
+++ b/src/utils/cluster_utils.js
@@ -1,0 +1,105 @@
+// Here we can store functions that don't return markup/UI and are used in more
+// than one component.
+
+// Regular clusters functions
+export function getNumberOfNodes(cluster) {
+  if (Object.keys(cluster).includes('status') && cluster.status != null) {
+    var nodes = cluster.status.cluster.nodes;
+    if (nodes.length == 0) {
+      return 0;
+    }
+
+    var workers = 0;
+    nodes.forEach(node => {
+      if (Object.keys(node).includes('labels')) {
+        if (
+          node.labels['role'] != 'master' &&
+          node.labels['kubernetes.io/role'] != 'master'
+        ) {
+          workers++;
+        }
+      }
+    });
+
+    if (workers === 0) {
+      // No node labels available? Fallback to assumption that one of the
+      // nodes is master and rest are workers.
+      workers = nodes.length - 1;
+    }
+
+    return workers;
+  }
+  return null;
+}
+
+export function getMemoryTotal(cluster) {
+  var workers = getNumberOfNodes(cluster);
+  if (workers === null || workers === 0 || !cluster.workers) {
+    return null;
+  }
+  var m = workers * cluster.workers[0].memory.size_gb;
+  return m.toFixed(2);
+}
+
+export function getStorageTotal(cluster) {
+  var workers = getNumberOfNodes(cluster);
+  if (workers === null || workers === 0 || !cluster.workers) {
+    return null;
+  }
+  var s = workers * cluster.workers[0].storage.size_gb;
+  return s.toFixed(2);
+}
+
+export function getCpusTotal(cluster) {
+  var workers = getNumberOfNodes(cluster);
+  if (workers === null || workers === 0 || !cluster.workers) {
+    return null;
+  }
+  return workers * cluster.workers[0].cpu.cores;
+}
+
+// Node pools clusters functions.
+export function getNumberOfNodePoolsNodes(cluster) {
+  const { nodePools } = cluster;
+
+  if (!nodePools || nodePools.length === 0) return 0;
+
+  return nodePools.reduce((accumulator, current) => {
+    return accumulator + current.status.nodes;
+  }, 0);
+}
+
+export function getMemoryTotalNodePools(cluster) {
+  if (!window.config.awsCapabilitiesJSON || !cluster.nodePools) {
+    return;
+  }
+
+  const { nodePools } = cluster;
+  const nodes = getNumberOfNodePoolsNodes(cluster);
+  const awsInstanceTypes = JSON.parse(window.config.awsCapabilitiesJSON);
+
+  const TotalRAM = nodePools.reduce((accumulator, nodePool) => {
+    const nodePoolRAM =
+      awsInstanceTypes[nodePool.node_spec.aws.instance_type].memory_size_gb;
+    return accumulator + nodePoolRAM;
+  }, 0);
+
+  return TotalRAM * nodes;
+}
+
+export function getCpusTotalNodePools(cluster) {
+  if (!window.config.awsCapabilitiesJSON || !cluster.nodePools) {
+    return;
+  }
+
+  const nodes = getNumberOfNodePoolsNodes(cluster);
+  const awsInstanceTypes = JSON.parse(window.config.awsCapabilitiesJSON);
+
+  const TotalCPUs = cluster.nodePools.reduce((accumulator, nodePool) => {
+    const nodePoolCPUs =
+      awsInstanceTypes[nodePool.node_spec.aws.instance_type].cpu_cores;
+    return accumulator + nodePoolCPUs;
+  }, 0);
+
+  return TotalCPUs * nodes;
+}


### PR DESCRIPTION
What I am doing here in this PR is:

- Extracting functions duplicated in `ClusterDetailView`, `ClusterDashboardItem`,  `ClusterDetailTable` components (some of them will be  also in `ClusterDetailNodePoolsTable`) to a utils file

- Desctucturing props

- Renaming `view.js` to `cluster_detail_view.js` because it is easier, at least for me, to use (almost) same names for the exported component and the file. 

Sorry for the size of the PR... it is not as big if you take into account that there is a lot of destructuring. Let me know if you think that I should have done destructuring in another PR. Thanks ❤️ 