### PR TITLE
Add entity error reducer and ErrorFallback component

### DIFF
--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -9,11 +9,15 @@ import React from 'react';
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { selectClusterNodePools } from 'selectors/clusterSelectors';
+import {
+  selectClusterNodePools,
+  selectClusterNodePoolsErrorsById,
+} from 'selectors/clusterSelectors';
 import { OrganizationsRoutes } from 'shared/constants/routes';
 import { Dot } from 'styles';
 import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
+import ErrorFallback from 'UI/ErrorFallback';
 import RefreshableLabel from 'UI/RefreshableLabel';
 
 import ClusterDashboardResources from './ClusterDashboardResources';
@@ -73,6 +77,7 @@ function ClusterDashboardItem({
   selectedOrganization,
   nodePools,
   dispatch,
+  nodePoolsLoadError,
 }) {
   /**
    * Returns true if the cluster is younger than 30 days
@@ -156,11 +161,14 @@ function ClusterDashboardItem({
           <Dot style={{ paddingLeft: 0 }} />
           Created {relativeDate(cluster.create_date)}
         </div>
-        <ClusterDashboardResources
-          cluster={cluster}
-          nodePools={nodePools}
-          isV5Cluster={isV5Cluster}
-        />
+
+        <ErrorFallback errorMessage={nodePoolsLoadError}>
+          <ClusterDashboardResources
+            cluster={cluster}
+            nodePools={nodePools}
+            isV5Cluster={isV5Cluster}
+          />
+        </ErrorFallback>
       </ContentWrapper>
 
       <ButtonsWrapper>
@@ -189,11 +197,16 @@ ClusterDashboardItem.propTypes = {
   dispatch: PropTypes.func,
   isV5Cluster: PropTypes.bool,
   nodePools: PropTypes.array,
+  nodePoolsLoadError: PropTypes.string,
 };
 
 function mapStateToProps(state, props) {
   return {
     nodePools: selectClusterNodePools(state, props.cluster.id),
+    nodePoolsLoadError: selectClusterNodePoolsErrorsById(
+      state,
+      props.cluster.id
+    ),
   };
 }
 

--- a/src/components/UI/ErrorFallback.js
+++ b/src/components/UI/ErrorFallback.js
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// ErrorFallback takes one string prop 'errorMessage' and will render the
+// message if it evaluates to true and the children otherwise.
+
+const ErrorWrapperSpan = styled.span`
+  color: ${props => props.theme.colors.error};
+  font-weight: 300;
+`;
+
+function ErrorFallback({ errorMessage, children }) {
+  return errorMessage ? (
+    <ErrorWrapperSpan>{errorMessage}</ErrorWrapperSpan>
+  ) : (
+    children
+  );
+}
+
+ErrorFallback.propTypes = {
+  errorMessage: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default ErrorFallback;

--- a/src/reducers/entityErrorReducer.js
+++ b/src/reducers/entityErrorReducer.js
@@ -9,7 +9,7 @@ const entityErrorReducer = produce((draft, action) => {
   const matches = /(.*)_(SUCCESS|ERROR)/.exec(type);
 
   // not a *_SUCCESS / *_ERROR actions, or no id -> we ignore them
-  if (!matches && !id) return;
+  if (!matches || !id) return;
 
   const [, requestName, requestState] = matches;
 

--- a/src/reducers/entityErrorReducer.js
+++ b/src/reducers/entityErrorReducer.js
@@ -1,0 +1,31 @@
+import produce from 'immer';
+
+const initialState = {};
+
+// Lets use this reducer to track API call errors where we need an ID to identify the
+// item that we are having problems with getting its info, ie getCluster or getNodePool
+const entityErrorReducer = produce((draft, action) => {
+  const { type, id, error } = action;
+  const matches = /(.*)_(SUCCESS|ERROR)/.exec(type);
+
+  // not a *_SUCCESS / *_ERROR actions, or no id -> we ignore them
+  if (!matches && !id) return;
+
+  const [, requestName, requestState] = matches;
+
+  switch (requestState) {
+    case 'ERROR':
+      draft[id] = { [requestName]: error ?? '' };
+
+      return;
+
+    // If the actions is a SUCCESS one, lets remove the key and keep the error object as
+    // minimal as possible.
+    case 'SUCCESS':
+      if (draft[id]?.[requestName]) {
+        delete draft[id][requestName];
+      }
+  }
+}, initialState);
+
+export default entityErrorReducer;

--- a/src/reducers/errorReducer.js
+++ b/src/reducers/errorReducer.js
@@ -13,7 +13,7 @@ const errorReducer = produce((draft, action) => {
 
   switch (requestState) {
     case 'ERROR':
-      draft[requestName] = payload?.message ?? '';
+      draft[requestName] = payload ?? '';
 
       return;
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import makeAppReducer from './appReducer';
 import catalogs from './catalogsReducer';
 import clusters from './clusterReducer';
 import credentials from './credentialReducer';
+import errorsByEntity from './entityErrorReducer';
 import errors from './errorReducer';
 import invitations from './invitationReducer';
 import loadingFlags from './loadingReducer';
@@ -33,6 +34,7 @@ const rootReducer = history =>
     modal,
     loadingFlags,
     errors,
+    errorsByEntity,
   });
 
 export default rootReducer;

--- a/src/selectors/clusterSelectors.js
+++ b/src/selectors/clusterSelectors.js
@@ -34,6 +34,10 @@ export const selectClusterNodePools = (state, clusterId) => {
   return clusterNodePoolsIds.map(nodePoolId => nodePools[nodePoolId]) || [];
 };
 
+export const selectClusterNodePoolsErrorsById = (state, clusterId) => {
+  return state.errorsByEntity[clusterId]?.CLUSTER_NODEPOOLS_LOAD ?? null;
+};
+
 // Memoized Reselect selectors
 // https://github.com/reduxjs/reselect#createselectorinputselectors--inputselectors-resultfunc
 // Using factory functions because they create new references each time that are called,


### PR DESCRIPTION
Introducing `ErrorFallback` and `entityErrorReducer`.

I want to display meaningful info in the view when something did go wrong. For example, when for any reason we can't fetch node pools, I don't want `0 nodes`(which is not true)  in the place when resources should be detailed in clusters list. I'd prefer to have a message telling something to the user:

<img width="975" alt="Captura de pantalla 2020-02-10 a las 17 25 56" src="https://user-images.githubusercontent.com/14203438/74169673-f96a0100-4c2b-11ea-97c0-d679f7b9de30.png">

- `ErrorFallback` is like `LoadingOverlay` but for errors.

- `entityErrorReducer` is used to keep track of errors that happen to every cluster/node pools/entity. Errors are stored in an `errorsByEntity` object so we can fetch and use them quickly in components.

ps: forget about ErrorBoundaries, and sorry for mixing concerns. Error Boundaries are for catching errors in the view. I am more concerned by how we handle errors from API calls.