### PR TITLE
Fix JWT token not being used after being refreshed

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -59,17 +59,6 @@ export function refreshUserInfo() {
     return usersApi
       .getCurrentUser()
       .then(data => {
-        // const userData = {
-        //   email: data.email,
-        //   auth: {
-        //     scheme: loggedInUser.auth.scheme,
-        //     token: loggedInUser.auth.token,
-        //   },
-        //   isAdmin: loggedInUser.isAdmin,
-        // };
-
-        // localStorage.setItem('user', JSON.stringify(userData));
-
         dispatch({
           type: types.REFRESH_USER_INFO_SUCCESS,
           email: data.email,

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -59,20 +59,20 @@ export function refreshUserInfo() {
     return usersApi
       .getCurrentUser()
       .then(data => {
-        const userData = {
-          email: data.email,
-          auth: {
-            scheme: loggedInUser.auth.scheme,
-            token: loggedInUser.auth.token,
-          },
-          isAdmin: loggedInUser.isAdmin,
-        };
+        // const userData = {
+        //   email: data.email,
+        //   auth: {
+        //     scheme: loggedInUser.auth.scheme,
+        //     token: loggedInUser.auth.token,
+        //   },
+        //   isAdmin: loggedInUser.isAdmin,
+        // };
 
-        localStorage.setItem('user', JSON.stringify(userData));
+        // localStorage.setItem('user', JSON.stringify(userData));
 
         dispatch({
           type: types.REFRESH_USER_INFO_SUCCESS,
-          userData: userData,
+          email: data.email,
         });
       })
       .catch(error => {

--- a/src/components/Auth/AdminLogin.js
+++ b/src/components/Auth/AdminLogin.js
@@ -25,9 +25,9 @@ class AdminLogin extends React.Component {
         // the user to the dashboard. Otherwise, send them to Auth0 to refresh the token that way.
         auth0
           .renewToken()
-          .then(result => {
+          .then(async result => {
             // Update state with new token.
-            this.props.dispatch(userActions.auth0Login(result));
+            await this.props.dispatch(userActions.auth0Login(result));
 
             // Redirect to dashboard.
             this.props.dispatch(push(AppRoutes.Home));

--- a/src/lib/giantswarmClientPatcher.js
+++ b/src/lib/giantswarmClientPatcher.js
@@ -38,9 +38,9 @@ function monkeyPatchGiantSwarmClient(store) {
       if (isJwtExpired(defaultClientAuth.apiKey)) {
         return auth0
           .renewToken()
-          .then(result => {
+          .then(async result => {
             // Update state with new token.
-            store.dispatch(auth0Login(result));
+            await store.dispatch(auth0Login(result));
 
             // Ensure the second attempt uses the new token.
             headerParams[

--- a/src/reducers/appReducer.js
+++ b/src/reducers/appReducer.js
@@ -26,10 +26,15 @@ const initialState = () => ({
 const makeAppReducer = () => {
   return produce((draft, action) => {
     switch (action.type) {
-      case types.REFRESH_USER_INFO_SUCCESS:
-        draft.loggedInUser = action.userData;
+      case types.REFRESH_USER_INFO_SUCCESS: {
+        const newUser = Object.assign({}, draft.loggedInUser, {
+          email: action.email,
+        });
+        setUserToStorage(newUser);
+        draft.loggedInUser = newUser;
 
         return;
+      }
 
       case types.INFO_LOAD_SUCCESS:
         draft.info = action.info;


### PR DESCRIPTION
I found 2 problems:
- We were manipulating data in the `refreshUserInfo` action creator, and when the action got triggered, it would just revert the change made by the token refresh action
- There was a race condition between refreshing the token and executing requests, because the response from the Auth0 servers would sometimes not be quick enough, so the actual authorization header would not be updated