### PR TITLE
Minor refactor cluster status call

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -474,7 +474,11 @@ function clusterLoadStatus(clusterId) {
       })
       .then(status => {
         // eslint-disable-next-line no-use-before-define
-        dispatch(clusterLoadStatusSuccess(clusterId, status));
+        dispatch({
+          type: types.CLUSTER_LOAD_STATUS_SUCCESS,
+          clusterId,
+          status,
+        });
 
         return status;
       })
@@ -484,11 +488,12 @@ function clusterLoadStatus(clusterId) {
         // eslint-disable-next-line no-console
         console.error(error);
         if (error.status === StatusCodes.NotFound) {
-          // eslint-disable-next-line no-use-before-define
-          dispatch(clusterLoadStatusNotFound(clusterId));
+          dispatch({
+            type: types.CLUSTER_LOAD_STATUS_NOT_FOUND,
+            clusterId,
+          });
         } else {
-          // eslint-disable-next-line no-use-before-define
-          dispatch(clusterLoadStatusError(clusterId, error));
+          dispatch({ type: types.CLUSTER_LOAD_STATUS_ERROR, error });
 
           new FlashMessage(
             'Something went wrong while trying to load the cluster status.',
@@ -496,8 +501,6 @@ function clusterLoadStatus(clusterId) {
             messageTTL.LONG,
             'Please try again later or contact support: support@giantswarm.io'
           );
-
-          // throw error;
         }
       });
   };
@@ -662,22 +665,6 @@ export function clusterLoadKeyPairs(clusterId) {
 export const clusterLoadDetailsError = (clusterId, error) => ({
   type: types.CLUSTER_LOAD_DETAILS_ERROR,
   clusterId,
-  error,
-});
-
-export const clusterLoadStatusSuccess = (clusterId, status) => ({
-  type: types.CLUSTER_LOAD_STATUS_SUCCESS,
-  clusterId,
-  status,
-});
-
-export const clusterLoadStatusNotFound = clusterId => ({
-  type: types.CLUSTER_LOAD_STATUS_NOT_FOUND,
-  clusterId,
-});
-
-export const clusterLoadStatusError = error => ({
-  type: types.CLUSTER_LOAD_STATUS_ERROR,
   error,
 });
 

--- a/src/reducers/loadingReducer.js
+++ b/src/reducers/loadingReducer.js
@@ -10,7 +10,7 @@ const initialState = {
 
 const loadingReducer = produce((draft, action) => {
   const { type } = action;
-  const matches = /(.*)_(REQUEST|SUCCESS|ERROR|FINISHED)/.exec(type);
+  const matches = /(.*)_(REQUEST|SUCCESS|ERROR|FINISHED|NOT_FOUND)/.exec(type);
 
   // not a *_REQUEST / *_SUCCESS / *_ERROR / *_FINISHED actions, so we ignore them
   if (!matches) return;


### PR DESCRIPTION
Several things going on here as a previous step for moving resource computations to `clusterActions`:

- Removed old `clusterLoadStatus()` because it was useless as we just call status endpoint for v4 clusters
- Added `NOT_FOUND` suffix to `loadingReducer.js` that will set loading flag to false (I owe you documentation explaining how this works, coming this week)
- And inlining action objects: I find that this is best for readibility, specially in big files. WDYT? Are you ok with this?