### PR TITLE
Fix error when no togglingState method is supplied

### DIFF
--- a/src/components/UI/view_edit_name.js
+++ b/src/components/UI/view_edit_name.js
@@ -58,7 +58,8 @@ class ViewAndEditName extends React.Component {
       inputFieldValue: this.state.name,
     });
 
-    this.props.toggleEditingState(true);
+    const { toggleEditingState } = this.props;
+    if (toggleEditingState) toggleEditingState(true);
   };
 
   deactivateEditMode = () => {
@@ -68,7 +69,8 @@ class ViewAndEditName extends React.Component {
       inputFieldValue: this.state.name,
     });
 
-    this.props.toggleEditingState(false);
+    const { toggleEditingState } = this.props;
+    if (toggleEditingState) toggleEditingState(false);
   };
 
   handleChange = () => {


### PR DESCRIPTION
This has been updated too many times lately, sorry
This fix an error that is thrown when `this.props.toggleEditingState`is not supplied