### PR TITLE
Fix logins for password users.

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -113,10 +113,8 @@ export function auth0Login(authResult) {
 // It then dispatches loginSuccess with the users token and email
 // the userReducer takes care of storing this in state.
 export function giantswarmLogin(email, password) {
-  return function(dispatch, getState) {
-    var usersApi = new GiantSwarm.UsersApi();
-    var authTokensApi = new GiantSwarm.AuthTokensApi();
-    var authToken;
+  return function(dispatch) {
+    let authTokensApi = new GiantSwarm.AuthTokensApi();
 
     dispatch({
       type: types.LOGIN,
@@ -129,17 +127,11 @@ export function giantswarmLogin(email, password) {
         password_base64: Base64.encode(password),
       })
       .then(response => {
-        authToken = response.auth_token;
-        return usersApi.getCurrentUser(
-          'giantswarm' + ' ' + response.auth_token
-        );
-      })
-      .then(data => {
-        var userData = {
-          email: data.email,
+        let userData = {
+          email: email,
           auth: {
             scheme: 'giantswarm',
-            token: authToken,
+            token: response.auth_token,
           },
         };
 
@@ -149,7 +141,6 @@ export function giantswarmLogin(email, password) {
         dispatch(loginSuccess(userData));
         return userData;
       })
-      .then(getInfo().bind(this, dispatch, getState))
       .catch(error => {
         console.error('Error trying to log in:', error);
 


### PR DESCRIPTION
This fixes a problem with logins due to my change in how authentication is set for the giantswarm-js-client.

After authenticating, the `loginSuccess` action sets the api instance's authentication.

But that happened after some follow up calls (getCurrentUser, and getInfo). Those calls actually aren't necessary anymore, since the componentDidMount of the Layout component calls this as well. 

So I removed those, and let the `loginSuccess` action do the job of setting the auth token of the api client, so that future requests will work once the Layout component is mounted.