### PR TITLE
Add unsafe chrome configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,14 @@
     {
       "type": "chrome",
       "request": "launch",
+      "name": "Debug happa [UNSAFE MODE]",
+      "runtimeArgs": ["--disable-web-security"],
+      "url": "http://localhost:7000",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
       "name": "Debug happa",
       "url": "http://localhost:7000",
       "webRoot": "${workspaceFolder}"


### PR DESCRIPTION
Enable VSCode debugging with the help of an unsafe chrome session (no moar CORS)