### PR TITLE
Don't show cert-exporter and net-exporter twice. 

### DIFF
--- a/__tests__/AppCatalog.js
+++ b/__tests__/AppCatalog.js
@@ -27,643 +27,663 @@ import {
 } from 'testUtils/mockHttpCalls';
 import { renderRouteWithStore } from 'testUtils/renderUtils';
 
-describe('AppCatalog', () => {
+describe('Apps and App Catalog', () => {
   beforeEach(() => {
     getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);
     getMockCall('/v4/clusters/', v4ClustersResponse);
     getMockCallTimes('/v4/organizations/', orgsResponse);
   });
 
-  /************ TESTS ************/
+  describe('App Catalogs, Apps, Installing Apps', () => {
+    it('renders all non internal app catalogs in the app catalogs overview', async () => {
+      getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
 
-  it('renders all non internal app catalogs in the app catalogs overview', async () => {
-    getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
+      nock('https://catalogshost')
+        .get('/giantswarm-incubator-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/giantswarm-test-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/helmstable/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
 
-    nock('https://catalogshost')
-      .get('/giantswarm-incubator-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/giantswarm-test-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/helmstable/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
+      const { findByText } = renderRouteWithStore(AppCatalogRoutes.Home);
 
-    const { findByText } = renderRouteWithStore(AppCatalogRoutes.Home);
+      const introText = await findByText(
+        'Pick an App Catalog to browse all the Apps in it.'
+      );
+      expect(introText).toBeInTheDocument();
 
-    const introText = await findByText(
-      'Pick an App Catalog to browse all the Apps in it.'
-    );
-    expect(introText).toBeInTheDocument();
+      for (const catalog of appCatalogsResponse) {
+        // Skip expectation for internal catalogs.
+        // They should not show up in Happa.
+        if (
+          catalog.metadata.labels['application.giantswarm.io/catalog-type'] ===
+          'internal'
+        ) {
+          continue;
+        }
 
-    for (const catalog of appCatalogsResponse) {
-      // Skip expectation for internal catalogs.
-      // They should not show up in Happa.
-      if (
-        catalog.metadata.labels['application.giantswarm.io/catalog-type'] ===
-        'internal'
-      ) {
-        continue;
+        const catalogTitle = await findByText(catalog.spec.title);
+        expect(catalogTitle).toBeInTheDocument();
       }
+    });
 
-      const catalogTitle = await findByText(catalog.spec.title);
+    it('renders all apps in the app list for a given catalog', async () => {
+      getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
+
+      nock('https://catalogshost')
+        .get('/giantswarm-incubator-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/giantswarm-test-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/helmstable/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+
+      const appCatalogListPath = RoutePath.createUsablePath(
+        AppCatalogRoutes.AppList,
+        { repo: 'giantswarm-incubator' }
+      );
+      const { findByText } = renderRouteWithStore(appCatalogListPath);
+
+      const catalogTitle = await findByText('Giant Swarm Incubator');
       expect(catalogTitle).toBeInTheDocument();
-    }
-  });
-
-  it('renders all apps in the app list for a given catalog', async () => {
-    getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
-
-    nock('https://catalogshost')
-      .get('/giantswarm-incubator-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/giantswarm-test-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/helmstable/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-
-    const appCatalogListPath = RoutePath.createUsablePath(
-      AppCatalogRoutes.AppList,
-      { repo: 'giantswarm-incubator' }
-    );
-    const { findByText } = renderRouteWithStore(appCatalogListPath);
-
-    const catalogTitle = await findByText('Giant Swarm Incubator');
-    expect(catalogTitle).toBeInTheDocument();
-  });
-
-  it('renders the app detail page for a given app', async () => {
-    getMockCallTimes('/v4/user/', userResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
-    getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
-
-    nock('https://catalogshost')
-      .get('/giantswarm-incubator-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/giantswarm-test-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/helmstable/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-
-    const appCatalogListPath = RoutePath.createUsablePath(
-      AppCatalogRoutes.AppDetail,
-      {
-        repo: 'giantswarm-incubator',
-        app: 'nginx-ingress-controller-app',
-      }
-    );
-    const { findByText } = renderRouteWithStore(appCatalogListPath);
-
-    // The app's description should be there.
-    // This comes from parsing the index.yaml, which is mocked in catalogIndexResponse.
-    const appDescription = await findByText(
-      'A Helm chart for the nginx ingress-controller'
-    );
-    expect(appDescription).toBeInTheDocument();
-  });
-
-  it('installs an app in a cluster, with default settings', async () => {
-    nock(API_ENDPOINT)
-      .intercept(
-        `/v4/clusters/${V4_CLUSTER.id}/apps/nginx-ingress-controller-app/`,
-        'PUT'
-      )
-      .reply(StatusCodes.Ok);
-
-    getMockCallTimes('/v4/user/', userResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
-    getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
-    getMockCallTimes(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse, 2);
-    getMockCallTimes(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse,
-      2
-    );
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/apps/`, appsResponse);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
-    getMockCall('/v4/releases/', releasesResponse);
-
-    nock('https://catalogshost')
-      .get('/giantswarm-incubator-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/giantswarm-test-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/helmstable/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-
-    const appCatalogListPath = RoutePath.createUsablePath(
-      AppCatalogRoutes.AppDetail,
-      {
-        repo: 'giantswarm-incubator',
-        app: 'nginx-ingress-controller-app',
-      }
-    );
-    const { findByText, findAllByText, getByText } = renderRouteWithStore(
-      appCatalogListPath
-    );
-
-    // Press the configure button
-    let installButton = await findByText(/configure & install/i);
-    fireEvent.click(installButton);
-
-    // Select the current cluster
-    fireEvent.click(getByText(V4_CLUSTER.name));
-
-    // Install the new app
-    installButton = await findByText(/install app/i);
-    fireEvent.click(installButton);
-
-    await findByText(/is being installed on/i);
-
-    // Check if the user got redirected to the cluster detail view
-    await findAllByText(V4_CLUSTER.name);
-    await findByText(/kubernetes endpoint uri/i);
-  });
-
-  it('installs an app in a cluster, with custom settings', async () => {
-    const testApp = 'nginx-ingress-controller-app';
-
-    const installAppResponse = {
-      code: 'RESOURCE_CREATED',
-      message: `We're installing your app called 'test-app' on ${V4_CLUSTER.id}`,
-    };
-    nock(API_ENDPOINT)
-      .intercept(`/v4/clusters/${V4_CLUSTER.id}/apps/test-app/`, 'PUT')
-      .reply(StatusCodes.Ok, installAppResponse);
-
-    getMockCallTimes('/v4/user/', userResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
-    getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
-    getMockCallTimes(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse, 2);
-    getMockCallTimes(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse,
-      2
-    );
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/apps/`, appsResponse);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
-    getMockCall('/v4/releases/', releasesResponse);
-
-    nock('https://catalogshost')
-      .get('/giantswarm-incubator-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/giantswarm-test-catalog/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-    nock('https://catalogshost')
-      .get('/helmstable/index.yaml')
-      .reply(StatusCodes.Ok, catalogIndexResponse);
-
-    const appCatalogListPath = RoutePath.createUsablePath(
-      AppCatalogRoutes.AppDetail,
-      {
-        repo: 'giantswarm-incubator',
-        app: testApp,
-      }
-    );
-    const {
-      findByText,
-      findAllByText,
-      getByText,
-      getByLabelText,
-    } = renderRouteWithStore(appCatalogListPath);
-
-    // Press the configure button
-    let installButton = await findByText(/configure & install/i);
-    fireEvent.click(installButton);
-
-    // Select the current cluster
-    fireEvent.click(getByText(V4_CLUSTER.name));
-
-    // Set a new application name
-    const appNameInput = getByLabelText(/application name/i);
-    fireEvent.change(appNameInput, {
-      target: { value: 'test-app' },
     });
 
-    // Check if namespace input is disabled
-    expect(getByLabelText(/namespace:/i).readOnly).toBeTruthy();
+    it('renders the app detail page for a given app', async () => {
+      getMockCallTimes('/v4/user/', userResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
+      getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
 
-    // Upload a configmap file
-    let fileInput = getByLabelText(/configmap:/i);
-    let file = new Blob(
-      [
-        JSON.stringify({
-          name: 'test',
-          namespace: 'some-other-test',
-        }),
-      ],
-      {
-        type: 'application/json',
-        name: 'config.json',
-      }
-    );
-    fireEvent.change(fileInput, {
-      target: {
-        files: [file],
-      },
+      nock('https://catalogshost')
+        .get('/giantswarm-incubator-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/giantswarm-test-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/helmstable/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+
+      const appCatalogListPath = RoutePath.createUsablePath(
+        AppCatalogRoutes.AppDetail,
+        {
+          repo: 'giantswarm-incubator',
+          app: 'nginx-ingress-controller-app',
+        }
+      );
+      const { findByText } = renderRouteWithStore(appCatalogListPath);
+
+      // The app's description should be there.
+      // This comes from parsing the index.yaml, which is mocked in catalogIndexResponse.
+      const appDescription = await findByText(
+        'A Helm chart for the nginx ingress-controller'
+      );
+      expect(appDescription).toBeInTheDocument();
     });
 
-    // Upload a secrets file
-    fileInput = getByLabelText(/secret:/i);
-    file = new Blob(
-      [
-        JSON.stringify({
-          name: 'test',
-          namespace: 'some-other-test',
-        }),
-      ],
-      {
-        type: 'application/json',
-        name: 'secrets.json',
-      }
-    );
-    fireEvent.change(fileInput, {
-      target: {
-        files: [file],
-      },
+    it('installs an app in a cluster, with default settings', async () => {
+      nock(API_ENDPOINT)
+        .intercept(
+          `/v4/clusters/${V4_CLUSTER.id}/apps/nginx-ingress-controller-app/`,
+          'PUT'
+        )
+        .reply(StatusCodes.Ok);
+
+      getMockCallTimes('/v4/user/', userResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
+      getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/`,
+        v4AWSClusterResponse,
+        2
+      );
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse,
+        2
+      );
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/apps/`, appsResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
+      getMockCall('/v4/releases/', releasesResponse);
+
+      nock('https://catalogshost')
+        .get('/giantswarm-incubator-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/giantswarm-test-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/helmstable/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+
+      const appCatalogListPath = RoutePath.createUsablePath(
+        AppCatalogRoutes.AppDetail,
+        {
+          repo: 'giantswarm-incubator',
+          app: 'nginx-ingress-controller-app',
+        }
+      );
+      const { findByText, findAllByText, getByText } = renderRouteWithStore(
+        appCatalogListPath
+      );
+
+      // Press the configure button
+      let installButton = await findByText(/configure & install/i);
+      fireEvent.click(installButton);
+
+      // Select the current cluster
+      fireEvent.click(getByText(V4_CLUSTER.name));
+
+      // Install the new app
+      installButton = await findByText(/install app/i);
+      fireEvent.click(installButton);
+
+      await findByText(/is being installed on/i);
+
+      // Check if the user got redirected to the cluster detail view
+      await findAllByText(V4_CLUSTER.name);
+      await findByText(/kubernetes endpoint uri/i);
     });
 
-    // Install the new app
-    installButton = await findByText(/install app/i);
-    fireEvent.click(installButton);
+    it('installs an app in a cluster, with custom settings', async () => {
+      const testApp = 'nginx-ingress-controller-app';
 
-    await findByText(/is being installed on/i);
+      const installAppResponse = {
+        code: 'RESOURCE_CREATED',
+        message: `We're installing your app called 'test-app' on ${V4_CLUSTER.id}`,
+      };
+      nock(API_ENDPOINT)
+        .intercept(`/v4/clusters/${V4_CLUSTER.id}/apps/test-app/`, 'PUT')
+        .reply(StatusCodes.Ok, installAppResponse);
 
-    // Check if the user got redirected to the cluster detail view
-    await findAllByText(V4_CLUSTER.name);
-    await findByText(/kubernetes endpoint uri/i);
+      getMockCallTimes('/v4/user/', userResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
+      getMockCallTimes('/v4/appcatalogs/', appCatalogsResponse, 2);
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/`,
+        v4AWSClusterResponse,
+        2
+      );
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse,
+        2
+      );
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/apps/`, appsResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
+      getMockCall('/v4/releases/', releasesResponse);
+
+      nock('https://catalogshost')
+        .get('/giantswarm-incubator-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/giantswarm-test-catalog/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+      nock('https://catalogshost')
+        .get('/helmstable/index.yaml')
+        .reply(StatusCodes.Ok, catalogIndexResponse);
+
+      const appCatalogListPath = RoutePath.createUsablePath(
+        AppCatalogRoutes.AppDetail,
+        {
+          repo: 'giantswarm-incubator',
+          app: testApp,
+        }
+      );
+      const {
+        findByText,
+        findAllByText,
+        getByText,
+        getByLabelText,
+      } = renderRouteWithStore(appCatalogListPath);
+
+      // Press the configure button
+      let installButton = await findByText(/configure & install/i);
+      fireEvent.click(installButton);
+
+      // Select the current cluster
+      fireEvent.click(getByText(V4_CLUSTER.name));
+
+      // Set a new application name
+      const appNameInput = getByLabelText(/application name/i);
+      fireEvent.change(appNameInput, {
+        target: { value: 'test-app' },
+      });
+
+      // Check if namespace input is disabled
+      expect(getByLabelText(/namespace:/i).readOnly).toBeTruthy();
+
+      // Upload a configmap file
+      let fileInput = getByLabelText(/configmap:/i);
+      let file = new Blob(
+        [
+          JSON.stringify({
+            name: 'test',
+            namespace: 'some-other-test',
+          }),
+        ],
+        {
+          type: 'application/json',
+          name: 'config.json',
+        }
+      );
+      fireEvent.change(fileInput, {
+        target: {
+          files: [file],
+        },
+      });
+
+      // Upload a secrets file
+      fileInput = getByLabelText(/secret:/i);
+      file = new Blob(
+        [
+          JSON.stringify({
+            name: 'test',
+            namespace: 'some-other-test',
+          }),
+        ],
+        {
+          type: 'application/json',
+          name: 'secrets.json',
+        }
+      );
+      fireEvent.change(fileInput, {
+        target: {
+          files: [file],
+        },
+      });
+
+      // Install the new app
+      installButton = await findByText(/install app/i);
+      fireEvent.click(installButton);
+
+      await findByText(/is being installed on/i);
+
+      // Check if the user got redirected to the cluster detail view
+      await findAllByText(V4_CLUSTER.name);
+      await findByText(/kubernetes endpoint uri/i);
+    });
   });
 
-  it('updates the config map of an already installed app', async () => {
-    nock(API_ENDPOINT)
-      .intercept(`/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/config/`, 'PATCH')
-      .reply(StatusCodes.Ok);
+  describe('App Detail Pane', () => {
+    it('updates the config map of an already installed app', async () => {
+      nock(API_ENDPOINT)
+        .intercept(
+          `/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/config/`,
+          'PATCH'
+        )
+        .reply(StatusCodes.Ok);
 
-    getMockCallTimes('/v4/user/', userResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
-    getMockCall('/v4/appcatalogs/', appCatalogsResponse);
+      getMockCallTimes('/v4/user/', userResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
+      getMockCall('/v4/appcatalogs/', appCatalogsResponse);
 
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCallTimes(
-      `/v4/clusters/${V4_CLUSTER.id}/apps/`,
-      [appResponseWithCustomConfig],
-      2
-    );
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
-    getMockCall('/v4/releases/', releasesResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/apps/`,
+        [appResponseWithCustomConfig],
+        2
+      );
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
+      getMockCall('/v4/releases/', releasesResponse);
 
-    const clusterDetailPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.Detail,
-      {
-        orgId: ORGANIZATION,
-        clusterId: V4_CLUSTER.id,
-      }
-    );
-    const { findByText, getByText } = renderRouteWithStore(clusterDetailPath);
+      const clusterDetailPath = RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.Detail,
+        {
+          orgId: ORGANIZATION,
+          clusterId: V4_CLUSTER.id,
+        }
+      );
+      const { findByText, getByText } = renderRouteWithStore(clusterDetailPath);
 
-    const appsTab = await findByText(/^apps$/i);
-    fireEvent.click(appsTab);
+      const appsTab = await findByText(/^apps$/i);
+      fireEvent.click(appsTab);
 
-    // Click on app details button to open the editing modal
-    const appLabel = getByText(/app version: 0.0.1/i);
-    const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
-      'button'
-    );
-    fireEvent.click(appDetailsButton);
+      // Click on app details button to open the editing modal
+      const appLabel = getByText(/app version: 0.0.1/i);
+      const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
+        'button'
+      );
+      fireEvent.click(appDetailsButton);
 
-    // Delete the existing file
-    const fileInputPlaceholder = getByText(/configmap has been set/i);
-    const fileInput = fileInputPlaceholder.parentNode.querySelector('input');
-    const file = new Blob(
-      [
-        JSON.stringify({
-          name: 'test',
-          namespace: 'some-other-test',
-        }),
-      ],
-      {
-        type: 'application/json',
-        name: 'config2.json',
-      }
-    );
+      // Delete the existing file
+      const fileInputPlaceholder = getByText(/configmap has been set/i);
+      const fileInput = fileInputPlaceholder.parentNode.querySelector('input');
+      const file = new Blob(
+        [
+          JSON.stringify({
+            name: 'test',
+            namespace: 'some-other-test',
+          }),
+        ],
+        {
+          type: 'application/json',
+          name: 'config2.json',
+        }
+      );
 
-    fireEvent.change(fileInput, {
-      target: {
-        files: [file],
-      },
+      fireEvent.change(fileInput, {
+        target: {
+          files: [file],
+        },
+      });
+
+      await findByText(/has successfully been updated./i);
     });
 
-    await findByText(/has successfully been updated./i);
-  });
+    it('deletes the config map of an already installed app', async () => {
+      nock(API_ENDPOINT)
+        .intercept(
+          `/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/config/`,
+          'DELETE'
+        )
+        .reply(StatusCodes.Ok);
 
-  it('deletes the config map of an already installed app', async () => {
-    nock(API_ENDPOINT)
-      .intercept(
-        `/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/config/`,
-        'DELETE'
-      )
-      .reply(StatusCodes.Ok);
+      getMockCallTimes('/v4/user/', userResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
+      getMockCall('/v4/appcatalogs/', appCatalogsResponse);
 
-    getMockCallTimes('/v4/user/', userResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
-    getMockCall('/v4/appcatalogs/', appCatalogsResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/apps/`,
+        [appResponseWithCustomConfig],
+        2
+      );
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
+      getMockCall('/v4/releases/', releasesResponse);
 
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCallTimes(
-      `/v4/clusters/${V4_CLUSTER.id}/apps/`,
-      [appResponseWithCustomConfig],
-      2
-    );
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
-    getMockCall('/v4/releases/', releasesResponse);
+      const clusterDetailPath = RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.Detail,
+        {
+          orgId: ORGANIZATION,
+          clusterId: V4_CLUSTER.id,
+        }
+      );
+      const { findByText, getByText, queryByText } = renderRouteWithStore(
+        clusterDetailPath
+      );
 
-    const clusterDetailPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.Detail,
-      {
-        orgId: ORGANIZATION,
-        clusterId: V4_CLUSTER.id,
-      }
-    );
-    const { findByText, getByText, queryByText } = renderRouteWithStore(
-      clusterDetailPath
-    );
+      const appsTab = await findByText(/^apps$/i);
+      fireEvent.click(appsTab);
 
-    const appsTab = await findByText(/^apps$/i);
-    fireEvent.click(appsTab);
+      // Click on app details button to open the editing modal
+      const appLabel = getByText(/app version: 0.0.1/i);
+      const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
+        'button'
+      );
+      fireEvent.click(appDetailsButton);
 
-    // Click on app details button to open the editing modal
-    const appLabel = getByText(/app version: 0.0.1/i);
-    const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
-      'button'
-    );
-    fireEvent.click(appDetailsButton);
+      // Upload a configmap file
+      const fileInputPlaceholder = getByText(/configmap has been set/i);
+      let deleteButton = fileInputPlaceholder.parentNode.querySelector(
+        '.btn-danger'
+      );
+      fireEvent.click(deleteButton);
 
-    // Upload a configmap file
-    const fileInputPlaceholder = getByText(/configmap has been set/i);
-    let deleteButton = fileInputPlaceholder.parentNode.querySelector(
-      '.btn-danger'
-    );
-    fireEvent.click(deleteButton);
+      // Confirm deletion
+      deleteButton = getByText(/^delete configmap$/i);
+      fireEvent.click(deleteButton);
 
-    // Confirm deletion
-    deleteButton = getByText(/^delete configmap$/i);
-    fireEvent.click(deleteButton);
+      await wait(() => {
+        expect(queryByText(/delete configmap/i)).not.toBeInTheDocument();
+      });
 
-    await wait(() => {
-      expect(queryByText(/delete configmap/i)).not.toBeInTheDocument();
+      await findByText(/has been deleted./i);
     });
 
-    await findByText(/has been deleted./i);
-  });
+    it('updates secrets of an already installed app', async () => {
+      nock(API_ENDPOINT)
+        .intercept(
+          `/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/secret/`,
+          'PATCH'
+        )
+        .reply(StatusCodes.Ok);
 
-  it('updates secrets of an already installed app', async () => {
-    nock(API_ENDPOINT)
-      .intercept(`/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/secret/`, 'PATCH')
-      .reply(StatusCodes.Ok);
+      getMockCallTimes('/v4/user/', userResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
+      getMockCall('/v4/appcatalogs/', appCatalogsResponse);
 
-    getMockCallTimes('/v4/user/', userResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
-    getMockCall('/v4/appcatalogs/', appCatalogsResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/apps/`,
+        [appResponseWithCustomConfig],
+        2
+      );
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
+      getMockCall('/v4/releases/', releasesResponse);
 
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCallTimes(
-      `/v4/clusters/${V4_CLUSTER.id}/apps/`,
-      [appResponseWithCustomConfig],
-      2
-    );
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
-    getMockCall('/v4/releases/', releasesResponse);
+      const clusterDetailPath = RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.Detail,
+        {
+          orgId: ORGANIZATION,
+          clusterId: V4_CLUSTER.id,
+        }
+      );
+      const { findByText, getByText, queryByText } = renderRouteWithStore(
+        clusterDetailPath
+      );
 
-    const clusterDetailPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.Detail,
-      {
-        orgId: ORGANIZATION,
-        clusterId: V4_CLUSTER.id,
-      }
-    );
-    const { findByText, getByText, queryByText } = renderRouteWithStore(
-      clusterDetailPath
-    );
+      const appsTab = await findByText(/^apps$/i);
+      fireEvent.click(appsTab);
 
-    const appsTab = await findByText(/^apps$/i);
-    fireEvent.click(appsTab);
+      // Click on app details button to open the editing modal
+      const appLabel = getByText(/app version: 0.0.1/i);
+      const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
+        'button'
+      );
+      fireEvent.click(appDetailsButton);
 
-    // Click on app details button to open the editing modal
-    const appLabel = getByText(/app version: 0.0.1/i);
-    const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
-      'button'
-    );
-    fireEvent.click(appDetailsButton);
+      // Upload a secrets file
+      const fileInputPlaceholder = getByText(/secret has been set/i);
+      const fileInput = fileInputPlaceholder.parentNode.querySelector('input');
+      const file = new Blob(
+        [
+          JSON.stringify({
+            name: 'test',
+            namespace: 'some-other-test',
+          }),
+        ],
+        {
+          type: 'application/json',
+          name: 'secret.json',
+        }
+      );
+      fireEvent.change(fileInput, {
+        target: {
+          files: [file],
+        },
+      });
 
-    // Upload a secrets file
-    const fileInputPlaceholder = getByText(/secret has been set/i);
-    const fileInput = fileInputPlaceholder.parentNode.querySelector('input');
-    const file = new Blob(
-      [
-        JSON.stringify({
-          name: 'test',
-          namespace: 'some-other-test',
-        }),
-      ],
-      {
-        type: 'application/json',
-        name: 'secret.json',
-      }
-    );
-    fireEvent.change(fileInput, {
-      target: {
-        files: [file],
-      },
+      await wait(() => {
+        expect(queryByText(/delete secret/i)).not.toBeInTheDocument();
+      });
+
+      await findByText(/has successfully been updated./i);
     });
 
-    await wait(() => {
-      expect(queryByText(/delete secret/i)).not.toBeInTheDocument();
+    it('deletes secrets of an already installed app', async () => {
+      nock(API_ENDPOINT)
+        .intercept(
+          `/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/secret/`,
+          'DELETE'
+        )
+        .reply(StatusCodes.Ok);
+
+      getMockCallTimes('/v4/user/', userResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
+      getMockCall('/v4/appcatalogs/', appCatalogsResponse);
+
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
+      getMockCall(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse
+      );
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/apps/`,
+        [appResponseWithCustomConfig],
+        2
+      );
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
+      getMockCall('/v4/releases/', releasesResponse);
+
+      const clusterDetailPath = RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.Detail,
+        {
+          orgId: ORGANIZATION,
+          clusterId: V4_CLUSTER.id,
+        }
+      );
+      const { findByText, getByText, queryByText } = renderRouteWithStore(
+        clusterDetailPath
+      );
+
+      const appsTab = await findByText(/^apps$/i);
+      fireEvent.click(appsTab);
+
+      // Click on app details button to open the editing modal
+      const appLabel = getByText(/app version: 0.0.1/i);
+      const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
+        'button'
+      );
+      fireEvent.click(appDetailsButton);
+
+      // Delete the existing file
+      const fileInputPlaceholder = getByText(/secret has been set/i);
+      let deleteButton = fileInputPlaceholder.parentNode.querySelector(
+        '.btn-danger'
+      );
+      fireEvent.click(deleteButton);
+
+      // Confirm deletion
+      deleteButton = getByText(/^delete secret$/i);
+      fireEvent.click(deleteButton);
+
+      await wait(() => {
+        expect(queryByText(/delete secret/i)).not.toBeInTheDocument();
+      });
+
+      await findByText(/has been deleted./i);
     });
 
-    await findByText(/has successfully been updated./i);
-  });
+    it('deletes already installed app', async () => {
+      nock(API_ENDPOINT)
+        .intercept(`/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/`, 'DELETE')
+        .reply(StatusCodes.Ok);
 
-  it('deletes secrets of an already installed app', async () => {
-    nock(API_ENDPOINT)
-      .intercept(
-        `/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/secret/`,
-        'DELETE'
-      )
-      .reply(StatusCodes.Ok);
+      getMockCallTimes('/v4/user/', userResponse);
+      getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+      getMockCall('/v4/appcatalogs/', appCatalogsResponse);
+      getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/`,
+        v4AWSClusterResponse,
+        2
+      );
+      getMockCallTimes(
+        `/v4/clusters/${V4_CLUSTER.id}/status/`,
+        v4AWSClusterStatusResponse,
+        2
+      );
+      getMockCallTimes(`/v4/clusters/${V4_CLUSTER.id}/apps/`, appsResponse, 2);
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
+      getMockCall('/v4/releases/', releasesResponse);
 
-    getMockCallTimes('/v4/user/', userResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
-    getMockCall('/v4/appcatalogs/', appCatalogsResponse);
+      const clusterDetailPath = RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.Detail,
+        {
+          orgId: ORGANIZATION,
+          clusterId: V4_CLUSTER.id,
+        }
+      );
+      const { findByText, getByText, queryByText } = renderRouteWithStore(
+        clusterDetailPath
+      );
 
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
-    getMockCall(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse
-    );
-    getMockCallTimes(
-      `/v4/clusters/${V4_CLUSTER.id}/apps/`,
-      [appResponseWithCustomConfig],
-      2
-    );
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
-    getMockCall('/v4/releases/', releasesResponse);
+      const appsTab = await findByText(/^apps$/i);
+      fireEvent.click(appsTab);
 
-    const clusterDetailPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.Detail,
-      {
-        orgId: ORGANIZATION,
-        clusterId: V4_CLUSTER.id,
-      }
-    );
-    const { findByText, getByText, queryByText } = renderRouteWithStore(
-      clusterDetailPath
-    );
+      // Click on app details button to open the editing modal
+      const appLabel = getByText(/app version: 0.0.1/i);
+      const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
+        'button'
+      );
+      fireEvent.click(appDetailsButton);
 
-    const appsTab = await findByText(/^apps$/i);
-    fireEvent.click(appsTab);
+      // Delete the app
+      let deleteButton = getByText(/delete app/i);
+      fireEvent.click(deleteButton);
 
-    // Click on app details button to open the editing modal
-    const appLabel = getByText(/app version: 0.0.1/i);
-    const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
-      'button'
-    );
-    fireEvent.click(appDetailsButton);
+      // Confirm deletion
+      deleteButton = getByText(/delete app/i);
+      fireEvent.click(deleteButton);
 
-    // Delete the existing file
-    const fileInputPlaceholder = getByText(/secret has been set/i);
-    let deleteButton = fileInputPlaceholder.parentNode.querySelector(
-      '.btn-danger'
-    );
-    fireEvent.click(deleteButton);
+      await wait(() => {
+        expect(queryByText(/delete app/i)).not.toBeInTheDocument();
+      });
 
-    // Confirm deletion
-    deleteButton = getByText(/^delete secret$/i);
-    fireEvent.click(deleteButton);
-
-    await wait(() => {
-      expect(queryByText(/delete secret/i)).not.toBeInTheDocument();
+      await findByText(/will be deleted/i);
     });
-
-    await findByText(/has been deleted./i);
-  });
-
-  it('deletes already installed app', async () => {
-    nock(API_ENDPOINT)
-      .intercept(`/v4/clusters/${V4_CLUSTER.id}/apps/my%20app/`, 'DELETE')
-      .reply(StatusCodes.Ok);
-
-    getMockCallTimes('/v4/user/', userResponse);
-    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
-    getMockCall('/v4/appcatalogs/', appCatalogsResponse);
-    getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
-    getMockCallTimes(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse, 2);
-    getMockCallTimes(
-      `/v4/clusters/${V4_CLUSTER.id}/status/`,
-      v4AWSClusterStatusResponse,
-      2
-    );
-    getMockCallTimes(`/v4/clusters/${V4_CLUSTER.id}/apps/`, appsResponse, 2);
-    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
-    getMockCall('/v4/releases/', releasesResponse);
-
-    const clusterDetailPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.Detail,
-      {
-        orgId: ORGANIZATION,
-        clusterId: V4_CLUSTER.id,
-      }
-    );
-    const { findByText, getByText, queryByText } = renderRouteWithStore(
-      clusterDetailPath
-    );
-
-    const appsTab = await findByText(/^apps$/i);
-    fireEvent.click(appsTab);
-
-    // Click on app details button to open the editing modal
-    const appLabel = getByText(/app version: 0.0.1/i);
-    const appDetailsButton = appLabel.parentNode.parentNode.querySelector(
-      'button'
-    );
-    fireEvent.click(appDetailsButton);
-
-    // Delete the app
-    let deleteButton = getByText(/delete app/i);
-    fireEvent.click(deleteButton);
-
-    // Confirm deletion
-    deleteButton = getByText(/delete app/i);
-    fireEvent.click(deleteButton);
-
-    await wait(() => {
-      expect(queryByText(/delete app/i)).not.toBeInTheDocument();
-    });
-
-    await findByText(/will be deleted/i);
   });
 });

--- a/__tests__/AppCatalog.js
+++ b/__tests__/AppCatalog.js
@@ -686,4 +686,36 @@ describe('Apps and App Catalog', () => {
       await findByText(/will be deleted/i);
     });
   });
+
+  it('shows a no apps installed message when there are no apps yet', async () => {
+    getMockCallTimes('/v4/user/', userResponse);
+    getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
+    getMockCall('/v4/appcatalogs/', appCatalogsResponse);
+    getMockCallTimes(`/v4/organizations/${ORGANIZATION}/credentials/`, [], 2);
+    getMockCallTimes(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse, 2);
+    getMockCallTimes(
+      `/v4/clusters/${V4_CLUSTER.id}/status/`,
+      v4AWSClusterStatusResponse,
+      2
+    );
+    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/apps/`, []);
+    getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
+    getMockCall('/v4/releases/', releasesResponse);
+
+    const clusterDetailPath = RoutePath.createUsablePath(
+      OrganizationsRoutes.Clusters.Detail,
+      {
+        orgId: ORGANIZATION,
+        clusterId: V4_CLUSTER.id,
+      }
+    );
+    const { findByText } = renderRouteWithStore(clusterDetailPath);
+
+    const appsTab = await findByText(/^apps$/i);
+    fireEvent.click(appsTab);
+
+    expect(
+      await findByText('No apps installed on this cluster')
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/Cluster/ClusterDetail/ClusterApps.js
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.js
@@ -103,12 +103,12 @@ class ClusterApps extends React.Component {
     },
     'cert-exporter': {
       name: 'cert-exporter',
-      logoUrl: '/images/app_icons/chart_operator@2x.png',
+      logoUrl: '/images/app_icons/cert_exporter@2x.png',
       category: 'management',
     },
     'net-exporter': {
       name: 'net-exporter',
-      logoUrl: '/images/app_icons/chart_operator@2x.png',
+      logoUrl: '/images/app_icons/net_exporter@2x.png',
       category: 'management',
     },
     'node-exporter': {
@@ -165,6 +165,12 @@ class ClusterApps extends React.Component {
 
     for (i = 0; i < this.props.release.components.length; i++) {
       const component = this.props.release.components[i];
+
+      // Remove component that is now present in the release response
+      // from the manuallyAddAppMetas list to avoid showing them twice.
+      this.manuallyAddAppMetas = this.manuallyAddAppMetas.filter(app => {
+        return app.name !== component.name;
+      });
 
       // Find the component in the mapping above. If it's not there, then
       // it isn't something we want to show here.

--- a/testUtils/mockHttpCalls/releases.js
+++ b/testUtils/mockHttpCalls/releases.js
@@ -141,6 +141,14 @@ export const releasesResponse = [
         version: '3.8.2',
       },
       {
+        name: 'cert-exporter',
+        version: '1.2.3',
+      },
+      {
+        name: 'net-exporter',
+        version: '2.3.4',
+      },
+      {
         name: 'cert-operator',
         version: '0.1.0',
       },


### PR DESCRIPTION
`cert-exporter` and `net-exporter` were originally not in the `releases` endpoint response. So we added them manually because we wanted to see them in Happa.

Now some clusters will have it in their release and some will not. So we need to deduplicate the app from the app detail pane.

This also adds a couple more tests to round off the app catalog tests, and organises the app catalog tests based on whether is about installing apps or if its about the app detail pane on the cluster detail page.

Fixes what you see below, the double cert-exporter and net-exporter:
<img width="334" alt="Screenshot 2020-03-02 at 1 55 25 PM" src="https://user-images.githubusercontent.com/455309/75649436-0eb3d780-5c8e-11ea-90e1-c0399326a4dc.png">
