### PR TITLE
Remove PR title prefix validation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+**IMPORTANT: The changelog for the next release is generated automatically, based on pull requests merged to `master`. In order to properly categorize the changes made, you should allocate a proper label to your pull request:**
+
+- Introducing a new feature
+
+  - `kind/feature`
+
+- Changing existing functionality
+
+  - `kind/change`
+  - `kind/refactor`
+  - `kind/ux-enhancement`
+
+- Soon-to-be removed features
+
+  - `kind/deprecation`
+
+- Removing features
+
+  - `kind/removal`
+
+- Fixing bugs
+
+  - `kind/bug`
+
+- Fixing vulnerabilities
+  - `kind/security`
+
+**Excluded from changelog**
+
+- `dependencies` (Updating dependencies)
+- `kind/dev-change` (Changing development commands, file structure, etc.)

--- a/.github/release-template.yml
+++ b/.github/release-template.yml
@@ -2,28 +2,31 @@ name-template: 'v$NEXT_PATCH_VERSION 🚀'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: 'Added'
-    label: '[FEATURE]'
+    label: 'kind/feature'
 
   - title: 'Changed'
-    label: '[CHANGE]'
+    labels:
+      - 'kind/change'
+      - 'kind/refactor'
+      - 'kind/ux-enhancement'
 
   - title: 'Deprecated'
-    label: '[DEPRECATE]'
+    label: 'kind/deprecation'
 
   - title: 'Removed'
-    label: '[REMOVE]'
+    label: 'kind/removal'
 
   - title: 'Fixed'
-    label: '[BUGFIX]'
+    label: 'kind/bug'
 
   - title: 'Security'
-    label: '[SECURITY]'
+    label: 'kind/security'
+
+exclude-labels:
+  - 'dependencies'
 
 change-template: '- $TITLE (#$NUMBER)'
 template: |
   ## What's changed
 
   $CHANGES
-replacers:
-  - search: '/\[([A-Z])+\]\s/g'
-    replace: ''

--- a/.github/release-template.yml
+++ b/.github/release-template.yml
@@ -24,6 +24,7 @@ categories:
 
 exclude-labels:
   - 'dependencies'
+  - 'kind/dev-change'
 
 change-template: '- $TITLE (#$NUMBER)'
 template: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,7 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@v1.0.0
         with:
-          regex: '\[([A-Z])+\]([ a-zA-Z0-9])+'
-          allowed_prefixes: '[FEATURE],[CHANGE],[DEPRECATE],[REMOVE],[BUGFIX],[SECURITY]'
+          regex: '([ a-zA-Z0-9])+'
           prefix_case_sensitive: false
           min_length: 5
           max_length: 100


### PR DESCRIPTION
Implement categorization of PR titles in draft release by PR labels

## Labels

* Introducing a new feature
  - `kind/feature`

* Changing existing functionality  
  - `kind/change`
  - `kind/refactor`
  - `kind/ux-enhancement`

* Soon-to-be removed features
  - `kind/deprecation`

* Removing features
  -  `kind/removal`

* Fixing bugs
  - `kind/bug`

* Fixing vulnerabilities
  - `kind/security`


**Excluded from changelog**
* `dependencies` (Updating dependencies)
* `kind/dev-change` (Changing development commands, file structure, etc.)
