### PR TITLE
Clusters are created in the currently selected organization, instead of a picked organization

### DIFF
--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -580,7 +580,6 @@ function mapStateToProps(state) {
   const minAZ = 1;
   const defaultAZ = AZ.default;
 
-  const selectedOrganization = state.app.selectedOrganization;
   const provider = state.app.info.general.provider;
   const clusterCreationStats = state.app.info.stats.cluster_creation_duration;
 
@@ -612,7 +611,6 @@ function mapStateToProps(state) {
     defaultCPUCores,
     defaultMemorySize,
     defaultDiskSize,
-    selectedOrganization,
     clusterCreationStats,
     minAZ,
     maxAZ,

--- a/src/components/Cluster/NewCluster/CreateRegularCluster.js
+++ b/src/components/Cluster/NewCluster/CreateRegularCluster.js
@@ -646,7 +646,6 @@ function mapStateToProps(state) {
   const propsToPush = {
     minAvailabilityZones: state.app.info.general.availability_zones.default,
     maxAvailabilityZones: state.app.info.general.availability_zones.max,
-    selectedOrganization: state.app.selectedOrganization,
     clusterCreationStats: state.app.info.stats.cluster_creation_duration,
     provider,
   };

--- a/src/components/Cluster/NewCluster/NewCluster.js
+++ b/src/components/Cluster/NewCluster/NewCluster.js
@@ -1,11 +1,13 @@
 import { loadReleases } from 'actions/releaseActions';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import cmp from 'semver-compare';
 import { Providers } from 'shared/constants';
+import { OrganizationsRoutes } from 'shared/constants/routes';
 import LoadingOverlay from 'UI/LoadingOverlay';
 
 import CreateNodePoolsCluster from './CreateNodePoolsCluster';
@@ -90,6 +92,12 @@ class NewCluster extends React.Component {
   };
 
   renderComponent = props => {
+    const route = RoutePath.parseWithTemplate(
+      OrganizationsRoutes.Clusters.New,
+      props.location.pathname
+    );
+    const { orgId } = route.params;
+
     const Component =
       this.semVerCompare() < 0 ||
       this.props.provider === Providers.AZURE ||
@@ -100,6 +108,7 @@ class NewCluster extends React.Component {
     return (
       <Component
         {...props}
+        selectedOrganization={orgId}
         informParent={this.setSelectedRelease}
         selectedRelease={this.state.selectedRelease}
         selectableReleases={this.state.selectableReleases}


### PR DESCRIPTION
Right now, we have the following scenario:
* Go to the organizations page
* Click on an organization that is not your currently selected one
* Press on the `Create Cluster` button
* Create a cluster

The new cluster will not be created in the organization that you clicked on, but on the currently selected organization (in the top dropdown)

This PR makes clusters be created in the organization that you clicked on 👍 