### PR TITLE
NPs clusters in cluster list

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -174,9 +174,6 @@ export function clustersLoad() {
     const v5Clusters = Array.from(clusters).filter(cluster =>
       cluster.path.startsWith('/v5')
     );
-    // // Again some weirdness with Arrays that this js client is returning...
-    // const v5ClustersArray = Array.from(v5Clusters);
-    // console.log(Object.values(['sdf', 8]));
 
     // Get the details for v5 clusters.
     if (window.config.environment === 'development') {

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -88,9 +88,9 @@ export function clustersLoad() {
     );
 
     // TODO at some point we will probably have just one flow for all clusters.
-    // Now we are not computing capabilities and not getting status either for
-    // v5 clusters, so we fetch v5 clusters details in a separate method at the
-    // end of this one.
+    // Now we can't as we are not computing capabilities and not getting status
+    // either for v5 clusters, so we fetch v5 clusters details in a separate method
+    // at the end of this one.
 
     /********************** V4 CLUSTER DETAILS FETCHING **********************/
 

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -65,143 +65,150 @@ function clustersLoadArrayToObject(clusters) {
  * action.
  */
 export function clustersLoad() {
-  return function(dispatch, getState) {
-    // TODO getClusters() will get all clusters, so we will need some logic here
-    // that separates regular clusters from NP clusters and then pass them to their
-    // respective methods.
+  return async function(dispatch, getState) {
+    // Fetch all clusters.
+    const clusters = await clustersApi
+      .getClusters()
+      .then(clusters => {
+        const enhancedClusters = enhanceWithCapabilities(
+          clusters,
+          getState().app.info.general.provider
+        );
 
-    clustersLoadV4(dispatch, getState);
+        return enhancedClusters;
+      })
+      .catch(error => {
+        console.error(error);
+        dispatch(clustersLoadErrorV4(error));
+      });
+
+    // Extract v4 clusters from the clusters fetched array.
+    const v4Clusters = clusters.filter(cluster =>
+      cluster.path.startsWith('/v4')
+    );
+
+    // TODO at some point we will probably have just one flow for all clusters.
+    // Now we are not computing capabilities and not getting status either for
+    // v5 clusters, so we fetch v5 clusters details in a separate method at the
+    // end of this one.
+
+    /********************** V4 CLUSTER DETAILS FETCHING **********************/
+
+    // Clusters array to object, because we are storing an object in the store
+    let v4ClustersObject = clustersLoadArrayToObject(v4Clusters);
+
+    // Fetch all details for each cluster.
+    const details = await Promise.all(
+      Object.keys(v4ClustersObject).map(clusterId => {
+        return clustersApi
+          .getCluster(clusterId)
+          .then(clusterDetails => {
+            clusterDetails.capabilities = computeCapabilities(
+              clusterDetails,
+              getState().app.info.general.provider
+            );
+            return clusterDetails;
+          })
+          .catch(error => {
+            console.error('Error loading cluster details:', error);
+            dispatch(clusterLoadDetailsError(clusterId, error));
+          });
+      })
+    );
+
+    // And merge them with each cluster
+    details.forEach(clusterDetail => {
+      v4ClustersObject[clusterDetail.id] = {
+        ...v4ClustersObject[clusterDetail.id],
+        ...clusterDetail,
+      };
+    });
+
+    // Fetch status for each cluster.
+    const status = await Promise.all(
+      Object.keys(v4ClustersObject).map(clusterId => {
+        if (window.config.environment === 'development') {
+          return { id: clusterId, ...mockedStatus };
+        } else {
+          // TODO: Find out why we are getting an empty object back from this call.
+          //Forcing us to use getClusterStatusWithHttpInfo instead of getClusterStatus
+          return clustersApi
+            .getClusterStatusWithHttpInfo(clusterId)
+            .then(clusterStatus => {
+              // For some reason we're getting an empty object back.
+              // The Giantswarm JS client is not parsing the returned JSON
+              // and giving us a object in the normal way anymore.
+              // Very stumped, since nothing has changed.
+              // So we need to access the raw response and parse the json
+              // ourselves.
+              let statusResponse = JSON.parse(clusterStatus.response.text);
+              return { id: clusterId, statusResponse: statusResponse };
+            })
+            .catch(error => {
+              if (error.status === 404) {
+                return { id: clusterId, statusResponse: null };
+              } else {
+                console.error(error);
+                dispatch(clusterLoadStatusError(clusterId, error));
+                throw error;
+              }
+            });
+        }
+      })
+    );
+
+    // And merge status with each cluster.
+    status.forEach(clusterStatus => {
+      v4ClustersObject[clusterStatus.id] = {
+        ...v4ClustersObject[clusterStatus.id],
+        ...{ status: clusterStatus.statusResponse },
+      };
+    });
+
+    const lastUpdated = Date.now();
+    dispatch(clustersLoadSuccessV4(v4ClustersObject, lastUpdated));
+
+    /********************** V5 CLUSTER DETAILS FETCHING **********************/
+
+    // Extract v5 clusters from the clusters fetched.
+    const v5Clusters = clusters.filter(cluster =>
+      cluster.path.startsWith('/v5')
+    );
+
+    // Get the details for v5 clusters.
     if (window.config.environment === 'development') {
-      clustersLoadV5(dispatch, getState);
+      clustersLoadV5(dispatch, getState, v5Clusters);
     }
   };
 }
 
-async function clustersLoadV4(dispatch, getState) {
-  // TODO this will be in getClusters() here in this function we just want to
-  // dispatch specific actions for v4 clusters.
-  // Or maybe we won't need this method at all.
-  const clustersObject = await clustersApi
-    .getClusters()
-    .then(clusters => {
-      const enhancedClusters = enhanceWithCapabilities(
-        clusters,
-        getState().app.info.general.provider
-      );
-
-      // Clusters array to object, because we are storing an object in the store
-      let clustersObject = clustersLoadArrayToObject(enhancedClusters);
-      return clustersObject;
-    })
-    .catch(error => {
-      console.error(error);
-      dispatch(clustersLoadErrorV4(error));
-    });
-
-  // We fetch all details for each cluster.
-  const details = await Promise.all(
-    Object.keys(clustersObject).map(clusterId => {
+async function clustersLoadV5(dispatch, v5Clusters) {
+  const clusters = await Promise.all(
+    v5Clusters.map(cluster => {
       return clustersApi
-        .getCluster(clusterId)
-        .then(clusterDetails => {
-          clusterDetails.capabilities = computeCapabilities(
-            clusterDetails,
-            getState().app.info.general.provider
-          );
-          return clusterDetails;
-        })
+        .getClusterV5(cluster.id)
+        .then(clusterDetails => clusterDetails)
         .catch(error => {
           console.error('Error loading cluster details:', error);
-          dispatch(clusterLoadDetailsError(clusterId, error));
+          dispatch(clusterLoadDetailsError(cluster.id, error));
         });
     })
   );
 
-  // And merge them in the clustersObject
-  details.forEach(clusterDetail => {
-    clustersObject[clusterDetail.id] = {
-      ...clustersObject[clusterDetail.id],
-      ...clusterDetail,
-    };
-  });
+  console.log(clusters);
 
-  // We fetch status for each cluster.
-  const status = await Promise.all(
-    Object.keys(clustersObject).map(clusterId => {
-      if (window.config.environment === 'development') {
-        return { id: clusterId, ...mockedStatus };
-      } else {
-        // TODO: Find out why we are getting an empty object back from this call.
-        //Forcing us to use getClusterStatusWithHttpInfo instead of getClusterStatus
-        return clustersApi
-          .getClusterStatusWithHttpInfo(clusterId)
-          .then(clusterStatus => {
-            // For some reason we're getting an empty object back.
-            // The Giantswarm JS client is not parsing the returned JSON
-            // and giving us a object in the normal way anymore.
-            // Very stumped, since nothing has changed.
-            // So we need to access the raw response and parse the json
-            // ourselves.
-            let statusResponse = JSON.parse(clusterStatus.response.text);
-            return { id: clusterId, statusResponse: statusResponse };
-          })
-          .catch(error => {
-            if (error.status === 404) {
-              return { id: clusterId, statusResponse: null };
-            } else {
-              console.error(error);
-              dispatch(clusterLoadStatusError(clusterId, error));
-              throw error;
-            }
-          });
-      }
-    })
+  // Clusters array to object, because we are storing an object in the store
+  let v5ClustersObject = clustersLoadArrayToObject(clusters);
+
+  // nodePoolsClusters is an array of NP clusters ids and will be stored in items.
+  const nodePoolsClusters = clusters.map(cluster => cluster.id);
+  const lastUpdated = Date.now();
+  dispatch(
+    clustersLoadSuccessV5(v5ClustersObject, nodePoolsClusters, lastUpdated)
   );
 
-  // And merge it in each cluster
-  status.forEach(clusterStatus => {
-    clustersObject[clusterStatus.id] = {
-      ...clustersObject[clusterStatus.id],
-      ...{ status: clusterStatus.statusResponse },
-    };
-  });
-
-  const lastUpdated = Date.now();
-  dispatch(clustersLoadSuccessV4(clustersObject, lastUpdated));
-}
-
-function clustersLoadV5(dispatch, getState) {
-  // TODO this will be in getClusters() here in this function we just want to
-  // dispatch specific actions for v5 clusters.
-  // Or maybe we won't need this method at all.
-  return clustersApi
-    .getClusterV5('m0ckd')
-    .then(clusters => {
-      // nodePoolsClusters is an array of NP clusters ids and will be stored in items.
-      const nodePoolsClusters = [clusters].map(cluster => cluster.id);
-      const lastUpdated = Date.now();
-      const enhancedClusters = enhanceWithCapabilities(
-        [clusters],
-        getState().app.info.general.provider
-      );
-
-      // Clusters array to object, because we are storing an object in the store.
-      const clustersObject = clustersLoadArrayToObject(enhancedClusters);
-
-      dispatch(
-        clustersLoadSuccessV5(clustersObject, nodePoolsClusters, lastUpdated)
-      );
-
-      // Once we have stored the Node Pools Clusters, let's fetch actual Node Pools.
-      dispatch(nodePoolsLoad());
-    })
-    .catch(error => {
-      console.error(error);
-      dispatch({
-        type: types.CLUSTERS_LOAD_ERROR_V5,
-        error: error,
-      });
-    });
+  // Once we have stored the Node Pools Clusters, let's fetch actual Node Pools.
+  dispatch(nodePoolsLoad(nodePoolsClusters));
 }
 
 /**

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -761,7 +761,7 @@ export const clustersLoadErrorV5 = error => ({
  * @param {Object} cluster Cluster object
  * @param {Object} payload object with just the data we want to modify
  */
-export function clusterPatch(cluster, payload) {
+export function clusterPatch(cluster, payload, isNodePoolCluster) {
   return function(dispatch) {
     // Optimistic update.
     dispatch({
@@ -770,7 +770,11 @@ export function clusterPatch(cluster, payload) {
       payload,
     });
 
-    return clustersApi.modifyCluster(cluster.id, payload).catch(error => {
+    const modifyCluster = isNodePoolCluster
+      ? clustersApi.modifyClusterV5(cluster.id, payload)
+      : clustersApi.modifyCluster(cluster.id, payload);
+
+    return modifyCluster.catch(error => {
       // Undo update to store if the API call fails.
       dispatch({
         type: types.CLUSTER_PATCH_ERROR,

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -171,7 +171,7 @@ export function clustersLoad() {
     /********************** V5 CLUSTER DETAILS FETCHING **********************/
 
     // Extract v5 clusters from the clusters fetched.
-    const v5Clusters = Array.from(clusters).filter(cluster =>
+    const v5Clusters = clusters.filter(cluster =>
       cluster.path.startsWith('/v5')
     );
 

--- a/src/actions/nodePoolsActions.js
+++ b/src/actions/nodePoolsActions.js
@@ -6,20 +6,21 @@ import GiantSwarm from 'giantswarm';
 const nodePoolsApi = new GiantSwarm.NodepoolsApi();
 
 //Loads all node pools for all node pools clusters.
-export function nodePoolsLoad(clusters) {
+export function nodePoolsLoad() {
   return async function(dispatch, getState) {
-    // const clusters = getState().entities.clusters.nodePoolsClusters || [];
+    const nodePoolsClustersId =
+      getState().entities.clusters.nodePoolsClusters || [];
 
     return Promise.all(
-      clusters.map(async cluster => {
-        const nodePools = await nodePoolsApi.getNodePools(cluster.id);
+      nodePoolsClustersId.map(async clusterId => {
+        const nodePools = await nodePoolsApi.getNodePools(clusterId);
 
         // Receiving an array-like with weird prototype from API call,
         // so converting it to an array.
         let nodePoolsArray = (Array.from(nodePools) || []).map(np => np.id);
 
         // Dispatch action for populating nodePools key inside cluster
-        dispatch(clusterNodePoolsLoadSucces(cluster.id, nodePoolsArray));
+        dispatch(clusterNodePoolsLoadSucces(clusterId, nodePoolsArray));
 
         return nodePools;
       })

--- a/src/actions/nodePoolsActions.js
+++ b/src/actions/nodePoolsActions.js
@@ -6,20 +6,20 @@ import GiantSwarm from 'giantswarm';
 const nodePoolsApi = new GiantSwarm.NodepoolsApi();
 
 //Loads all node pools for all node pools clusters.
-export function nodePoolsLoad() {
+export function nodePoolsLoad(clusters) {
   return async function(dispatch, getState) {
-    const clusters = getState().entities.clusters.nodePoolsClusters || [];
+    // const clusters = getState().entities.clusters.nodePoolsClusters || [];
 
     return Promise.all(
-      clusters.map(async clusterId => {
-        const nodePools = await nodePoolsApi.getNodePools(clusterId);
+      clusters.map(async cluster => {
+        const nodePools = await nodePoolsApi.getNodePools(cluster.id);
 
         // Receiving an array-like with weird prototype from API call,
         // so converting it to an array.
         let nodePoolsArray = (Array.from(nodePools) || []).map(np => np.id);
 
         // Dispatch action for populating nodePools key inside cluster
-        dispatch(clusterNodePoolsLoadSucces(clusterId, nodePoolsArray));
+        dispatch(clusterNodePoolsLoadSucces(cluster.id, nodePoolsArray));
 
         return nodePools;
       })

--- a/src/components/cluster/detail/cluster_detail_view.js
+++ b/src/components/cluster/detail/cluster_detail_view.js
@@ -209,7 +209,13 @@ class ClusterDetailView extends React.Component {
   editClusterName = value => {
     return new Promise((resolve, reject) => {
       this.props
-        .dispatch(clusterPatch(this.props.cluster, { name: value }))
+        .dispatch(
+          clusterPatch(
+            this.props.cluster,
+            { name: value },
+            this.props.isNodePoolView
+          )
+        )
         .then(() => {
           new FlashMessage(
             'Succesfully edited cluster name.',

--- a/src/components/home/cluster_dashboard_item.js
+++ b/src/components/home/cluster_dashboard_item.js
@@ -32,17 +32,26 @@ class ClusterDashboardItem extends React.Component {
   componentDidMount() {
     this.registerReRenderInterval();
 
-    const { cluster, nodePools } = this.props;
-
     if (this.props.isNodePool) {
-      const nodePoolsData = clusterNodePools(nodePools, cluster);
-      this.setState({ nodePools: nodePoolsData });
+      this.setClusterNodePools();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.isNodePool && prevProps.nodePools !== this.props.nodePools) {
+      this.setClusterNodePools();
     }
   }
 
   componentWillUnmount() {
     window.clearInterval(this.reRenderInterval);
   }
+
+  setClusterNodePools = () => {
+    const { cluster, nodePools } = this.props;
+    const nodePoolsData = clusterNodePools(nodePools, cluster);
+    this.setState({ nodePools: nodePoolsData });
+  };
 
   /**
    * Activates periodic re-rendering to keep displayed info, like relative

--- a/src/utils/cluster_utils.js
+++ b/src/utils/cluster_utils.js
@@ -113,6 +113,7 @@ export function getCpusTotalNodePools(nodePools = []) {
 
 // Finds node pools for a cluster and returns an array of node pools objects
 export const clusterNodePools = (nodePools, cluster) => {
+  // This is to avoid a TypeError when trying to map an undefined variable
   if (nodePools && Object.entries(nodePools).length !== 0) {
     return cluster.nodePools.map(np => {
       return nodePools[np];

--- a/src/utils/cluster_utils.js
+++ b/src/utils/cluster_utils.js
@@ -113,7 +113,7 @@ export function getCpusTotalNodePools(nodePools = []) {
 
 // Finds node pools for a cluster and returns an array of node pools objects
 export const clusterNodePools = (nodePools, cluster) => {
-  return cluster.nodePools.map(np => {
-    return nodePools[np];
-  });
+  // return cluster.nodePools.map(np => {
+  //   return nodePools[np];
+  // });
 };

--- a/src/utils/cluster_utils.js
+++ b/src/utils/cluster_utils.js
@@ -113,7 +113,9 @@ export function getCpusTotalNodePools(nodePools = []) {
 
 // Finds node pools for a cluster and returns an array of node pools objects
 export const clusterNodePools = (nodePools, cluster) => {
-  // return cluster.nodePools.map(np => {
-  //   return nodePools[np];
-  // });
+  if (nodePools && Object.entries(nodePools).length !== 0) {
+    return cluster.nodePools.map(np => {
+      return nodePools[np];
+    });
+  }
 };


### PR DESCRIPTION
Marian has added the mocked NP cluster to the cluster list response in the `add-mock-cluster-to-list` API branch so now we can have a `clustersLoad` method that gets all clusters (v4 and v5)

In this PR I have:

- Modified the `clustersLoad()` function to fetch everything
- Removed logic for introducing `m0ckd` v5 cluster manually in the store
- Adapt `ClusterDashboardItem` to the modifications made

⚠️ ⚠️  From now on (once this is merged) in the local testing api we must use the `add-mock-cluster-to-list` branch. ⚠️ ⚠️ 