### PR TITLE
Show a 'n/a' label when there are no nodes loaded yet

### DIFF
--- a/src/components/Cluster/ClusterDetail/WorkerNodesAWS.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesAWS.js
@@ -6,7 +6,7 @@ import AvailabilityZonesLabels from 'UI/AvailabilityZonesLabels';
 import Button from 'UI/Button';
 import RefreshableLabel from 'UI/RefreshableLabel';
 
-import { LineDiv, WrapperDiv } from './WorkerNodesAzure';
+import { LineDiv, ScalingNodeCounter, WrapperDiv } from './WorkerNodesAzure';
 
 function WorkerNodesAWS({
   az,
@@ -52,9 +52,9 @@ function WorkerNodesAWS({
       </LineDiv>
       <LineDiv>
         <div>Scaling</div>
-        <RefreshableLabel value={scalingText} style={{ marginRight: '25px' }}>
+        <ScalingNodeCounter value={scalingText}>
           {scalingText}
-        </RefreshableLabel>
+        </ScalingNodeCounter>
         <Button onClick={showScalingModal}>Edit</Button>
       </LineDiv>
       <LineDiv data-testid='desired-nodes'>

--- a/src/components/Cluster/ClusterDetail/WorkerNodesAzure.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesAzure.js
@@ -21,12 +21,18 @@ export const LineDiv = styled.div`
   }
 `;
 
+export const ScalingNodeCounter = styled(RefreshableLabel)`
+  margin-right: 25px;
+`;
+
 function WorkerNodesAzure({ instanceType, nodes, showScalingModal }) {
   const instanceTypeText = instanceType
     ? // prettier-ignore
       // eslint-disable-next-line no-magic-numbers
       `${instanceType.numberOfCores} CPUs, ${(instanceType.memoryInMb / 1000.0).toFixed(1)} GB RAM`
     : '0 CPUs, 0 GB RAM';
+
+  const nodeCount = nodes || 'n/a';
 
   return (
     <WrapperDiv>
@@ -41,11 +47,7 @@ function WorkerNodesAzure({ instanceType, nodes, showScalingModal }) {
       </LineDiv>
       <LineDiv>
         <div>Nodes</div>
-        {nodes && nodes !== 0 && (
-          <RefreshableLabel value={nodes} style={{ marginRight: '25px' }}>
-            {nodes}
-          </RefreshableLabel>
-        )}{' '}
+        <ScalingNodeCounter value={nodeCount}>{nodeCount}</ScalingNodeCounter>
         <Button onClick={showScalingModal}>Edit</Button>
       </LineDiv>
     </WrapperDiv>

--- a/src/components/Cluster/ClusterDetail/WorkerNodesKVM.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesKVM.js
@@ -3,12 +3,14 @@ import React from 'react';
 import Button from 'UI/Button';
 import RefreshableLabel from 'UI/RefreshableLabel';
 
-import { LineDiv, WrapperDiv } from './WorkerNodesAzure';
+import { LineDiv, ScalingNodeCounter, WrapperDiv } from './WorkerNodesAzure';
 
 function WorkerNodesKVM({ worker, nodes, showScalingModal }) {
   const nodeSpecText = worker
     ? `${worker.cpu.cores} CPUs, ${worker.memory.size_gb} GB RAM`
     : '0 CPUs, 0 GB RAM';
+
+  const nodeCount = nodes || 'n/a';
 
   return (
     <WrapperDiv>
@@ -18,11 +20,7 @@ function WorkerNodesKVM({ worker, nodes, showScalingModal }) {
       </LineDiv>
       <LineDiv>
         <div>Nodes</div>
-        {nodes && nodes !== 0 && (
-          <RefreshableLabel value={nodes} style={{ marginRight: '25px' }}>
-            {nodes}
-          </RefreshableLabel>
-        )}{' '}
+        <ScalingNodeCounter value={nodeCount}>{nodeCount}</ScalingNodeCounter>
         <Button onClick={showScalingModal}>Edit</Button>
       </LineDiv>
     </WrapperDiv>

--- a/src/components/UI/RefreshableLabel.js
+++ b/src/components/UI/RefreshableLabel.js
@@ -41,11 +41,14 @@ const Wrapper = styled.div`
  */
 
 // As this hook has styles, we are going to pass a styles prop to overwrite/add any styles
-function RefreshableLabel({ children, value, style }) {
+function RefreshableLabel({ children, value, style, className }) {
   // used for outputting 'changed' css class
   const [hasDataChanged, setHasDataChanged] = useState(false);
   // used for storing previous value and so be able to compare with new value
   const prevValue = usePrevious(value);
+
+  let labelClassName = className;
+  if (hasDataChanged) labelClassName += ' changed';
 
   useEffect(() => {
     const sToMs = 1000;
@@ -66,7 +69,7 @@ function RefreshableLabel({ children, value, style }) {
   }, [prevValue, value]);
 
   return (
-    <Wrapper className={hasDataChanged && 'changed'} style={style}>
+    <Wrapper className={labelClassName} style={style}>
       {children}
     </Wrapper>
   );
@@ -74,6 +77,7 @@ function RefreshableLabel({ children, value, style }) {
 
 RefreshableLabel.propTypes = {
   children: PropTypes.node,
+  className: PropTypes.string,
   style: PropTypes.object,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };

--- a/src/components/UI/RefreshableLabel.js
+++ b/src/components/UI/RefreshableLabel.js
@@ -40,8 +40,7 @@ const Wrapper = styled.div`
  * value changes, visual highlighting is triggered.
  */
 
-// As this hook has styles, we are going to pass a styles prop to overwrite/add any styles
-function RefreshableLabel({ children, value, style, className }) {
+function RefreshableLabel({ children, value, className }) {
   // used for outputting 'changed' css class
   const [hasDataChanged, setHasDataChanged] = useState(false);
   // used for storing previous value and so be able to compare with new value
@@ -68,11 +67,7 @@ function RefreshableLabel({ children, value, style, className }) {
     return () => clearTimeout(timer);
   }, [prevValue, value]);
 
-  return (
-    <Wrapper className={labelClassName} style={style}>
-      {children}
-    </Wrapper>
-  );
+  return <Wrapper className={labelClassName}>{children}</Wrapper>;
 }
 
 RefreshableLabel.propTypes = {

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -42,7 +42,7 @@ export function getNumberOfNodes(cluster) {
 export function getMemoryTotal(workers, memorySizeGB) {
   if (!workers || workers.length === 0) return 0;
 
-  return workers * memorySizeGB.toFixed(2);
+  return (workers * memorySizeGB).toFixed(2);
 }
 
 export function getStorageTotal(cluster) {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/8567

- Create a `ScalingNodeCounter` component, that it's reused for all providers, for consistent styling
- Show a `n/a` label instead of showing `0` nodes if the cluster is not loaded yet
- *BONUS:* Lower the precision of the total memory displayed in the cluster detail, as it would sometimes display 64-bit floats


**Preview**

<img width="507" alt="Screenshot 2020-01-23 at 15 50 10" src="https://user-images.githubusercontent.com/13508038/72997274-642dd680-3dfc-11ea-8404-5a152a400ee9.png">
