### PR TITLE
More minor fixes for Azure and KVM WorkersNodes components

### DIFF
--- a/src/components/cluster/detail/NodesRunning.js
+++ b/src/components/cluster/detail/NodesRunning.js
@@ -33,8 +33,8 @@ const NodesRunning = ({ workerNodesRunning, RAM, CPUs, nodePools }) => {
 
 NodesRunning.propTypes = {
   workerNodesRunning: PropTypes.number,
-  RAM: PropTypes.number,
-  CPUs: PropTypes.number,
+  RAM: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  CPUs: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   nodePools: PropTypes.array,
 };
 

--- a/src/components/cluster/detail/NodesRunning.js
+++ b/src/components/cluster/detail/NodesRunning.js
@@ -33,6 +33,7 @@ const NodesRunning = ({ workerNodesRunning, RAM, CPUs, nodePools }) => {
 
 NodesRunning.propTypes = {
   workerNodesRunning: PropTypes.number,
+  // TODO Change this when cluster_utils functions are refactored
   RAM: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   CPUs: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   nodePools: PropTypes.array,

--- a/src/components/cluster/detail/WorkerNodesAzure.js
+++ b/src/components/cluster/detail/WorkerNodesAzure.js
@@ -40,8 +40,8 @@ function WorkerNodesAzure({ instanceType, nodes, showScalingModal }) {
       </LineDiv>
       <LineDiv>
         <div>Nodes</div>
-        {nodes && (
-          <RefreshableLabel value={nodes} style={{ marginRight: '30px' }}>
+        {nodes && nodes !== 0 && (
+          <RefreshableLabel value={nodes} style={{ marginRight: '25px' }}>
             {nodes}
           </RefreshableLabel>
         )}

--- a/src/components/cluster/detail/WorkerNodesKVM.js
+++ b/src/components/cluster/detail/WorkerNodesKVM.js
@@ -17,9 +17,11 @@ function WorkerNodesKVM({ worker, nodes, showScalingModal }) {
       </LineDiv>
       <LineDiv>
         <div>Nodes</div>
-        <div style={{ marginRight: '30px' }}>
-          {nodes && <RefreshableLabel value={nodes}>{nodes}</RefreshableLabel>}
-        </div>
+        {nodes && nodes !== 0 && (
+          <RefreshableLabel value={nodes} style={{ marginRight: '25px' }}>
+            {nodes}
+          </RefreshableLabel>
+        )}
         <Button onClick={showScalingModal}>Edit</Button>
       </LineDiv>
     </WrapperDiv>

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,8 @@
 
   <script>
   var config = {
-    apiEndpoint: 'http://localhost:8000',
+    // apiEndpoint: 'http://localhost:8000',
+    apiEndpoint: 'https://api.g8s.ghost.westeurope.azure.gigantic.io',
     passageEndpoint: 'http://localhost:5001',
 
     // environment is set to:

--- a/src/index.html
+++ b/src/index.html
@@ -17,8 +17,7 @@
 
   <script>
   var config = {
-    // apiEndpoint: 'http://localhost:8000',
-    apiEndpoint: 'https://api.g8s.ghost.westeurope.azure.gigantic.io',
+    apiEndpoint: 'http://localhost:8000',
     passageEndpoint: 'http://localhost:5001',
 
     // environment is set to:


### PR DESCRIPTION
This fixes worker nodes not being rendered when `workerNodes === 0`.

Also, this is a dirty fix for a warning from `PropTypes` in `NodesRunning` also when when `workerNodes === 0`.

I created an issue for improving this, cause it feels like we can do it better here: https://github.com/giantswarm/giantswarm/issues/7852