### PR TITLE
Number picker refactor

### DIFF
--- a/src/components/UI/number_picker.js
+++ b/src/components/UI/number_picker.js
@@ -141,29 +141,29 @@ class NumberPicker extends React.Component {
     var currentValue = this.props.value;
     var desiredValue = currentValue + this.props.stepSize;
 
-    if (desiredValue <= this.props.max) {
-      this.updateInput({
-        target: { value: desiredValue },
-      });
-    }
+    this.updateInput({
+      target: { value: desiredValue },
+    });
   };
 
   decrement = () => {
-    var currentValue = this.props.value;
-    var desiredValue = currentValue - this.props.stepSize;
+    const currentValue = this.props.value;
+    const desiredValue = currentValue - this.props.stepSize;
 
-    if (desiredValue >= this.props.min) {
-      this.updateInput({
-        target: { value: desiredValue },
-      });
-    }
+    this.updateInput({
+      target: { value: desiredValue },
+    });
   };
 
   updateInput = e => {
-    var desiredValue = e.target.value;
+    const desiredValue = e.target.value;
 
     // Validate.
-    var { value, valid, validationError } = this.validateInput(desiredValue);
+    const { value, valid, validationError } = this.validateInput(desiredValue);
+    if (!valid) {
+      this.setState({ validationError });
+      return;
+    }
 
     // Update state.
     this.setState(

--- a/src/components/cluster/new/view.js
+++ b/src/components/cluster/new/view.js
@@ -392,7 +392,7 @@ class CreateCluster extends React.Component {
                       <p>
                         Select the number of availability zones for your nodes.
                       </p>
-                      <div className='col-3'>
+                      <div>
                         <NumberPicker
                           label=''
                           max={this.props.maxAvailabilityZones}


### PR DESCRIPTION
Validation message in number picker was not popping up because the code responsible for it was never reached. Now it is:

<img width="445" alt="Captura de pantalla 2019-09-24 a las 9 49 49" src="https://user-images.githubusercontent.com/14203438/65495124-7a5f7080-deb6-11e9-95dc-f4fab39d15e5.png">
