### PR TITLE
Don't show empty state when switching orgs.

### DIFF
--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -93,7 +93,7 @@ class Home extends React.Component {
                     <i className='fa fa-add-circle' /> Launch New Cluster
                   </Button>
                 </Link>
-                {this.props.clusters.length === 0
+                {this.props.clusters.length === 0 && !this.props.clustersLoading
                   ? 'Ready to launch your first cluster? Click the green button!'
                   : ''}
               </div>
@@ -101,7 +101,7 @@ class Home extends React.Component {
               undefined
             )}
 
-            {this.props.clusters.length === 0 ? (
+            {this.props.clusters.length === 0 && !this.props.clustersLoading ? (
               <ClusterEmptyState
                 errorLoadingClusters={this.props.errorLoadingClusters}
                 organizations={this.props.organizations}
@@ -171,6 +171,7 @@ function mapStateToProps(state) {
   var errorLoadingClusters = state.entities.clusters.errorLoading;
   const nodePoolsClusters = state.entities.clusters.nodePoolsClusters;
   const nodePools = state.entities.nodePools.items;
+  const clustersLoading = state.entities.clusters.isFetching;
 
   var clusters = [];
   if (selectedOrganization) {
@@ -181,6 +182,7 @@ function mapStateToProps(state) {
 
   return {
     clusters: clusters,
+    clustersLoading,
     organizations: organizations,
     errorLoadingClusters: errorLoadingClusters,
     selectedOrganization: selectedOrganization,

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -28,6 +28,10 @@ const initialState = {
 
 const clusterReducer = produce((draft, action) => {
   switch (action.type) {
+    case types.CLUSTERS_LOAD:
+      draft.isFetching = true;
+      return;
+
     case types.CLUSTERS_LOAD_SUCCESS:
       Object.keys(action.v4Clusters).forEach(clusterId => {
         const withAwsKeys = ensureWorkersHaveAWSkey(
@@ -43,6 +47,7 @@ const clusterReducer = produce((draft, action) => {
       });
       draft.lastUpdated = action.lastUpdated;
       draft.nodePoolsClusters = action.nodePoolsClusters;
+      draft.isFetching = false;
       return;
 
     case types.CLUSTERS_LOAD_ERROR:


### PR DESCRIPTION
Fixes the empty state that pops up when switching orgs.