### PR TITLE
Refactor ReleaseSelector and parent components

### DIFF
--- a/src/components/cluster/new/CreateNodePoolsCluster.js
+++ b/src/components/cluster/new/CreateNodePoolsCluster.js
@@ -399,7 +399,13 @@ class CreateNodePoolsCluster extends Component {
                 <label className='release-version' htmlFor='release-version'>
                   <span className='label-span'>Release version</span>
                   <div>
-                    <ReleaseSelector selectRelease={this.selectRelease} />
+                    <ReleaseSelector
+                      selectRelease={this.selectRelease}
+                      selectedRelease={this.props.selectedRelease}
+                      selectableReleases={this.props.selectableReleases}
+                      releases={this.props.releases}
+                      activeSortedReleases={this.props.activeSortedReleases}
+                    />
                   </div>
                 </label>
                 {/* Master Node AZ */}
@@ -555,6 +561,7 @@ CreateNodePoolsCluster.propTypes = {
   availabilityZones: PropTypes.array,
   allowedInstanceTypes: PropTypes.array,
   selectedOrganization: PropTypes.string,
+  selectedRelease: PropTypes.string,
   dispatch: PropTypes.func,
   provider: PropTypes.string,
   defaultInstanceType: PropTypes.string,
@@ -566,6 +573,9 @@ CreateNodePoolsCluster.propTypes = {
   clusterId: PropTypes.string,
   closeForm: PropTypes.func,
   informParent: PropTypes.func,
+  selectableReleases: PropTypes.array,
+  releases: PropTypes.object,
+  activeSortedReleases: PropTypes.array,
 };
 
 function mapStateToProps(state) {

--- a/src/components/cluster/new/CreateRegularCluster.js
+++ b/src/components/cluster/new/CreateRegularCluster.js
@@ -372,7 +372,13 @@ class CreateRegularCluster extends React.Component {
                 <h3 className='table-label'>Release Version</h3>
               </div>
               <div className='col-9'>
-                <ReleaseSelector selectRelease={this.selectRelease} />
+                <ReleaseSelector
+                  selectRelease={this.selectRelease}
+                  selectedRelease={this.props.selectedRelease}
+                  selectableReleases={this.props.selectableReleases}
+                  releases={this.props.releases}
+                  activeSortedReleases={this.props.activeSortedReleases}
+                />
               </div>
             </div>
 
@@ -561,6 +567,7 @@ CreateRegularCluster.propTypes = {
   allowedInstanceTypes: PropTypes.array,
   allowedVMSizes: PropTypes.array,
   selectedOrganization: PropTypes.string,
+  selectedRelease: PropTypes.string,
   dispatch: PropTypes.func,
   provider: PropTypes.string,
   defaultInstanceType: PropTypes.string,
@@ -571,6 +578,9 @@ CreateRegularCluster.propTypes = {
   match: PropTypes.object,
   clusterCreationStats: PropTypes.object,
   informParent: PropTypes.func,
+  selectableReleases: PropTypes.array,
+  releases: PropTypes.object,
+  activeSortedReleases: PropTypes.array,
 };
 
 function mapStateToProps(state) {

--- a/src/components/cluster/new/ReleaseSelector.js
+++ b/src/components/cluster/new/ReleaseSelector.js
@@ -1,10 +1,8 @@
 import { connect } from 'react-redux';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
-import { loadReleases } from 'actions/releaseActions';
 import { spinner } from 'images';
 import _ from 'underscore';
 import Button from 'UI/button';
-import cmp from 'semver-compare';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReleaseComponentLabel from 'UI/release_component_label';
@@ -29,112 +27,8 @@ const FlexRowDiv = styled.div`
 
 class ReleaseSelector extends React.Component {
   state = {
-    loading: true,
-    error: false,
-    selectedRelease: '',
-    selectableReleases: [],
+    loading: false,
   };
-
-  componentDidMount() {
-    this.loadReleases();
-  }
-
-  /**
-   * Loads available releases into this.props.releases.
-   * Triggers a flash message if something went wrong.
-   */
-  loadReleases() {
-    this.setState({
-      loading: true,
-      error: false,
-    });
-
-    this.props
-      .dispatch(loadReleases())
-      .then(() => {
-        // Select latest active release as a default.
-        // If there is no latest active release, then allow selection from WIP
-        // releases, with a info message to non admins that this is a WIP installation.
-        let selectableReleases = [];
-        if (this.props.activeSortedReleases.length > 0) {
-          selectableReleases = this.props.activeSortedReleases;
-        } else {
-          selectableReleases = Object.entries(this.props.releases).map(
-            ([, release]) => release.version
-          );
-          this.informWIP();
-        }
-
-        // Sets the currently selected release
-        const release = selectableReleases[0];
-        this.setRelease(release);
-
-        this.setState({
-          loading: false,
-          error: false,
-          selectableReleases,
-        });
-      })
-      .catch(error => {
-        this.setState({
-          loading: false,
-          error: true,
-        });
-
-        new FlashMessage(
-          'Something went wrong while trying to fetch the list of releases.',
-          messageType.ERROR,
-          messageTTL.LONG,
-          'please try again later or contact support: support@giantswarm.io'
-        );
-
-        throw error;
-      });
-  }
-
-  // Lets non admin users know that creating a cluster will probably fail for them,
-  // since all releases are WIP and only admins can create clusters from WIP releases.
-  //
-  // TODO: Remove this, as there are releases for Azure now.
-  informWIP() {
-    if (!this.props.user.isAdmin) {
-      if (this.props.provider === 'azure') {
-        new FlashMessage(
-          'Support for Microsoft Azure is still in an early stage.',
-          messageType.INFO,
-          messageTTL.FOREVER,
-          'There is no active release yet. To create a cluster you will need admin permissions.'
-        );
-      } else {
-        new FlashMessage(
-          'No active releases available at the moment.',
-          messageType.INFO,
-          messageTTL.FOREVER,
-          'There is no active release yet. To create a cluster you will need admin permissions.'
-        );
-      }
-    }
-  }
-
-  /**
-   * Sets the currently selected release
-   */
-  setRelease = selectedRelease => {
-    this.setState({ selectedRelease });
-    this.props.selectRelease(selectedRelease);
-  };
-
-  openModal = () => {
-    this.releaseDetailsModal.show();
-  };
-
-  buttonText() {
-    if (this.props.activeSortedReleases.length === 1) {
-      return 'Show Details';
-    } else {
-      return 'Details and Alternatives';
-    }
-  }
 
   loadingContent() {
     return (
@@ -147,16 +41,22 @@ class ReleaseSelector extends React.Component {
   }
 
   hasActiveReleases() {
-    if (this.state.selectedRelease) {
+    const { selectedRelease } = this.props;
+
+    if (selectedRelease) {
       var kubernetes = _.find(
-        this.props.releases[this.state.selectedRelease].components,
+        this.props.releases[selectedRelease].components,
         component => component.name === 'kubernetes'
       );
 
       return (
         <FlexRowDiv>
-          <p>{this.state.selectedRelease}</p>
-          <Button onClick={this.openModal}>{this.buttonText()}</Button>
+          <p>{selectedRelease}</p>
+          <Button onClick={() => this.releaseDetailsModal.show()}>
+            {this.props.activeSortedReleases.length === 1
+              ? 'Show Details'
+              : 'Details and Alternatives'}
+          </Button>
           <br />
           <br />
 
@@ -185,21 +85,15 @@ class ReleaseSelector extends React.Component {
   render() {
     return (
       <>
-        {this.state.loading
-          ? this.loadingContent()
-          : this.state.error
-          ? undefined
-          : this.hasActiveReleases()}
+        {this.state.loading ? this.loadingContent() : this.hasActiveReleases()}
 
         <ReleaseDetailsModal
           ref={r => {
             this.releaseDetailsModal = r;
           }}
-          releaseSelected={this.setRelease}
-          releases={this.state.selectableReleases.map(version => {
-            return this.props.releases[version];
-          })}
-          selectedRelease={this.state.selectedRelease}
+          releaseSelected={this.props.selectRelease}
+          releases={this.props.selectableReleases}
+          selectedRelease={this.props.selectedRelease}
         />
       </>
     );
@@ -210,34 +104,11 @@ ReleaseSelector.propTypes = {
   dispatch: PropTypes.func,
   provider: PropTypes.string,
   selectRelease: PropTypes.func,
+  selectedRelease: PropTypes.string,
+  selectableReleases: PropTypes.array,
   releases: PropTypes.object, // Version string to a release object i.e.: {"0.1.0": {...}, "0.2.0", {...}}
   activeSortedReleases: PropTypes.array, // Array of strings i.e: ["0.1.0", "0.2.0"]
   user: PropTypes.object,
 };
 
-function mapDispatchToProps(dispatch) {
-  return {
-    dispatch,
-  };
-}
-
-function mapStateToProps(state) {
-  var provider = state.app.info.general.provider;
-  var releases = Object.assign({}, state.entities.releases.items);
-
-  var activeSortedReleases = _.filter(releases, release => release.active);
-  activeSortedReleases = activeSortedReleases.map(release => release.version);
-  activeSortedReleases.sort(cmp).reverse();
-
-  return {
-    activeSortedReleases,
-    provider,
-    releases,
-    user: state.app.loggedInUser,
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ReleaseSelector);
+export default ReleaseSelector;

--- a/src/components/modals/release_details_modal.js
+++ b/src/components/modals/release_details_modal.js
@@ -24,93 +24,93 @@ class ReleaseDetailsModal extends React.Component {
     });
   };
 
-  selectRelease = version => {
-    this.props.releaseSelected(version);
-  };
-
   render() {
-    return (
-      <BootstrapModal
-        className='release-selector-modal'
-        onHide={this.close}
-        show={this.state.modalVisible}
-      >
-        <BootstrapModal.Header closeButton>
-          <BootstrapModal.Title>Release Details</BootstrapModal.Title>
-        </BootstrapModal.Header>
-        <BootstrapModal.Body>
-          {this.props.releases.map(release => {
-            // group changes by component
-            let changes = _.groupBy(release.changelog, item => {
-              return item.component;
-            });
+    if (this.props.releases && this.props.releases.length > 0) {
+      return (
+        <BootstrapModal
+          className='release-selector-modal'
+          onHide={this.close}
+          show={this.state.modalVisible}
+        >
+          <BootstrapModal.Header closeButton>
+            <BootstrapModal.Title>Release Details</BootstrapModal.Title>
+          </BootstrapModal.Header>
+          <BootstrapModal.Body>
+            {this.props.releases.map(release => {
+              // group changes by component
+              let changes = _.groupBy(release.changelog, item => {
+                return item.component;
+              });
 
-            let changedComponents = Object.keys(changes).sort();
+              let changedComponents = Object.keys(changes).sort();
 
-            return (
-              <div
-                className='release-selector-modal--release-details'
-                key={release.version}
-              >
-                <h2>
-                  Version {release.version}{' '}
-                  {// If we have a way of selecting a release, show the selection
-                  // buttons. This way the create cluster screen can show the
-                  // select button, and the cluster detail screen can omit it.
-                  this.props.releaseSelected ? (
-                    this.props.selectedRelease === release.version ? (
-                      <span className='selected'>Selected</span>
+              return (
+                <div
+                  className='release-selector-modal--release-details'
+                  key={release.version}
+                >
+                  <h2>
+                    Version {release.version}{' '}
+                    {// If we have a way of selecting a release, show the selection
+                    // buttons. This way the create cluster screen can show the
+                    // select button, and the cluster detail screen can omit it.
+                    this.props.releaseSelected ? (
+                      this.props.selectedRelease === release.version ? (
+                        <span className='selected'>Selected</span>
+                      ) : (
+                        <Button
+                          onClick={() =>
+                            this.props.releaseSelected(release.version)
+                          }
+                        >
+                          Select
+                        </Button>
+                      )
                     ) : (
-                      <Button
-                        onClick={this.selectRelease.bind(this, release.version)}
-                      >
-                        Select
-                      </Button>
-                    )
-                  ) : (
-                    undefined
-                  )}
-                </h2>
-                <p className='release-selector-modal--release-details--date'>
-                  Released <span>{relativeDate(release.timestamp)}</span>
-                </p>
+                      undefined
+                    )}
+                  </h2>
+                  <p className='release-selector-modal--release-details--date'>
+                    Released <span>{relativeDate(release.timestamp)}</span>
+                  </p>
 
-                <div className='release-selector-modal--components'>
-                  {_.sortBy(release.components, 'name').map(component => {
-                    return (
-                      <ReleaseComponentLabel
-                        key={component.name}
-                        name={component.name}
-                        version={component.version}
-                      />
-                    );
-                  })}
+                  <div className='release-selector-modal--components'>
+                    {_.sortBy(release.components, 'name').map(component => {
+                      return (
+                        <ReleaseComponentLabel
+                          key={component.name}
+                          name={component.name}
+                          version={component.version}
+                        />
+                      );
+                    })}
+                  </div>
+
+                  <p>Changes</p>
+
+                  <dl>
+                    {changedComponents.map((componentName, index) => {
+                      return (
+                        <ComponentChangelog
+                          changes={changes[componentName].map(c => {
+                            return c.description;
+                          })}
+                          key={index}
+                          name={componentName}
+                        />
+                      );
+                    })}
+                  </dl>
                 </div>
-
-                <p>Changes</p>
-
-                <dl>
-                  {changedComponents.map((componentName, index) => {
-                    return (
-                      <ComponentChangelog
-                        changes={changes[componentName].map(c => {
-                          return c.description;
-                        })}
-                        key={index}
-                        name={componentName}
-                      />
-                    );
-                  })}
-                </dl>
-              </div>
-            );
-          })}
-        </BootstrapModal.Body>
-        <BootstrapModal.Footer>
-          <Button onClick={this.close}>Close</Button>
-        </BootstrapModal.Footer>
-      </BootstrapModal>
-    );
+              );
+            })}
+          </BootstrapModal.Body>
+          <BootstrapModal.Footer>
+            <Button onClick={this.close}>Close</Button>
+          </BootstrapModal.Footer>
+        </BootstrapModal>
+      );
+    }
   }
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@
 
   <script>
   var config = {
-    apiEndpoint: 'http://localhost:8000',
+    apiEndpoint: 'https://api.g8s.gauss.eu-central-1.aws.gigantic.io',
     passageEndpoint: 'http://localhost:5001',
     environment: 'development',
     ingressBaseDomain: 'k8s.sample.io',

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,8 @@
 
   <script>
   var config = {
-    apiEndpoint: 'https://api.g8s.gauss.eu-central-1.aws.gigantic.io',
+    apiEndpoint: 'http://localhost:8000',
+    // apiEndpoint: 'https://api.g8s.gauss.eu-central-1.aws.gigantic.io',
     passageEndpoint: 'http://localhost:5001',
     environment: 'development',
     ingressBaseDomain: 'k8s.sample.io',

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,6 @@
   <script>
   var config = {
     apiEndpoint: 'http://localhost:8000',
-    // apiEndpoint: 'https://api.g8s.gauss.eu-central-1.aws.gigantic.io',
     passageEndpoint: 'http://localhost:5001',
     environment: 'development',
     ingressBaseDomain: 'k8s.sample.io',

--- a/src/reducers/releaseReducer.js
+++ b/src/reducers/releaseReducer.js
@@ -7,6 +7,11 @@ const releaseReducer = produce((draft, action) => {
   switch (action.type) {
     case types.RELEASES_LOAD_SUCCESS:
       draft.items = action.releases;
+      draft.activeSortedReleases = action.activeSortedReleases;
+      return;
+
+    case types.RELEASES_LOAD_ERROR:
+      draft.errorLoading = true;
       return;
 
     case types.RELEASE_SELECTED:


### PR DESCRIPTION
In order to have two different cluster creation forms in Happa that can be switched when the user changes the release version in the form, we need to control release version from the parent wrapper component, `NewCluster`, instead of controlling it from `ReleaseSelector`.

the In this PR we are transforming `ReleaseSelector` into a _dumb_ component that is not connected to the store. Now it just returns a release version to its parent instead of deciding which release the form has a default value, so it is more reusable.

- Moved async logic to action file
- Lifted up state from `ReleaseSelector`to `NewCluster` which is the wrapper component for the two cluster creation forms (v4 and v5) so 