### PR TITLE
remove obsolete TODOs & switch to 5.6.7.8 for passage endpoint in tests

### DIFF
--- a/__tests__/PasswordForgot.js
+++ b/__tests__/PasswordForgot.js
@@ -29,7 +29,7 @@ it('takes us to the forgot password form when clicking on "Forgot your password?
 
 it('gives me a confirmation message after entering something into the email field and clicking submit ', async () => {
   // Given Passage responds favourably to a password reset call.
-  const forgotPasswordRequest = nock('http://localhost:5001')
+  const forgotPasswordRequest = nock('http://5.6.7.8')
     .post('/recovery/', { email: 'iforgotmypassword@giantswarm.io' })
     .reply(StatusCodes.Ok, {
       email: 'iforgotmypassword@giantswarm.io',

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,12 +5,12 @@ process.env.DEBUG_PRINT_LIMIT = 10000;
 module.exports = {
   testEnvironment: 'jest-environment-jsdom', // or jest-environment-node
   testURL: 'http://localhost',
-  setupFiles: [path.resolve(__dirname + '/testUtils/browserMocks.js')],
+  setupFiles: [path.resolve(`${__dirname}/testUtils/browserMocks.js`)],
   moduleDirectories: [
     'node_modules',
-    path.resolve(__dirname + '/src'),
-    path.resolve(__dirname + '/src/components'),
-    path.resolve(__dirname + '/'),
+    path.resolve(`${__dirname}/src`),
+    path.resolve(`${__dirname}/src/components`),
+    path.resolve(`${__dirname}/`),
   ],
   moduleNameMapper: {
     '\\.css$': require.resolve('./testUtils/assetsMock.js'),
@@ -23,7 +23,7 @@ module.exports = {
     // window.config object will now be available in all tests
     config: {
       apiEndpoint: 'http://1.2.3.4',
-      passageEndpoint: 'http://localhost:5001',
+      passageEndpoint: 'http://5.6.7.8',
       environment: 'development',
       ingressBaseDomain: 'k8s.sample.io',
       awsCapabilitiesJSON:

--- a/src/actions/forgotPasswordActions.js
+++ b/src/actions/forgotPasswordActions.js
@@ -2,11 +2,6 @@ import Passage from 'lib/passageClient';
 
 import * as types from './actionTypes';
 
-// TODO: Figure out a way to make the test suite know about our standard
-// 'window.config' object. Or change the way these config params are passed
-// in. Or change the way these components get at these supporting libraries.
-window.config = window.config || { passageEndpoint: 'http://localhost:5000' };
-// EndTODO
 const passage = new Passage({ endpoint: window.config.passageEndpoint });
 
 export function requestPasswordRecoveryToken(email) {

--- a/src/components/SignUp/SignUp.js
+++ b/src/components/SignUp/SignUp.js
@@ -14,11 +14,6 @@ import PasswordField from './PasswordField';
 import StatusMessage from './StatusMessage';
 import TermsOfService from './TermsOfService';
 
-// TODO: Figure out a way to make the test suite know about our standard
-// 'window.config' object. Or change the way these config params are passed
-// in. Or change the way these components get at these supporting libraries.
-window.config = window.config || { passageEndpoint: 'http://localhost:5000' };
-// EndTODO
 const passage = new Passage({ endpoint: window.config.passageEndpoint });
 
 export class SignUp extends React.Component {


### PR DESCRIPTION
This removes obsolete TODOs from Login tests