### PR TITLE
Restore Fragment wrapper

### DIFF
--- a/src/components/app_catalog/AppList/AppList.js
+++ b/src/components/app_catalog/AppList/AppList.js
@@ -19,15 +19,17 @@ const AppList = ({ catalog, ...props }) => {
       }}
     >
       <DocumentTitle title={'Apps | Giant Swarm '}>
-        <Link className='back-link' to={'/app-catalogs/'}>
-          <i aria-hidden='true' className='fa fa-chevron-left' />
-          Back to all catalogs
-        </Link>
-        <br />
-        <br />
-        <LoadingOverlay loading={isLoading}>
-          <AppListInner catalog={catalog} {...props} />
-        </LoadingOverlay>
+        <>
+          <Link className='back-link' to={'/app-catalogs/'}>
+            <i aria-hidden='true' className='fa fa-chevron-left' />
+            Back to all catalogs
+          </Link>
+          <br />
+          <br />
+          <LoadingOverlay loading={isLoading}>
+            <AppListInner catalog={catalog} {...props} />
+          </LoadingOverlay>
+        </>
       </DocumentTitle>
     </Breadcrumb>
   );


### PR DESCRIPTION
This PR restores the required Fragment to the AppList component in the AppCatalog. It seems the DocumentTitle Component only supports single element children. ¯\_(ツ)_/¯