### PR TITLE
Remove some flashing of unstyled content.

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -30,7 +30,10 @@ import 'noty/lib/noty.css';
 import 'react-datepicker/dist/react-datepicker.css';
 import 'styles/app.sass';
 
-var appContainer = document.getElementById('app');
+const appContainer = document.getElementById('app');
+const body = document.getElementsByTagName('body')[0];
+
+body.classList.remove('loading');
 
 const store = configureStore({});
 

--- a/src/index.html
+++ b/src/index.html
@@ -52,7 +52,7 @@
   </noscript>
 
   <div id="app"></div>
-  <footer id="footer" class="col-9">
+  <footer class="col-9">
     Happa VERSION · <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">Release Notes</a>
   </footer>
   <script type="text/javascript" src="/vendor/modernizr.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -28,13 +28,17 @@
   </script>
 
   <style>
-    footer {
+    body {
+      background: #234a61;
+    }
+
+    .loading footer{
       display: none;
     }
   </style>
 
 </head>
-<body>
+<body class="loading">
   <!--[if lt IE 8]>
     <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
   <![endif]-->
@@ -42,13 +46,13 @@
   <noscript>
     <div class="container-fluid">
       <div class="alert alert-warning">
-        Dear user, it seems like <strong>JavaScript is blocked</strong> through your browser or connection. Please make sure you can execute JavaScript in order to make use of this application.
+        Dear user, it seems like JavaScript is blocked through your browser or connection. Please make sure you can execute JavaScript in order to make use of this application.
       </div>
     </div>
   </noscript>
 
   <div id="app"></div>
-  <footer class="col-9">
+  <footer id="footer" class="col-9">
     Happa VERSION · <a rel='noopener noreferrer' href="https://github.com/giantswarm/happa/releases">Release Notes</a>
   </footer>
   <script type="text/javascript" src="/vendor/modernizr.js"></script>


### PR DESCRIPTION
This makes the initial load of Happa more calm.

The footer content won't show up on a blank page anymore, and the page should start off blue.

I've also fixed a unreadable portion of the warning that shows up when users do not have javascript enabled. The `strong` tag rendered the text in white.