### PR TITLE
V4 cluster form additions

### DIFF
--- a/src/components/cluster/detail/AddNodePool.js
+++ b/src/components/cluster/detail/AddNodePool.js
@@ -337,7 +337,7 @@ class AddNodePool extends Component {
               readOnly={false}
               value={this.state.aws.instanceType.value}
             />
-            <p>{`${RAM} CPU cores, ${CPUCores} GB RAM each`}</p>
+            <p>{`${CPUCores} CPU cores, ${RAM} GB RAM each`}</p>
           </FlexWrapperDiv>
         </label>
         <AZLabel htmlFor='availability-zones'>

--- a/src/components/cluster/detail/AddNodePool.js
+++ b/src/components/cluster/detail/AddNodePool.js
@@ -288,8 +288,7 @@ class AddNodePool extends Component {
     const instanceTypesKeys = Object.keys(this.state.awsInstanceTypes);
 
     const hasInstances =
-      instanceTypesKeys.length > 0 &&
-      instanceTypesKeys.find(type => type === instanceType);
+      instanceTypesKeys && instanceTypesKeys.includes(instanceType);
 
     const RAM = hasInstances
       ? this.state.awsInstanceTypes[instanceType].memory_size_gb

--- a/src/components/cluster/new/CreateRegularCluster.js
+++ b/src/components/cluster/new/CreateRegularCluster.js
@@ -344,7 +344,7 @@ class CreateRegularCluster extends React.Component {
     const { awsInstanceTypes } = this.state;
     const instanceType = this.state.aws.instanceType.value;
 
-    // Check whether this.state.instanceTypes is populated and that instance name
+    // Check whether this.state.awsInstanceTypes is populated and that instance name
     // in input matches an instance in the array
     const instanceTypesKeys = Object.keys(awsInstanceTypes);
 
@@ -365,7 +365,7 @@ class CreateRegularCluster extends React.Component {
     const { azureInstanceTypes } = this.state;
     const instanceType = this.state.azure.vmSize.value;
 
-    // Check whether this.state.instanceTypes is populated and that instance name
+    // Check whether this.state.azureInstanceTypes is populated and that instance name
     // in input matches an instance in the array
     const instanceTypesKeys = Object.keys(azureInstanceTypes);
 

--- a/src/components/cluster/new/CreateRegularCluster.js
+++ b/src/components/cluster/new/CreateRegularCluster.js
@@ -349,8 +349,7 @@ class CreateRegularCluster extends React.Component {
     const instanceTypesKeys = Object.keys(awsInstanceTypes);
 
     const hasInstances =
-      instanceTypesKeys.length > 0 &&
-      instanceTypesKeys.find(type => type === instanceType);
+      instanceTypesKeys && instanceTypesKeys.includes(instanceType);
 
     const RAM = hasInstances
       ? awsInstanceTypes[instanceType].memory_size_gb
@@ -370,8 +369,7 @@ class CreateRegularCluster extends React.Component {
     const instanceTypesKeys = Object.keys(azureInstanceTypes);
 
     const hasInstances =
-      instanceTypesKeys.length > 0 &&
-      instanceTypesKeys.find(type => type === instanceType);
+      instanceTypesKeys && instanceTypesKeys.includes(instanceType);
 
     const RAM = hasInstances
       ? (azureInstanceTypes[instanceType].memoryInMb / 1000).toFixed(2)

--- a/src/components/cluster/new/CreateRegularCluster.js
+++ b/src/components/cluster/new/CreateRegularCluster.js
@@ -73,7 +73,7 @@ class CreateRegularCluster extends React.Component {
       valid: true,
     },
     releaseVersion: this.props.selectedRelease,
-    clusterName: 'My cluster',
+    clusterName: 'Unnamed cluster',
     scaling: {
       automatic: false,
       min: 3,
@@ -200,7 +200,10 @@ class CreateRegularCluster extends React.Component {
             min: this.state.scaling.min,
             max: this.state.scaling.max,
           },
-          name: this.state.clusterName,
+          name:
+            this.state.clusterName === ''
+              ? 'Unnamed cluster'
+              : this.state.clusterName,
           owner: this.props.selectedOrganization,
           release_version: this.props.selectedRelease,
           workers: workers,
@@ -404,6 +407,9 @@ class CreateRegularCluster extends React.Component {
                     type='text'
                     id='name'
                     value={this.state.clusterName}
+                    placeholder={
+                      this.state.clusterName === '' ? 'Unnamed cluster' : null
+                    }
                   />
                 </div>
                 <p>Give your cluster a name to recognize it among others.</p>

--- a/src/components/cluster/new/CreateRegularCluster.js
+++ b/src/components/cluster/new/CreateRegularCluster.js
@@ -336,7 +336,7 @@ class CreateRegularCluster extends React.Component {
 
   valid() {
     // If any of the releaseVersion hasn't been set yet, return false
-    if (this.props.selectedRelease === '') {
+    if (!this.props.selectedRelease) {
       return false;
     }
 


### PR DESCRIPTION
In this PR:

- When there is no release in create cluster form submit button is disabled
- *Unnamed cluster* as a default name and placeholder when input is empty
- Added meesage *X CPU Cores,  X GB RAM each* message next to the instance type selected.
- Fixed the message in `AddNodePool` component, data was wrongly placed.