### PR TITLE
Use isV5 instead isNodePools

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -113,8 +113,8 @@ export function clusterLoadApps(clusterId) {
     // This method is going to work for NP clusters, now in local dev it is not
     // working, so early return if the cluster is a NP one.
     const nodePoolsClusters = getState().entities.clusters.nodePoolsClusters;
-    const isNodePoolsCluster = nodePoolsClusters.includes(clusterId);
-    if (isNodePoolsCluster) {
+    const isV5Cluster = nodePoolsClusters.includes(clusterId);
+    if (isV5Cluster) {
       dispatch({
         type: types.CLUSTER_LOAD_APPS_SUCCESS,
         clusterId,
@@ -713,7 +713,7 @@ export const clusterDeleteError = (clusterId, error) => ({
  * @param {Object} cluster Cluster object
  * @param {Object} payload object with just the data we want to modify
  */
-export function clusterPatch(cluster, payload, isNodePoolCluster) {
+export function clusterPatch(cluster, payload, isV5Cluster) {
   return function(dispatch) {
     // Optimistic update.
     dispatch({
@@ -722,7 +722,7 @@ export function clusterPatch(cluster, payload, isNodePoolCluster) {
       payload,
     });
 
-    const modifyCluster = isNodePoolCluster
+    const modifyCluster = isV5Cluster
       ? clustersApi.modifyClusterV5(cluster.id, payload)
       : clustersApi.modifyCluster(cluster.id, payload);
 

--- a/src/components/Cluster/ClusterDetail/ClusterDetail.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetail.js
@@ -52,7 +52,7 @@ ClusterDetail.propTypes = {
   provider: PropTypes.string,
   targetRelease: PropTypes.object,
   user: PropTypes.object,
-  isNodePoolsCluster: PropTypes.bool,
+  isV5Cluster: PropTypes.bool,
 };
 function mapStateToProps(state, ownProps) {
   const cluster =
@@ -61,7 +61,7 @@ function mapStateToProps(state, ownProps) {
   let release;
   // eslint-disable-next-line init-declarations
   let targetReleaseVersion;
-  let isNodePoolsCluster = false;
+  let isV5Cluster = false;
 
   if (cluster) {
     if (cluster.release_version && cluster.release_version !== '') {
@@ -93,9 +93,7 @@ function mapStateToProps(state, ownProps) {
         ];
     }
 
-    isNodePoolsCluster = state.entities.clusters.v5Clusters.includes(
-      cluster.id
-    );
+    isV5Cluster = state.entities.clusters.v5Clusters.includes(cluster.id);
   }
 
   return {
@@ -110,7 +108,7 @@ function mapStateToProps(state, ownProps) {
     targetRelease: state.entities.releases.items[targetReleaseVersion],
     user: state.app.loggedInUser,
     region: state.app.info.general.datacenter,
-    isNodePoolsCluster,
+    isV5Cluster,
   };
 }
 

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -98,7 +98,7 @@ class ClusterDetailView extends React.Component {
       batchedClusterDetailView(
         organizationId,
         cluster.id,
-        this.props.isNodePoolsCluster
+        this.props.isV5Cluster
       )
     );
   };
@@ -107,7 +107,7 @@ class ClusterDetailView extends React.Component {
     this.props.dispatch(
       batchedRefreshClusterDetailView(
         this.props.cluster.id,
-        this.props.isNodePoolsCluster
+        this.props.isV5Cluster
       )
     );
   };
@@ -206,7 +206,7 @@ class ClusterDetailView extends React.Component {
           clusterActions.clusterPatch(
             this.props.cluster,
             { name: value },
-            this.props.isNodePoolsCluster
+            this.props.isV5Cluster
           )
         )
         .then(() => {
@@ -228,7 +228,7 @@ class ClusterDetailView extends React.Component {
       cluster,
       credentials,
       dispatch,
-      isNodePoolsCluster,
+      isV5Cluster,
       nodePools,
       provider,
       release,
@@ -264,7 +264,7 @@ class ClusterDetailView extends React.Component {
                 <div className='col-12'>
                   <Tabs>
                     <Tab eventKey={1} title='General'>
-                      {isNodePoolsCluster ? (
+                      {isV5Cluster ? (
                         <V5ClusterDetailTable
                           accessCluster={this.accessCluster}
                           canClusterUpgrade={this.canClusterUpgrade()}
@@ -334,7 +334,7 @@ class ClusterDetailView extends React.Component {
                   </Tabs>
                 </div>
               </div>
-              {!isNodePoolsCluster && (
+              {!isV5Cluster && (
                 <ScaleClusterModal
                   cluster={cluster}
                   provider={provider}
@@ -376,7 +376,7 @@ ClusterDetailView.propTypes = {
   clusterId: PropTypes.string,
   credentials: PropTypes.object,
   dispatch: PropTypes.func,
-  isNodePoolsCluster: PropTypes.bool,
+  isV5Cluster: PropTypes.bool,
   nodePools: PropTypes.object,
   organizationId: PropTypes.string,
   releaseActions: PropTypes.object,

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -77,13 +77,16 @@ class ClusterDashboardItem extends React.Component {
   componentDidMount() {
     this.registerReRenderInterval();
 
-    if (this.props.isV5) {
+    if (this.props.isV5Cluster) {
       this.setClusterNodePools();
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.isV5 && prevProps.nodePools !== this.props.nodePools) {
+    if (
+      this.props.isV5Cluster &&
+      prevProps.nodePools !== this.props.nodePools
+    ) {
       this.setClusterNodePools();
     }
   }
@@ -142,7 +145,7 @@ class ClusterDashboardItem extends React.Component {
 
   // eslint-disable-next-line complexity
   render() {
-    const { cluster, isV5, selectedOrganization } = this.props;
+    const { cluster, isV5Cluster, selectedOrganization } = this.props;
 
     const { nodePools } = this.state;
 
@@ -203,7 +206,7 @@ class ClusterDashboardItem extends React.Component {
           <ClusterDashboardResources
             cluster={cluster}
             nodePools={nodePools}
-            isV5={isV5}
+            isV5Cluster={isV5Cluster}
           />
         </ContentWrapper>
 
@@ -232,7 +235,7 @@ ClusterDashboardItem.propTypes = {
   selectedOrganization: PropTypes.string,
   animate: PropTypes.bool,
   dispatch: PropTypes.func,
-  isV5: PropTypes.bool,
+  isV5Cluster: PropTypes.bool,
   nodePools: PropTypes.object,
 };
 

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -77,13 +77,13 @@ class ClusterDashboardItem extends React.Component {
   componentDidMount() {
     this.registerReRenderInterval();
 
-    if (this.props.isNodePool) {
+    if (this.props.isV5) {
       this.setClusterNodePools();
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.isNodePool && prevProps.nodePools !== this.props.nodePools) {
+    if (this.props.isV5 && prevProps.nodePools !== this.props.nodePools) {
       this.setClusterNodePools();
     }
   }
@@ -142,7 +142,7 @@ class ClusterDashboardItem extends React.Component {
 
   // eslint-disable-next-line complexity
   render() {
-    const { cluster, isNodePool, selectedOrganization } = this.props;
+    const { cluster, isV5, selectedOrganization } = this.props;
 
     const { nodePools } = this.state;
 
@@ -203,7 +203,7 @@ class ClusterDashboardItem extends React.Component {
           <ClusterDashboardResources
             cluster={cluster}
             nodePools={nodePools}
-            isNodePool={isNodePool}
+            isV5={isV5}
           />
         </ContentWrapper>
 
@@ -232,7 +232,7 @@ ClusterDashboardItem.propTypes = {
   selectedOrganization: PropTypes.string,
   animate: PropTypes.bool,
   dispatch: PropTypes.func,
-  isNodePool: PropTypes.bool,
+  isV5: PropTypes.bool,
   nodePools: PropTypes.object,
 };
 

--- a/src/components/Home/ClusterDashboardResources.js
+++ b/src/components/Home/ClusterDashboardResources.js
@@ -22,13 +22,13 @@ function ClusterDashboardResources({
   loadingClusters,
   loadingNodePools,
   loadingStatus,
-  isV5,
+  isV5Cluster,
   resources,
 }) {
   const { memory, storage, cores, numberOfNodes } = resources;
   const hasNodePools = cluster.nodePools && cluster.nodePools.length !== 0;
   const loading =
-    loadingClusters || loadingStatus || (isV5 && loadingNodePools);
+    loadingClusters || loadingStatus || (isV5Cluster && loadingNodePools);
 
   return (
     <ClusterDetailsDiv>
@@ -72,7 +72,7 @@ function ClusterDashboardResources({
 
 ClusterDashboardResources.propTypes = {
   cluster: PropTypes.object,
-  isV5: PropTypes.bool,
+  isV5Cluster: PropTypes.bool,
   nodePools: PropTypes.array,
   resources: PropTypes.object,
   loadingClusters: PropTypes.bool,
@@ -85,7 +85,7 @@ const makeMapStateToProps = () => {
   const resourcesV5 = selectResourcesV5();
   const mapStateToProps = (state, props) => {
     return {
-      resources: props.isV5
+      resources: props.isV5Cluster
         ? resourcesV5(state, props)
         : resourcesV4(state, props),
       loadingClusters: state.loadingFlags.CLUSTERS_LOAD_DETAILS,

--- a/src/components/Home/ClusterDashboardResources.js
+++ b/src/components/Home/ClusterDashboardResources.js
@@ -22,13 +22,13 @@ function ClusterDashboardResources({
   loadingClusters,
   loadingNodePools,
   loadingStatus,
-  isNodePool,
+  isV5,
   resources,
 }) {
   const { memory, storage, cores, numberOfNodes } = resources;
   const hasNodePools = cluster.nodePools && cluster.nodePools.length !== 0;
   const loading =
-    loadingClusters || loadingStatus || (isNodePool && loadingNodePools);
+    loadingClusters || loadingStatus || (isV5 && loadingNodePools);
 
   return (
     <ClusterDetailsDiv>
@@ -72,7 +72,7 @@ function ClusterDashboardResources({
 
 ClusterDashboardResources.propTypes = {
   cluster: PropTypes.object,
-  isNodePool: PropTypes.bool,
+  isV5: PropTypes.bool,
   nodePools: PropTypes.array,
   resources: PropTypes.object,
   loadingClusters: PropTypes.bool,
@@ -85,7 +85,7 @@ const makeMapStateToProps = () => {
   const resourcesV5 = selectResourcesV5();
   const mapStateToProps = (state, props) => {
     return {
-      resources: props.isNodePool
+      resources: props.isV5
         ? resourcesV5(state, props)
         : resourcesV4(state, props),
       loadingClusters: state.loadingFlags.CLUSTERS_LOAD_DETAILS,

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -124,7 +124,7 @@ class Home extends React.Component {
                     <ClusterDashboardItem
                       animate={true}
                       cluster={cluster}
-                      isV5={this.props.v5Clusters.includes(cluster.id)}
+                      isV5Cluster={this.props.v5Clusters.includes(cluster.id)}
                       key={cluster.id}
                       nodePools={this.props.nodePools}
                       selectedOrganization={this.props.selectedOrganization}

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -124,7 +124,7 @@ class Home extends React.Component {
                     <ClusterDashboardItem
                       animate={true}
                       cluster={cluster}
-                      isNodePool={this.props.v5Clusters.includes(cluster.id)}
+                      isV5={this.props.v5Clusters.includes(cluster.id)}
                       key={cluster.id}
                       nodePools={this.props.nodePools}
                       selectedOrganization={this.props.selectedOrganization}


### PR DESCRIPTION
We have different names for the same concept: `isV5Cluster` and `isNodePoolsCluster`

I decided to drop `isNodePools` and use `isV5` instead because it is shorter and because it is less related to a specific feature.