### PR TITLE
Show cluster's app tab after creating an app.

### DIFF
--- a/src/components/app_catalog/detail/install_app_modal.js
+++ b/src/components/app_catalog/detail/install_app_modal.js
@@ -169,7 +169,7 @@ const InstallAppModal = props => {
           push(
             `/organizations/${
               props.clusters.find(c => c.id === clusterID).owner
-            }/clusters/${clusterID}/`
+            }/clusters/${clusterID}/apps/`
           )
         );
       })

--- a/src/components/cluster/detail/ClusterDetail.js
+++ b/src/components/cluster/detail/ClusterDetail.js
@@ -21,7 +21,25 @@ class ClusterDetail extends React.Component {
           <Route
             exact
             path={`${this.props.match.path}`}
-            render={() => <ClusterDetailView {...this.props} />}
+            render={() => (
+              <ClusterDetailView {...this.props} defaultActiveTab='general' />
+            )}
+          />
+
+          <Route
+            exact
+            path={`${this.props.match.path}/apps/`}
+            render={() => (
+              <ClusterDetailView {...this.props} defaultActiveTab='apps' />
+            )}
+          />
+
+          <Route
+            exact
+            path={`${this.props.match.path}/keypairs/`}
+            render={() => (
+              <ClusterDetailView {...this.props} defaultActiveTab='keypairs' />
+            )}
           />
 
           <Route

--- a/src/components/cluster/detail/ClusterDetailView.js
+++ b/src/components/cluster/detail/ClusterDetailView.js
@@ -232,6 +232,7 @@ class ClusterDetailView extends React.Component {
     const {
       cluster,
       credentials,
+      defaultActiveTab,
       dispatch,
       isNodePoolsCluster,
       nodePools,
@@ -279,8 +280,8 @@ class ClusterDetailView extends React.Component {
               </div>
               <div className='row'>
                 <div className='col-12'>
-                  <Tabs>
-                    <Tab eventKey={1} title='General'>
+                  <Tabs defaultActiveKey={defaultActiveTab}>
+                    <Tab eventKey={'general'} title='General'>
                       {isNodePoolsCluster ? (
                         <V5ClusterDetailTable
                           accessCluster={this.accessCluster}
@@ -332,10 +333,10 @@ class ClusterDetailView extends React.Component {
                         </div>
                       </div>
                     </Tab>
-                    <Tab eventKey={2} title='Key Pairs'>
+                    <Tab eventKey={'keypairs'} title='Key Pairs'>
                       <KeyPairs cluster={cluster} />
                     </Tab>
-                    <Tab eventKey={3} title='Apps'>
+                    <Tab eventKey={'apps'} title='Apps'>
                       {release ? (
                         <ClusterApps
                           clusterId={this.props.clusterId}
@@ -404,6 +405,7 @@ ClusterDetailView.propTypes = {
   cluster: PropTypes.object,
   clusterId: PropTypes.string,
   credentials: PropTypes.object,
+  defaultActiveTab: PropTypes.string,
   dispatch: PropTypes.func,
   isNodePoolsCluster: PropTypes.bool,
   nodePools: PropTypes.object,

--- a/src/components/cluster/detail/Tabs.js
+++ b/src/components/cluster/detail/Tabs.js
@@ -4,13 +4,18 @@ import React from 'react';
 
 const Tabs = props => {
   return (
-    <BootstrapTabs animation={false} defaultActiveKey={1} id='tabs'>
+    <BootstrapTabs
+      animation={false}
+      defaultActiveKey={props.defaultActiveKey || 1}
+      id='tabs'
+    >
       {props.children}
     </BootstrapTabs>
   );
 };
 
 Tabs.propTypes = {
+  defaultActiveKey: PropTypes.any,
   children: PropTypes.node,
 };
 


### PR DESCRIPTION
This lets us show a specific tab of the cluster detail view.

It then uses that when creating an app, to show the app tab of a cluster directly after creating an app. Instead of showing the general tab, which feels like a sudden context drop.