### PR TITLE
Add error reducer

### DIFF
--- a/src/reducers/errorReducer.js
+++ b/src/reducers/errorReducer.js
@@ -1,0 +1,29 @@
+import produce from 'immer';
+
+const initialState = {};
+
+const errorReducer = produce((draft, action) => {
+  const { type, payload } = action;
+  const matches = /(.*)_(SUCCESS|ERROR)/.exec(type);
+
+  // not a *_SUCCESS / *_ERROR actions, so we ignore them
+  if (!matches) return;
+
+  const [, requestName, requestState] = matches;
+
+  switch (requestState) {
+    case 'ERROR':
+      draft[requestName] = payload?.message ? payload.message : '';
+
+      return;
+
+    // If the actions is a SUCCESS one, lets remove the key and keep the error object as
+    // minimal as possible.
+    case 'SUCCESS':
+      if (draft[requestName]) {
+        delete draft[requestName];
+      }
+  }
+}, initialState);
+
+export default errorReducer;

--- a/src/reducers/errorReducer.js
+++ b/src/reducers/errorReducer.js
@@ -13,7 +13,7 @@ const errorReducer = produce((draft, action) => {
 
   switch (requestState) {
     case 'ERROR':
-      draft[requestName] = payload?.message ? payload.message : '';
+      draft[requestName] = payload?.message ?? '';
 
       return;
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import makeAppReducer from './appReducer';
 import catalogs from './catalogsReducer';
 import clusters from './clusterReducer';
 import credentials from './credentialReducer';
+import errors from './errorReducer';
 import invitations from './invitationReducer';
 import loadingFlags from './loadingReducer';
 import modal from './modalReducer';
@@ -31,6 +32,7 @@ const rootReducer = history =>
     entities,
     modal,
     loadingFlags,
+    errors,
   });
 
 export default rootReducer;


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6716

The idea is to centralise our error flags/messages into an `error` object in the store, and use them in error boundaries.