### PR TITLE
Set the cpu/ram default to 4/4 and min to 2/3

### DIFF
--- a/src/components/cluster/new/view.js
+++ b/src/components/cluster/new/view.js
@@ -456,7 +456,7 @@ class CreateCluster extends React.Component {
                         <NumberPicker
                           label='CPU Cores'
                           max={999}
-                          min={1}
+                          min={2}
                           onChange={this.updateCPUCores}
                           stepSize={1}
                           value={this.state.kvm.cpuCores.value}
@@ -466,7 +466,7 @@ class CreateCluster extends React.Component {
                         <NumberPicker
                           label='Memory (GB)'
                           max={999}
-                          min={1}
+                          min={3}
                           onChange={this.updateMemorySize}
                           stepSize={1}
                           unit='GB'
@@ -598,8 +598,8 @@ function mapStateToProps(state) {
     defaultVMSize = 'Standard_D2s_v3';
   }
 
-  var defaultCPUCores = 1; // TODO
-  var defaultMemorySize = 1; // TODO
+  var defaultCPUCores = 4; // TODO
+  var defaultMemorySize = 4; // TODO
   var defaultDiskSize = 20; // TODO
 
   var allowedInstanceTypes = [];


### PR DESCRIPTION
This is a quick fix to make sure that Happa can't make clusters that are invalid. 

Once https://github.com/giantswarm/api/pull/855 is merged , kvm clusters with less than 2CPU and 3GB RAM are invalid, so this makes sure people can't even try to create smaller clusters.

Once https://github.com/giantswarm/api-spec/pull/167 is _implemented_ I will make this value dynamic, populated by what the info endpoint returns.

But for now this is a quick fix to stop people from making invalid clusters.

See also: https://gigantic.slack.com/archives/C76JX6YLQ/p1567516000045900?thread_ts=1567509332.042700&cid=C76JX6YLQ for the 4/4 default.