### PR TITLE
Fix tag filter now that we prepend with v.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               only: /.*/
       - architect/push-to-docker-legacy:
@@ -24,7 +24,7 @@ workflows:
             - push-happa-to-aliyun-master
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
             branches:
               ignore: /.*/
       - deploy-to-testing:


### PR DESCRIPTION
😅 Now that we prepend tags with `v` the deploy is not triggered.