### PR TITLE
Don't crash if we can't get instance type details.

### DIFF
--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -85,8 +85,11 @@ export function getMemoryTotalNodePools(nodePools = []) {
   // TODO When working with Spot Instances a node pool could have different types
   // of instances, and this method will have to be modified
   const TotalRAM = nodePools.reduce((accumulator, nodePool) => {
-    const instanceTypeRAM =
-      awsInstanceTypes[nodePool.node_spec.aws.instance_type].memory_size_gb;
+    let instanceTypeRAM = 0;
+    if (awsInstanceTypes[nodePool.node_spec.aws.instance_type]) {
+      instanceTypeRAM =
+        awsInstanceTypes[nodePool.node_spec.aws.instance_type].memory_size_gb;
+    }
 
     return accumulator + instanceTypeRAM * nodePool.status.nodes_ready;
   }, 0);
@@ -107,8 +110,11 @@ export function getCpusTotalNodePools(nodePools = []) {
   // TODO When working with Spot Instances a node pool could have different types
   // of instances, and this method will have to be modified
   const TotalCPUs = nodePools.reduce((accumulator, nodePool) => {
-    const instanceTypeCPUs =
-      awsInstanceTypes[nodePool.node_spec.aws.instance_type].cpu_cores;
+    let instanceTypeCPUs = 0;
+    if (awsInstanceTypes[nodePool.node_spec.aws.instance_type]) {
+      instanceTypeCPUs =
+        awsInstanceTypes[nodePool.node_spec.aws.instance_type].cpu_cores;
+    }
 
     return accumulator + instanceTypeCPUs * nodePool.status.nodes_ready;
   }, 0);


### PR DESCRIPTION
This makes happa be a bit more graceful about not getting the instance type details.

There will still be a buggy situation, we'll show 0 CPU and 0 RAM in this case, but this is just a way to make happa a bit more graceful in the meanwhile.