### PR TITLE
Fix upgrading v5 clusters.

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -713,8 +713,11 @@ export const clusterDeleteError = (clusterId, error) => ({
  * @param {Object} cluster Cluster object
  * @param {Object} payload object with just the data we want to modify
  */
-export function clusterPatch(cluster, payload, isV5Cluster) {
-  return function(dispatch) {
+export function clusterPatch(cluster, payload) {
+  return function(dispatch, getState) {
+    const v5Clusters = getState().entities.clusters.v5Clusters;
+    const isV5Cluster = v5Clusters.includes(cluster.id);
+
     // Optimistic update.
     dispatch({
       type: types.CLUSTER_PATCH,

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -203,11 +203,7 @@ class ClusterDetailView extends React.Component {
     return new Promise((resolve, reject) => {
       this.props
         .dispatch(
-          clusterActions.clusterPatch(
-            this.props.cluster,
-            { name: value },
-            this.props.isV5Cluster
-          )
+          clusterActions.clusterPatch(this.props.cluster, { name: value })
         )
         .then(() => {
           new FlashMessage(


### PR DESCRIPTION
The cluster upgrade and cluster scale modal do not pass the `isV5Cluster` param to the `clusterPatch` action. This should actually somehow mean it was never possible to correctly upgrade or scale v5 clusters, so I am a bit confused.

But instead of teaching them how to find out if their cluster is v5 or not, I moved the logic into the action, as that is a thing we do in some other actions as well. That way the components have to know less about the right way to call the action, which I think is a good thing.

