### PR TITLE
Update getting started

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -26,10 +26,8 @@ RUN yarn add node-sass@4.9.4
 COPY package.json /usr/src/app/
 COPY .babelrc /usr/src/app/
 COPY .eslintrc /usr/src/app/
-COPY ./Gruntfile.js /usr/src/app/
 COPY ./package.json /usr/src/app/
-COPY ./webpack.config.js /usr/src/app/
-COPY ./webpack.dist.config.js /usr/src/app/
+COPY ./webpack* /usr/src/app/
 
 COPY ./scripts/dev.sh /usr/src/app/
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Currently only Giant Swarm employees are able to see that repo. We're considerin
 open sourcing it.
 
 Start the `api` and dependencies first by going to the `api` [repo](https://github.com/giantswarm/api) and running
-the dockercompose file there:
+the dockercompose file in the testing folder there:
 
 ```nohighlight
 cd $GOPATH/src/github.com/giantswarm/api/testing

--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ the dockercompose file there:
 
 ```nohighlight
 cd $GOPATH/src/github.com/giantswarm/api/testing
+make aws
 make up
 ```
+
+> Notice the `make aws` command in that example? There is also `make azure` and `make kvm`
+to create a docker-compose file that sets up the API and other microservices as if
+they were on these types of installations.
 
 As part of `make up`, `./fixtures.sh` will run and create the initial user and
 organization you can log in with.

--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ Happa is a single page JavaScript application using React+Redux and runs in mode
 
 ## Getting started with development / demoing
 
-Happa has to be configured for an API endpoint. There are two alternative methods
-when running happa locally:
+Happa has to talk to an API endpoint. It used to be possible to change a locally
+running happa's configuration to talk to any API server. This has since been
+restricted with CORS accept headers.
 
-- (A) Bring up the API suite locally. See [giantswarm/api/](https://github.com/giantswarm/api/tree/master/testing) for details.
-- (B) Modify the base config in [index.html](https://github.com/giantswarm/happa/blob/master/src/index.html) to point to a test installation.
+The only option now is to bring up the API suite locally, or demo happa running
+on one of our installations.
 
-### For (A) – Bring up the API suite locally
+### Bring up the API suite locally
 
-This requires Docker and `docker-compose`.
+This requires Docker and `docker-compose`, and access to our private `api` repo.
+Currently only Giant Swarm employees are able to see that repo. We're considering
+open sourcing it.
 
 Start the `api` and dependencies first by going to the `api` [repo](https://github.com/giantswarm/api) and running
 the dockercompose file there:
@@ -41,16 +44,6 @@ make up
 
 As part of `make up`, `./fixtures.sh` will run and create the initial user and
 organization you can log in with.
-
-### For (B)
-
-Find the `apiEndpoint` setting in `src/index.html` and set it to the API endpoint of the test
-installation you want to use.
-
-If you want to test password resetting and other user account transactions,
-also adapt `passageEndpoint` value.
-
-### For (A) and (B)
 
 You should now be able to start happa's development server from within this
 (giantswarm/happa) repo like so:
@@ -81,7 +74,7 @@ Use `docker-compose stop` to stop containers or `docker-compose down` to remove 
 Running tests
 -------------
 
-There are no automated tests for Happa at the moment.
+We have a few tests, and are adding more. Run them with `yarn test`
 
 Deploying
 ---------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,38 +13,6 @@ services:
       # to persist info on used dependencies to the repo
       - $PWD/yarn.lock:/usr/src/app/yarn.lock:z
 
-  passage:
-    image: quay.io/giantswarm/passage:latest
-    ports:
-      - "5001:8000"
-    environment:
-      DEBUGGING: 1
-      HAPPA_BASE_URI: http://localhost:7000
-      GIANTSWARM_API_URI: http://api:8000
-      GIANTSWARM_USERD_URI: http://userd:8000
-      GIANTSWARM_COMPANYD_URI: http://companyd:8000
-      #NUM_PROXIES: "0"
-      RATELIMIT_GLOBAL: 1000 per day, 100 per hour, 30 per minute
-      RATELIMIT_STORAGE_URL: redis://redis:6379
-    links:
-      - redis:redis
-      - mailcatcher:mailcatcher
-
-  redis:
-    image: redis:3.2
-    ports:
-      - "6379:6379"
-    volumes:
-      - $PWD/docker-volumes/redis-data:/data:z
-
-  mailcatcher:
-    image: quay.io/giantswarm/mailcatcher:latest
-    ports:
-      - "1080:1080"
-      - "1025:1025"
-    depends_on:
-      - redis
-
 networks:
   default:
     external:

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -2,4 +2,4 @@
 
 # This is the entry point for the development Dockerfile.
 yarn install --non-interactive --production=false
-npm start
+yarn start

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = merge(common, {
     contentBase: './src',
     hotOnly: true,
     port: 7000,
-    host: 'localhost',
+    host: '0.0.0.0',
     historyApiFallback: true,
   },
   plugins: [new webpack.HotModuleReplacementPlugin()],


### PR DESCRIPTION
Things have changed a bit since we wrote the getting started part of the README.

This updates that.

It also removes passage and mailcatcher from the dockerfile, I will move it to the dockerfile in api instead, so we don't have to think about starting another docker-compose before testing anything related to invitations. 

FYI @ograu. I gave you some instructions on how to start `passage`, but now I am removing that from `happa`. So what I said here will no longer work after this PR is merged. Instead I will add it to the docker-compose in `api` so that it is always running, and invitations are always working.

https://github.com/giantswarm/happa/pull/712#issuecomment-521104734