### PR TITLE
Move providers to enums

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
 import { modalHide } from './modalActions';
@@ -33,7 +34,7 @@ function computeCapabilities(cluster, provider) {
   // or any provider and larger than 8.2.0
   if (
     (cmp(releaseVer, '8.0.99') === 1 &&
-      (provider === 'aws' || provider === 'kvm')) ||
+      (provider === Providers.AWS || provider === Providers.KVM)) ||
     cmp(releaseVer, '8.1.99') === 1
   ) {
     capabilities.canInstallApps = true;

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -1,8 +1,8 @@
-import * as Providers from 'shared/constants';
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
 import { modalHide } from './modalActions';
 import { nodePoolsLoad } from './nodePoolActions';
+import { Providers } from 'shared/constants';
 import { push } from 'connected-react-router';
 import cmp from 'semver-compare';
 import GiantSwarm from 'giantswarm';

--- a/src/actions/organizationActions.js
+++ b/src/actions/organizationActions.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
 import { modalHide } from './modalActions';
@@ -472,7 +473,7 @@ export function organizationCredentialsSetConfirmed(provider, orgId, data) {
     let requestBody = new GiantSwarm.V4AddCredentialsRequest();
     requestBody.provider = provider;
 
-    if (provider === 'azure') {
+    if (provider === Providers.AZURE) {
       requestBody.azure = new GiantSwarm.V4AddCredentialsRequestAzure();
       requestBody.azure.credential = new GiantSwarm.V4AddCredentialsRequestAzureCredential(
         data.azureClientID,
@@ -480,7 +481,7 @@ export function organizationCredentialsSetConfirmed(provider, orgId, data) {
         data.azureSubscriptionID,
         data.azureTenantID
       );
-    } else if (provider === 'aws') {
+    } else if (provider === Providers.AWS) {
       requestBody.aws = new GiantSwarm.V4AddCredentialsRequestAws();
       requestBody.aws.roles = new GiantSwarm.V4AddCredentialsRequestAwsRoles(
         data.awsAdminRoleARN,

--- a/src/actions/organizationActions.js
+++ b/src/actions/organizationActions.js
@@ -1,7 +1,7 @@
-import * as Providers from 'shared/constants';
 import * as types from './actionTypes';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
 import { modalHide } from './modalActions';
+import { Providers } from 'shared/constants';
 import { setOrganizationToStorage } from 'utils/localStorageUtils';
 import GiantSwarm from 'giantswarm';
 import React from 'react';

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -1,4 +1,5 @@
 import * as types from './actionTypes';
+import { AuthorizationTypes } from 'shared/constants';
 import { Base64 } from 'js-base64';
 import {
   clearQueues,
@@ -98,7 +99,7 @@ export function auth0Login(authResult) {
       var userData = {
         email: authResult.idTokenPayload.email,
         auth: {
-          scheme: 'Bearer',
+          scheme: AuthorizationTypes.BEARER,
           token: authResult.accessToken,
         },
         isAdmin: isAdmin,

--- a/src/components/UI/__tests__/catalog_type_label.js
+++ b/src/components/UI/__tests__/catalog_type_label.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
-import React from 'react';
 import CatalogTypeLabel from 'UI/catalog_type_label';
+import React from 'react';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');

--- a/src/components/UI/organization_list/index.js
+++ b/src/components/UI/organization_list/index.js
@@ -1,5 +1,5 @@
-import * as Providers from 'shared/constants';
 import { clustersForOrg } from 'lib/helpers';
+import { Providers } from 'shared/constants';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Row from './row';

--- a/src/components/UI/organization_list/index.js
+++ b/src/components/UI/organization_list/index.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { clustersForOrg } from 'lib/helpers';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -17,7 +18,7 @@ const OrganizationList = ({ provider, ...props }) => {
           <StyledTableHeader centered={true}>Clusters</StyledTableHeader>
           <StyledTableHeader centered={true}>Members</StyledTableHeader>
 
-          {provider !== 'kvm' && (
+          {provider !== Providers.KVM && (
             <StyledTableHeader centered={true}>
               Provider Credentials
             </StyledTableHeader>

--- a/src/components/UI/organization_list/row.js
+++ b/src/components/UI/organization_list/row.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -31,7 +32,7 @@ const OrganizationListRow = ({
         <Link to={organizationDetailURL}>{organization.members.length}</Link>
       </StyledTableDataCell>
 
-      {provider !== 'kvm' && (
+      {provider !== Providers.KVM && (
         <StyledTableDataCell centered={true}>
           {hasCredentials && (
             <Link to={organizationDetailURL}>

--- a/src/components/UI/organization_list/row.js
+++ b/src/components/UI/organization_list/row.js
@@ -1,5 +1,5 @@
-import * as Providers from 'shared/constants';
 import { Link } from 'react-router-dom';
+import { Providers } from 'shared/constants';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';

--- a/src/components/auth/admin.js
+++ b/src/components/auth/admin.js
@@ -1,4 +1,5 @@
 import * as userActions from 'actions/userActions';
+import { AuthorizationTypes } from 'shared/constants';
 import { bindActionCreators } from 'redux';
 import { clearQueues } from 'lib/flash_message';
 import { connect } from 'react-redux';
@@ -16,7 +17,7 @@ class AdminLogin extends React.Component {
     if (
       this.props.user &&
       this.props.user.auth &&
-      this.props.user.auth.scheme === 'Bearer'
+      this.props.user.auth.scheme === AuthorizationTypes.BEARER
     ) {
       if (isJwtExpired(this.props.user.auth.token)) {
         // Token is expired. Try to renew it silently, and if that succeeds, redirect

--- a/src/components/auth/logout.js
+++ b/src/components/auth/logout.js
@@ -1,4 +1,5 @@
 import * as userActions from 'actions/userActions';
+import { AuthorizationTypes } from 'shared/constants';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { push } from 'connected-react-router';
@@ -14,7 +15,7 @@ class Logout extends React.Component {
       this.props.user.auth &&
       this.props.user.auth.scheme
     ) {
-      if (this.props.user.auth.scheme === 'Bearer') {
+      if (this.props.user.auth.scheme === AuthorizationTypes.BEARER) {
         this.props.dispatch(push('/login'));
         this.props.actions.logoutSuccess();
       } else {

--- a/src/components/cluster/detail/AddNodePool.js
+++ b/src/components/cluster/detail/AddNodePool.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { connect } from 'react-redux';
 import { css } from '@emotion/core';
 import { hasAppropriateLength } from 'lib/helpers';
@@ -544,7 +545,9 @@ function mapStateToProps(state) {
   const defaultDiskSize = 20; // TODO
 
   const allowedInstanceTypes =
-    provider === 'aws' ? state.app.info.workers.instance_type.options : [];
+    provider === Providers.AWS
+      ? state.app.info.workers.instance_type.options
+      : [];
 
   return {
     availabilityZones,

--- a/src/components/cluster/detail/AddNodePool.js
+++ b/src/components/cluster/detail/AddNodePool.js
@@ -1,7 +1,7 @@
-import * as Providers from 'shared/constants';
 import { connect } from 'react-redux';
 import { css } from '@emotion/core';
 import { hasAppropriateLength } from 'lib/helpers';
+import { Providers } from 'shared/constants';
 import { RadioWrapper } from '../new/CreateNodePoolsCluster';
 import AvailabilityZonesParser from './AvailabilityZonesParser';
 import AWSInstanceTypeSelector from '../new/AWSInstanceTypeSelector';

--- a/src/components/cluster/detail/ClusterDetailView.js
+++ b/src/components/cluster/detail/ClusterDetailView.js
@@ -1,6 +1,5 @@
 import * as clusterActions from 'actions/clusterActions';
 import * as nodePoolActions from 'actions/nodePoolActions';
-import * as Providers from 'shared/constants';
 import * as releaseActions from 'actions/releaseActions';
 import { bindActionCreators } from 'redux';
 import { clusterPatch } from 'actions/clusterActions';
@@ -8,6 +7,7 @@ import { connect } from 'react-redux';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
 import { getNumberOfNodes } from 'utils/cluster_utils';
 import { organizationCredentialsLoad } from 'actions/organizationActions';
+import { Providers } from 'shared/constants';
 import { push } from 'connected-react-router';
 import Button from 'UI/button';
 import ClusterApps from './ClusterApps';

--- a/src/components/cluster/detail/ClusterDetailView.js
+++ b/src/components/cluster/detail/ClusterDetailView.js
@@ -1,5 +1,6 @@
 import * as clusterActions from 'actions/clusterActions';
 import * as nodePoolActions from 'actions/nodePoolActions';
+import * as Providers from 'shared/constants';
 import * as releaseActions from 'actions/releaseActions';
 import { bindActionCreators } from 'redux';
 import { clusterPatch } from 'actions/clusterActions';
@@ -160,17 +161,17 @@ class ClusterDetailView extends React.Component {
       return false;
     }
 
-    if (this.props.provider === 'aws') {
+    if (this.props.provider === Providers.AWS) {
       return true;
     }
 
-    if (this.props.provider === 'kvm') {
+    if (this.props.provider === Providers.KVM) {
       return true;
     }
 
     // on Azure, release version must be >= 1.0.0
     if (
-      this.props.provider === 'azure' &&
+      this.props.provider === Providers.AZURE &&
       cmp(this.props.cluster.release_version, '1.0.0') !== -1
     ) {
       return true;
@@ -181,7 +182,7 @@ class ClusterDetailView extends React.Component {
     // Desired number of nodes only makes sense with auto-scaling and that is
     // only available on AWS starting from release 6.3.0 onwards.
     if (
-      this.props.provider !== 'aws' ||
+      this.props.provider !== Providers.AWS ||
       cmp(this.props.cluster.release_version, '6.2.99') !== 1
     ) {
       return null;

--- a/src/components/cluster/detail/CredentialInfoRow.js
+++ b/src/components/cluster/detail/CredentialInfoRow.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { FlexRowWithTwoBlocksOnEdges } from 'styles';
 import AWSAccountID from 'UI/aws_account_id';
 import PropTypes from 'prop-types';
@@ -27,7 +28,7 @@ function CredentialInfoRow({ cluster, credentials, provider }) {
         </div>
       );
     } else {
-      if (provider === 'aws') {
+      if (provider === Providers.AWS) {
         credentialInfoRows.push(
           <div key='awsAccountID'>
             <div>AWS account</div>
@@ -38,7 +39,7 @@ function CredentialInfoRow({ cluster, credentials, provider }) {
             </div>
           </div>
         );
-      } else if (provider === 'azure') {
+      } else if (provider === Providers.AZURE) {
         credentialInfoRows.push(
           <div key='azureSubscriptionID'>
             <div>Azure subscription</div>

--- a/src/components/cluster/detail/CredentialInfoRow.js
+++ b/src/components/cluster/detail/CredentialInfoRow.js
@@ -1,5 +1,5 @@
-import * as Providers from 'shared/constants';
 import { FlexRowWithTwoBlocksOnEdges } from 'styles';
+import { Providers } from 'shared/constants';
 import AWSAccountID from 'UI/aws_account_id';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/cluster/detail/KeyPairCreateModal.js
+++ b/src/components/cluster/detail/KeyPairCreateModal.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { dedent, makeKubeConfigTextFile } from 'lib/helpers';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from 'UI/button';
@@ -260,7 +261,7 @@ const KeyPairCreateModal = props => {
                       onChange={handleTTLChange}
                     />
 
-                    {props.provider === 'aws' && (
+                    {props.provider === Providers.AWS && (
                       <>
                         <br />
 

--- a/src/components/cluster/detail/KeyPairCreateModal.js
+++ b/src/components/cluster/detail/KeyPairCreateModal.js
@@ -1,5 +1,5 @@
-import * as Providers from 'shared/constants';
 import { dedent, makeKubeConfigTextFile } from 'lib/helpers';
+import { Providers } from 'shared/constants';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from 'UI/button';
 import copy from 'copy-to-clipboard';

--- a/src/components/cluster/detail/ScaleClusterModal.js
+++ b/src/components/cluster/detail/ScaleClusterModal.js
@@ -1,9 +1,9 @@
 import * as clusterActions from 'actions/clusterActions';
-import * as Providers from 'shared/constants';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
+import { Providers } from 'shared/constants';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from 'UI/button';
 import ClusterIDLabel from 'UI/cluster_id_label';

--- a/src/components/cluster/detail/ScaleClusterModal.js
+++ b/src/components/cluster/detail/ScaleClusterModal.js
@@ -1,4 +1,5 @@
 import * as clusterActions from 'actions/clusterActions';
+import * as Providers from 'shared/constants';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
@@ -70,7 +71,7 @@ class ScaleClusterModal extends React.Component {
    * @param String Semantic release version number
    */
   supportsAutoscaling(provider, releaseVer) {
-    if (provider != 'aws') {
+    if (provider !== Providers.AWS) {
       return false;
     }
 

--- a/src/components/cluster/detail/ScaleNodePoolModal.js
+++ b/src/components/cluster/detail/ScaleNodePoolModal.js
@@ -1,9 +1,9 @@
 import * as nodePoolActions from 'actions/nodePoolActions';
-import * as Providers from 'shared/constants';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
+import { Providers } from 'shared/constants';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import Button from 'UI/button';
 import ClusterIDLabel from 'UI/cluster_id_label';

--- a/src/components/cluster/detail/ScaleNodePoolModal.js
+++ b/src/components/cluster/detail/ScaleNodePoolModal.js
@@ -1,4 +1,5 @@
 import * as nodePoolActions from 'actions/nodePoolActions';
+import * as Providers from 'shared/constants';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
@@ -68,7 +69,7 @@ class ScaleNodePoolModal extends React.Component {
   };
 
   supportsAutoscaling(provider) {
-    if (provider != 'aws') return false;
+    if (provider !== Providers.AWS) return false;
     return true;
   }
 

--- a/src/components/cluster/detail/V4ClusterDetailTable.js
+++ b/src/components/cluster/detail/V4ClusterDetailTable.js
@@ -1,7 +1,7 @@
-import * as Providers from 'shared/constants';
 import { Code, Dot, FlexRowWithTwoBlocksOnEdges } from 'styles';
 import { CopyToClipboardDiv } from './V5ClusterDetailTable';
 import { getCpusTotal, getMemoryTotal } from 'utils/cluster_utils';
+import { Providers } from 'shared/constants';
 import Button from 'UI/button';
 import copy from 'copy-to-clipboard';
 import CredentialInfoRow from './CredentialInfoRow';

--- a/src/components/cluster/detail/V4ClusterDetailTable.js
+++ b/src/components/cluster/detail/V4ClusterDetailTable.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { Code, Dot, FlexRowWithTwoBlocksOnEdges } from 'styles';
 import { CopyToClipboardDiv } from './V5ClusterDetailTable';
 import { getCpusTotal, getMemoryTotal } from 'utils/cluster_utils';
@@ -178,7 +179,7 @@ class V4ClusterDetailTable extends React.Component {
 
         <hr style={{ margin: '25px 0' }} />
         <h2>Worker nodes</h2>
-        {provider === 'azure' && (
+        {provider === Providers.AZURE && (
           <WorkerNodesAzure
             instanceType={
               this.state.azureVMSizes[cluster.workers[0].azure.vm_size]
@@ -187,14 +188,14 @@ class V4ClusterDetailTable extends React.Component {
             showScalingModal={this.props.showScalingModal}
           />
         )}
-        {provider === 'kvm' && (
+        {provider === Providers.KVM && (
           <WorkerNodesKVM
             worker={cluster.workers[0]}
             nodes={workerNodesRunning}
             showScalingModal={this.props.showScalingModal}
           />
         )}
-        {provider === 'aws' && (
+        {provider === Providers.AWS && (
           <WorkerNodesAWS
             az={cluster.availability_zones}
             instanceName={cluster.workers[0].aws.instance_type}

--- a/src/components/cluster/new/CreateNodePoolsCluster.js
+++ b/src/components/cluster/new/CreateNodePoolsCluster.js
@@ -1,4 +1,3 @@
-import * as Providers from 'shared/constants';
 import {
   AddNodePoolFlexColumnDiv,
   AddNodePoolWrapper,
@@ -10,6 +9,7 @@ import { css } from '@emotion/core';
 import { hasAppropriateLength } from 'lib/helpers';
 import { Input } from 'styles/index';
 import { nodePoolsCreate } from 'actions/nodePoolActions';
+import { Providers } from 'shared/constants';
 import { push } from 'connected-react-router';
 import { TransitionGroup } from 'react-transition-group';
 import AddNodePool from '../detail/AddNodePool';

--- a/src/components/cluster/new/CreateNodePoolsCluster.js
+++ b/src/components/cluster/new/CreateNodePoolsCluster.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import {
   AddNodePoolFlexColumnDiv,
   AddNodePoolWrapper,
@@ -607,7 +608,9 @@ function mapStateToProps(state) {
   const defaultDiskSize = 20; // TODO
 
   const allowedInstanceTypes =
-    provider === 'aws' ? state.app.info.workers.instance_type.options : [];
+    provider === Providers.AWS
+      ? state.app.info.workers.instance_type.options
+      : [];
 
   return {
     availabilityZones,

--- a/src/components/cluster/new/CreateRegularCluster.js
+++ b/src/components/cluster/new/CreateRegularCluster.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { clusterCreate } from 'actions/clusterActions';
 import { connect } from 'react-redux';
@@ -159,7 +160,7 @@ class CreateRegularCluster extends React.Component {
     // for the 'third' cluster type that we support to be able to make decisions
     // about a meaningful abstraction. For now, going with a easy solution.
 
-    if (this.props.provider === 'aws') {
+    if (this.props.provider === Providers.AWS) {
       for (i = 0; i < this.state.scaling.min; i++) {
         workers.push({
           aws: {
@@ -167,7 +168,7 @@ class CreateRegularCluster extends React.Component {
           },
         });
       }
-    } else if (this.props.provider === 'azure') {
+    } else if (this.props.provider === Providers.AZURE) {
       for (i = 0; i < this.state.scaling.min; i++) {
         workers.push({
           azure: {
@@ -244,7 +245,7 @@ class CreateRegularCluster extends React.Component {
   };
 
   isScalingAutomatic(provider, releaseVer) {
-    if (provider != 'aws') {
+    if (provider !== Providers.AWS) {
       return false;
     }
 
@@ -475,7 +476,7 @@ class CreateRegularCluster extends React.Component {
 
             <FlexColumnDiv>
               <div className='worker-nodes'>Worker nodes</div>
-              {this.props.provider === 'aws' && (
+              {this.props.provider === Providers.AWS && (
                 <label
                   className='availability-zones'
                   htmlFor='availability-zones'
@@ -519,7 +520,7 @@ class CreateRegularCluster extends React.Component {
               <label htmlFor='instance-type'>
                 {(() => {
                   switch (this.props.provider) {
-                    case 'aws': {
+                    case Providers.AWS: {
                       const [RAM, CPUCores] = this.produceRAMAndCoresAWS();
 
                       return (
@@ -539,7 +540,7 @@ class CreateRegularCluster extends React.Component {
                         </>
                       );
                     }
-                    case 'kvm':
+                    case Providers.KVM:
                       return (
                         <>
                           <span className='label-span'>
@@ -585,7 +586,7 @@ class CreateRegularCluster extends React.Component {
                           />
                         </>
                       );
-                    case 'azure': {
+                    case Providers.AZURE: {
                       const [RAM, CPUCores] = this.produceRAMAndCoresAzure();
 
                       return (
@@ -709,12 +710,12 @@ function mapStateToProps(state) {
     propsToPush.defaultVMSize = state.app.info.workers.vm_size.default;
   }
 
-  if (provider === 'aws') {
+  if (provider === Providers.AWS) {
     propsToPush.allowedInstanceTypes =
       state.app.info.workers.instance_type.options;
   }
 
-  if (provider === 'azure') {
+  if (provider === Providers.AZURE) {
     propsToPush.allowedVMSizes = state.app.info.workers.vm_size.options;
   }
 

--- a/src/components/cluster/new/CreateRegularCluster.js
+++ b/src/components/cluster/new/CreateRegularCluster.js
@@ -1,8 +1,8 @@
-import * as Providers from 'shared/constants';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { clusterCreate } from 'actions/clusterActions';
 import { connect } from 'react-redux';
 import { FlexColumnDiv, Wrapper } from './CreateNodePoolsCluster';
+import { Providers } from 'shared/constants';
 import { push } from 'connected-react-router';
 import AWSInstanceTypeSelector from './AWSInstanceTypeSelector';
 import AzureVMSizeSelector from './AzureVMSizeSelector';

--- a/src/components/cluster/new/NewCluster.js
+++ b/src/components/cluster/new/NewCluster.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { connect } from 'react-redux';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
 import { loadReleases } from 'actions/releaseActions';
@@ -57,7 +58,7 @@ class NewCluster extends React.Component {
   // TODO: Remove this, as there are releases for Azure now.
   informWIP() {
     if (!this.props.user.isAdmin) {
-      if (this.props.provider === 'azure') {
+      if (this.props.provider === Providers.AZURE) {
         new FlashMessage(
           'Support for Microsoft Azure is still in an early stage.',
           messageType.INFO,
@@ -85,8 +86,8 @@ class NewCluster extends React.Component {
   renderComponent = props => {
     const Component =
       this.semVerCompare() < 0 ||
-      this.props.provider === 'azure' ||
-      this.props.provider === 'kvm'
+      this.props.provider === Providers.AZURE ||
+      this.props.provider === Providers.KVM
         ? CreateRegularCluster // new v4 form
         : CreateNodePoolsCluster; // new v5 form
 

--- a/src/components/cluster/new/NewCluster.js
+++ b/src/components/cluster/new/NewCluster.js
@@ -1,7 +1,7 @@
-import * as Providers from 'shared/constants';
 import { connect } from 'react-redux';
 import { FlashMessage, messageTTL, messageType } from 'lib/flash_message';
 import { loadReleases } from 'actions/releaseActions';
+import { Providers } from 'shared/constants';
 import { Route, Switch } from 'react-router-dom';
 import cmp from 'semver-compare';
 import CreateNodePoolsCluster from './CreateNodePoolsCluster';

--- a/src/components/cluster/new/ProviderCredentials.js
+++ b/src/components/cluster/new/ProviderCredentials.js
@@ -1,6 +1,6 @@
-import * as Providers from 'shared/constants';
 import { connect } from 'react-redux';
 import { organizationCredentialsLoad } from 'actions/organizationActions';
+import { Providers } from 'shared/constants';
 import AWSAccountID from 'UI/aws_account_id';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/cluster/new/ProviderCredentials.js
+++ b/src/components/cluster/new/ProviderCredentials.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { connect } from 'react-redux';
 import { organizationCredentialsLoad } from 'actions/organizationActions';
 import AWSAccountID from 'UI/aws_account_id';
@@ -24,7 +25,7 @@ class ProviderCredentials extends React.Component {
       !this.props.credentials.isFetching &&
       this.props.credentials.items.length > 0
     ) {
-      if (this.props.provider === 'aws') {
+      if (this.props.provider === Providers.AWS) {
         showInfo = true;
         details = (
           <p>
@@ -35,7 +36,7 @@ class ProviderCredentials extends React.Component {
             , as set for this organization.
           </p>
         );
-      } else if (this.props.provider === 'azure') {
+      } else if (this.props.provider === Providers.AZURE) {
         showInfo = true;
         details = (
           <p>

--- a/src/components/organizations/detail/credentials.js
+++ b/src/components/organizations/detail/credentials.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import { connect } from 'react-redux';
 import {
   organizationCredentialsLoad,
@@ -112,7 +113,7 @@ class CredentialsDisplay extends React.Component {
           </Button>
         );
 
-        if (this.props.provider === 'azure') {
+        if (this.props.provider === Providers.AZURE) {
           return (
             <div>
               <p>
@@ -275,7 +276,7 @@ class CredentialsForm extends React.Component {
    * input field values. If yes, this.state.isValid is set to true.
    */
   validate = () => {
-    if (this.props.provider === 'azure') {
+    if (this.props.provider === Providers.AZURE) {
       if (
         this.state.azureSubscriptionID &&
         this.state.azureTenantID &&
@@ -326,7 +327,7 @@ class CredentialsForm extends React.Component {
   };
 
   render() {
-    if (this.props.provider === 'azure') {
+    if (this.props.provider === Providers.AZURE) {
       return (
         <form>
           <p>
@@ -412,7 +413,7 @@ class CredentialsForm extends React.Component {
           </Button>
         </form>
       );
-    } else if (this.props.provider === 'aws') {
+    } else if (this.props.provider === Providers.AWS) {
       return (
         <form>
           <p>

--- a/src/components/organizations/detail/credentials.js
+++ b/src/components/organizations/detail/credentials.js
@@ -1,10 +1,10 @@
-import * as Providers from 'shared/constants';
 import { connect } from 'react-redux';
 import {
   organizationCredentialsLoad,
   organizationCredentialsSet,
   organizationCredentialsSetConfirmed,
 } from 'actions/organizationActions';
+import { Providers } from 'shared/constants';
 import { spinner } from 'images';
 import AWSAccountID from 'UI/aws_account_id';
 import Button from 'UI/button';

--- a/src/components/organizations/detail/view.js
+++ b/src/components/organizations/detail/view.js
@@ -1,4 +1,5 @@
 import * as OrganizationActions from 'actions/organizationActions';
+import * as Providers from 'shared/constants';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -27,7 +28,7 @@ class OrganizationDetail extends React.Component {
   // determine whether the component should deal with BYOC credentials
   // (not relevant on KVM)
   canCredentials = provider => {
-    if (provider === 'aws' || provider === 'azure') {
+    if (provider === Providers.AWS || provider === Providers.AZURE) {
       return true;
     }
     return false;

--- a/src/components/organizations/detail/view.js
+++ b/src/components/organizations/detail/view.js
@@ -1,8 +1,8 @@
 import * as OrganizationActions from 'actions/organizationActions';
-import * as Providers from 'shared/constants';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { Providers } from 'shared/constants';
 import { relativeDate } from 'lib/helpers.js';
 import BootstrapTable from 'react-bootstrap-table-next';
 import Button from 'react-bootstrap/lib/Button';

--- a/src/lib/giantswarm_client_patcher.js
+++ b/src/lib/giantswarm_client_patcher.js
@@ -1,4 +1,5 @@
 import { auth0Login } from 'actions/userActions';
+import { AuthorizationTypes } from 'shared/constants';
 import { isJwtExpired } from 'lib/helpers';
 import Auth0 from 'lib/auth0';
 import GiantSwarm from 'giantswarm';
@@ -31,7 +32,7 @@ function monkeyPatchGiantSwarmClient(store) {
     // If we're using a JWT token, and it's expired, refresh the token before making
     // any call.
     if (
-      defaultClientAuth.apiKeyPrefix === 'Bearer' &&
+      defaultClientAuth.apiKeyPrefix === AuthorizationTypes.BEARER &&
       defaultClientAuth.apiKey
     ) {
       if (isJwtExpired(defaultClientAuth.apiKey)) {
@@ -42,7 +43,9 @@ function monkeyPatchGiantSwarmClient(store) {
             store.dispatch(auth0Login(result));
 
             // Ensure the second attempt uses the new token.
-            headerParams['Authorization'] = 'Bearer ' + result.accessToken;
+            headerParams[
+              'Authorization'
+            ] = `${AuthorizationTypes.BEARER} ${result.accessToken}`;
 
             return origCallApi(
               path,

--- a/src/mockedStatus.js
+++ b/src/mockedStatus.js
@@ -1,4 +1,4 @@
-import * as Providers from 'shared/constants';
+import { Providers } from 'shared/constants';
 
 const mockedStatus = {
   aws: {

--- a/src/mockedStatus.js
+++ b/src/mockedStatus.js
@@ -1,3 +1,5 @@
+import * as Providers from 'shared/constants';
+
 const mockedStatus = {
   aws: {
     availabilityZones: [
@@ -37,7 +39,7 @@ const mockedStatus = {
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.6.23',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -60,7 +62,7 @@ const mockedStatus = {
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.6.28',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -83,7 +85,7 @@ const mockedStatus = {
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.6.39',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -106,7 +108,7 @@ const mockedStatus = {
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.6.91',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':

--- a/src/shared/constants/AuthorizationTypes.js
+++ b/src/shared/constants/AuthorizationTypes.js
@@ -1,0 +1,3 @@
+export const BEARER = 'Bearer';
+
+export const BASIC = 'Basic';

--- a/src/shared/constants/Providers.js
+++ b/src/shared/constants/Providers.js
@@ -1,0 +1,5 @@
+export const AWS = 'aws';
+
+export const AZURE = 'azure';
+
+export const KVM = 'kvm';

--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -1,0 +1,1 @@
+export * from './Providers';

--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -1,1 +1,4 @@
-export * from './Providers';
+import * as AuthorizationTypes from './Providers';
+import * as Providers from './Providers';
+
+export { Providers, AuthorizationTypes };

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,0 +1,1 @@
+export * from './constants';

--- a/test_utils/initialState.js
+++ b/test_utils/initialState.js
@@ -1,3 +1,5 @@
+import * as Providers from 'shared/constants';
+
 const initialState = function() {
   return {
     app: {
@@ -14,7 +16,7 @@ const initialState = function() {
       info: {
         general: {
           installation_name: 'local',
-          provider: 'aws',
+          provider: Providers.AWS,
           availability_zones: {
             max: 3,
             default: 1,

--- a/test_utils/initialState.js
+++ b/test_utils/initialState.js
@@ -1,4 +1,4 @@
-import * as Providers from 'shared/constants';
+import { AuthorizationTypes, Providers } from 'shared/constants';
 
 const initialState = function() {
   return {
@@ -8,7 +8,7 @@ const initialState = function() {
       loggedInUser: {
         email: 'oriol@giantswarm.io',
         auth: {
-          scheme: 'Bearer',
+          scheme: AuthorizationTypes.BEARER,
           token: 'a-valid-token',
         },
         isAdmin: true,

--- a/test_utils/mockHttpCalls.js
+++ b/test_utils/mockHttpCalls.js
@@ -1,3 +1,4 @@
+import * as Providers from 'shared/constants';
 import nock from 'nock';
 
 /***** Constants *****/
@@ -45,7 +46,7 @@ export const infoResponse = {
     },
     datacenter: 'eu-central-1',
     installation_name: 'local',
-    provider: 'aws',
+    provider: Providers.AWS,
   },
   features: { nodepools: { release_version_minimum: '10.0.0' } },
   stats: { cluster_creation_duration: { median: 805, p25: 657, p75: 1031 } },
@@ -226,7 +227,7 @@ export const v4AWSClusterStatusResponse = {
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.2.18',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -249,7 +250,7 @@ export const v4AWSClusterStatusResponse = {
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.2.49',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -272,7 +273,7 @@ export const v4AWSClusterStatusResponse = {
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.2.52',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -295,7 +296,7 @@ export const v4AWSClusterStatusResponse = {
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.2.85',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':

--- a/test_utils/mockHttpCalls.js
+++ b/test_utils/mockHttpCalls.js
@@ -1,4 +1,4 @@
-import * as Providers from 'shared/constants';
+import { Providers } from 'shared/constants';
 import nock from 'nock';
 
 /***** Constants *****/

--- a/test_utils/statusState.js
+++ b/test_utils/statusState.js
@@ -1,3 +1,5 @@
+import * as Providers from 'shared/constants';
+
 const statusState = () => ({
   aws: {
     availabilityZones: [
@@ -37,7 +39,7 @@ const statusState = () => ({
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.6.23',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -60,7 +62,7 @@ const statusState = () => ({
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.6.28',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -83,7 +85,7 @@ const statusState = () => ({
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.6.39',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':
@@ -106,7 +108,7 @@ const statusState = () => ({
           'beta.kubernetes.io/os': 'linux',
           'failure-domain.beta.kubernetes.io/region': 'eu-central-1',
           'failure-domain.beta.kubernetes.io/zone': 'eu-central-1c',
-          'giantswarm.io/provider': 'aws',
+          'giantswarm.io/provider': Providers.AWS,
           ip: '10.1.6.91',
           'kubernetes.io/arch': 'amd64',
           'kubernetes.io/hostname':

--- a/test_utils/statusState.js
+++ b/test_utils/statusState.js
@@ -1,4 +1,4 @@
-import * as Providers from 'shared/constants';
+import { Providers } from 'shared/constants';
 
 const statusState = () => ({
   aws: {


### PR DESCRIPTION
Fixes giantswarm/happa#859

- Create shared folder where we can place constants / other cool stuff
- Create constants for providers
- Create constants for authorization types
- Replace usage of hard-coded providers/authorization types with the enum-like object values

Please go on and suggest what else to write in this manner. (apart from the URLs, that will be separate)