### PR TITLE
Show app name instead of object Object in flash and error to reducer

### DIFF
--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -121,8 +121,13 @@ export function installApp(app, clusterID) {
           },
         },
       }).catch(error => {
-        showAppInstallationErrorFlashMessage(app, clusterID, error);
-        throw error;
+        showAppInstallationErrorFlashMessage(app.name, clusterID, error);
+
+        dispatch({
+          type: types.CLUSTER_INSTALL_APP_ERROR,
+          id: clusterID,
+          error,
+        });
       });
 
       dispatch({


### PR DESCRIPTION
Fixes error handling when creating an app already installed: https://gigantic.slack.com/archives/C13MG9F0W/p1582714381022700