### PR TITLE
Wait for delete before redirecting.

### DIFF
--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -177,9 +177,9 @@ export const batchedClusterDeleteConfirmed = cluster => async dispatch => {
         orgId: cluster.owner,
       }
     );
-    dispatch(push(organizationDetailPath));
 
     await dispatch(clusterActions.clusterDeleteConfirmed(cluster));
+    dispatch(push(organizationDetailPath));
     dispatch(modalActions.modalHide());
   } catch (err) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Wait for the cluster delete action to complete before redirecting to the organization overview.

It's possible that deleting fails, so then we should still be on the cluster detail page.