### PR TITLE
More organizations tests

### DIFF
--- a/__tests__/Login.js
+++ b/__tests__/Login.js
@@ -1,17 +1,19 @@
 import '@testing-library/jest-dom/extend-expect';
 import {
+  API_ENDPOINT,
+  AWSInfoResponse,
   authTokenResponse,
   getPersistedMockCall,
-  AWSInfoResponse,
   postMockCall,
   userResponse,
 } from 'testUtils/mockHttpCalls';
 import { fireEvent, wait } from '@testing-library/react';
-import { renderRouteWithStore } from 'testUtils/renderUtils';
+import { StatusCodes } from 'shared/constants';
 import nock from 'nock';
+import { renderRouteWithStore } from 'testUtils/renderUtils';
 
 it('renders the login page at /login', async () => {
-  const { getByText } = renderRouteWithStore('/login');
+  const { getByText } = renderRouteWithStore('/login', {}, {});
 
   await wait(() => {
     expect(getByText('Log in to Giant Swarm')).toBeInTheDocument();
@@ -114,15 +116,16 @@ it('tells the user to give a email if they leave it blank', async () => {
 
 it('shows an error if the user logs in with invalid credentials', async () => {
   // Don't want to pollute the terminal with this error
+  /* eslint-disable no-console */
   const originalConsoleError = console.error;
   console.error = jest.fn();
 
   // Given I have a Giant Swarm API that does not accept my login attempt
 
   // The failed 401 response to the login call
-  const authTokensRequest = nock('http://localhost:8000')
+  const authTokensRequest = nock(API_ENDPOINT)
     .post('/v4/auth-tokens/')
-    .reply(401);
+    .reply(StatusCodes.Unauthorized);
 
   // And I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore('/login', {}, {});
@@ -145,6 +148,8 @@ it('shows an error if the user logs in with invalid credentials', async () => {
     expect(getByText(/Could not log in/i)).toBeInTheDocument();
   });
 
+  authTokensRequest.done();
   // Restore console.og
   console.error = originalConsoleError;
+  /* eslint-enable no-console */
 });

--- a/__tests__/Organization.js
+++ b/__tests__/Organization.js
@@ -50,211 +50,216 @@ afterEach(() => {
   nock.cleanAll();
 });
 
-it('navigation has selected the right page when in organization list route', async () => {
-  getMockCall('/v4/organizations/', orgsResponse);
-  const { getByText } = renderRouteWithStore(BASE_ROUTE);
-
-  await wait(() => {
-    expect(
-      //
-      getByText(
-        (content, element) =>
-          element.tagName.toLowerCase() === 'a' &&
-          element.attributes['aria-current'] &&
-          element.attributes['aria-current'].value === 'page' &&
-          content === 'Organizations'
-      )
-    ).toBeInTheDocument();
-  });
-});
-
-it('correctly renders the organizations list', async () => {
-  getMockCall('/v4/organizations/', orgsResponse);
-  const { getByText, getByTestId } = renderRouteWithStore(BASE_ROUTE);
-
-  // We want to make sure correct values appear in the row for number of clusters
-  // and members.
-  const members = orgResponse.members.length.toString();
-  const clusters = v4ClustersResponse
-    .filter(cluster => cluster.owner === orgResponse.id)
-    .length.toString();
-
-  await wait(() =>
-    expect(getByTestId(`${orgResponse.id}-name`)).toBeInTheDocument()
-  );
-
-  expect(getByTestId(`${orgResponse.id}-members`).textContent).toBe(members);
-  expect(getByTestId(`${orgResponse.id}-clusters`).textContent).toBe(clusters);
-  expect(getByTestId(`${orgResponse.id}-delete`)).toBeInTheDocument();
-
-  expect(getByText(/create new organization/i)).toBeInTheDocument();
-});
-
-it('shows the organization creation modal when requested and organization creation success flash', async () => {
-  getMockCall('/v4/organizations/', orgsResponse);
-  const newOrganizationId = generateRandomString();
-  const newOrganizationPutRequest = nock(API_ENDPOINT)
-    .intercept(`/v4/organizations/${newOrganizationId}/`, 'PUT')
-    .reply(StatusCodes.Created, { id: newOrganizationId, members: null });
-
-  const { getByText, getByLabelText, getByTestId } = renderRouteWithStore(
-    BASE_ROUTE
-  );
-
-  await wait(() => {
-    expect(getByText('Create New Organization')).toBeInTheDocument();
-  });
-  fireEvent.click(getByText('Create New Organization'));
-
-  await wait(() => {
-    expect(getByText('Create an Organization')).toBeInTheDocument();
+describe('Organizations basic', () => {
+  beforeEach(() => {
+    getMockCall('/v4/organizations/', orgsResponse);
   });
 
-  const newOrganizationNameInput = getByLabelText(/Organization Name:/);
-  expect(newOrganizationNameInput).toBeInTheDocument();
+  it('navigation has selected the right page when in organization list route', async () => {
+    const { getByText } = renderRouteWithStore(BASE_ROUTE);
 
-  fireEvent.change(newOrganizationNameInput, {
-    target: { value: newOrganizationId },
+    await wait(() => {
+      expect(
+        getByText(
+          (content, element) =>
+            element.tagName.toLowerCase() === 'a' &&
+            element.attributes['aria-current'] &&
+            element.attributes['aria-current'].value === 'page' &&
+            content === 'Organizations'
+        )
+      ).toBeInTheDocument();
+    });
   });
 
-  fireEvent.click(getByText('Create Organization'));
+  it('correctly renders the organizations list', async () => {
+    const { getByText, getByTestId } = renderRouteWithStore(BASE_ROUTE);
 
-  newOrganizationPutRequest.done();
-  getMockCall(`/v4/organizations/${newOrganizationId}/`, {
-    id: newOrganizationId,
-    members: [],
-    credentials: null,
-  });
-  getMockCall(`/v4/organizations/${newOrganizationId}/credentials/`);
+    // We want to make sure correct values appear in the row for number of clusters
+    // and members.
+    const members = orgResponse.members.length.toString();
+    const clusters = v4ClustersResponse
+      .filter(cluster => cluster.owner === orgResponse.id)
+      .length.toString();
 
-  const updatedOrganizationsRequest = getMockCall('/v4/organizations/', [
-    ...orgsResponse,
-    { id: newOrganizationId },
-  ]);
-
-  await wait(() => {
-    expect(
-      getByText(
-        (_, element) =>
-          element.innerHTML ===
-          `Organization <code>${newOrganizationId}</code> has been created`
-      )
-    ).toBeInTheDocument();
-  });
-  updatedOrganizationsRequest.done();
-
-  await wait(() => {
-    expect(getByTestId(`${newOrganizationId}-name`)).toBeInTheDocument();
-  });
-});
-
-it('shows the organization deletion modal when requested and organization deletion success flash', async () => {
-  const organizationToDeleteId = generateRandomString();
-  getMockCall('/v4/organizations/', [
-    ...orgsResponse,
-    { id: organizationToDeleteId },
-  ]);
-  const organizationToDeleteRequest = getMockCall(
-    `/v4/organizations/${organizationToDeleteId}/`,
-    {
-      id: organizationToDeleteId,
-      members: [],
-      credentials: [],
-    }
-  );
-  const credentialsRequest = getMockCall(
-    `/v4/organizations/${organizationToDeleteId}/credentials/`
-  );
-  const deleteOrganizationRequest = nock(API_ENDPOINT)
-    .intercept(`/v4/organizations/${organizationToDeleteId}/`, 'DELETE')
-    .reply(StatusCodes.Ok, {
-      code: 'RESOURCE_DELETED',
-      message: `The organization with ID \`${organizationToDeleteId}\` has been deleted.`,
+    await wait(() => {
+      expect(getByTestId(`${orgResponse.id}-name`)).toBeInTheDocument();
     });
 
-  const { getByText, getByTestId, queryByTestId } = renderRouteWithStore(
-    BASE_ROUTE
-  );
+    expect(getByTestId(`${orgResponse.id}-members`).textContent).toBe(members);
+    expect(getByTestId(`${orgResponse.id}-clusters`).textContent).toBe(
+      clusters
+    );
+    expect(getByTestId(`${orgResponse.id}-delete`)).toBeInTheDocument();
 
-  await wait(() => {
-    expect(getByTestId(`${organizationToDeleteId}-name`)).toBeInTheDocument();
+    expect(getByText(/create new organization/i)).toBeInTheDocument();
   });
 
-  organizationToDeleteRequest.done();
-  credentialsRequest.done();
+  it('shows the organization creation modal when requested and organization creation success flash', async () => {
+    const newOrganizationId = generateRandomString();
+    const newOrganizationPutRequest = nock(API_ENDPOINT)
+      .intercept(`/v4/organizations/${newOrganizationId}/`, 'PUT')
+      .reply(StatusCodes.Created, { id: newOrganizationId, members: null });
 
-  fireEvent.click(getByTestId(`${organizationToDeleteId}-delete`));
+    const { getByText, getByLabelText, getByTestId } = renderRouteWithStore(
+      BASE_ROUTE
+    );
 
-  await wait(() => {
+    await wait(() => {
+      expect(getByText('Create New Organization')).toBeInTheDocument();
+    });
+    fireEvent.click(getByText('Create New Organization'));
+
+    await wait(() => {
+      expect(getByText('Create an Organization')).toBeInTheDocument();
+    });
+
+    const newOrganizationNameInput = getByLabelText(/Organization Name:/);
+    expect(newOrganizationNameInput).toBeInTheDocument();
+
+    fireEvent.change(newOrganizationNameInput, {
+      target: { value: newOrganizationId },
+    });
+
+    fireEvent.click(getByText('Create Organization'));
+
+    newOrganizationPutRequest.done();
+    getMockCall(`/v4/organizations/${newOrganizationId}/`, {
+      id: newOrganizationId,
+      members: [],
+      credentials: null,
+    });
+    getMockCall(`/v4/organizations/${newOrganizationId}/credentials/`);
+
+    const updatedOrganizationsRequest = getMockCall('/v4/organizations/', [
+      ...orgsResponse,
+      { id: newOrganizationId },
+    ]);
+
+    await wait(() => {
+      expect(
+        getByText(
+          (_, element) =>
+            element.innerHTML ===
+            `Organization <code>${newOrganizationId}</code> has been created`
+        )
+      ).toBeInTheDocument();
+    });
+    updatedOrganizationsRequest.done();
+
+    await wait(() => {
+      expect(getByTestId(`${newOrganizationId}-name`)).toBeInTheDocument();
+    });
+  });
+
+  it('shows organization details correctly', async () => {
+    const {
+      findByText,
+      getByText,
+      getByTestId,
+      queryByTestId,
+      getByTitle,
+    } = renderRouteWithStore(`${BASE_ROUTE}/${orgResponse.id}`);
+
+    const pageTitle = await findByText(`Organization: ${orgResponse.id}`);
+    expect(pageTitle).toBeInTheDocument();
+
+    // id column in clusters table
+    expect(
+      getByTitle(`Unique Cluster ID: ${v4AWSClusterResponse.id}`)
+    ).toBeInTheDocument();
+
+    // name cloumn in clusters table
+    expect(getByText(V4_CLUSTER.name)).toBeInTheDocument();
+
+    // release column in clusters table
+    expect(getByText(V4_CLUSTER.releaseVersion)).toBeInTheDocument();
+
+    // users
+    const usersTable = getByTestId('org-detail-users-wrapper');
+    expect(usersTable.querySelector('tbody > tr > td').textContent).toBe(
+      orgResponse.members[0].email
+    );
+
+    await wait(() => {
+      expect(queryByTestId('Loading credentials')).not.toBeInTheDocument();
+    });
+
     expect(
       getByText(
-        (_, element) =>
-          element.textContent ===
-          `Are you sure you want to delete ${organizationToDeleteId}?`
+        'No credentials set. Clusters of this organization will be created in the default tenant cluster account of this installation.'
       )
     ).toBeInTheDocument();
-    expect(getByText('There is no undo')).toBeInTheDocument();
-  });
-
-  getMockCall('/v4/organizations/', orgsResponse);
-  fireEvent.click(getByText('Delete Organization'));
-
-  await wait(() => {
-    expect(
-      getByText(
-        (_, element) =>
-          element.innerHTML ===
-          `Organization <code>${organizationToDeleteId}</code> deleted`
-      )
-    ).toBeInTheDocument();
-  });
-
-  deleteOrganizationRequest.done();
-  await wait(() => {
-    expect(getByTestId(`${orgResponse.id}-name`)).toBeInTheDocument();
-    expect(
-      queryByTestId(`${organizationToDeleteId}-name`)
-    ).not.toBeInTheDocument();
   });
 });
 
-it('shows organization details correctly', async () => {
-  getMockCall('/v4/organizations/', orgsResponse);
-  const {
-    findByText,
-    getByText,
-    getByTestId,
-    queryByTestId,
-    getByTitle,
-  } = renderRouteWithStore(`${BASE_ROUTE}/${orgResponse.id}`);
+describe('Organization deletion', () => {
+  it('shows the organization deletion modal when requested and organization deletion success flash', async () => {
+    const organizationToDeleteId = generateRandomString();
+    getMockCall('/v4/organizations/', [
+      ...orgsResponse,
+      { id: organizationToDeleteId },
+    ]);
+    const organizationToDeleteRequest = getMockCall(
+      `/v4/organizations/${organizationToDeleteId}/`,
+      {
+        id: organizationToDeleteId,
+        members: [],
+        credentials: [],
+      }
+    );
+    const credentialsRequest = getMockCall(
+      `/v4/organizations/${organizationToDeleteId}/credentials/`
+    );
+    const deleteOrganizationRequest = nock(API_ENDPOINT)
+      .intercept(`/v4/organizations/${organizationToDeleteId}/`, 'DELETE')
+      .reply(StatusCodes.Ok, {
+        code: 'RESOURCE_DELETED',
+        message: `The organization with ID \`${organizationToDeleteId}\` has been deleted.`,
+      });
 
-  const pageTitle = await findByText(`Organization: ${orgResponse.id}`);
-  expect(pageTitle).toBeInTheDocument();
+    const { getByText, getByTestId, queryByTestId } = renderRouteWithStore(
+      BASE_ROUTE
+    );
 
-  // id column in clusters table
-  expect(
-    getByTitle(`Unique Cluster ID: ${v4AWSClusterResponse.id}`)
-  ).toBeInTheDocument();
+    await wait(() => {
+      expect(getByTestId(`${organizationToDeleteId}-name`)).toBeInTheDocument();
+    });
 
-  // name cloumn in clusters table
-  expect(getByText(V4_CLUSTER.name)).toBeInTheDocument();
+    organizationToDeleteRequest.done();
+    credentialsRequest.done();
 
-  // release column in clusters table
-  expect(getByText(V4_CLUSTER.releaseVersion)).toBeInTheDocument();
+    fireEvent.click(getByTestId(`${organizationToDeleteId}-delete`));
 
-  // users
-  const usersTable = getByTestId('org-detail-users-wrapper');
-  expect(usersTable.querySelector('tbody > tr > td').textContent).toBe(
-    orgResponse.members[0].email
-  );
+    await wait(() => {
+      expect(
+        getByText(
+          (_, element) =>
+            element.textContent ===
+            `Are you sure you want to delete ${organizationToDeleteId}?`
+        )
+      ).toBeInTheDocument();
+      expect(getByText('There is no undo')).toBeInTheDocument();
+    });
 
-  await wait(() => {
-    expect(queryByTestId('Loading credentials')).not.toBeInTheDocument();
+    getMockCall('/v4/organizations/', orgsResponse);
+    fireEvent.click(getByText('Delete Organization'));
+
+    await wait(() => {
+      expect(
+        getByText(
+          (_, element) =>
+            element.innerHTML ===
+            `Organization <code>${organizationToDeleteId}</code> deleted`
+        )
+      ).toBeInTheDocument();
+    });
+
+    deleteOrganizationRequest.done();
+    await wait(() => {
+      expect(getByTestId(`${orgResponse.id}-name`)).toBeInTheDocument();
+      expect(
+        queryByTestId(`${organizationToDeleteId}-name`)
+      ).not.toBeInTheDocument();
+    });
   });
-
-  expect(
-    getByText(
-      'No credentials set. Clusters of this organization will be created in the default tenant cluster account of this installation.'
-    )
-  ).toBeInTheDocument();
 });

--- a/__tests__/Organization.js
+++ b/__tests__/Organization.js
@@ -1,25 +1,26 @@
 import '@testing-library/jest-dom/extend-expect';
+
+import { fireEvent, wait } from '@testing-library/react';
+import nock from 'nock';
+import { StatusCodes } from 'shared/constants';
 import {
   API_ENDPOINT,
-  AWSInfoResponse,
-  ORGANIZATION,
-  V4_CLUSTER,
   appCatalogsResponse,
   appsResponse,
+  AWSInfoResponse,
   generateRandomString,
   getMockCall,
   getPersistedMockCall,
+  ORGANIZATION,
   orgResponse,
   orgsResponse,
   releasesResponse,
   userResponse,
+  V4_CLUSTER,
   v4AWSClusterResponse,
   v4AWSClusterStatusResponse,
   v4ClustersResponse,
 } from 'testUtils/mockHttpCalls';
-import { fireEvent, wait } from '@testing-library/react';
-import { StatusCodes } from 'shared/constants';
-import nock from 'nock';
 import { renderRouteWithStore } from 'testUtils/renderUtils';
 
 const BASE_ROUTE = '/organizations';

--- a/__tests__/Organization.js
+++ b/__tests__/Organization.js
@@ -189,8 +189,8 @@ it('shows the organization deletion modal when requested and organization deleti
     expect(
       getByText(
         (_, element) =>
-          element.innerHTML ===
-          `Are you sure you want to delete <code>${organizationToDeleteId}</code>?`
+          element.textContent ===
+          `Are you sure you want to delete ${organizationToDeleteId}?`
       )
     ).toBeInTheDocument();
     expect(getByText('There is no undo')).toBeInTheDocument();
@@ -216,4 +216,45 @@ it('shows the organization deletion modal when requested and organization deleti
       queryByTestId(`${organizationToDeleteId}-name`)
     ).not.toBeInTheDocument();
   });
+});
+
+it('shows organization details correctly', async () => {
+  getMockCall('/v4/organizations/', orgsResponse);
+  const {
+    getByText,
+    getByTestId,
+    queryByTestId,
+    getByTitle,
+  } = renderRouteWithStore(`${BASE_ROUTE}/${orgResponse.id}`);
+
+  await wait(() => {
+    expect(getByText(`Organization: ${orgResponse.id}`)).toBeInTheDocument();
+  });
+
+  // id column in clusters table
+  expect(
+    getByTitle(`Unique Cluster ID: ${v4AWSClusterResponse.id}`)
+  ).toBeInTheDocument();
+
+  // name cloumn in clusters table
+  expect(getByText(V4_CLUSTER.name)).toBeInTheDocument();
+
+  // release column in clusters table
+  expect(getByText(V4_CLUSTER.releaseVersion)).toBeInTheDocument();
+
+  // users
+  const usersTable = getByTestId('org-detail-users-wrapper');
+  expect(usersTable.querySelector('tbody > tr > td').textContent).toBe(
+    orgResponse.members[0].email
+  );
+
+  await wait(() => {
+    expect(queryByTestId('Loading credentials')).not.toBeInTheDocument();
+  });
+
+  expect(
+    getByText(
+      'No credentials set. Clusters of this organization will be created in the default tenant cluster account of this installation.'
+    )
+  ).toBeInTheDocument();
 });

--- a/__tests__/Organization.js
+++ b/__tests__/Organization.js
@@ -221,15 +221,15 @@ it('shows the organization deletion modal when requested and organization deleti
 it('shows organization details correctly', async () => {
   getMockCall('/v4/organizations/', orgsResponse);
   const {
+    findByText,
     getByText,
     getByTestId,
     queryByTestId,
     getByTitle,
   } = renderRouteWithStore(`${BASE_ROUTE}/${orgResponse.id}`);
 
-  await wait(() => {
-    expect(getByText(`Organization: ${orgResponse.id}`)).toBeInTheDocument();
-  });
+  const pageTitle = await findByText(`Organization: ${orgResponse.id}`);
+  expect(pageTitle).toBeInTheDocument();
 
   // id column in clusters table
   expect(

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,7 @@ module.exports = {
   globals: {
     // window.config object will now be available in all tests
     config: {
-      apiEndpoint: 'http://localhost:8000',
+      apiEndpoint: 'http://1.2.3.4',
       passageEndpoint: 'http://localhost:5001',
       environment: 'development',
       ingressBaseDomain: 'k8s.sample.io',

--- a/src/actions/organizationActions.js
+++ b/src/actions/organizationActions.js
@@ -178,7 +178,7 @@ export function organizationDeleteConfirmed(orgId) {
       .deleteOrganization(orgId)
       .then(() => {
         new FlashMessage(
-          `Organization  <code>${orgId}</code> deleted`,
+          `Organization <code>${orgId}</code> deleted`,
           messageType.INFO,
           messageTTL.SHORT
         );

--- a/src/components/Modals/Modals.js
+++ b/src/components/Modals/Modals.js
@@ -193,8 +193,8 @@ class Modals extends React.Component {
               </p>
 
               <form onSubmit={this.addMember.bind(this)}>
-                <label>Email:</label>
                 <EmailField
+                  label='Email:'
                   autofocus
                   errorMessage={this.props.modal.templateValues.errorMessage}
                   name='email'

--- a/src/components/Organizations/Detail/View.js
+++ b/src/components/Organizations/Detail/View.js
@@ -179,7 +179,7 @@ class OrganizationDetail extends React.Component {
               <div className='col-3'>
                 <h3 className='table-label'>Members</h3>
               </div>
-              <div className='col-9'>
+              <div className='col-9' data-testid='org-detail-users-wrapper'>
                 {this.props.organization.members.length === 0 ? (
                   <p>This organization has no members</p>
                 ) : (

--- a/testUtils/mockHttpCalls/constantsAndHelpers.js
+++ b/testUtils/mockHttpCalls/constantsAndHelpers.js
@@ -23,6 +23,12 @@ export const getMockCall = (endpoint, response = []) =>
     .get(endpoint)
     .reply(StatusCodes.Ok, response);
 
+export const getMockCallTimes = (endpoint, response = [], times = 1) =>
+  nock(API_ENDPOINT)
+    .get(endpoint)
+    .times(times)
+    .reply(StatusCodes.Ok, response);
+
 export const getPersistedMockCall = (endpoint, response = []) =>
   nock(API_ENDPOINT)
     .persist()

--- a/testUtils/mockHttpCalls/constantsAndHelpers.js
+++ b/testUtils/mockHttpCalls/constantsAndHelpers.js
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'shared/constants';
 import nock from 'nock';
 
 export const API_ENDPOINT = 'http://localhost:8000';
@@ -17,24 +18,24 @@ export const V5_CLUSTER = {
 };
 
 /***** Helper functions *****/
-/* eslint-disable no-magic-numbers */
 export const getMockCall = (endpoint, response = []) =>
   nock(API_ENDPOINT)
     .get(endpoint)
-    .reply(200, response);
+    .reply(StatusCodes.Ok, response);
 
 export const getPersistedMockCall = (endpoint, response = []) =>
   nock(API_ENDPOINT)
     .persist()
     .get(endpoint)
-    .reply(200, response);
+    .reply(StatusCodes.Ok, response);
 
 export const postMockCall = (endpoint, response = []) =>
   nock(API_ENDPOINT)
     .post(endpoint)
-    .reply(200, response);
+    .reply(StatusCodes.Ok, response);
 
 // https://gist.github.com/6174/6062387#gistcomment-2651745
+/* eslint-disable no-magic-numbers */
 export const generateRandomString = (length = 8) =>
   Array.from({ length }, () => (~~(Math.random() * 36)).toString(36)).join('');
 /* eslint-enable no-magic-numbers */

--- a/testUtils/mockHttpCalls/constantsAndHelpers.js
+++ b/testUtils/mockHttpCalls/constantsAndHelpers.js
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'shared/constants';
 import nock from 'nock';
 
-export const API_ENDPOINT = 'http://localhost:8000';
+export const API_ENDPOINT = 'http://1.2.3.4';
 export const USER_EMAIL = 'developer@giantswarm.io';
 export const ORGANIZATION = 'acme';
 export const V4_CLUSTER = {

--- a/testUtils/mockHttpCalls/user.js
+++ b/testUtils/mockHttpCalls/user.js
@@ -3,5 +3,5 @@ import { USER_EMAIL } from './constantsAndHelpers';
 export const userResponse = {
   email: USER_EMAIL,
   created: '2019-09-19T12:40:16.2231629Z',
-  expiry: '2020-01-01T00:00:00Z',
+  expiry: new Date(Date.now() + 31556952000).toISOString(), // eslint-disable-line no-magic-numbers
 };


### PR DESCRIPTION
This contains some changes:

- I changed the `API_ENDPOINT` to differ from the one used in local development, to prevent accidental usage of a locally running API
- Make the user response never expire in the user response mock
- Added Organization tests