### PR TITLE
Fix errors getting cluster status

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -153,7 +153,6 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
       });
     })
     .then(clustersObject => {
-      console.log(clustersObject);
       const lastUpdated = Date.now();
       dispatch(clustersLoadSuccessV4(clustersObject, lastUpdated));
     })

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -128,9 +128,16 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
             return { id: clusterId, ...mockedStatus };
           } else {
             return clustersApi
-              .getClusterStatus(scheme + ' ' + token, clusterId)
-              .then(clusterStatus => {
-                return { id: clusterId, ...clusterStatus };
+              .getClusterStatusWithHttpInfo(scheme + ' ' + token, clusterId)
+              .then(data => {
+                // For some reason we're getting an empty object back.
+                // The Giantswarm JS client is not parsing the returned JSON
+                // and giving us a object in the normal way anymore.
+                // Very stumped, since nothing has changed.
+                // So we need to access the raw response and parse the json
+                // ourselves.
+                let status = JSON.parse(data.response.text);
+                return { id: clusterId, ...status };
               });
           }
         })

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -127,6 +127,7 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
           if (window.config.environment === 'development') {
             return { id: clusterId, ...mockedStatus };
           } else {
+            // TODO: Find out why we are getting an empty object back from this call. Forcing us to use getClusterStatusWithHttpInfo instead of getClusterStatus
             return clustersApi
               .getClusterStatusWithHttpInfo(scheme + ' ' + token, clusterId)
               .then(data => {

--- a/src/components/UI/view_edit_name.js
+++ b/src/components/UI/view_edit_name.js
@@ -80,7 +80,7 @@ class ViewAndEditName extends React.Component {
   handleSubmit = evt => {
     evt.preventDefault();
 
-    const { entity, onSubmit, dispatch } = this.props;
+    const { onSubmit } = this.props;
     const inputFieldValue = this.nameInputRef.current.value;
 
     var validate = this.validate();


### PR DESCRIPTION
This fixes something new that I don't have a good explanation for.

Suddenly the `getclusterstatus` call of the `giantswarm-js-client` started returning `{}` even though I could see in the network tab that a successful request had been made, and it contained real data in the response.

It's very weird, and couldn't be due to any changes or experiments in `giantswarm-js-client`, I haven't merged any of my changes there to master.

This PR also fixes some console warnings and output I noticed while debugging. 