### PR TITLE
Fix issues with cluster updating.

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -719,14 +719,7 @@ export function clusterPatch(cluster, payload) {
     });
 
     return clustersApi
-      .modifyCluster(scheme + ' ' + token, payload, cluster.id)
-      .then(() => {
-        new FlashMessage(
-          'Cluster name changed',
-          messageType.SUCCESS,
-          messageTTL.SHORT
-        );
-      })
+      .modifyCluster(scheme + ' ' + token, cluster.id, payload)
       .catch(error => {
         // Undo update to store if the API call fails.
         dispatch({
@@ -736,7 +729,7 @@ export function clusterPatch(cluster, payload) {
         });
 
         new FlashMessage(
-          'Something went wrong while trying to update the cluster name',
+          'Something went wrong while trying to update the cluster',
           messageType.ERROR,
           messageTTL.MEDIUM,
           'Please try again later or contact support: support@giantswarm.io'

--- a/src/components/UI/view_edit_name.js
+++ b/src/components/UI/view_edit_name.js
@@ -103,7 +103,8 @@ class ViewAndEditName extends React.Component {
         name: inputFieldValue,
       });
 
-      this.props.toggleEditingState(false);
+      const { toggleEditingState } = this.props;
+      if (toggleEditingState) toggleEditingState(false);
     });
   };
 

--- a/src/components/cluster/detail/upgrade_cluster_modal.js
+++ b/src/components/cluster/detail/upgrade_cluster_modal.js
@@ -208,9 +208,7 @@ class UpgradeClusterModal extends React.Component {
             release_version: targetReleaseVersion,
           })
           .then(patchedCluster => {
-            this.props.clusterActions.clusterLoadDetailsSuccess(
-              patchedCluster
-            );
+            this.props.clusterActions.clusterLoadDetailsSuccess(patchedCluster);
 
             new FlashMessage(
               'Cluster upgrade initiated.',

--- a/src/components/cluster/detail/upgrade_cluster_modal.js
+++ b/src/components/cluster/detail/upgrade_cluster_modal.js
@@ -27,6 +27,7 @@ class UpgradeClusterModal extends React.Component {
 
   close = () => {
     this.setState({
+      loading: false,
       modalVisible: false,
     });
   };
@@ -81,6 +82,7 @@ class UpgradeClusterModal extends React.Component {
               let component = components[diffEdit.path[0]];
               return (
                 <ReleaseComponentLabel
+                  key={component.name}
                   name={component.name}
                   oldVersion={diffEdit.lhs}
                   version={diffEdit.rhs}
@@ -202,30 +204,22 @@ class UpgradeClusterModal extends React.Component {
         var targetReleaseVersion = this.props.targetRelease.version;
 
         this.props.clusterActions
-          .clusterPatch({
-            id: this.props.cluster.id,
+          .clusterPatch(this.props.cluster, {
             release_version: targetReleaseVersion,
           })
           .then(patchedCluster => {
-            this.setState(
-              {
-                loading: false,
-              },
-              () => {
-                this.props.clusterActions.clusterLoadDetailsSuccess(
-                  patchedCluster
-                );
-
-                new FlashMessage(
-                  'Cluster upgrade initiated.',
-                  messageType.INFO,
-                  messageTTL.MEDIUM,
-                  'Keep an eye on <code>kubectl get nodes</code> to follow the upgrade progress.'
-                );
-
-                this.close();
-              }
+            this.props.clusterActions.clusterLoadDetailsSuccess(
+              patchedCluster
             );
+
+            new FlashMessage(
+              'Cluster upgrade initiated.',
+              messageType.INFO,
+              messageTTL.MEDIUM,
+              'Keep an eye on <code>kubectl get nodes</code> to follow the upgrade progress.'
+            );
+
+            this.close();
           })
           .catch(error => {
             this.setState({


### PR DESCRIPTION
There were some problems after the recent changes to clusterpatch.

ClusterPatch is used for two things, changing the cluster name and upgrading the cluster version.

Both weren't working very well anymore from the old screen. I did some quick fixes to make it work again.

I think we should also reconsider the approach in ViewEditName component, I think it knows too much about what to do when pressing submit. 

Lets talk later @ograu !