### PR TITLE
Version picker during app installation

### DIFF
--- a/src/components/AppCatalog/AppDetail/AppDetail.js
+++ b/src/components/AppCatalog/AppDetail/AppDetail.js
@@ -52,14 +52,14 @@ class AppDetail extends React.Component {
           ) && (
             <Breadcrumb
               data={{
-                title: this.props.app.name,
+                title: this.props.latestAppVersion.name,
                 pathname: this.props.match.url,
               }}
             >
-              <DocumentTitle title={this.props.app.name}>
+              <DocumentTitle title={this.props.latestAppVersion.name}>
                 {repo && (
                   <AppDetails
-                    app={this.props.app}
+                    app={this.props.latestAppVersion}
                     appVersions={this.props.appVersions}
                     imgError={this.imgError}
                     imgErrorFlag={this.state.imgError}
@@ -70,8 +70,8 @@ class AppDetail extends React.Component {
                     <InstallAppModal
                       app={{
                         catalog: repo.metadata.name,
-                        name: this.props.app.name,
-                        version: this.props.app.version,
+                        name: this.props.latestAppVersion.name,
+                        versions: this.props.appVersions,
                       }}
                       selectedClusterID={this.props.selectedClusterID}
                     />
@@ -87,7 +87,7 @@ class AppDetail extends React.Component {
 }
 
 AppDetail.propTypes = {
-  app: PropTypes.object,
+  latestAppVersion: PropTypes.object,
   appVersions: PropTypes.array,
   location: PropTypes.object,
   match: PropTypes.object,
@@ -110,8 +110,8 @@ function mapStateToProps(state, ownProps) {
   }
 
   return {
-    app: appVersions[0],
     appVersions: appVersions,
+    latestAppVersion: appVersions[0],
     repo: state.entities.catalogs.items[repo],
     selectedClusterID: state.app.selectedClusterID,
   };

--- a/src/components/AppCatalog/AppDetail/Input.js
+++ b/src/components/AppCatalog/AppDetail/Input.js
@@ -71,13 +71,17 @@ const TextInput = props => {
       </Text>
       <InputWrapper>
         {props.icon ? <Icon className={`fa fa-${props.icon}`} /> : undefined}
-        <Input
-          id={props.label}
-          onChange={onChange}
-          type='text'
-          value={props.value}
-          readOnly={props.readOnly}
-        />
+        {props.children ? (
+          props.children
+        ) : (
+          <Input
+            id={props.label}
+            onChange={onChange}
+            type='text'
+            value={props.value}
+            readOnly={props.readOnly}
+          />
+        )}
       </InputWrapper>
       {props.validationError ? (
         <ValidationError>
@@ -99,6 +103,7 @@ TextInput.propTypes = {
   validationError: PropTypes.string,
   value: PropTypes.string,
   readOnly: PropTypes.bool,
+  children: PropTypes.node,
 };
 
 export default TextInput;

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
+import VersionPicker from 'UI/VersionPicker/VersionPicker';
 
 import FileInput from './FileInput';
 import Input from './Input';
@@ -55,6 +56,12 @@ const InstallAppForm = props => {
     }
   };
 
+  const updateVersion = version => {
+    if (props.onChangeVersion) {
+      props.onChangeVersion(version);
+    }
+  };
+
   const formAbilities = AppFormAbilities(props.appName, updateNamespace);
 
   return (
@@ -67,6 +74,18 @@ const InstallAppForm = props => {
         validationError={props.nameError}
         value={props.name}
       />
+
+      <Input
+        label='Chart Version:'
+        description='This will determine what version of the app eventually gets installed.'
+        hint={<>&nbsp;</>}
+      >
+        <VersionPicker
+          onChange={updateVersion}
+          selectedVersion={props.version}
+          versions={props.availableVersions}
+        />
+      </Input>
 
       {formAbilities.hasFixedNamespace ? (
         <Input
@@ -116,11 +135,14 @@ InstallAppForm.propTypes = {
   namespaceError: PropTypes.string,
   valuesYAMLError: PropTypes.string,
   valuesYAML: PropTypes.object,
+  version: PropTypes.string,
+  availableVersions: PropTypes.array,
   secretsYAMLError: PropTypes.string,
   secretsYAML: PropTypes.object,
   onChangeName: PropTypes.func,
   onChangeNamespace: PropTypes.func,
   onChangeValuesYAML: PropTypes.func,
+  onChangeVersion: PropTypes.func,
   onChangeSecretsYAML: PropTypes.func,
 };
 

--- a/src/components/AppCatalog/AppDetail/InstallAppModal.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppModal.js
@@ -38,6 +38,8 @@ const InstallAppModal = props => {
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
 
+  const [version, setVersion] = useState(props.app.versions[0].version);
+
   const next = () => {
     if (page < pages.length - 1) {
       setPage(page + 1);
@@ -133,6 +135,10 @@ const InstallAppModal = props => {
     setNameError(validate(newName));
   };
 
+  const updateVersion = newVersion => {
+    setVersion(newVersion);
+  };
+
   const updateValuesYAML = files => {
     const reader = new FileReader();
 
@@ -183,7 +189,7 @@ const InstallAppModal = props => {
             name: name,
             catalog: props.app.catalog,
             chartName: props.app.name,
-            version: props.app.version,
+            version: version,
             namespace: namespace,
             valuesYAML: valuesYAML,
             secretsYAML: secretsYAML,
@@ -282,10 +288,15 @@ const InstallAppModal = props => {
                   nameError={nameError}
                   namespace={namespace}
                   namespaceError={namespaceError}
+                  version={version}
+                  availableVersions={props.app.versions.map(v => ({
+                    version: v.version,
+                  }))}
                   onChangeName={updateName}
                   onChangeNamespace={updateNamespace}
                   onChangeSecretsYAML={updateSecretsYAML}
                   onChangeValuesYAML={updateValuesYAML}
+                  onChangeVersion={updateVersion}
                   secretsYAML={secretsYAML}
                   secretsYAMLError={secretsYAMLError}
                   valuesYAML={valuesYAML}

--- a/src/components/UI/VersionPicker/VersionPicker.js
+++ b/src/components/UI/VersionPicker/VersionPicker.js
@@ -16,6 +16,7 @@ const Wrapper = styled.div`
     line-height: normal;
     padding: 8px 10px;
     width: auto;
+    height: 34px;
 
     .caret {
       margin-left: 10px;


### PR DESCRIPTION
Looks like this right now:

<img width="606" alt="Screenshot 2020-03-04 at 6 24 36 PM" src="https://user-images.githubusercontent.com/455309/75870160-8d9f4080-5e45-11ea-8dd2-8d4948e54849.png">

The 'test' versions feature of the version picker is not something I can implement yet, so I will make a tweak to the version picker to be able to not show the test version check box, since right now it does nothing.

~- [ ] Show what app version this will install.~ will do that as a UX improvement in another PR.
- [x] Truncate long version names.
- [x] Remove test version checkbox if there are no test versions.

Towards: https://github.com/giantswarm/giantswarm/issues/8021
Some design discussion: https://github.com/giantswarm/giantswarm/issues/8846