### PR TITLE
Fallback message when nodes are not ready yet

### DIFF
--- a/__tests__/V5ClusterManagement.js
+++ b/__tests__/V5ClusterManagement.js
@@ -76,7 +76,7 @@ afterAll(() => {
 
 /************ TESTS ************/
 
-it('renders all the v5 cluster data correctly with 0 nodes ready', async () => {
+it('renders all the v5 cluster data correctly', async () => {
   const clusterDetailPath = RoutePath.createUsablePath(
     OrganizationsRoutes.Clusters.Detail,
     {

--- a/src/components/Cluster/ClusterDetail/NodesRunning.js
+++ b/src/components/Cluster/ClusterDetail/NodesRunning.js
@@ -1,13 +1,18 @@
+import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FallbackMessages } from 'shared/constants';
 import { Dot } from 'styles';
 
+const FallbackSpan = styled.span`
+  opacity: 0.5;
+`;
+
 const NodesRunning = ({ workerNodesRunning, RAM, CPUs, nodePools }) => {
   if (workerNodesRunning === 0) {
     return (
       <div data-testid='nodes-running'>
-        <span>{FallbackMessages.NODES_NOT_READY}</span>
+        <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
       </div>
     );
   }

--- a/src/components/Cluster/ClusterDetail/NodesRunning.js
+++ b/src/components/Cluster/ClusterDetail/NodesRunning.js
@@ -1,8 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { FallbackMessages } from 'shared/constants';
 import { Dot } from 'styles';
 
 const NodesRunning = ({ workerNodesRunning, RAM, CPUs, nodePools }) => {
+  if (workerNodesRunning === 0) {
+    return (
+      <div data-testid='nodes-running'>
+        <span>{FallbackMessages.NODES_NOT_READY}</span>
+      </div>
+    );
+  }
+
   const nodesSingularPlural = workerNodesRunning === 1 ? ' node' : ' nodes';
   const npSingularPlural =
     nodePools && nodePools.length === 1 ? ' node pool' : ' node pools';

--- a/src/components/Home/ClusterDashboardResources.js
+++ b/src/components/Home/ClusterDashboardResources.js
@@ -6,6 +6,7 @@ import {
   selectResourcesV4,
   selectResourcesV5,
 } from 'selectors/clusterSelectors';
+import { FallbackMessages } from 'shared/constants';
 import { Dot } from 'styles';
 import RefreshableLabel from 'UI/RefreshableLabel';
 
@@ -44,7 +45,9 @@ function ClusterDashboardResources({
           )}
           <RefreshableLabel value={numberOfNodes}>
             <span>
-              {numberOfNodes} {numberOfNodes === 1 ? 'node' : 'nodes'}
+              {numberOfNodes === 0
+                ? FallbackMessages.NODES_NOT_READY
+                : `${numberOfNodes} ${numberOfNodes === 1 ? 'node' : 'nodes'}`}
             </span>
           </RefreshableLabel>
           {numberOfNodes !== 0 && hasNodePools && (

--- a/src/components/Home/ClusterDashboardResources.js
+++ b/src/components/Home/ClusterDashboardResources.js
@@ -19,6 +19,10 @@ const ClusterDetailsDiv = styled.div`
   }
 `;
 
+const FallbackSpan = styled.span`
+  opacity: 0.5;
+`;
+
 function ClusterDashboardResources({
   cluster,
   loadingClusters,
@@ -44,11 +48,13 @@ function ClusterDashboardResources({
             </RefreshableLabel>
           )}
           <RefreshableLabel value={numberOfNodes}>
-            <span>
-              {numberOfNodes === 0
-                ? FallbackMessages.NODES_NOT_READY
-                : `${numberOfNodes} ${numberOfNodes === 1 ? 'node' : 'nodes'}`}
-            </span>
+            {numberOfNodes === 0 ? (
+              <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
+            ) : (
+              <span>{`${numberOfNodes} ${
+                numberOfNodes === 1 ? 'node' : 'nodes'
+              }`}</span>
+            )}
           </RefreshableLabel>
           {numberOfNodes !== 0 && hasNodePools && (
             <>

--- a/src/shared/constants/fallbackMessages.js
+++ b/src/shared/constants/fallbackMessages.js
@@ -1,0 +1,3 @@
+// We can use this file for custom fallback and error messages.
+
+export const NODES_NOT_READY = 'Nodes not ready yet';

--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -1,8 +1,9 @@
 import * as AuthorizationTypes from './authorizationTypes';
+import * as FallbackMessages from './fallbackMessages';
 import * as Providers from './providers';
 import * as StatusCodes from './statusCodes';
 
-export { Providers, AuthorizationTypes, StatusCodes };
+export { Providers, AuthorizationTypes, StatusCodes, FallbackMessages };
 
 export const Constants = {
   DEFAULT_NODEPOOL_NAME: 'Unnamed node pool',


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8860

We want to give relevant information in the resources components when the cluster is being created. Now we are showing this:

![image](https://user-images.githubusercontent.com/14203438/74230949-b52b3f00-4cc5-11ea-9206-a929c0a4e950.png)

In this PR I am proposing this:

![image](https://user-images.githubusercontent.com/14203438/74232854-e0b02880-4cc9-11ea-8f1e-5c16a6040eda.png)

And this:

![image](https://user-images.githubusercontent.com/14203438/74232753-b9595b80-4cc9-11ea-94bd-cbbda19ff8a9.png)



ps: not sure if the message is really appropiate