### PR TITLE
Fix an exception when clicking on an AZ label

### DIFF
--- a/src/components/UI/AvailabilityZonesLabel.js
+++ b/src/components/UI/AvailabilityZonesLabel.js
@@ -86,16 +86,15 @@ function AvailabilityZonesLabel({
     isMaxReached && !isRadioButtons ? 'is-max-reached' : '';
   const classNames = `${letter} ${notCheckedClass} ${pointerClass} ${isMaxReachedClass}`;
 
+  const onClick = () => {
+    isMaxReached && !isChecked && !isRadioButtons
+      ? null
+      : onToggleChecked &&
+        onToggleChecked(!isChecked, { title, letter, label });
+  };
+
   return (
-    <Wrapper
-      className={classNames}
-      title={title}
-      onClick={
-        isMaxReached && !isChecked && !isRadioButtons
-          ? null
-          : () => onToggleChecked(!isChecked, { title, letter, label })
-      }
-    >
+    <Wrapper className={classNames} title={title} onClick={onClick}>
       {label}
     </Wrapper>
   );


### PR DESCRIPTION
This adds a check for `onToggleChecked` to the `onClick` action of the AZ Label, so that we do not try to call an undefined function.

I moved the onClick logic out of the JSX and into a function called `onClick` as a little refactoring.

another note I have here is that I think this component is too smart about what it is and what kinds of context it is used in.

I would just expect it to take a onClick function, that we will call if it is not undefined.

right now it seems to know more about the specific situations it will be in, and that kind of logic is I think better left to the implementor of this component. 

But opting not to refactor that now.