### PR TITLE
Fix mocked status response.

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -129,7 +129,7 @@ export function clustersLoad() {
     const status = await Promise.all(
       Object.keys(v4ClustersObject).map(clusterId => {
         if (window.config.environment === 'development') {
-          return { id: clusterId, ...mockedStatus };
+          return { id: clusterId, statusResponse: mockedStatus };
         } else {
           // TODO: Find out why we are getting an empty object back from this call.
           //Forcing us to use getClusterStatusWithHttpInfo instead of getClusterStatus


### PR DESCRIPTION
I noticed in development we occasionally got the 0 node, 0 CPU bug again.

That's because of a change in the status action which wasn't carried through in the mocked status response part.

This feels like a regression though, not sure how this came back in the dev env, which is a bit scary.