### PR TITLE
Fix triggering of update cluster modal

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -334,16 +334,14 @@ class ClusterDetailView extends React.Component {
                 />
               )}
 
-              {canClusterUpgrade && (
-                <UpgradeClusterModal
-                  cluster={cluster}
-                  ref={s => {
-                    this.upgradeClusterModal = s;
-                  }}
-                  release={release}
-                  targetRelease={targetRelease}
-                />
-              )}
+              <UpgradeClusterModal
+                cluster={cluster}
+                ref={s => {
+                  this.upgradeClusterModal = s;
+                }}
+                release={release}
+                targetRelease={targetRelease}
+              />
             </WrapperDiv>
           </DocumentTitle>
         )}


### PR DESCRIPTION
Removed the conditional because we are not doing the check here. 

Not sure what is cheaper: checking if the cluster can update or rendering the modal.