### PR TITLE
Make view and edit name know a bit less about our tech stack.

### DIFF
--- a/src/actions/nodePoolsActions.js
+++ b/src/actions/nodePoolsActions.js
@@ -90,13 +90,6 @@ export function nodePoolPatch(nodePool, payload) {
 
     return nodePoolsApi
       .modifyNodePool(scheme + ' ' + token, clusterId, nodePool, payload)
-      .then(() => {
-        new FlashMessage(
-          'Node pool name changed',
-          messageType.SUCCESS,
-          messageTTL.SHORT
-        );
-      })
       .catch(error => {
         // Undo update to store if the API call fails.
         dispatch(nodePoolPatchError(error, nodePool));

--- a/src/components/UI/view_edit_name.js
+++ b/src/components/UI/view_edit_name.js
@@ -93,19 +93,22 @@ class ViewAndEditName extends React.Component {
       return;
     }
 
-    dispatch(
-      // We need the object and the change we want to make to it in order to be able
-      // to do optimistic updates
-      onSubmit(entity, { name: inputFieldValue })
-    ).then(() => {
-      this.setState({
-        editing: false,
-        name: inputFieldValue,
-      });
+    onSubmit(inputFieldValue)
+      .then(() => {
+        this.setState({
+          editing: false,
+          name: inputFieldValue,
+        });
 
-      const { toggleEditingState } = this.props;
-      if (toggleEditingState) toggleEditingState(false);
-    });
+        const { toggleEditingState } = this.props;
+        if (toggleEditingState) toggleEditingState(false);
+      })
+      .catch(error => {
+        console.error(error);
+        // this.setState({
+        //   errorMessage: error.message
+        // });
+      });
   };
 
   handleKey = evt => {

--- a/src/components/UI/view_edit_name.js
+++ b/src/components/UI/view_edit_name.js
@@ -105,9 +105,6 @@ class ViewAndEditName extends React.Component {
       })
       .catch(error => {
         console.error(error);
-        // this.setState({
-        //   errorMessage: error.message
-        // });
       });
   };
 

--- a/src/components/cluster/detail/cluster_detail_view.js
+++ b/src/components/cluster/detail/cluster_detail_view.js
@@ -203,8 +203,6 @@ class ClusterDetailView extends React.Component {
     return new Promise((resolve, reject) => {
       this.props
         .dispatch(
-          // We need the object and the change we want to make to it in order to be able
-          // to do optimistic updates
           clusterPatch(this.props.cluster, { name: value })
         )
         .then(() => {

--- a/src/components/cluster/detail/cluster_detail_view.js
+++ b/src/components/cluster/detail/cluster_detail_view.js
@@ -202,9 +202,7 @@ class ClusterDetailView extends React.Component {
   editClusterName = value => {
     return new Promise((resolve, reject) => {
       this.props
-        .dispatch(
-          clusterPatch(this.props.cluster, { name: value })
-        )
+        .dispatch(clusterPatch(this.props.cluster, { name: value }))
         .then(() => {
           new FlashMessage(
             'Succesfully edited cluster name.',

--- a/src/components/cluster/detail/cluster_detail_view.js
+++ b/src/components/cluster/detail/cluster_detail_view.js
@@ -199,6 +199,28 @@ class ClusterDetailView extends React.Component {
     );
   };
 
+  editClusterName = value => {
+    return new Promise((resolve, reject) => {
+      this.props
+        .dispatch(
+          // We need the object and the change we want to make to it in order to be able
+          // to do optimistic updates
+          clusterPatch(this.props.cluster, { name: value })
+        )
+        .then(() => {
+          new FlashMessage(
+            'Succesfully edited cluster name.',
+            messageType.SUCCESS,
+            messageTTL.MEDIUM
+          );
+          resolve();
+        })
+        .catch(error => {
+          reject(error);
+        });
+    });
+  };
+
   render() {
     const {
       cluster,
@@ -229,7 +251,7 @@ class ClusterDetailView extends React.Component {
                   <ViewAndEditName
                     entity={cluster}
                     entityType='cluster'
-                    onSubmit={clusterPatch}
+                    onSubmit={this.editClusterName}
                   />{' '}
                   {loading ? (
                     <img

--- a/src/components/cluster/detail/node_pool.js
+++ b/src/components/cluster/detail/node_pool.js
@@ -29,9 +29,7 @@ class NodePool extends Component {
   editNodePoolName = value => {
     return new Promise((resolve, reject) => {
       this.props
-        .dispatch(
-          nodePoolPatch(this.props.nodePool, { name: value })
-        )
+        .dispatch(nodePoolPatch(this.props.nodePool, { name: value }))
         .then(() => {
           new FlashMessage(
             'Succesfully edited node pool name.',

--- a/src/components/cluster/detail/node_pool.js
+++ b/src/components/cluster/detail/node_pool.js
@@ -1,4 +1,6 @@
 import { Code } from 'styles/';
+import { connect } from 'react-redux';
+import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
 import { nodePoolPatch } from 'actions/nodePoolsActions';
 import AvailabilityZonesWrapper from './availability_zones_wrapper';
 import NodePoolDropdownMenu from './node_pool_dropdown_menu';
@@ -24,6 +26,27 @@ class NodePool extends Component {
   toggleEditingState = isNameBeingEdited =>
     this.setState({ isNameBeingEdited });
 
+  editNodePoolName = value => {
+    return new Promise((resolve, reject) => {
+      this.props
+        .dispatch(
+          nodePoolPatch(this.props.nodePool, { name: value })
+        )
+        .then(() => {
+          new FlashMessage(
+            'Succesfully edited node pool name.',
+            messageType.SUCCESS,
+            messageTTL.MEDIUM
+          );
+          resolve();
+        })
+        .catch(error => {
+          console.error(error);
+          reject(error);
+        });
+    });
+  };
+
   render() {
     const { availableZonesGridTemplateAreas, nodePool } = this.props;
 
@@ -45,7 +68,7 @@ class NodePool extends Component {
           <ViewAndEditName
             entity={nodePool}
             entityType='node pool'
-            onSubmit={nodePoolPatch}
+            onSubmit={this.editNodePoolName}
             toggleEditingState={this.toggleEditingState}
           />
         </div>
@@ -99,4 +122,13 @@ NodePool.propTypes = {
   dispatch: PropTypes.func,
 };
 
-export default NodePool;
+function mapDispatchToProps(dispatch) {
+  return {
+    dispatch: dispatch,
+  };
+}
+
+export default connect(
+  undefined,
+  mapDispatchToProps
+)(NodePool);


### PR DESCRIPTION
@ograu, this would be my approach to make it so that the view and edit name component doesn't know it has to dispatch anything. 

Instead all it expects is a Promise for the onsubmit call, so it stays concerned with calling that function and dealing with a success or a failure.

Side effect, no more optimistic updates. Which I question a bit to be honest. I'd rather show a spinner, to let the user know something is happening, and then an error, instead of doing a optimistic update, and then throwing an error after the fact.

This PR is for discussion so you can see the approach I would take here, and see what you think of it.

Is this promise stuff too old school or weird or bad practice?