### PR TITLE
Added returns & removed export

### DIFF
--- a/src/reducers/nodePoolsReducer.js
+++ b/src/reducers/nodePoolsReducer.js
@@ -8,21 +8,24 @@ import produce from 'immer';
 // From the docs: "Notice that it is not needed to handle the default case, a producer
 // that doesn't do anything will simply return the original state."
 
-export const nodePools = produce((draft, action) => {
+const nodePools = produce((draft, action) => {
   switch (action.type) {
     case types.NODEPOOLS_LOAD_SUCCESS:
       return action.nodePools;
 
     case types.NODEPOOLS_LOAD_ERROR:
       draft.errorLoading = true;
+      return;
 
     case types.NODEPOOL_PATCH:
       Object.keys(action.payload).forEach(key => {
         draft[action.nodePool.id][key] = action.payload[key];
       });
+      return;
 
     case types.NODEPOOL_PATCH_ERROR:
       draft[action.nodePool.id] = action.nodePool;
+      return;
   }
   // This empty obeject is the default state.
 }, {});


### PR DESCRIPTION
Added `return`s because I have observed that, even though in Immer docs they say `return`s are not needed (or at least this is what I understood [here](https://github.com/immerjs/immer#returning-data-from-producers)) in one specific case a fallthrought occurred.