### PR TITLE
Ellipsis in members list and as a composable

### DIFF
--- a/src/components/Cluster/ClusterDetail/NodePool.js
+++ b/src/components/Cluster/ClusterDetail/NodePool.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { Code } from 'styles/';
+import { Code, Ellipsis } from 'styles/';
 import theme from 'styles/theme';
 import ViewAndEditName from 'UI/ViewEditName';
 
@@ -32,10 +32,8 @@ const NameWrapperDiv = styled.div`
     display: flex;
   }
   a {
-    text-overflow: ellipsis;
-    max-width: 95%;
+    ${Ellipsis}
     display: inline-block;
-    overflow: hidden;
   }
 `;
 

--- a/src/components/Organizations/Detail/View.js
+++ b/src/components/Organizations/Detail/View.js
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import * as OrganizationActions from 'actions/organizationActions';
 import DocumentTitle from 'components/shared/DocumentTitle';
 import { relativeDate } from 'lib/helpers.js';
@@ -12,9 +13,16 @@ import { bindActionCreators } from 'redux';
 import cmp from 'semver-compare';
 import { Providers } from 'shared/constants';
 import { OrganizationsRoutes } from 'shared/constants/routes';
+import { Ellipsis } from 'styles';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 
 import Credentials from './Credentials';
+
+const MembersTable = styled.div`
+  .member-email {
+    ${Ellipsis}
+  }
+`;
 
 const clusterTableDefaultSorting = [
   {
@@ -108,6 +116,7 @@ class OrganizationDetail extends React.Component {
         sort: true,
         attrs: {
           'data-testid': 'organization-member-email',
+          className: 'member-email',
         },
       },
       {
@@ -188,7 +197,7 @@ class OrganizationDetail extends React.Component {
               <div className='col-3'>
                 <h3 className='table-label'>Members</h3>
               </div>
-              <div className='col-9'>
+              <MembersTable className='col-9'>
                 {this.props.organization.members.length === 0 ? (
                   <p>This organization has no members</p>
                 ) : (
@@ -204,7 +213,7 @@ class OrganizationDetail extends React.Component {
                 <Button bsStyle='default' onClick={this.addMember}>
                   <i className='fa fa-add-circle' /> Add Member
                 </Button>
-              </div>
+              </MembersTable>
             </div>
 
             {credentialsSection}

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -38,6 +38,12 @@ export const Input = props => css`
   }
 `;
 
+export const Ellipsis = css`
+  text-overflow: ellipsis;
+  max-width: 95%;
+  overflow: hidden;
+`;
+
 /***** STYLED ELEMENTS *****/
 
 // Layout


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/9083 in organization view.

Before:

![image](https://user-images.githubusercontent.com/14203438/75336895-42f15780-588c-11ea-8b77-3bb8f7a0ab77.png)

After:

![image](https://user-images.githubusercontent.com/14203438/75337705-c52e4b80-588d-11ea-842c-f006e06e40e7.png)

And adds `Ellipsis` as a composable styles that you can throw anywhere you want this behaviour as long as its parent is a `block` element and has `white-space: no-wrap`
