### PR TITLE
Fix error loading cluster action.

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -710,8 +710,9 @@ export const clusterLoadDetailsSuccess = cluster => ({
   cluster,
 });
 
-export const clusterLoadDetailsError = error => ({
+export const clusterLoadDetailsError = (clusterId, error) => ({
   type: types.CLUSTER_LOAD_DETAILS_ERROR,
+  clusterId,
   error,
 });
 

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -70,7 +70,7 @@ const clusterReducer = produce((draft, action) => {
     }
 
     case types.CLUSTER_LOAD_DETAILS_ERROR:
-      draft.items[action.cluster.id].errorLoading = true;
+      draft.items[action.clusterId].errorLoading = true;
       return;
 
     case types.CLUSTERS_LOAD_NODEPOOLS_SUCCESS:


### PR DESCRIPTION
The action we dispatched never included the cluster. So the reducer would always throw a `cannot read property id`

Brought it more in line with the other reducers.