### PR TITLE
Simplify auth state

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "copy-to-clipboard": "3.2.0",
     "deep-diff": "1.0.2",
     "emotion-theming": "^10.0.10",
-    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git#test-auth-param",
+    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git",
     "history": "^4.7.2",
     "immer": "^3.2.0",
     "immutable": "3.8.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "copy-to-clipboard": "3.2.0",
     "deep-diff": "1.0.2",
     "emotion-theming": "^10.0.10",
-    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git#master",
+    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git#test-auth-param",
     "history": "^4.7.2",
     "immer": "^3.2.0",
     "immutable": "3.8.2",

--- a/src/actions/appConfigActions.js
+++ b/src/actions/appConfigActions.js
@@ -10,10 +10,7 @@ import GiantSwarm from 'giantswarm';
  * @param {Object} values The values which will be set for the uservalues configmap.
  */
 export function updateAppConfig(appName, clusterID, values) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.CLUSTER_UPDATE_APP_CONFIG,
       clusterID,
@@ -23,7 +20,7 @@ export function updateAppConfig(appName, clusterID, values) {
     var appConfigsApi = new GiantSwarm.AppConfigsApi();
 
     return appConfigsApi
-      .modifyClusterAppConfig(scheme + ' ' + token, clusterID, appName, {
+      .modifyClusterAppConfig(clusterID, appName, {
         body: values,
       })
       .then(() => {
@@ -77,10 +74,7 @@ export function updateAppConfig(appName, clusterID, values) {
  * @param {Object} values The values which will be set for the uservalues configmap.
  */
 export function createAppConfig(appName, clusterID, values) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.CLUSTER_CREATE_APP_CONFIG,
       clusterID,
@@ -90,7 +84,7 @@ export function createAppConfig(appName, clusterID, values) {
     var appConfigsApi = new GiantSwarm.AppConfigsApi();
 
     return appConfigsApi
-      .createClusterAppConfig(scheme + ' ' + token, clusterID, appName, {
+      .createClusterAppConfig(clusterID, appName, {
         body: values,
       })
       .then(() => {
@@ -143,10 +137,7 @@ export function createAppConfig(appName, clusterID, values) {
  * @param {Object} clusterID What cluster it is on.
  */
 export function deleteAppConfig(appName, clusterID) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.CLUSTER_DELETE_APP_CONFIG,
       clusterID,
@@ -156,7 +147,7 @@ export function deleteAppConfig(appName, clusterID) {
     var appConfigsApi = new GiantSwarm.AppConfigsApi();
 
     return appConfigsApi
-      .deleteClusterAppConfig(scheme + ' ' + token, clusterID, appName)
+      .deleteClusterAppConfig(clusterID, appName)
       .then(() => {
         dispatch({
           type: types.CLUSTER_DELETE_APP_CONFIG_SUCCESS,

--- a/src/actions/catalogActions.js
+++ b/src/actions/catalogActions.js
@@ -45,16 +45,13 @@ function loadCatalogIndex(catalog) {
 // with catalogs and apps in the right places.
 //
 export function catalogsLoad() {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     dispatch({ type: types.CATALOGS_LOAD });
-
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
 
     var appsApi = new GiantSwarm.AppsApi();
 
     return appsApi
-      .getAppCatalogs(scheme + ' ' + token)
+      .getAppCatalogs()
       .then(catalogs => {
         let catalogsDict = {};
 

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -67,25 +67,23 @@ function clustersLoadArrayToObject(clusters) {
  */
 export function clustersLoad() {
   return function(dispatch, getState) {
-    const token = getState().app.loggedInUser.auth.token;
-    const scheme = getState().app.loggedInUser.auth.scheme;
     // TODO getClusters() will get all clusters, so we will need some logic here
     // that separates regular clusters from NP clusters and then pass them to their
     // respective methods.
 
-    clustersLoadV4(token, scheme, dispatch, getState);
+    clustersLoadV4(dispatch, getState);
     if (window.config.environment === 'development') {
-      clustersLoadV5(token, scheme, dispatch, getState);
+      clustersLoadV5(dispatch, getState);
     }
   };
 }
 
-function clustersLoadV4(token, scheme, dispatch, getState) {
+function clustersLoadV4(dispatch, getState) {
   // TODO this will be in getClusters() here in this function we just want to
   // dispatch specific actions for v4 clusters.
   // Or maybe we won't need this method at all.
   return clustersApi
-    .getClusters(scheme + ' ' + token)
+    .getClusters()
     .then(clusters => {
       const enhancedClusters = enhanceWithCapabilities(
         clusters,
@@ -99,16 +97,14 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
     .then(clustersObject => {
       return Promise.all(
         Object.keys(clustersObject).map(clusterId => {
-          return clustersApi
-            .getCluster(scheme + ' ' + token, clusterId)
-            .then(clusterDetails => {
-              clusterDetails.capabilities = computeCapabilities(
-                clusterDetails,
-                getState().app.info.general.provider
-              );
+          return clustersApi.getCluster(clusterId).then(clusterDetails => {
+            clusterDetails.capabilities = computeCapabilities(
+              clusterDetails,
+              getState().app.info.general.provider
+            );
 
-              return clusterDetails;
-            });
+            return clusterDetails;
+          });
         })
       ).then(clusterDetailsArray => {
         clusterDetailsArray.forEach(clusterDetail => {
@@ -129,7 +125,7 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
           } else {
             // TODO: Find out why we are getting an empty object back from this call. Forcing us to use getClusterStatusWithHttpInfo instead of getClusterStatus
             return clustersApi
-              .getClusterStatusWithHttpInfo(scheme + ' ' + token, clusterId)
+              .getClusterStatusWithHttpInfo(clusterId)
               .then(data => {
                 // For some reason we're getting an empty object back.
                 // The Giantswarm JS client is not parsing the returned JSON
@@ -176,12 +172,12 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
     });
 }
 
-function clustersLoadV5(token, scheme, dispatch, getState) {
+function clustersLoadV5(dispatch, getState) {
   // TODO this will be in getClusters() here in this function we just want to
   // dispatch specific actions for v5 clusters.
   // Or maybe we won't need this method at all.
   return clustersApi
-    .getClusterV5(scheme + ' ' + token, 'm0ckd')
+    .getClusterV5('m0ckd')
     .then(clusters => {
       // nodePoolsClusters is an array of NP clusters ids and will be stored in items.
       const nodePoolsClusters = [clusters].map(cluster => cluster.id);
@@ -230,9 +226,6 @@ export function clusterLoadApps(clusterId) {
       return;
     }
 
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
     dispatch({
       type: types.CLUSTER_LOAD_APPS,
       clusterId,
@@ -241,7 +234,7 @@ export function clusterLoadApps(clusterId) {
     var appsApi = new GiantSwarm.AppsApi();
 
     return appsApi
-      .getClusterApps(scheme + ' ' + token, clusterId)
+      .getClusterApps(clusterId)
       .then(apps => {
         dispatch({
           type: types.CLUSTER_LOAD_APPS_SUCCESS,
@@ -284,10 +277,7 @@ export function clusterLoadApps(clusterId) {
  * @param {Object} clusterID Where to install the app.
  */
 export function clusterInstallApp(app, clusterID) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.CLUSTER_INSTALL_APP,
       clusterID,
@@ -302,7 +292,7 @@ export function clusterInstallApp(app, clusterID) {
         // If we have user config that we want to create, then
         // fire off the call to create it.
         appConfigsApi
-          .createClusterAppConfig(scheme + ' ' + token, clusterID, app.name, {
+          .createClusterAppConfig(clusterID, app.name, {
             body: app.valuesYAML,
           })
           .then(() => {
@@ -341,7 +331,7 @@ export function clusterInstallApp(app, clusterID) {
     return optionalCreateAppConfiguration
       .then(() => {
         return appsApi
-          .createClusterApp(scheme + ' ' + token, clusterID, app.name, {
+          .createClusterApp(clusterID, app.name, {
             body: {
               spec: {
                 catalog: app.catalog,
@@ -408,10 +398,7 @@ export function clusterInstallApp(app, clusterID) {
  * @param {Object} clusterID Where to delete the app.
  */
 export function clusterDeleteApp(appName, clusterID) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.CLUSTER_DELETE_APP,
       clusterID,
@@ -421,7 +408,7 @@ export function clusterDeleteApp(appName, clusterID) {
     var appsApi = new GiantSwarm.AppsApi();
 
     return appsApi
-      .deleteClusterApp(scheme + ' ' + token, clusterID, appName)
+      .deleteClusterApp(clusterID, appName)
       .then(() => {
         new FlashMessage(
           `App <code>${appName}</code> will be deleted on <code>${clusterID}</code>`,
@@ -448,8 +435,6 @@ export function clusterDeleteApp(appName, clusterID) {
  */
 export function clusterLoadDetails(clusterId) {
   return async function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
     const nodePoolsClusters = getState().entities.clusters.nodePoolsClusters;
     const isNodePoolsCluster = nodePoolsClusters.includes(clusterId);
 
@@ -460,8 +445,8 @@ export function clusterLoadDetails(clusterId) {
 
     try {
       const cluster = isNodePoolsCluster
-        ? await clustersApi.getClusterV5(scheme + ' ' + token, clusterId)
-        : await clustersApi.getCluster(scheme + ' ' + token, clusterId);
+        ? await clustersApi.getClusterV5(clusterId)
+        : await clustersApi.getCluster(clusterId);
       dispatch(clusterLoadStatus(clusterId));
 
       cluster.capabilities = computeCapabilities(
@@ -494,8 +479,6 @@ export function clusterLoadDetails(clusterId) {
  */
 export function clusterLoadStatus(clusterId) {
   return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
     const nodePoolsClusters = getState().entities.clusters.nodePoolsClusters;
     const isNodePoolsCluster = nodePoolsClusters.includes(clusterId);
 
@@ -503,11 +486,11 @@ export function clusterLoadStatus(clusterId) {
       // Here we will have something like clusterLoadStatusV5(...);
       return;
     }
-    clusterLoadStatusV4(dispatch, clusterId, token, scheme);
+    clusterLoadStatusV4(dispatch, clusterId);
   };
 }
 
-function clusterLoadStatusV4(dispatch, clusterId, token, scheme) {
+function clusterLoadStatusV4(dispatch, clusterId) {
   dispatch({
     type: types.CLUSTER_LOAD_STATUS,
     clusterId,
@@ -518,7 +501,7 @@ function clusterLoadStatusV4(dispatch, clusterId, token, scheme) {
   });
 
   return apiClusterStatus
-    .getClusterStatus(scheme + ' ' + token, clusterId)
+    .getClusterStatus(clusterId)
     .then(status => {
       dispatch(clusterLoadStatusSuccess(clusterId, status));
       return status;
@@ -555,17 +538,14 @@ function clusterLoadStatusV4(dispatch, clusterId, token, scheme) {
  * @param {Object} cluster Cluster definition object
  */
 export function clusterCreate(cluster) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.CLUSTER_CREATE,
       cluster,
     });
 
     return clustersApi
-      .addClusterWithHttpInfo(scheme + ' ' + token, cluster)
+      .addClusterWithHttpInfo(cluster)
       .then(data => {
         var location = data.response.headers.location;
         if (location === undefined) {
@@ -604,17 +584,14 @@ export function clusterCreate(cluster) {
  * @param {Object} cluster Cluster definition object, containing ID and owner
  */
 export function clusterDeleteConfirmed(cluster) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.CLUSTER_DELETE_CONFIRMED,
       cluster,
     });
 
     return clustersApi
-      .deleteCluster(scheme + ' ' + token, cluster.id)
+      .deleteCluster(cluster.id)
       .then(() => {
         dispatch(push('/organizations/' + cluster.owner));
         dispatch(clusterDeleteSuccess(cluster.id));
@@ -663,8 +640,6 @@ export function clusterLoadKeyPairs(clusterId) {
     const isNodePoolsCluster = nodePoolsClusters.includes(clusterId);
     if (isNodePoolsCluster) return Promise.resolve([]);
 
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
     var keypairsApi = new GiantSwarm.KeyPairsApi();
 
     dispatch({
@@ -673,7 +648,7 @@ export function clusterLoadKeyPairs(clusterId) {
     });
 
     return keypairsApi
-      .getKeyPairs(scheme + ' ' + token, clusterId)
+      .getKeyPairs(clusterId)
       .then(keyPairs => {
         // Add expire_date to keyPairs based on ttl_hours
         const keyPairsWithDates = Object.entries(keyPairs).map(
@@ -786,10 +761,7 @@ export const clustersLoadErrorV5 = error => ({
  * @param {Object} payload object with just the data we want to modify
  */
 export function clusterPatch(cluster, payload) {
-  return function(dispatch, getState) {
-    const token = getState().app.loggedInUser.auth.token;
-    const scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     // Optimistic update.
     dispatch({
       type: types.CLUSTER_PATCH,
@@ -797,26 +769,24 @@ export function clusterPatch(cluster, payload) {
       payload,
     });
 
-    return clustersApi
-      .modifyCluster(scheme + ' ' + token, cluster.id, payload)
-      .catch(error => {
-        // Undo update to store if the API call fails.
-        dispatch({
-          type: types.CLUSTER_PATCH_ERROR,
-          error,
-          cluster,
-        });
-
-        new FlashMessage(
-          'Something went wrong while trying to update the cluster',
-          messageType.ERROR,
-          messageTTL.MEDIUM,
-          'Please try again later or contact support: support@giantswarm.io'
-        );
-
-        console.error(error);
-        throw error;
+    return clustersApi.modifyCluster(cluster.id, payload).catch(error => {
+      // Undo update to store if the API call fails.
+      dispatch({
+        type: types.CLUSTER_PATCH_ERROR,
+        error,
+        cluster,
       });
+
+      new FlashMessage(
+        'Something went wrong while trying to update the cluster',
+        messageType.ERROR,
+        messageTTL.MEDIUM,
+        'Please try again later or contact support: support@giantswarm.io'
+      );
+
+      console.error(error);
+      throw error;
+    });
   };
 }
 
@@ -829,10 +799,7 @@ export function clusterPatch(cluster, payload) {
  * @param {Object} keypair   Key pair object
  */
 export function clusterCreateKeyPair(clusterId, keypair) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.CLUSTER_CREATE_KEY_PAIR,
       keypair,
@@ -840,7 +807,7 @@ export function clusterCreateKeyPair(clusterId, keypair) {
 
     var keypairsApi = new GiantSwarm.KeyPairsApi();
     return keypairsApi
-      .addKeyPair(scheme + ' ' + token, clusterId, keypair)
+      .addKeyPair(clusterId, keypair)
       .then(keypair => {
         dispatch({
           type: types.CLUSTER_CREATE_KEY_PAIR_SUCCESS,

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -137,8 +137,15 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
                 // Very stumped, since nothing has changed.
                 // So we need to access the raw response and parse the json
                 // ourselves.
-                let status = JSON.parse(data.response.text);
-                return { id: clusterId, ...status };
+                let statusResponse = JSON.parse(data.response.text);
+                return { id: clusterId, statusResponse: statusResponse };
+              })
+              .catch(error => {
+                if (error.status === 404) {
+                  return { id: clusterId, statusResponse: null };
+                } else {
+                  throw error;
+                }
               });
           }
         })
@@ -146,7 +153,7 @@ function clustersLoadV4(token, scheme, dispatch, getState) {
         clusterStatusArray.forEach(clusterStatus => {
           clustersObject[clusterStatus.id] = {
             ...clustersObject[clusterStatus.id],
-            ...{ status: clusterStatus },
+            ...{ status: clusterStatus.statusResponse },
           };
         });
 

--- a/src/actions/nodePoolsActions.js
+++ b/src/actions/nodePoolsActions.js
@@ -12,16 +12,11 @@ const nodePoolsApi = new GiantSwarm.NodepoolsApi();
  */
 export function nodePoolsLoad() {
   return async function(dispatch, getState) {
-    const token = getState().app.loggedInUser.auth.token;
-    const scheme = getState().app.loggedInUser.auth.scheme;
     const clusters = getState().entities.clusters.nodePoolsClusters || [];
 
     return Promise.all(
       clusters.map(async clusterId => {
-        const nodePools = await nodePoolsApi.getNodePools(
-          scheme + ' ' + token,
-          clusterId
-        );
+        const nodePools = await nodePoolsApi.getNodePools(clusterId);
 
         // Receiving an array-like with weird prototype from API call,
         // so converting it to an array.
@@ -67,9 +62,6 @@ export function nodePoolsLoad() {
  */
 export function nodePoolPatch(nodePool, payload) {
   return function(dispatch, getState) {
-    const token = getState().app.loggedInUser.auth.token;
-    const scheme = getState().app.loggedInUser.auth.scheme;
-
     // This is to get the cluster id.
     const clusters = getState().entities.clusters.items;
     const nodePoolsClusters = getState().entities.clusters.nodePoolsClusters;
@@ -89,7 +81,7 @@ export function nodePoolPatch(nodePool, payload) {
     dispatch(nodePoolPatchAction(nodePool, payload));
 
     return nodePoolsApi
-      .modifyNodePool(scheme + ' ' + token, clusterId, nodePool, payload)
+      .modifyNodePool(clusterId, nodePool, payload)
       .catch(error => {
         // Undo update to store if the API call fails.
         dispatch(nodePoolPatchError(error, nodePool));

--- a/src/actions/organizationActions.js
+++ b/src/actions/organizationActions.js
@@ -44,9 +44,6 @@ export function organizationsLoadSuccess(organizations, selectedOrganization) {
 //
 export function organizationsLoad() {
   return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
     var organizationsApi = new GiantSwarm.OrganizationsApi();
 
     var alreadyFetching = getState().entities.organizations.isFetching;
@@ -60,7 +57,7 @@ export function organizationsLoad() {
     dispatch({ type: types.ORGANIZATIONS_LOAD });
 
     return organizationsApi
-      .getOrganizations(scheme + ' ' + token)
+      .getOrganizations()
       .then(organizations => {
         var organizationsArray = organizations.map(organization => {
           return organization.id;
@@ -69,7 +66,7 @@ export function organizationsLoad() {
         var orgDetails = Promise.all(
           organizationsArray.map(organizationName => {
             return organizationsApi
-              .getOrganization(scheme + ' ' + token, organizationName)
+              .getOrganization(organizationName)
               .then(organization => {
                 return organization;
               });
@@ -117,15 +114,13 @@ export function organizationsLoad() {
 // and organization. It performs the API call to actually delete the organization
 // and dispatches actions accordingly.
 export function organizationDeleteConfirmed(orgId) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
+  return function(dispatch) {
     dispatch({ type: types.ORGANIZATION_DELETE_CONFIRMED, orgId: orgId });
 
     var organizationsApi = new GiantSwarm.OrganizationsApi();
 
     return organizationsApi
-      .deleteOrganization(scheme + ' ' + token, orgId)
+      .deleteOrganization(orgId)
       .then(() => {
         new FlashMessage(
           'Organization  <code>' + orgId + '</code> deleted',
@@ -175,9 +170,6 @@ export function organizationCreate() {
 // and dispatches actions accordingly.
 export function organizationCreateConfirmed(orgId) {
   return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
     dispatch({ type: types.ORGANIZATION_CREATE_CONFIRMED });
 
     var organizationsApi = new GiantSwarm.OrganizationsApi();
@@ -192,7 +184,7 @@ export function organizationCreateConfirmed(orgId) {
     }
 
     return organizationsApi
-      .addOrganization(scheme + ' ' + token, orgId, {
+      .addOrganization(orgId, {
         members: members,
       })
       .then(() => {
@@ -275,19 +267,13 @@ export function organizationAddMemberConfirmed(orgId, email) {
       }
     }
 
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
     var organizationsApi = new GiantSwarm.OrganizationsApi();
 
     return organizationsApi
-      .getOrganization(scheme + ' ' + token, orgId)
+      .getOrganization(orgId)
       .then(organization => {
         var members = organization.members.concat([{ email: email }]);
-        return organizationsApi.modifyOrganization(
-          scheme + ' ' + token,
-          orgId,
-          { members }
-        );
+        return organizationsApi.modifyOrganization(orgId, { members });
       })
       .then(() => {
         new FlashMessage(
@@ -321,10 +307,7 @@ export function organizationAddMemberConfirmed(orgId, email) {
 // a member from an organization. It performs the API call to actually do the job,
 // and dispatches actions accordingly.
 export function organizationRemoveMemberConfirmed(orgId, email) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.ORGANIZATION_REMOVE_MEMBER_CONFIRMED,
       orgId: orgId,
@@ -334,16 +317,12 @@ export function organizationRemoveMemberConfirmed(orgId, email) {
     var organizationsApi = new GiantSwarm.OrganizationsApi();
 
     organizationsApi
-      .getOrganization(scheme + ' ' + token, orgId)
+      .getOrganization(orgId)
       .then(organization => {
         var members = organization.members.filter(member => {
           return member.email !== email;
         });
-        return organizationsApi.modifyOrganization(
-          scheme + ' ' + token,
-          orgId,
-          { members }
-        );
+        return organizationsApi.modifyOrganization(orgId, { members });
       })
       .then(() => {
         new FlashMessage(
@@ -390,10 +369,7 @@ export function organizationRemoveMember(orgId, email) {
 
 // organizationCredentialsLoad is called to load credentials for an organization.
 export function organizationCredentialsLoad(orgId) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.ORGANIZATION_CREDENTIALS_LOAD,
     });
@@ -401,7 +377,7 @@ export function organizationCredentialsLoad(orgId) {
     var organizationsApi = new GiantSwarm.OrganizationsApi();
 
     organizationsApi
-      .getCredentials(scheme + ' ' + token, orgId)
+      .getCredentials(orgId)
       .then(credentials => {
         dispatch({
           type: types.ORGANIZATION_CREDENTIALS_LOAD_SUCCESS,
@@ -437,10 +413,7 @@ export function organizationCredentialsSet() {
 // organizationCredentialsSetConfirmed performs the API request to set the credentials
 // for an organization and handles the result.
 export function organizationCredentialsSetConfirmed(provider, orgId, data) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch({
       type: types.ORGANIZATION_CREDENTIALS_SET_CONFIRMED,
     });
@@ -466,7 +439,7 @@ export function organizationCredentialsSetConfirmed(provider, orgId, data) {
 
     var organizationsApi = new GiantSwarm.OrganizationsApi();
     organizationsApi
-      .addCredentials(scheme + ' ' + token, orgId, requestBody)
+      .addCredentials(orgId, requestBody)
       .then(response => {
         new FlashMessage(
           'Credentials have been stored successfully',

--- a/src/actions/releaseActions.js
+++ b/src/actions/releaseActions.js
@@ -16,16 +16,13 @@ const releasesLoadError = error => ({
 });
 
 export function loadReleases() {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     dispatch(releasesLoad());
 
     var releasesApi = new GiantSwarm.ReleasesApi();
 
     return releasesApi
-      .getReleases(scheme + ' ' + token)
+      .getReleases()
       .then(releases => {
         const versionKeyedReleases = releases.reduce((accumulator, release) => {
           return { ...accumulator, [release.version]: release };

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -50,11 +50,9 @@ export function refreshUserInfo() {
       });
       throw 'No logged in user to refresh.';
     }
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
 
     return usersApi
-      .getCurrentUser(scheme + ' ' + token)
+      .getCurrentUser()
       .then(data => {
         var userData = {
           email: data.email,
@@ -232,9 +230,7 @@ export function unauthorized() {
 // getInfo calls the /v4/info/ endpoint and dispatches accordingly to store
 // the resulting info into the state.
 export function getInfo() {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
+  return function(dispatch) {
     var infoApi = new GiantSwarm.InfoApi();
 
     dispatch({
@@ -242,7 +238,7 @@ export function getInfo() {
     });
 
     return infoApi
-      .getInfo(scheme + ' ' + token)
+      .getInfo()
       .then(info => {
         dispatch({
           type: types.INFO_LOAD_SUCCESS,
@@ -268,9 +264,6 @@ export function getInfo() {
 // /v4/users/
 export function usersLoad() {
   return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
     var usersApi = new GiantSwarm.UsersApi();
 
     var alreadyFetching = getState().entities.users.isFetching;
@@ -284,7 +277,7 @@ export function usersLoad() {
     dispatch({ type: types.USERS_LOAD });
 
     return usersApi
-      .getUsers(scheme + ' ' + token)
+      .getUsers()
       .then(usersArray => {
         var users = {};
 
@@ -319,17 +312,15 @@ export function usersLoad() {
 // ----------------
 // Removes the expiration date from a given user.
 export function userRemoveExpiration(email) {
-  return function(dispatch, getState) {
+  return function(dispatch) {
     const NEVER_EXPIRES = '0001-01-01T00:00:00Z';
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
 
     var usersApi = new GiantSwarm.UsersApi();
 
     dispatch({ type: types.USERS_REMOVE_EXPIRATION });
 
     return usersApi
-      .modifyUser(scheme + ' ' + token, email, { expiry: NEVER_EXPIRES })
+      .modifyUser(email, { expiry: NEVER_EXPIRES })
       .then(user => {
         dispatch({
           type: types.USERS_REMOVE_EXPIRATION_SUCCESS,
@@ -356,16 +347,13 @@ export function userRemoveExpiration(email) {
 // ----------------
 // Deletes the given user.
 export function userDelete(email) {
-  return function(dispatch, getState) {
-    var token = getState().app.loggedInUser.auth.token;
-    var scheme = getState().app.loggedInUser.auth.scheme;
-
+  return function(dispatch) {
     var usersApi = new GiantSwarm.UsersApi();
 
     dispatch({ type: types.USERS_DELETE });
 
     return usersApi
-      .deleteUser(scheme + ' ' + token, email)
+      .deleteUser(email)
       .then(() => {
         dispatch({
           type: types.USERS_DELETE_SUCCESS,

--- a/src/components/account_settings/change_email_form.js
+++ b/src/components/account_settings/change_email_form.js
@@ -65,9 +65,6 @@ class ChangeEmailForm extends React.Component {
 
     // Don't submit the form if nothing changed.
     if (this.props.user.email != this.state.fields.email.value) {
-      var token = this.props.user.auth.token;
-      var scheme = this.props.user.auth.scheme;
-
       var usersApi = new GiantSwarm.UsersApi();
 
       this.setState({
@@ -76,7 +73,7 @@ class ChangeEmailForm extends React.Component {
       });
 
       usersApi
-        .modifyUser(scheme + ' ' + token, this.props.user.email, {
+        .modifyUser(this.props.user.email, {
           email: this.state.fields.email.value,
         })
         .then(() => {

--- a/src/components/account_settings/change_password_form.js
+++ b/src/components/account_settings/change_password_form.js
@@ -108,13 +108,10 @@ class ChangePassword extends React.Component {
       error: false,
     });
 
-    var token = this.props.user.auth.token;
-    var scheme = this.props.user.auth.scheme;
-
     var usersApi = new GiantSwarm.UsersApi();
 
     usersApi
-      .modifyPassword(scheme + ' ' + token, this.props.user.email, {
+      .modifyPassword(this.props.user.email, {
         current_password_base64: Base64.encode(this.current_password.value()),
         new_password_base64: Base64.encode(this.new_password.value()),
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4831,9 +4831,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-"giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git#master":
+"giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git#test-auth-param":
   version "4.0.0"
-  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#a58008532eed847ac85ec3145d5c8637ae74db52"
+  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#13b38b996b563481c9b30155245b70b494553b45"
   dependencies:
     superagent "3.8.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4831,9 +4831,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-"giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git#test-auth-param":
+"giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git":
   version "4.0.0"
-  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#13b38b996b563481c9b30155245b70b494553b45"
+  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#013e1285b8f465e058f256b40b6e7c9af97f7134"
   dependencies:
     superagent "3.8.3"
 


### PR DESCRIPTION
This removes the need to constantly set scheme and token when doing an api request.

The api wrapper handles fetching a new token when a call fails, however with the way we are doing it in some chained requests, when this new token is acquired, we're still using the old token that we took from the state, instead of being able to rely on the instance of the API having its authentication set correctly.

By removing the authentication header we manually added to each call in the api-spec, we can use the javascript client in this more 'natural' way.