### PR TITLE
Make prettier only focus on js files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "pretty-quick --staged --pattern ./src/**/*.js"
     }
   }
 }


### PR DESCRIPTION
So that we don't run prettier on `yaml` or `html` if they happen to be in our commit.