### PR TITLE
Revert "Change nodes not ready condition"

### DIFF
--- a/src/components/Cluster/ClusterDetail/NodesRunning.js
+++ b/src/components/Cluster/ClusterDetail/NodesRunning.js
@@ -3,22 +3,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FallbackMessages } from 'shared/constants';
 import { Dot } from 'styles';
-import { isClusterYoungerThanOneHour } from 'utils/clusterUtils';
 
 const FallbackSpan = styled.span`
   opacity: 0.5;
 `;
 
-const NodesRunning = ({
-  workerNodesRunning,
-  createDate,
-  RAM,
-  CPUs,
-  nodePools,
-}) => {
-  //  If it was created more than an hour ago, then we should not show this message
-  //  because something went wrong, so it's best to make it noticeable.
-  if (workerNodesRunning === 0 && isClusterYoungerThanOneHour(createDate)) {
+const NodesRunning = ({ workerNodesRunning, RAM, CPUs, nodePools }) => {
+  if (workerNodesRunning === 0) {
     return (
       <div data-testid='nodes-running'>
         <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
@@ -50,7 +41,6 @@ const NodesRunning = ({
 
 NodesRunning.propTypes = {
   workerNodesRunning: PropTypes.number,
-  createDate: PropTypes.string,
   // TODO Change this when cluster_utils functions are refactored
   RAM: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   CPUs: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
@@ -82,7 +82,6 @@ class V4ClusterDetailTable extends React.Component {
           <div>
             <NodesRunning
               workerNodesRunning={numberOfNodes}
-              createDate={create_date}
               RAM={memory}
               CPUs={cores}
             />

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -368,7 +368,6 @@ class V5ClusterDetailTable extends React.Component {
           <div>
             <NodesRunning
               workerNodesRunning={numberOfNodes}
-              createDate={create_date}
               RAM={memory}
               CPUs={cores}
               nodePools={nodePools}

--- a/src/components/Home/ClusterDashboardResources.js
+++ b/src/components/Home/ClusterDashboardResources.js
@@ -11,7 +11,6 @@ import {
 import { FallbackMessages } from 'shared/constants';
 import { Dot } from 'styles';
 import RefreshableLabel from 'UI/RefreshableLabel';
-import { isClusterYoungerThanOneHour } from 'utils/clusterUtils';
 
 import ClusterDashboardLoadingPlaceholder from './ClusterDashboardLoadingPlaceholder';
 
@@ -51,10 +50,7 @@ function ClusterDashboardResources({
             </RefreshableLabel>
           )}
           <RefreshableLabel value={numberOfNodes}>
-            {/* If it was created more than an hour ago, then we should not show this message
-             because something went wrong, so it's best to make it noticeable. */}
-            {numberOfNodes === 0 &&
-            isClusterYoungerThanOneHour(cluster.create_date) ? (
+            {numberOfNodes === 0 ? (
               <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
             ) : (
               <span>{`${numberOfNodes} ${

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -148,7 +148,3 @@ export function computeCapabilities(releaseVersion, provider) {
       provider === Providers.AWS && cmp(releaseVersion, '10.0.99') === 1,
   };
 }
-
-export const isClusterYoungerThanOneHour = createDate =>
-  // eslint-disable-next-line no-magic-numbers
-  (Date.now() - Date.parse(createDate)) / 1000 / 60 < 1;


### PR DESCRIPTION
Reverts giantswarm/happa#1108 as cluster data doesn't include timezone, so date comparisons are not possible.