### PR TITLE
Delete cluster on 404

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -452,15 +452,17 @@ export function clusterLoadDetails(
     } catch (error) {
       if (error.status === StatusCodes.NotFound) {
         new FlashMessage(
-          'This cluster no longer exists.',
+          `Cluster <code>${clusterId}</code> no longer exists.`,
           messageType.INFO,
-          messageTTL.MEDIUM,
-          'Redirecting you to your organization clusters list'
+          messageTTL.MEDIUM
         );
 
         // Delete the cluster in the store.
-        // eslint-disable-next-line no-use-before-define
-        dispatch(clusterDeleteSuccess(clusterId, Date.now()));
+        dispatch({
+          type: types.CLUSTER_DELETE,
+          clusterId,
+          isV5Cluster,
+        });
         dispatch(push(AppRoutes.Home));
 
         return {};

--- a/src/reducers/clusterReducer.js
+++ b/src/reducers/clusterReducer.js
@@ -103,9 +103,20 @@ const clusterReducer = produce((draft, action) => {
 
       return;
 
+    // This is the action that is dispatched when deletion is confirmed in the modal.
+    // The cluster is not removed from the store, but it is now marked as a deleted one.
     case types.CLUSTER_DELETE_SUCCESS:
       draft.items[action.clusterId].delete_date = action.timestamp;
       draft.lastUpdated = Date.now();
+
+      return;
+
+    // This is the action that we dipatch in order to actually remove a cluster from the store.
+    case types.CLUSTER_DELETE:
+      delete draft.items[action.clusterId];
+      if (action.isV5) {
+        draft.v5Clusters.filter(id => id !== action.clusterId);
+      }
 
       return;
 


### PR DESCRIPTION
When a cluster is finally removed (excluded from response in `/v4/clusters` after been marked as `deleted`) Happa has to remove the cluster from the store, otherwise it will be trying to fetch data for a cluster that no longer exists and triggering error messages.