### PR TITLE
Filter out apps that are pre installed from the user installed apps list

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "copy-to-clipboard": "3.2.0",
     "deep-diff": "1.0.2",
     "emotion-theming": "^10.0.10",
-    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git#add-app-labels",
+    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git",
     "history": "^4.7.2",
     "immer": "^3.2.0",
     "immutable": "3.8.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "copy-to-clipboard": "3.2.0",
     "deep-diff": "1.0.2",
     "emotion-theming": "^10.0.10",
-    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git",
+    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git#add-app-labels",
     "history": "^4.7.2",
     "immer": "^3.2.0",
     "immutable": "3.8.2",

--- a/src/components/cluster/detail/ClusterApps.js
+++ b/src/components/cluster/detail/ClusterApps.js
@@ -199,16 +199,17 @@ class ClusterApps extends React.Component {
     });
   };
 
-  // userInstallApps returns a list of just the apps that the user installed
+  // getUserInstallApps returns a list of just the apps that the user installed
   // since the list of apps in a cluster also includes apps that were installed
   // automatically.
-  userInstalledApps = () => {
+  getUserInstalledApps = () => {
     if (!this.props.installedApps) {
       return [];
     }
 
     return this.props.installedApps.filter(
-      x => x.metadata.labels['giantswarm.io/managed-by'] !== 'cluster-operator'
+      app =>
+        app.metadata.labels['giantswarm.io/managed-by'] !== 'cluster-operator'
     );
   };
 
@@ -219,8 +220,8 @@ class ClusterApps extends React.Component {
           <div data-testid='installed-apps-section' id='installed-apps-section'>
             <h3 className='table-label'>Installed Apps</h3>
             <div className='row'>
-              {this.userInstalledApps() &&
-                this.userInstalledApps().length === 0 &&
+              {this.getUserInstalledApps() &&
+                this.getUserInstalledApps().length === 0 &&
                 !this.props.errorLoading && (
                   <p
                     className='well'
@@ -246,48 +247,49 @@ class ClusterApps extends React.Component {
                   again.
                 </p>
               )}
-              {this.userInstalledApps() && this.userInstalledApps().length > 0 && (
-                <div data-testid='installed-apps' id='installed-apps'>
-                  {this.userInstalledApps().map(app => {
-                    return (
-                      <div
-                        className='installed-apps--app'
-                        key={app.metadata.name}
-                      >
-                        <div className='details'>
-                          {app.logoUrl &&
-                            !this.state.iconErrors[app.logoUrl] && (
-                              <img
-                                alt={app.metadata.name + ' icon'}
-                                height='36'
-                                onError={this.imgError}
-                                src={app.logoUrl}
-                                width='36'
-                              />
-                            )}
-                          {app.metadata.name}
-                          <small>
-                            App Version:{' '}
-                            {app && app.spec && app.spec.version
-                              ? app.spec.version
-                              : 'n/a'}
-                          </small>
+              {this.getUserInstalledApps() &&
+                this.getUserInstalledApps().length > 0 && (
+                  <div data-testid='installed-apps' id='installed-apps'>
+                    {this.getUserInstalledApps().map(app => {
+                      return (
+                        <div
+                          className='installed-apps--app'
+                          key={app.metadata.name}
+                        >
+                          <div className='details'>
+                            {app.logoUrl &&
+                              !this.state.iconErrors[app.logoUrl] && (
+                                <img
+                                  alt={app.metadata.name + ' icon'}
+                                  height='36'
+                                  onError={this.imgError}
+                                  src={app.logoUrl}
+                                  width='36'
+                                />
+                              )}
+                            {app.metadata.name}
+                            <small>
+                              App Version:{' '}
+                              {app && app.spec && app.spec.version
+                                ? app.spec.version
+                                : 'n/a'}
+                            </small>
+                          </div>
+                          <div className='actions'>
+                            <Button
+                              onClick={this.showAppDetail.bind(
+                                this,
+                                app.metadata.name
+                              )}
+                            >
+                              Details
+                            </Button>
+                          </div>
                         </div>
-                        <div className='actions'>
-                          <Button
-                            onClick={this.showAppDetail.bind(
-                              this,
-                              app.metadata.name
-                            )}
-                          >
-                            Details
-                          </Button>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
+                      );
+                    })}
+                  </div>
+                )}
 
               <div className='browse-apps'>
                 <Button onClick={this.openAppCatalog}>

--- a/src/components/cluster/detail/ClusterApps.js
+++ b/src/components/cluster/detail/ClusterApps.js
@@ -220,7 +220,8 @@ class ClusterApps extends React.Component {
             <h3 className='table-label'>Installed Apps</h3>
             <div className='row'>
               {this.userInstalledApps() &&
-                this.userInstalledApps().length === 0 && (
+                this.userInstalledApps().length === 0 &&
+                !this.props.errorLoading && (
                   <p
                     className='well'
                     data-testid='no-apps-found'

--- a/src/components/cluster/detail/__tests__/ClusterApps.js
+++ b/src/components/cluster/detail/__tests__/ClusterApps.js
@@ -58,6 +58,7 @@ it('renders a block for installed apps if there are some', () => {
     {
       metadata: {
         name: 'test-app',
+        labels: {},
       },
     },
   ];

--- a/test_utils/mockHttpCalls.js
+++ b/test_utils/mockHttpCalls.js
@@ -321,7 +321,28 @@ export const v4AWSClusterStatusResponse = {
 // Apps
 export const appsResponse = [
   {
-    metadata: { name: 'chart-operator' },
+    metadata: { name: 'my app', labels: {} },
+    spec: {
+      catalog: 'default',
+      name: 'my-app',
+      namespace: 'giantswarm',
+      user_config: {
+        configmap: { name: '', namespace: '' },
+        secret: { name: '', namespace: '' },
+      },
+      version: '0.0.1',
+    },
+    status: {
+      app_version: '',
+      release: { last_deployed: '0001-01-01T00:00:00Z', status: '' },
+      version: '',
+    },
+  },
+  {
+    metadata: {
+      name: 'chart-operator',
+      labels: { 'giantswarm.io/managed-by': 'cluster-operator' },
+    },
     spec: {
       catalog: 'default',
       name: 'chart-operator',
@@ -339,7 +360,10 @@ export const appsResponse = [
     },
   },
   {
-    metadata: { name: 'kube-state-metrics' },
+    metadata: {
+      name: 'kube-state-metrics',
+      labels: { 'giantswarm.io/managed-by': 'cluster-operator' },
+    },
     spec: {
       catalog: 'default',
       name: 'kube-state-metrics-app',
@@ -357,7 +381,10 @@ export const appsResponse = [
     },
   },
   {
-    metadata: { name: 'metrics-server' },
+    metadata: {
+      name: 'metrics-server',
+      labels: { 'giantswarm.io/managed-by': 'cluster-operator' },
+    },
     spec: {
       catalog: 'default',
       name: 'metrics-server-app',
@@ -375,7 +402,10 @@ export const appsResponse = [
     },
   },
   {
-    metadata: { name: 'node-exporter' },
+    metadata: {
+      name: 'node-exporter',
+      labels: { 'giantswarm.io/managed-by': 'cluster-operator' },
+    },
     spec: {
       catalog: 'default',
       name: 'node-exporter-app',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5051,9 +5051,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-"giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git":
+"giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git#add-app-labels":
   version "4.0.0"
-  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#929066e353b4c563904b2242cdae47af3139fb70"
+  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#32fc8c69b5107f2ed61e76a04cd1c070e7da136c"
   dependencies:
     superagent "3.8.3"
 


### PR DESCRIPTION
This filters out apps like `chart-operator`, `kube-state-metrics`, `metrics-server`, and `node-exporter`

from the user installed apps list. They appear there now because we have `App CRs` for them in the meanwhile and Happa assumed every App was user installed.