### PR TITLE
Remove nodeport from service

### DIFF
--- a/helm/happa-chart/templates/service.yaml
+++ b/helm/happa-chart/templates/service.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: happa
-  namespace: giantswarm
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
   labels:
-    app: happa
+    app: {{ .Values.name }}
 spec:
-  type: NodePort
   ports:
-  - port: 8000
+  - name: {{ .Values.name }}
+    port: {{ .Values.port }}
+    targetPort: {{ .Values.port }}
   selector:
-    app: happa
+    app: {{ .Values.name }}

--- a/helm/happa-chart/values.yaml
+++ b/helm/happa-chart/values.yaml
@@ -3,3 +3,5 @@ namespace: giantswarm
 
 userID: 100
 groupID: 101
+
+port: 8000


### PR DESCRIPTION
- remove unecessary nodeport from service.
- migrate to using values instead of hardcoding.