### PR TITLE
Es lint changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,11 +30,8 @@
     "react/prefer-es6-class": [1, "always"],
     "react/no-find-dom-node": 0,
     "strict": 2,
-    "sort-imports-es6-autofix/sort-imports-es6": [2, {
-      "ignoreCase": true,
-      "ignoreMemberSort": false,
-      "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
-    }]
+    "sort-imports-es6-autofix/sort-imports-es6": 0,
+    "no-unreachable": 1
   },
   "extends": [
     "eslint:recommended",

--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,6 @@
     "react/prefer-es6-class": [1, "always"],
     "react/no-find-dom-node": 0,
     "strict": 2,
-    "sort-imports-es6-autofix/sort-imports-es6": 0,
     "no-unreachable": 1
   },
   "extends": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,11 @@
     "react/prefer-es6-class": [1, "always"],
     "react/no-find-dom-node": 0,
     "strict": 2,
+    "sort-imports-es6-autofix/sort-imports-es6": [1, {
+      "ignoreCase": true,
+      "ignoreMemberSort": false,
+      "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+    }],
     "no-unreachable": 1
   },
   "extends": [

--- a/src/components/UI/availability_zones_label.js
+++ b/src/components/UI/availability_zones_label.js
@@ -85,6 +85,8 @@ function AvailabilityZonesLabel({ label, letter, title, onToggleChecked }) {
     }
   }, [checked]);
 
+  return 'hey';
+
   return (
     <Wrapper
       className={classNames}

--- a/src/components/UI/availability_zones_label.js
+++ b/src/components/UI/availability_zones_label.js
@@ -85,8 +85,6 @@ function AvailabilityZonesLabel({ label, letter, title, onToggleChecked }) {
     }
   }, [checked]);
 
-  return 'hey';
-
   return (
     <Wrapper
       className={classNames}


### PR DESCRIPTION
- Unreacheable code to warning, because I like to do early returns when debugging without needing to comment x lines of code below the `return`statement.
- Removed sort imports rule because I prefer to sort imports in custom ways (node modules, components, custom hooks, UI, styles)  or not ordering them at all

WDYT Marian?