### PR TITLE
Get started button tests

### DIFF
--- a/__tests__/GettingStarted.js
+++ b/__tests__/GettingStarted.js
@@ -26,8 +26,10 @@ beforeEach(() => {
   getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
   getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
   getMockCall('/v4/appcatalogs/', appCatalogsResponse);
-  // prettier-ignore
-  getMockCall(`/v4/clusters/${V4_CLUSTER.id}/status/`,v4AWSClusterStatusResponse);
+  getMockCall(
+    `/v4/clusters/${V4_CLUSTER.id}/status/`,
+    v4AWSClusterStatusResponse
+  );
 });
 
 afterEach(async () => {

--- a/__tests__/GettingStarted.js
+++ b/__tests__/GettingStarted.js
@@ -20,17 +20,14 @@ import { renderRouteWithStore } from 'testUtils/renderUtils';
 
 // Responses to requests
 beforeEach(() => {
-  // prettier-ignore
   getMockCall('/v4/user/', userResponse);
   getMockCall('/v4/info/', AWSInfoResponse);
   getMockCall('/v4/organizations/', orgsResponse);
   getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
   getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
   getMockCall('/v4/appcatalogs/', appCatalogsResponse);
-  getMockCall(
-    `/v4/clusters/${V4_CLUSTER.id}/status/`,
-    v4AWSClusterStatusResponse
-  );
+  // prettier-ignore
+  getMockCall(`/v4/clusters/${V4_CLUSTER.id}/status/`,v4AWSClusterStatusResponse);
 });
 
 afterEach(async () => {
@@ -84,12 +81,8 @@ it('the get started button does not show up if the cluster is older than 30 days
 
   // prettier-ignore
   getMockCall('/v4/clusters/', [Object.assign({}, v4ClustersResponse[0], {create_date: clusterCreateDate2MonthsLater})]);
-  getMockCall(
-    `/v4/clusters/${V4_CLUSTER.id}/`,
-    Object.assign({}, v4AWSClusterResponse, {
-      create_date: clusterCreateDate2MonthsLater,
-    })
-  );
+  // prettier-ignore
+  getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`,Object.assign({}, v4AWSClusterResponse, {create_date: clusterCreateDate2MonthsLater,}));
 
   const { findByText, queryByText } = renderRouteWithStore(AppRoutes.Home);
 

--- a/__tests__/GettingStarted.js
+++ b/__tests__/GettingStarted.js
@@ -79,10 +79,17 @@ it('the get started button does not show up if the cluster is older than 30 days
 
   const clusterCreateDate2MonthsLater = futureDate.toISOString();
 
-  // prettier-ignore
-  getMockCall('/v4/clusters/', [Object.assign({}, v4ClustersResponse[0], {create_date: clusterCreateDate2MonthsLater})]);
-  // prettier-ignore
-  getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`,Object.assign({}, v4AWSClusterResponse, {create_date: clusterCreateDate2MonthsLater,}));
+  const modifiedClustersResponse = [
+    Object.assign({}, v4ClustersResponse[0], {
+      create_date: clusterCreateDate2MonthsLater,
+    }),
+  ];
+  const modifiedClusterResponse = Object.assign({}, v4AWSClusterResponse, {
+    create_date: clusterCreateDate2MonthsLater,
+  });
+
+  getMockCall('/v4/clusters/', modifiedClustersResponse);
+  getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, modifiedClusterResponse);
 
   const { findByText, queryByText } = renderRouteWithStore(AppRoutes.Home);
 

--- a/__tests__/GettingStarted.js
+++ b/__tests__/GettingStarted.js
@@ -1,16 +1,15 @@
 import '@testing-library/jest-dom/extend-expect';
 
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, wait } from '@testing-library/react';
+import nock from 'nock';
 import { AppRoutes } from 'shared/constants/routes';
 import {
   appCatalogsResponse,
-  appsResponse,
   AWSInfoResponse,
-  getPersistedMockCall,
+  getMockCall,
   ORGANIZATION,
   orgResponse,
   orgsResponse,
-  releasesResponse,
   userResponse,
   V4_CLUSTER,
   v4AWSClusterResponse,
@@ -19,56 +18,39 @@ import {
 } from 'testUtils/mockHttpCalls';
 import { renderRouteWithStore } from 'testUtils/renderUtils';
 
-// Tests setup
-const requests = {};
-
 // Responses to requests
-beforeAll(() => {
+beforeEach(() => {
   // prettier-ignore
-  requests.userInfo = getPersistedMockCall('/v4/user/', userResponse);
-  requests.info = getPersistedMockCall('/v4/info/', AWSInfoResponse);
-  requests.organizations = getPersistedMockCall(
-    '/v4/organizations/',
-    orgsResponse
-  );
-  requests.organization = getPersistedMockCall(
-    `/v4/organizations/${ORGANIZATION}/`,
-    orgResponse
-  );
-  requests.clusters = getPersistedMockCall('/v4/clusters/', v4ClustersResponse);
-  requests.cluster = getPersistedMockCall(
-    `/v4/clusters/${V4_CLUSTER.id}/`,
-    v4AWSClusterResponse
-  );
-  requests.status = getPersistedMockCall(
+  getMockCall('/v4/user/', userResponse);
+  getMockCall('/v4/info/', AWSInfoResponse);
+  getMockCall('/v4/organizations/', orgsResponse);
+  getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+  getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
+  getMockCall('/v4/appcatalogs/', appCatalogsResponse);
+  getMockCall(
     `/v4/clusters/${V4_CLUSTER.id}/status/`,
     v4AWSClusterStatusResponse
   );
-  requests.apps = getPersistedMockCall(
-    `/v4/clusters/${V4_CLUSTER.id}/apps/`,
-    appsResponse
-  );
-  requests.credentials = getPersistedMockCall(
-    `/v4/organizations/${ORGANIZATION}/credentials/`
-  );
-  requests.releases = getPersistedMockCall('/v4/releases/', releasesResponse);
-
-  requests.appcatalogs = getPersistedMockCall(
-    '/v4/appcatalogs/',
-    appCatalogsResponse
-  );
 });
 
-// Stop persisting responses
-afterAll(() => {
-  Object.keys(requests).forEach(req => {
-    requests[req].persist(false);
-  });
+afterEach(async () => {
+  if (!nock.isDone()) {
+    // eslint-disable-next-line no-console
+    console.error('Nock has pending mocks:', nock.pendingMocks());
+  }
+
+  await wait(() => expect(nock.isDone()).toBeTruthy());
+
+  nock.cleanAll();
 });
 
 /************ TESTS ************/
 
 it('lets me get there from the dashboard and go through the pages', async () => {
+  // prettier-ignore
+  getMockCall('/v4/clusters/', v4ClustersResponse);
+  getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+
   const { findByText } = renderRouteWithStore(AppRoutes.Home);
 
   const getStartedButton = await findByText('Get Started');
@@ -92,4 +74,27 @@ it('lets me get there from the dashboard and go through the pages', async () => 
 
   const congratulations = await findByText('Congratulations');
   expect(congratulations).toBeInTheDocument();
+});
+
+it('the get started button does not show up if the cluster is older than 30 days', async () => {
+  const futureDate = new Date();
+  futureDate.setMonth(futureDate.getMonth() + 2);
+
+  const clusterCreateDate2MonthsLater = futureDate.toISOString();
+
+  // prettier-ignore
+  getMockCall('/v4/clusters/', [Object.assign({}, v4ClustersResponse[0], {create_date: clusterCreateDate2MonthsLater})]);
+  getMockCall(
+    `/v4/clusters/${V4_CLUSTER.id}/`,
+    Object.assign({}, v4AWSClusterResponse, {
+      create_date: clusterCreateDate2MonthsLater,
+    })
+  );
+
+  const { findByText, queryByText } = renderRouteWithStore(AppRoutes.Home);
+
+  await findByText(V4_CLUSTER.id);
+  expect(queryByText('Get Started')).not.toBeInTheDocument();
+
+  await wait(() => expect(nock.isDone()).toBeTruthy());
 });


### PR DESCRIPTION
Towards: https://github.com/giantswarm/happa/issues/759

We're already indirectly testing that the get started button shows up in the Getting Started tests. I added a test now to check that it goes away when the cluster is older than 30 days.

Also refactored to non-persisted nock calls.