### PR TITLE
Validate organization creation input

### DIFF
--- a/src/components/Modals/Modals.js
+++ b/src/components/Modals/Modals.js
@@ -20,6 +20,7 @@ import ClusterIDLabel from 'UI/ClusterIDLabel';
 class Modals extends React.Component {
   state = {
     emailValid: false,
+    organizationNameValid: false,
   };
 
   close = () => {
@@ -84,6 +85,11 @@ class Modals extends React.Component {
     }
   };
 
+  organizationNameFieldChanged = event => {
+    const { target } = event;
+    this.setState({ organizationNameValid: target.validity.valid });
+  };
+
   render() {
     switch (this.props.modal.template) {
       case 'organizationDelete':
@@ -141,6 +147,15 @@ class Modals extends React.Component {
               </BootstrapModal.Title>
             </BootstrapModal.Header>
             <BootstrapModal.Body>
+              <p>Organization names must:</p>
+              <ul>
+                <li>be between 4 and 63 characters long</li>
+                <li>
+                  contain only letters, numbers, dots (.), hyphens (-) and
+                  underscores (_)
+                </li>
+                <li>must start and end with a letter or number</li>
+              </ul>
               <form onSubmit={this.createOrganisation.bind(this)}>
                 <label htmlFor='create-organization-name'>
                   Organization Name:
@@ -152,6 +167,11 @@ class Modals extends React.Component {
                     this.orgId = i;
                   }}
                   type='text'
+                  required
+                  minLength='4'
+                  maxLength='63'
+                  pattern='^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
+                  onChange={this.organizationNameFieldChanged}
                 />
               </form>
             </BootstrapModal.Body>
@@ -162,6 +182,7 @@ class Modals extends React.Component {
                 loadingPosition='left'
                 onClick={this.createOrganisation.bind(this)}
                 type='submit'
+                disabled={!this.state.organizationNameValid}
               >
                 {this.props.modal.templateValues.loading
                   ? 'Creating Organization'

--- a/src/components/Modals/Modals.js
+++ b/src/components/Modals/Modals.js
@@ -14,6 +14,7 @@ import React from 'react';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import { connect } from 'react-redux';
 import EmailField from 'shared/EmailField';
+import InputField from 'shared/InputField';
 import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 
@@ -21,6 +22,7 @@ class Modals extends React.Component {
   state = {
     emailValid: false,
     organizationNameValid: false,
+    organizationName: '',
   };
 
   close = () => {
@@ -39,8 +41,8 @@ class Modals extends React.Component {
     if (e) {
       e.preventDefault();
     }
-    const orgId = this.orgId.value;
-    this.props.dispatch(organizationCreateConfirmed(orgId));
+    const organizationName = this.orgId.value();
+    this.props.dispatch(organizationCreateConfirmed(organizationName));
   };
 
   addMember = e => {
@@ -85,9 +87,45 @@ class Modals extends React.Component {
     }
   };
 
-  organizationNameFieldChanged = event => {
-    const { target } = event;
-    this.setState({ organizationNameValid: target.validity.valid });
+  onOrganizationNameChange = organizationName => {
+    this.setState({ organizationName });
+  };
+
+  validateOrganizationName = organizationName => {
+    if (!organizationName) {
+      return {
+        valid: false,
+        validationError: '',
+      };
+    }
+
+    // eslint-disable-next-line no-magic-numbers
+    if (organizationName.length < 4 || organizationName.length > 63) {
+      this.setState({ organizationNameValid: false });
+
+      return {
+        valid: false,
+        validationError: 'must be between 4 and 63 characters long',
+      };
+    }
+
+    if (
+      !/^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$/.test(organizationName)
+    ) {
+      this.setState({ organizationNameValid: false });
+
+      return {
+        valid: false,
+        validationError: 'invalid format',
+      };
+    }
+
+    this.setState({ organizationNameValid: true });
+
+    return {
+      valid: true,
+      validationError: '',
+    };
   };
 
   render() {
@@ -157,21 +195,18 @@ class Modals extends React.Component {
                 <li>must start and end with a letter or number</li>
               </ul>
               <form onSubmit={this.createOrganisation.bind(this)}>
-                <label htmlFor='create-organization-name'>
-                  Organization Name:
-                </label>
-                <input
+                <InputField
                   id='create-organization-name'
+                  name='create-organization-name'
                   autoFocus
+                  label='Organization Name:'
+                  type='text'
                   ref={i => {
                     this.orgId = i;
                   }}
-                  type='text'
-                  required
-                  minLength='4'
-                  maxLength='63'
-                  pattern='^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
-                  onChange={this.organizationNameFieldChanged}
+                  value={this.state.organizationName}
+                  validate={this.validateOrganizationName}
+                  onChange={this.onOrganizationNameChange}
                 />
               </form>
             </BootstrapModal.Body>


### PR DESCRIPTION
Towards giantswarm/giantswarm#8403

Validates the input field for creating organizations using `minlength`, `maxlength` and `pattern` fields and only allows to click the button if validation succeeds