### PR TITLE
Replace less than three nodes warning with recommendation in scaling dialog

### DIFF
--- a/src/components/cluster/detail/ScaleClusterModal.js
+++ b/src/components/cluster/detail/ScaleClusterModal.js
@@ -306,8 +306,8 @@ class ScaleClusterModal extends React.Component {
           timeout={this.rollupAnimationDuration}
         >
           <p key='unsupported'>
-            <i className='fa fa-warning' /> We recommend that you run clusters with at
-            least three worker nodes.
+            <i className='fa fa-warning' /> We recommend that you run clusters
+            with at least three worker nodes.
           </p>
         </CSSTransition>
       );

--- a/src/components/cluster/detail/ScaleClusterModal.js
+++ b/src/components/cluster/detail/ScaleClusterModal.js
@@ -306,7 +306,7 @@ class ScaleClusterModal extends React.Component {
           timeout={this.rollupAnimationDuration}
         >
           <p key='unsupported'>
-            <i className='fa fa-warning' /> We recommend to run clusters with at
+            <i className='fa fa-warning' /> We recommend that you run clusters with at
             least three worker nodes.
           </p>
         </CSSTransition>

--- a/src/components/cluster/detail/ScaleClusterModal.js
+++ b/src/components/cluster/detail/ScaleClusterModal.js
@@ -305,11 +305,8 @@ class ScaleClusterModal extends React.Component {
           timeout={this.rollupAnimationDuration}
         >
           <p key='unsupported'>
-            <i className='fa fa-warning' /> With less than 3 worker nodes, the
-            cluster does not fall under the Giant Swarm{' '}
-            <abbr title='Service Level Agreement'>SLA</abbr>. Giant Swarm staff
-            will not be alerted in case of problems and will not provide
-            proactive support.
+            <i className='fa fa-warning' /> We recommend to run clusters with at
+            least three worker nodes.
           </p>
         </CSSTransition>
       );

--- a/src/components/cluster/detail/ScaleNodePoolModal.js
+++ b/src/components/cluster/detail/ScaleNodePoolModal.js
@@ -267,8 +267,8 @@ class ScaleNodePoolModal extends React.Component {
           timeout={this.rollupAnimationDuration}
         >
           <p key='unsupported'>
-            <i className='fa fa-warning' /> We recommend that you run clusters with at
-            least three worker nodes.
+            <i className='fa fa-warning' /> We recommend that you run clusters
+            with at least three worker nodes.
           </p>
         </CSSTransition>
       );

--- a/src/components/cluster/detail/ScaleNodePoolModal.js
+++ b/src/components/cluster/detail/ScaleNodePoolModal.js
@@ -266,11 +266,8 @@ class ScaleNodePoolModal extends React.Component {
           timeout={this.rollupAnimationDuration}
         >
           <p key='unsupported'>
-            <i className='fa fa-warning' /> With less than 3 worker nodes, the
-            cluster does not fall under the Giant Swarm{' '}
-            <abbr title='Service Level Agreement'>SLA</abbr>. Giant Swarm staff
-            will not be alerted in case of problems and will not provide
-            proactive support.
+            <i className='fa fa-warning' /> We recommend to run clusters with at
+            least three worker nodes.
           </p>
         </CSSTransition>
       );

--- a/src/components/cluster/detail/ScaleNodePoolModal.js
+++ b/src/components/cluster/detail/ScaleNodePoolModal.js
@@ -267,7 +267,7 @@ class ScaleNodePoolModal extends React.Component {
           timeout={this.rollupAnimationDuration}
         >
           <p key='unsupported'>
-            <i className='fa fa-warning' /> We recommend to run clusters with at
+            <i className='fa fa-warning' /> We recommend that you run clusters with at
             least three worker nodes.
           </p>
         </CSSTransition>


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5770

This replace a warning mentioning that we do not support or monitor clusters below three worker nodes (which is not the case) with a recommendation to have at least three worker nodes.

### Before

![image](https://user-images.githubusercontent.com/273727/69648828-53ffb200-106c-11ea-815f-d9643f1a416b.png)
