### PR TITLE
Adjust deletion behaviour.

### DIFF
--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -145,8 +145,6 @@ export const batchedClusterDeleteConfirmed = cluster => async dispatch => {
     dispatch(push(`/organizations/${cluster.owner}`));
     await dispatch(clusterActions.clusterDeleteConfirmed(cluster));
     dispatch(modalActions.modalHide());
-    // ensure refreshing of the clusters list
-    await dispatch(clusterActions.clustersList({ withLoadingFlags: false }));
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('Error in batchedClusterDeleteConfirmed', err);

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -446,7 +446,7 @@ export function clusterLoadDetails(clusterId, { withLoadingFlags }) {
 
         // Delete the cluster in the store.
         // eslint-disable-next-line no-use-before-define
-        dispatch(clusterDeleteSuccess(clusterId));
+        dispatch(clusterDeleteSuccess(clusterId, Date.now()));
         dispatch(push('/'));
 
         return {};
@@ -595,7 +595,7 @@ export function clusterDeleteConfirmed(cluster) {
       .deleteCluster(cluster.id)
       .then(data => {
         // eslint-disable-next-line no-use-before-define
-        dispatch(clusterDeleteSuccess(cluster.id));
+        dispatch(clusterDeleteSuccess(cluster.id, Date.now()));
 
         new FlashMessage(
           `Cluster <code>${cluster.id}</code> will be deleted`,
@@ -688,9 +688,10 @@ export const clusterDelete = cluster => ({
   cluster,
 });
 
-export const clusterDeleteSuccess = clusterId => ({
+export const clusterDeleteSuccess = (clusterId, timestamp) => ({
   type: types.CLUSTER_DELETE_SUCCESS,
   clusterId,
+  timestamp,
 });
 
 export const clusterDeleteError = (clusterId, error) => ({

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -129,7 +129,7 @@ const clusterReducer = produce((draft, action) => {
       return;
 
     case types.CLUSTER_DELETE_SUCCESS:
-      delete draft.items[action.clusterId];
+      draft.items[action.clusterId].delete_date = Date.now();
       draft.lastUpdated = Date.now();
 
       return;

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -129,7 +129,7 @@ const clusterReducer = produce((draft, action) => {
       return;
 
     case types.CLUSTER_DELETE_SUCCESS:
-      draft.items[action.clusterId].delete_date = Date.now();
+      draft.items[action.clusterId].delete_date = action.timestamp;
       draft.lastUpdated = Date.now();
 
       return;


### PR DESCRIPTION
Instead of deleting the cluster object, I am setting the `deleted_date`, which is more like how the API works too.

That way we don't remove it from the list, and then have it suddenly pop back in again in case it is taking a while to be deleted.

Related to: https://github.com/giantswarm/happa/issues/1034