### PR TITLE
Extract routes and add preloginState

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -3,20 +3,11 @@ import { ConnectedRouter } from 'connected-react-router';
 import { hot } from 'react-hot-loader';
 import { Provider } from 'react-redux';
 import { render } from 'react-dom';
-import { Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'emotion-theming';
-import AdminLogin from './auth/admin';
 import configureStore from 'stores/configureStore';
-import ForgotPassword from './forgot_password/index';
 import history from 'stores/history';
-import Layout from './layout';
-import Login from './auth/login';
-import Logout from './auth/logout';
-import OAuthCallback from './auth/oauth_callback';
 import React from 'react';
-import SetPassword from './forgot_password/set_password';
-import SignUp from './signup/index';
-import StyleGuide from './UI/style_guide';
+import Routes from './routes';
 import theme from 'styles/theme';
 
 // CSS Imports
@@ -46,19 +37,7 @@ const renderApp = () =>
     <Provider store={store}>
       <ThemeProvider theme={theme}>
         <ConnectedRouter history={history}>
-          <div>
-            <Switch>
-              <Route component={AdminLogin} path='/admin-login' />
-              <Route component={Login} path='/login' />
-              <Route component={Logout} path='/logout' />
-              <Route component={SetPassword} path='/forgot_password/:token/' />
-              <Route component={ForgotPassword} path='/forgot_password' />
-              <Route component={SignUp} path='/signup/:token' />
-              <Route component={OAuthCallback} path='/oauth/callback' />
-              <Route component={StyleGuide} path='/styleguide' />
-              <Route component={Layout} path='/' />
-            </Switch>
-          </div>
+          <Routes />
         </ConnectedRouter>
       </ThemeProvider>
     </Provider>,

--- a/src/components/routes.js
+++ b/src/components/routes.js
@@ -1,0 +1,29 @@
+import { Route, Switch } from 'react-router-dom';
+import AdminLogin from './auth/admin';
+import ForgotPassword from './forgot_password/index';
+import Layout from './layout';
+import Login from './auth/login';
+import Logout from './auth/logout';
+import OAuthCallback from './auth/oauth_callback';
+import React from 'react';
+import SetPassword from './forgot_password/set_password';
+import SignUp from './signup/index';
+import StyleGuide from './UI/style_guide';
+
+const Routes = () => {
+  return (
+    <Switch>
+      <Route component={AdminLogin} path='/admin-login' />
+      <Route component={Login} path='/login' />
+      <Route component={Logout} path='/logout' />
+      <Route component={SetPassword} path='/forgot_password/:token/' />
+      <Route component={ForgotPassword} path='/forgot_password' />
+      <Route component={SignUp} path='/signup/:token' />
+      <Route component={OAuthCallback} path='/oauth/callback' />
+      <Route component={StyleGuide} path='/styleguide' />
+      <Route component={Layout} path='/' />
+    </Switch>
+  );
+};
+
+export default Routes;

--- a/test_utils/preloginState.js
+++ b/test_utils/preloginState.js
@@ -1,0 +1,68 @@
+// This is what the state looks like when someone brand new arrives at the site
+// and they are not logged in at all.
+
+export default {
+  router: {
+    location: {
+      pathname: '/login',
+      search: '',
+      hash: '',
+      key: '0fgz24'
+    },
+    action: 'POP'
+  },
+  app: {
+    selectedOrganization: null,
+    firstLoadComplete: false,
+    loggedInUser: null,
+    info: {
+      general: {
+        availability_zones: {
+          'default': 0,
+          max: 0
+        },
+        provider: ''
+      }
+    }
+  },
+  entities: {
+    catalogs: {
+      lastUpdated: 0,
+      isFetching: false,
+      items: []
+    },
+    clusters: {
+      lastUpdated: null,
+      isFetching: false,
+      items: {},
+      nodePoolsClusters: []
+    },
+    credentials: {
+      lastUpdated: 0,
+      isFetching: false,
+      items: []
+    },
+    invitations: {
+      lastUpdated: 0,
+      isFetching: false,
+      items: {}
+    },
+    organizations: {
+      lastUpdated: 0,
+      isFetching: false,
+      items: {}
+    },
+    releases: {
+      items: {}
+    },
+    users: {
+      lastUpdated: 0,
+      isFetching: false,
+      items: {}
+    },
+    nodePools: {}
+  },
+  modal: {
+    visible: false
+  }
+};

--- a/test_utils/renderRouteWithStore.js
+++ b/test_utils/renderRouteWithStore.js
@@ -2,9 +2,9 @@ import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { ThemeProvider } from 'emotion-theming';
+import Routes from 'routes';
 import configureStore from 'stores/configureStore';
 import initialState from 'test_utils/initialState';
-import Layout from 'layout';
 import React from 'react';
 import theme from 'styles/theme';
 
@@ -25,7 +25,7 @@ export function renderRouteWithStore(
     <Provider store={store}>
       <ThemeProvider theme={theme}>
         <MemoryRouter initialEntries={[route]}>
-          <Layout />
+          <Routes />
         </MemoryRouter>
       </ThemeProvider>
     </Provider>,


### PR DESCRIPTION
This makes sure we render really the _full_ app with `renderRouteWithStore` instead of just the `Layout` component.

This is because the routes for Login are 'before' we show the `Layout` component.

This will let me test the login screen going from the login form to the screen that shows the `Layout` component.