### PR TITLE
moved Root app Component to own file

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,0 +1,26 @@
+import { ConnectedRouter } from 'connected-react-router';
+import { ThemeProvider } from 'emotion-theming';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { hot } from 'react-hot-loader';
+import { Provider } from 'react-redux';
+
+import Routes from './Routes';
+
+const App = ({ store, theme, history }) => (
+  <Provider store={store}>
+    <ThemeProvider theme={theme}>
+      <ConnectedRouter history={history}>
+        <Routes />
+      </ConnectedRouter>
+    </ThemeProvider>
+  </Provider>
+);
+
+App.propTypes = {
+  store: PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
+};
+
+export default hot(module)(App);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,23 +9,15 @@ import 'react-datepicker/dist/react-datepicker.css';
 import 'styles/app.sass';
 
 import { Notifier } from '@airbrake/browser';
-import { ConnectedRouter } from 'connected-react-router';
-import { ThemeProvider } from 'emotion-theming';
 import monkeyPatchGiantSwarmClient from 'lib/giantswarmClientPatcher';
 import { Requester } from 'lib/patchedAirbrakeRequester';
 import React from 'react';
 import { render } from 'react-dom';
-import { hot } from 'react-hot-loader';
-import { Provider } from 'react-redux';
 import configureStore from 'stores/configureStore';
 import history from 'stores/history';
 import theme from 'styles/theme';
 
-import Routes from './Routes';
-
-// Remove the loading class on the body, the javascript has loaded now.
-const body = document.getElementsByTagName('body')[0];
-body.classList.remove('loading');
+import App from './App';
 
 // Configure the redux store.
 const store = configureStore({}, history);
@@ -70,19 +62,10 @@ history.listen(() => {
   window.scrollTo(0, 0);
 });
 
+// Remove the loading class on the body, the javascript has loaded now.
+const body = document.getElementsByTagName('body')[0];
+body.classList.remove('loading');
+
 // Finally, render the app!
 const appContainer = document.getElementById('app');
-
-const App = () => (
-  <Provider store={store}>
-    <ThemeProvider theme={theme}>
-      <ConnectedRouter history={history}>
-        <Routes />
-      </ConnectedRouter>
-    </ThemeProvider>
-  </Provider>
-);
-
-const HotApp = hot(module)(App);
-
-render(<HotApp />, appContainer);
+render(<App {...{ store, theme, history }} />, appContainer);

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
-  entry: './src/components/app.js',
+  entry: ['react-hot-loader/patch', './src/components/index.js'],
   context: __dirname,
   output: {
     publicPath: '/',


### PR DESCRIPTION
While working on #1124 I've noticed hot reloading threw some error about using `hot` and `render` in the same file being discouraged and linking to the [Getting Started](https://github.com/gaearon/react-hot-loader/#getting-started) documentation of `react-hot-loader`. 

These changes resolve the error for me and also in #1124 

Somehow tests seem to be failing randomly on my machine.. lets see how this behaves in CI