### PR TITLE
Kubesystem for ingress app namespace

### DIFF
--- a/src/components/AppCatalog/AppDetail/Input.js
+++ b/src/components/AppCatalog/AppDetail/Input.js
@@ -27,6 +27,14 @@ const Input = styled.input`
   line-height: normal;
   padding: 8px 10px;
   width: 100%;
+
+  &:read-only {
+    cursor: not-allowed;
+  }
+
+  &:read-only:focus {
+    outline: none;
+  }
 `;
 
 const Icon = styled.i`
@@ -68,6 +76,7 @@ const TextInput = props => {
           onChange={onChange}
           type='text'
           value={props.value}
+          readOnly={props.readOnly}
         />
       </InputWrapper>
       {props.validationError ? (
@@ -89,6 +98,7 @@ TextInput.propTypes = {
   onChange: PropTypes.func,
   validationError: PropTypes.string,
   value: PropTypes.string,
+  readOnly: PropTypes.bool,
 };
 
 export default TextInput;

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -60,9 +60,9 @@ const InstallAppForm = props => {
       {formAbilities.hasFixedNamespace ? (
         <Input
           description={
-            'This app must be installed in the ' +
-            formAbilities.fixedNamespace +
-            'namespace'
+            `This app must be installed in the ${ 
+            formAbilities.fixedNamespace 
+            }namespace`
           }
           hint={<>&nbsp;</>}
           label='Namespace:'

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -60,9 +60,9 @@ const InstallAppForm = props => {
       {formAbilities.hasFixedNamespace ? (
         <Input
           description={
-            `This app must be installed in the ${ 
-            formAbilities.fixedNamespace 
-            }namespace`
+            `This app must be installed in the ${
+            formAbilities.fixedNamespace
+            } namespace`
           }
           hint={<>&nbsp;</>}
           label='Namespace:'

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -32,7 +32,9 @@ const AppFormAbilities = (appName, updateNamespace) => {
 
 const InstallAppForm = props => {
   const updateName = name => {
-    props.onChangeName(name);
+    if (props.onChangeName) {
+      props.onChangeName(name);
+    }
   };
 
   const updateNamespace = namespace => {
@@ -42,11 +44,15 @@ const InstallAppForm = props => {
   };
 
   const updateValuesYAML = files => {
-    props.onChangeValuesYAML(files);
+    if (props.onChangeValuesYAML) {
+      props.onChangeValuesYAML(files);
+    }
   };
 
   const updateSecretsYAML = files => {
-    props.onChangeSecretsYAML(files);
+    if (props.onChangeSecretsYAML) {
+      props.onChangeSecretsYAML(files);
+    }
   };
 
   const formAbilities = AppFormAbilities(props.appName, updateNamespace);

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -14,13 +14,14 @@ const FormWrapper = styled.div`
 // Some apps have special rules about what namespace they are allowed to be in.
 // In the future there might be other rules.
 // This object is a place to keep this logic.
