### PR TITLE
Remove deprecated version checks

### DIFF
--- a/src/components/AppCatalog/AppDetail/InstallAppModal.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppModal.js
@@ -231,7 +231,7 @@ const InstallAppModal = props => {
                 visible={visible}
               >
                 <ClusterPicker
-                  clusters={clusters.filter(c => c.capabilities.canInstallApps)}
+                  clusters={clusters}
                   onChangeQuery={setQuery}
                   onSelectCluster={onSelectCluster}
                   query={query}

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -16,7 +16,6 @@ import Tab from 'react-bootstrap/lib/Tab';
 import { connect } from 'react-redux';
 import ReactTimeout from 'react-timeout';
 import { bindActionCreators } from 'redux';
-import cmp from 'semver-compare';
 import { Providers } from 'shared/constants';
 import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
@@ -157,32 +156,13 @@ class ClusterDetailView extends React.Component {
       return false;
     }
 
-    if (this.props.provider === Providers.AWS) {
-      return true;
-    }
-
-    if (this.props.provider === Providers.KVM) {
-      return true;
-    }
-
-    // on Azure, release version must be >= 1.0.0
-    if (
-      this.props.provider === Providers.AZURE &&
-      cmp(this.props.cluster.release_version, '1.0.0') !== -1
-    ) {
-      return true;
-    }
-
-    return false;
+    return true;
   }
 
   getDesiredNumberOfNodes() {
     // Desired number of nodes only makes sense with auto-scaling and that is
     // only available on AWS starting from release 6.3.0 onwards.
-    if (
-      this.props.provider !== Providers.AWS ||
-      cmp(this.props.cluster.release_version, '6.2.99') !== 1
-    ) {
+    if (this.props.provider !== Providers.AWS) {
       return null;
     }
 
@@ -333,8 +313,7 @@ class ClusterDetailView extends React.Component {
                         installedApps={cluster.apps}
                         release={release}
                         showInstalledAppsBlock={
-                          Object.keys(this.props.catalogs.items).length > 0 &&
-                          cluster.capabilities.canInstallApps
+                          Object.keys(this.props.catalogs.items).length > 0
                         }
                       />
                     </Tab>

--- a/src/components/Cluster/NewCluster/CreateRegularCluster.js
+++ b/src/components/Cluster/NewCluster/CreateRegularCluster.js
@@ -68,7 +68,7 @@ const FlexWrapperAZDiv = styled.div`
 
 class CreateRegularCluster extends React.Component {
   static isScalingAutomatic(provider) {
-    return provider !== Providers.AWS;
+    return provider === Providers.AWS;
   }
 
   state = {

--- a/src/components/Cluster/NewCluster/CreateRegularCluster.js
+++ b/src/components/Cluster/NewCluster/CreateRegularCluster.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
-import cmp from 'semver-compare';
 import { Providers } from 'shared/constants';
 import NodeCountSelector from 'shared/NodeCountSelector';
 import Button from 'UI/Button';
@@ -68,14 +67,8 @@ const FlexWrapperAZDiv = styled.div`
 `;
 
 class CreateRegularCluster extends React.Component {
-  static isScalingAutomatic(provider, releaseVer) {
-    if (provider !== Providers.AWS) {
-      return false;
-    }
-
-    // In order to have support for automatic scaling and therefore for scaling
-    // limits, provider must be AWS and cluster release >= 6.3.0.
-    return cmp(releaseVer, '6.2.99') === 1;
+  static isScalingAutomatic(provider) {
+    return provider !== Providers.AWS;
   }
 
   state = {
@@ -459,38 +452,20 @@ class CreateRegularCluster extends React.Component {
                   htmlFor='availability-zones'
                 >
                   <span className='label-span'>Availability Zones</span>
-                  {// For now we want to handle cases where older clusters do
-                  // still not support AZ selection. The special handling here
-                  // can be removed once all clusters run at least on 6.1.0.
-                  //
-                  //     https://github.com/giantswarm/giantswarm/pull/2202
-                  //
-                  cmp(this.props.selectedRelease, '6.0.0') === 1 ? (
-                    <FlexWrapperAZDiv>
-                      <p>Number of availability zones to use:</p>
-                      <div>
-                        <NumberPicker
-                          label=''
-                          max={this.props.maxAvailabilityZones}
-                          min={this.props.minAvailabilityZones}
-                          onChange={this.updateAvailabilityZonesPicker}
-                          readOnly={false}
-                          stepSize={1}
-                          value={this.state.availabilityZonesPicker.value}
-                        />
-                      </div>
-                    </FlexWrapperAZDiv>
-                  ) : (
-                    <>
-                      <p>
-                        Selection of availability zones is only possible for
-                        release version 6.1.0 or greater.
-                      </p>
-                      <div className='col-3'>
-                        <NumberPicker readOnly={true} value={1} />
-                      </div>
-                    </>
-                  )}
+                  <FlexWrapperAZDiv>
+                    <p>Number of availability zones to use:</p>
+                    <div>
+                      <NumberPicker
+                        label=''
+                        max={this.props.maxAvailabilityZones}
+                        min={this.props.minAvailabilityZones}
+                        onChange={this.updateAvailabilityZonesPicker}
+                        readOnly={false}
+                        stepSize={1}
+                        value={this.state.availabilityZonesPicker.value}
+                      />
+                    </div>
+                  </FlexWrapperAZDiv>
                 </label>
               )}
 

--- a/src/utils/__tests__/computeCapabilities.js
+++ b/src/utils/__tests__/computeCapabilities.js
@@ -1,58 +1,5 @@
 import { computeCapabilities } from '../clusterUtils';
 
-describe('canInstallApps', () => {
-  describe('on azure', () => {
-    it('is false for Azure below 8.2.0', () => {
-      const capabilities = computeCapabilities('8.1.0', 'azure');
-      expect(capabilities.canInstallApps).toBe(false);
-    });
-
-    it('is true for Azure at 8.2.0', () => {
-      const capabilities = computeCapabilities('8.2.0', 'azure');
-      expect(capabilities.canInstallApps).toBe(true);
-    });
-
-    it('is true for Azure above 8.2.0', () => {
-      const capabilities = computeCapabilities('8.3.0', 'azure');
-      expect(capabilities.canInstallApps).toBe(true);
-    });
-  });
-
-  describe('on aws', () => {
-    it('is false for AWS below 8.1.0', () => {
-      const capabilities = computeCapabilities('8.0.0', 'aws');
-      expect(capabilities.canInstallApps).toBe(false);
-    });
-
-    it('is true for AWS at 8.1.0', () => {
-      const capabilities = computeCapabilities('8.1.0', 'aws');
-      expect(capabilities.canInstallApps).toBe(true);
-    });
-
-    it('is true for AWS above 8.1.0', () => {
-      const capabilities = computeCapabilities('8.2.0', 'aws');
-      expect(capabilities.canInstallApps).toBe(true);
-    });
-  });
-
-  describe('on kvm', () => {
-    it('is false for KVM below 8.1.0', () => {
-      const capabilities = computeCapabilities('8.0.0', 'kvm');
-      expect(capabilities.canInstallApps).toBe(false);
-    });
-
-    it('is true for KVM at 8.1.0', () => {
-      const capabilities = computeCapabilities('8.1.0', 'kvm');
-      expect(capabilities.canInstallApps).toBe(true);
-    });
-
-    it('is true for KVM above 8.1.0', () => {
-      const capabilities = computeCapabilities('8.2.0', 'kvm');
-      expect(capabilities.canInstallApps).toBe(true);
-    });
-  });
-});
-
 describe('hasOptionalIngress', () => {
   describe('on azure', () => {
     it('is false for Azure at any version', () => {

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -140,27 +140,8 @@ export const clusterNodePools = (nodePools, cluster) => {
 // computeCapabilities takes a release version and provider and returns a
 // capabilities object with the features that this cluster supports.
 export function computeCapabilities(releaseVersion, provider) {
-  const capabilities = {
-    canInstallApps: false,
-    hasOptionalIngress: false,
+  return {
+    hasOptionalIngress:
+      provider === Providers.AWS && cmp(releaseVersion, '10.0.99') === 1,
   };
-
-  // Installing Apps
-  // Must be AWS or KVM and larger than 8.1.0
-  // or any provider and larger than 8.2.0
-  if (
-    (cmp(releaseVersion, '8.0.99') === 1 &&
-      (provider === Providers.AWS || provider === Providers.KVM)) ||
-    cmp(releaseVersion, '8.1.99') === 1
-  ) {
-    capabilities.canInstallApps = true;
-  }
-
-  // Optional Ingress
-  // Must be AWS and larger than 10.1.0
-  if (provider === Providers.AWS && cmp(releaseVersion, '10.0.99') === 1) {
-    capabilities.hasOptionalIngress = true;
-  }
-
-  return capabilities;
 }


### PR DESCRIPTION
This pull request removes tennant cluster release versions from some places in happa.

I checked tennant cluster versions with lowest to be `8.0.0` (I've done this with [these](https://github.com/giantswarm/giantswarm/blob/master/ops-recipes/list-tenant-clusters.md) instructions)

I am sure you'll find this change to be very controversial in regard to removing these kind of guards. In my opinion removing these checks is a good thing because it removes code that isn't executed anyway when no one is using these old cluster versions.
