### PR TITLE
Error handling in cluster creation views

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -273,11 +273,9 @@ export function clusterCreate(cluster, isV5Cluster) {
     try {
       dispatch({ type: types.CLUSTER_CREATE_REQUEST });
 
-      const method = isV5Cluster
-        ? 'addClusterV5WithHttpInfo'
-        : 'addClusterWithHttpInfo';
-
-      const data = await clustersApi[method](cluster);
+      const data = isV5Cluster
+        ? await clustersApi.addClusterV5WithHttpInfo(cluster)
+        : await clustersApi.addClusterWithHttpInfo(cluster);
 
       const location = data.response.headers.location;
       if (typeof location === 'undefined') {

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -1,5 +1,6 @@
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import * as actionTypes from 'actions/actionTypes';
 import { batchedClusterCreate } from 'actions/batchedActions';
 import DocumentTitle from 'components/shared/DocumentTitle';
 import produce from 'immer';
@@ -9,10 +10,12 @@ import React, { Component } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { TransitionGroup } from 'react-transition-group';
+import { selectErrorByAction } from 'selectors/clusterSelectors';
 import { Constants, Providers } from 'shared/constants';
 import { Input } from 'styles';
 import SlideTransition from 'styles/transitions/SlideTransition';
 import Button from 'UI/Button';
+import ErrorFallback from 'UI/ErrorFallback';
 import ValidationErrorMessage from 'UI/ValidationErrorMessage';
 
 import AddNodePool from '../ClusterDetail/AddNodePool';
@@ -500,16 +503,18 @@ class CreateNodePoolsCluster extends Component {
             {this.state.error && CreateNodePoolsCluster.errorState()}
 
             <FlexRowDiv>
-              <Button
-                bsSize='large'
-                bsStyle='primary'
-                disabled={!this.isValid()}
-                loading={submitting}
-                onClick={this.createCluster}
-                type='button'
-              >
-                Create Cluster
-              </Button>
+              <ErrorFallback errors={this.props.clusterCreateError}>
+                <Button
+                  bsSize='large'
+                  bsStyle='primary'
+                  disabled={!this.isValid()}
+                  loading={submitting}
+                  onClick={this.createCluster}
+                  type='button'
+                >
+                  Create Cluster
+                </Button>
+              </ErrorFallback>
               {/* We want to hide cancel button when the Create NP button has been clicked */}
               {!submitting && (
                 <Button
@@ -558,6 +563,7 @@ CreateNodePoolsCluster.propTypes = {
   defaultAZ: PropTypes.number,
   clusterName: PropTypes.string,
   updateClusterNameInParent: PropTypes.func,
+  clusterCreateError: PropTypes.string,
 };
 
 function mapStateToProps(state) {
@@ -606,6 +612,10 @@ function mapStateToProps(state) {
     minAZ,
     maxAZ,
     defaultAZ,
+    clusterCreateError: selectErrorByAction(
+      state,
+      actionTypes.CLUSTER_CREATE_REQUEST
+    ),
   };
 }
 

--- a/src/components/Cluster/NewCluster/CreateRegularCluster.js
+++ b/src/components/Cluster/NewCluster/CreateRegularCluster.js
@@ -1,13 +1,16 @@
 import styled from '@emotion/styled';
+import * as actionTypes from 'actions/actionTypes';
 import { batchedClusterCreate } from 'actions/batchedActions';
 import DocumentTitle from 'components/shared/DocumentTitle';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
+import { selectErrorByAction } from 'selectors/clusterSelectors';
 import { Constants, Providers } from 'shared/constants';
 import NodeCountSelector from 'shared/NodeCountSelector';
 import Button from 'UI/Button';
+import ErrorFallback from 'UI/ErrorFallback';
 import NumberPicker from 'UI/NumberPicker';
 
 import AWSInstanceTypeSelector from './AWSInstanceTypeSelector';
@@ -578,18 +581,19 @@ class CreateRegularCluster extends React.Component {
 
             <hr style={{ margin: '37px 0 31px' }} />
 
-            <FlexColumnDiv>
-              <Button
-                bsSize='large'
-                bsStyle='primary'
-                disabled={!this.valid()}
-                loading={this.state.submitting}
-                onClick={this.createCluster}
-                type='submit'
-                style={{ marginBottom: '23px' }}
-              >
-                Create Cluster
-              </Button>
+            <FlexColumnDiv style={{ marginBottom: '23px' }}>
+              <ErrorFallback errors={this.props.clusterCreateError}>
+                <Button
+                  bsSize='large'
+                  bsStyle='primary'
+                  disabled={!this.valid()}
+                  loading={this.state.submitting}
+                  onClick={this.createCluster}
+                  type='submit'
+                >
+                  Create Cluster
+                </Button>
+              </ErrorFallback>
               <ClusterCreationDuration
                 stats={this.props.clusterCreationStats}
               />
@@ -634,6 +638,7 @@ CreateRegularCluster.propTypes = {
   activeSortedReleases: PropTypes.array,
   clusterName: PropTypes.string,
   updateClusterNameInParent: PropTypes.func,
+  clusterCreateError: PropTypes.string,
 };
 
 function mapStateToProps(state) {
@@ -675,7 +680,13 @@ function mapStateToProps(state) {
       state.app.info.workers.count_per_cluster.max;
   }
 
-  return propsToPush;
+  return {
+    ...propsToPush,
+    clusterCreateError: selectErrorByAction(
+      state,
+      actionTypes.CLUSTER_CREATE_REQUEST
+    ),
+  };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/src/reducers/errorReducer.js
+++ b/src/reducers/errorReducer.js
@@ -3,7 +3,7 @@ import produce from 'immer';
 const initialState = {};
 
 const errorReducer = produce((draft, action) => {
-  const { type, payload } = action;
+  const { type, error } = action;
   const matches = /(.*)_(SUCCESS|ERROR)/.exec(type);
 
   // not a *_SUCCESS / *_ERROR actions, so we ignore them
@@ -13,7 +13,7 @@ const errorReducer = produce((draft, action) => {
 
   switch (requestState) {
     case 'ERROR':
-      draft[requestName] = payload ?? '';
+      draft[requestName] = error ?? '';
 
       return;
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8860
Fixes https://github.com/giantswarm/giantswarm/issues/9088

This fixes some quirks in v4/v5 creation form: https://gigantic.slack.com/archives/CQ465CFG8/p1582631553009400 . Basically, no error message and an endless spinner.

Now it will show a flash message and the actual error message instead the buttons:

<img width="1010" alt="Captura de pantalla 2020-02-25 a las 17 17 06" src="https://user-images.githubusercontent.com/14203438/75275370-b3ed2c80-5804-11ea-9057-b6a5e3455d65.png">

This is a quick fix. IMO it's not ideal and we should think how do we want to translate these kind of errors into meaningful pieces of UI. Maybe adding a button for retry would be a better option.