-const AppFormAbilities = appName => {
+const AppFormAbilities = (appName, updateNamespace) => {
   let hasFixedNamespace = false;
   let fixedNamespace = '';
 
   if (appName === 'nginx-ingress-controller-app') {
     hasFixedNamespace = true;
     fixedNamespace = 'kube-system';
+    updateNamespace('kube-system');
   }
 
   return {
@@ -46,6 +47,8 @@ const InstallAppForm = props => {
     props.onChangeSecretsYAML(files);
   };
 
+  const formAbilities = AppFormAbilities(props.appName, updateNamespace);
+
   return (
     <FormWrapper>
       <Input
@@ -59,11 +62,7 @@ const InstallAppForm = props => {
 
       {formAbilities.hasFixedNamespace ? (
         <Input
-          description={
-            `This app must be installed in the ${
-            formAbilities.fixedNamespace
-            } namespace`
-          }
+          description={`This app must be installed in the ${formAbilities.fixedNamespace} namespace`}
           hint={<>&nbsp;</>}
           label='Namespace:'
           value={formAbilities.fixedNamespace}

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -36,7 +36,9 @@ const InstallAppForm = props => {
   };
 
   const updateNamespace = namespace => {
-    props.onChangeNamespace(namespace);
+    if (props.onChangeNamespace) {
+      props.onChangeNamespace(namespace);
+    }
   };
 
   const updateValuesYAML = files => {

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -10,6 +10,25 @@ const FormWrapper = styled.div`
   flex-direction: column;
 `;
 
+// AppFormAbilities is an object that helps us with the form.
+// Some apps have special rules about what namespace they are allowed to be in.
+// In the future there might be other rules.
+// This object is a place to keep this logic.
+const AppFormAbilities = appName => {
+  let hasFixedNamespace = false;
+  let fixedNamespace = '';
+
+  if (appName === 'nginx-ingress-controller-app') {
+    hasFixedNamespace = true;
+    fixedNamespace = 'kube-system';
+  }
+
+  return {
+    hasFixedNamespace,
+    fixedNamespace,
+  };
+};
+
 const InstallAppForm = props => {
   const updateName = name => {
     props.onChangeName(name);
@@ -38,14 +57,28 @@ const InstallAppForm = props => {
         value={props.name}
       />
 
-      <Input
-        description='We recommend that you create a dedicated namespace. The namespace will be created if it doesn’t exist yet.'
-        hint={<>&nbsp;</>}
-        label='Namespace:'
-        onChange={updateNamespace}
-        validationError={props.namespaceError}
-        value={props.namespace}
-      />
+      {formAbilities.hasFixedNamespace ? (
+        <Input
+          description={
+            'This app must be installed in the ' +
+            formAbilities.fixedNamespace +
+            'namespace'
+          }
+          hint={<>&nbsp;</>}
+          label='Namespace:'
+          value={formAbilities.fixedNamespace}
+          readOnly={true}
+        />
+      ) : (
+        <Input
+          description='We recommend that you create a dedicated namespace. The namespace will be created if it doesn’t exist yet.'
+          hint={<>&nbsp;</>}
+          label='Namespace:'
+          onChange={updateNamespace}
+          validationError={props.namespaceError}
+          value={props.namespace}
+        />
+      )}
 
       <FileInput
         description='Apps can be configured using a values.yaml file. If you have one, you can upload it here already.'
@@ -69,6 +102,7 @@ const InstallAppForm = props => {
 };
 
 InstallAppForm.propTypes = {
+  appName: PropTypes.string,
   name: PropTypes.string,
   nameError: PropTypes.string,
   namespace: PropTypes.string,

--- a/src/components/AppCatalog/AppDetail/InstallAppModal.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppModal.js
@@ -272,6 +272,7 @@ const InstallAppModal = props => {
                 visible={visible}
               >
                 <InstallAppForm
+                  appName={props.app.name}
                   name={name}
                   nameError={nameError}
                   namespace={namespace}

--- a/src/components/AppCatalog/AppDetail/__tests__/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/__tests__/InstallAppForm.js
@@ -1,37 +1,24 @@
 import '@testing-library/jest-dom/extend-expect';
 
-import { render } from '@testing-library/react';
-import { ThemeProvider } from 'emotion-theming';
-import React from 'react';
-import theme from 'styles/theme';
+import { renderWithTheme } from 'testUtils/renderUtils';
 
 import InstallAppForm from '../InstallAppForm';
 
 it('renders without crashing', () => {
-  render(
-    <ThemeProvider theme={theme}>
-      <InstallAppForm />
-    </ThemeProvider>
-  );
+  renderWithTheme(InstallAppForm);
 });
 
 it('renders a normal namespace field usually', () => {
-  const { getByLabelText } = render(
-    <ThemeProvider theme={theme}>
-      <InstallAppForm />
-    </ThemeProvider>
-  );
+  const { getByLabelText } = renderWithTheme(InstallAppForm);
 
   const namespaceField = getByLabelText('Namespace:');
   expect(namespaceField).not.toHaveAttribute('read-only');
 });
 
 it('renders a readonly namespace field for nginx-ingress-controller-app', () => {
-  const { getByLabelText } = render(
-    <ThemeProvider theme={theme}>
-      <InstallAppForm appName='nginx-ingress-controller-app' />
-    </ThemeProvider>
-  );
+  const { getByLabelText } = renderWithTheme(InstallAppForm, {
+    appName: 'nginx-ingress-controller-app',
+  });
 
   const namespaceField = getByLabelText('Namespace:');
   expect(namespaceField).toHaveAttribute('readOnly');

--- a/src/components/AppCatalog/AppDetail/__tests__/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/__tests__/InstallAppForm.js
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom/extend-expect';
+
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'emotion-theming';
+import React from 'react';
+import theme from 'styles/theme';
+
+import InstallAppForm from '../InstallAppForm';
+
+it('renders without crashing', () => {
+  render(
+    <ThemeProvider theme={theme}>
+      <InstallAppForm />
+    </ThemeProvider>
+  );
+});
+
+it('renders a normal namespace field usually', () => {
+  const { getByLabelText } = render(
+    <ThemeProvider theme={theme}>
+      <InstallAppForm />
+    </ThemeProvider>
+  );
+
+  const namespaceField = getByLabelText('Namespace:');
+  expect(namespaceField).not.toHaveAttribute('read-only');
+});
+
+it('renders a readonly namespace field for nginx-ingress-controller-app', () => {
+  const { getByLabelText } = render(
+    <ThemeProvider theme={theme}>
+      <InstallAppForm appName='nginx-ingress-controller-app' />
+    </ThemeProvider>
+  );
+
+  const namespaceField = getByLabelText('Namespace:');
+  expect(namespaceField).toHaveAttribute('readOnly');
+});


### PR DESCRIPTION
This ensures that the  `nginx-ingress-controller-app` can only be installed to the `kube-system` namespace.