### PR TITLE
Fetch everything at once

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -87,15 +87,67 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
   return clustersApi
     .getClusters(scheme + ' ' + token)
     .then(clusters => {
-      const lastUpdated = Date.now();
       const enhancedClusters = enhanceWithCapabilities(
         clusters,
         getState().app.info.general.provider
       );
 
       // Clusters array to object, because we are storing an object in the store
-      const clustersObject = clustersLoadArrayToObject(enhancedClusters);
+      let clustersObject = clustersLoadArrayToObject(enhancedClusters);
+      return clustersObject;
+    })
+    .then(clustersObject => {
+      return Promise.all(
+        Object.keys(clustersObject).map(clusterId => {
+          return clustersApi
+            .getCluster(scheme + ' ' + token, clusterId)
+            .then(clusterDetails => {
+              clusterDetails.capabilities = computeCapabilities(
+                clusterDetails,
+                getState().app.info.general.provider
+              );
 
+              return clusterDetails;
+            });
+        })
+      ).then(clusterDetailsArray => {
+        clusterDetailsArray.forEach(clusterDetail => {
+          clustersObject[clusterDetail.id] = {
+            ...clustersObject[clusterDetail.id],
+            ...clusterDetail,
+          };
+        });
+
+        return clustersObject;
+      });
+    })
+    .then(clustersObject => {
+      return Promise.all(
+        Object.keys(clustersObject).map(clusterId => {
+          if (window.config.environment === 'development') {
+            return { id: clusterId, ...mockedStatus };
+          } else {
+            return clustersApi
+              .getClusterStatus(scheme + ' ' + token, clusterId)
+              .then(clusterStatus => {
+                return { id: clusterId, ...clusterStatus };
+              });
+          }
+        })
+      ).then(clusterStatusArray => {
+        clusterStatusArray.forEach(clusterStatus => {
+          clustersObject[clusterStatus.id] = {
+            ...clustersObject[clusterStatus.id],
+            ...{ status: clusterStatus },
+          };
+        });
+
+        return clustersObject;
+      });
+    })
+    .then(clustersObject => {
+      console.log(clustersObject);
+      const lastUpdated = Date.now();
       dispatch(clustersLoadSuccessV4(clustersObject, lastUpdated));
     })
     .catch(error => {

--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -21,20 +21,6 @@ class Home extends React.Component {
   componentDidMount() {
     this.registerRefreshInterval();
     this.visibilityTracker.addEventListener(this.handleVisibilityChange);
-    this.fetchClusterDetails(this.props.clusters);
-  }
-
-  componentDidUpdate(prevProps) {
-    // load cluster details if cluster list has changed
-    if (
-      !_.isEqual(
-        // inmutability?
-        this.props.clusters.map(x => x.id),
-        prevProps.clusters.map(x => x.id)
-      )
-    ) {
-      this.fetchClusterDetails(this.props.clusters);
-    }
   }
 
   componentWillUnmount() {
@@ -65,16 +51,6 @@ class Home extends React.Component {
       this.registerRefreshInterval();
     }
   };
-
-  fetchClusterDetails(clusters) {
-    return Promise.all(
-      _.flatten(
-        clusters.map(cluster => {
-          return [this.props.actions.clusterLoadDetails(cluster.id)];
-        })
-      )
-    );
-  }
 
   /**
    * Returns the string to use as the document.title

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -32,19 +32,8 @@ const clusterReducer = produce((draft, action) => {
       Object.keys(action.clusters).forEach(clusterId => {
         const withAwsKeys = ensureWorkersHaveAWSkey(action.clusters[clusterId]);
 
-        let status = draft.items[clusterId]
-          ? draft.items[clusterId].status
-          : undefined;
-
-        let workers = draft.items[clusterId]
-          ? draft.items[clusterId].workers
-          : undefined;
-
         draft.items[clusterId] = action.clusters[clusterId];
         draft.items[clusterId].workers = withAwsKeys.workers;
-
-        draft.items[clusterId].status = status;
-        draft.items[clusterId].workers = workers;
       });
 
       draft.lastUpdated = action.lastUpdated;

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -31,8 +31,15 @@ const clusterReducer = produce((draft, action) => {
     case types.CLUSTERS_LOAD_SUCCESS_V4:
       Object.keys(action.clusters).forEach(clusterId => {
         const withAwsKeys = ensureWorkersHaveAWSkey(action.clusters[clusterId]);
+
+        let status = draft.items[clusterId]
+          ? draft.items[clusterId].status
+          : undefined;
+
         draft.items[clusterId] = action.clusters[clusterId];
         draft.items[clusterId].workers = withAwsKeys.workers;
+
+        draft.items[clusterId].status = status;
       });
 
       draft.lastUpdated = action.lastUpdated;

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -36,10 +36,15 @@ const clusterReducer = produce((draft, action) => {
           ? draft.items[clusterId].status
           : undefined;
 
+        let workers = draft.items[clusterId]
+          ? draft.items[clusterId].workers
+          : undefined;
+
         draft.items[clusterId] = action.clusters[clusterId];
         draft.items[clusterId].workers = withAwsKeys.workers;
 
         draft.items[clusterId].status = status;
+        draft.items[clusterId].workers = workers;
       });
 
       draft.lastUpdated = action.lastUpdated;


### PR DESCRIPTION
Instead of trying to merge things as they come in, this makes the clustersLoad action fetch everything about all clusters all at once.

The disadvantages here are that this will be fine for small installations, but not so great for installations with many clusters.

What is happening now, if we have 100 clusters across 10 orgs, is that each time we will do ~300~ 201 requests, even if we are only looking at a org that has only 10 clusters.

So that's probably one of the reason the code evolved the way it did. Lets keep thinking, and submitting this now so you can see what it looks like.