### PR TITLE
Placholder in clusters list using react-content-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-bootstrap": "0.33.1",
     "react-bootstrap-table-next": "3.3.3",
     "react-breadcrumbs": "2.1.7",
+    "react-content-loader": "^5.0.0",
     "react-datepicker": "2.11.0",
     "react-dom": "16.12.0",
     "react-gravatar": "2.6.3",

--- a/src/components/Home/ClusterDashboardLoadingPlaceholder.js
+++ b/src/components/Home/ClusterDashboardLoadingPlaceholder.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ContentLoader from 'react-content-loader';
+import theme from 'styles/theme';
+
+// It renders loading placeholders for v5 and v4 clusters.
+const ClusterDashboardLoadingPlaceholder = ({ isV5Cluster }) => (
+  <ContentLoader
+    viewBox='0 0 400 25'
+    speed={1}
+    backgroundColor={theme.colors.darkBlueLighter2}
+    foregroundColor={theme.colors.loadingForeground}
+  >
+    {isV5Cluster ? (
+      <>
+        <rect x='0' y='4' rx='4' ry='4' width='145' height='20' />
+        <rect x='155' y='4' rx='4' ry='4' width='75' height='20' />
+        <rect x='240' y='4' rx='4' ry='4' width='70' height='20' />
+      </>
+    ) : (
+      <rect x='0' y='4' rx='4' ry='4' width='80' height='20' />
+    )}
+  </ContentLoader>
+);
+
+ClusterDashboardLoadingPlaceholder.propTypes = {
+  isV5Cluster: PropTypes.bool,
+};
+
+export default ClusterDashboardLoadingPlaceholder;

--- a/src/components/Home/ClusterDashboardResources.js
+++ b/src/components/Home/ClusterDashboardResources.js
@@ -7,8 +7,9 @@ import {
   selectResourcesV5,
 } from 'selectors/clusterSelectors';
 import { Dot } from 'styles';
-import LoadingOverlayWithoutStyles from 'UI/LoadingOverlayWithoutStyles';
 import RefreshableLabel from 'UI/RefreshableLabel';
+
+import ClusterDashboardLoadingPlaceholder from './ClusterDashboardLoadingPlaceholder';
 
 const ClusterDetailsDiv = styled.div`
   height: 27px;
@@ -32,7 +33,9 @@ function ClusterDashboardResources({
 
   return (
     <ClusterDetailsDiv>
-      <LoadingOverlayWithoutStyles loading={loading}>
+      {loading ? (
+        <ClusterDashboardLoadingPlaceholder isV5Cluster={isV5Cluster} />
+      ) : (
         <div>
           {numberOfNodes !== 0 && hasNodePools && (
             <RefreshableLabel value={numberOfNodes}>
@@ -65,7 +68,7 @@ function ClusterDashboardResources({
             </span>
           )}
         </div>
-      </LoadingOverlayWithoutStyles>
+      )}
     </ClusterDetailsDiv>
   );
 }

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -49,6 +49,8 @@ const theme = {
     red: 'red',
     gray: '#ccc',
     error: '#e49090',
+
+    loadingForeground: '#507184',
   },
   border_radius: '4px',
   breakpoints: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9818,6 +9818,11 @@ react-breadcrumbs@2.1.7:
     redux "^3.6.0"
     uuid "^3.0.1"
 
+react-content-loader@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-5.0.0.tgz#6a8ac5cd9d6f3c2a6651813f9bbcbb86c2eb573f"
+  integrity sha512-cjiFpErrWLAgCFmlrwoUVFhilew0EQ8DUrx0gRuQuxqTRivuAnSfJ83N5mazGJGw6sgOqi0xcVuQvNGaj44z8Q==
+
 react-datepicker@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-2.11.0.tgz#61aa79750856f91ee452f296d91b9ae4ebbacb4d"


### PR DESCRIPTION
Added a component that renders placeholders in place of resources in cluster dashboard item when loading state === `true`.

Using react-content-loader, which is really lightweight: https://github.com/danilowoz/react-content-loader#features

Placeholders have an animated background using a two color linear gradient.

It renders just one box for v4 clusters and three for v5 clusters, as we are rendering more info for v5 clusters:

![image](https://user-images.githubusercontent.com/14203438/73174056-1fa98000-4107-11ea-93d7-151e3e28d0ec.png)
