### PR TITLE
Fix cluster creation payload structure for master node availability zone

### DIFF
--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -280,20 +280,22 @@ class CreateNodePoolsCluster extends Component {
       np => np.data
     );
 
+    let createPayload = {
+      owner: this.props.selectedOrganization,
+      name: this.state.name.value,
+      release_version: this.props.selectedRelease,
+      master: {},
+    };
+
+    if (this.state.hasAZLabels) {
+      // TODO: don't use array here as long as there can be only one master node.
+      createPayload.master = this.state.availabilityZonesLabels.zonesArray[0];
+    }
+
     try {
       const newCluster = await this.props.dispatch(
-        // TODO: Remove random AZ generation here, as this is done on the API side.
         clusterCreate(
-          {
-            owner: this.props.selectedOrganization,
-            name: this.state.name.value,
-            release_version: this.props.selectedRelease,
-            master: {
-              availability_zone: this.state.hasAZLabels
-                ? this.state.availabilityZonesLabels.zonesArray
-                : this.state.availabilityZonesRandom.value,
-            },
-          },
+          createPayload,
           true // is v5
         )
       );

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -284,12 +284,13 @@ class CreateNodePoolsCluster extends Component {
       owner: this.props.selectedOrganization,
       name: this.state.name.value,
       release_version: this.props.selectedRelease,
-      master: {},
     };
 
     if (this.state.hasAZLabels) {
       // TODO: don't use array here as long as there can be only one master node.
-      createPayload.master = this.state.availabilityZonesLabels.zonesArray[0];
+      createPayload.master = {
+        availability_zones: this.state.availabilityZonesLabels.zonesArray[0],
+      };
     }
 
     try {

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -280,7 +280,7 @@ class CreateNodePoolsCluster extends Component {
       np => np.data
     );
 
-    let createPayload = {
+    const createPayload = {
       owner: this.props.selectedOrganization,
       name: this.state.name.value,
       release_version: this.props.selectedRelease,

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -282,13 +282,14 @@ class CreateNodePoolsCluster extends Component {
 
     try {
       const newCluster = await this.props.dispatch(
+        // TODO: Remove random AZ generation here, as this is done on the API side.
         clusterCreate(
           {
             owner: this.props.selectedOrganization,
             name: this.state.name.value,
             release_version: this.props.selectedRelease,
             master: {
-              availabilityZone: this.state.hasAZLabels
+              availability_zone: this.state.hasAZLabels
                 ? this.state.availabilityZonesLabels.zonesArray
                 : this.state.availabilityZonesRandom.value,
             },

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -289,7 +289,7 @@ class CreateNodePoolsCluster extends Component {
     if (this.state.hasAZLabels) {
       // TODO: don't use array here as long as there can be only one master node.
       createPayload.master = {
-        availability_zones: this.state.availabilityZonesLabels.zonesArray[0],
+        availability_zone: this.state.availabilityZonesLabels.zonesArray[0],
       };
     }
 


### PR DESCRIPTION
Fix https://github.com/giantswarm/giantswarm/issues/8205

The attribute name submitted in the POST request for cluster creation is fixed to `availability_zone`. Before, the name `availabilityZone` was used, which caused the API to ignore the attribute as unknown.

### Business logic change

In addition, the `master` attribute is only set when the user has manually selected an availability zone to use. Otherwise it is not contained in the payload, to leave defaulting to the API.