### PR TITLE
Use [hash] for js asset in dev

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,6 +11,9 @@ const webpack = require('webpack');
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
+  output: {
+    filename: 'assets/[name].[hash].js',
+  },
   devServer: {
     contentBase: './src',
     hotOnly: true,


### PR DESCRIPTION
This fixes the webpack development config broken since #1130 