### PR TITLE
Prevent exception for clusters being undefined

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -87,9 +87,10 @@ export function clustersLoad() {
       });
 
     // Extract v4 clusters from the clusters fetched array.
-    const v4Clusters = clusters.filter(cluster =>
-      cluster.path.startsWith('/v4')
-    );
+    let v4Clusters = [];
+    if (clusters) {
+      v4Clusters = clusters.filter(cluster => cluster.path.startsWith('/v4'));
+    }
 
     // TODO at some point we will probably have just one flow for all clusters.
     // Now we can't as we are not computing capabilities and not getting status


### PR DESCRIPTION
This is an attempt to prevent the following exception:

```
TypeError: Cannot read property 'filter' of undefined
 at filter (webpack:///./src/actions/clusterActions.js:90:32)
 at call (webpack:///./node_modules/babel-polyfill/node_modules/regenerator-runtime/runtime.js:65:39)
 at tryCatch (webpack:///./node_modules/babel-polyfill/node_modules/regenerator-runtime/runtime.js:303:21)
 at _invoke (webpack:///./node_modules/babel-polyfill/node_modules/regenerator-runtime/runtime.js:117:20)
 at  (webpack:///./src/actions/nodePoolActions.js:238:2)
 at  (webpack:///./src/actions/nodePoolActions.js:238:2)
```