### PR TITLE
Add support for chaining HttpClient methods

### DIFF
--- a/src/model/clients/HttpClient.js
+++ b/src/model/clients/HttpClient.js
@@ -145,6 +145,8 @@ export class HttpClient {
     );
 
     this.requestConfig.headers = Object.assign({}, config?.headers);
+
+    return this;
   }
 
   /**
@@ -154,6 +156,8 @@ export class HttpClient {
    */
   setHeader(key, value = '') {
     this.requestConfig.headers[key] = value;
+
+    return this;
   }
 
   /**
@@ -163,6 +167,8 @@ export class HttpClient {
    */
   setAuthorizationToken(authType, token) {
     this.setHeader('Authorization', `${authType} ${token}`);
+
+    return this;
   }
 
   /**
@@ -171,6 +177,8 @@ export class HttpClient {
    */
   setRequestMethod(method) {
     this.requestConfig.method = method;
+
+    return this;
   }
 
   /**
@@ -179,6 +187,8 @@ export class HttpClient {
    */
   setBody(body) {
     this.requestConfig.data = body;
+
+    return this;
   }
 
   /**
@@ -187,6 +197,8 @@ export class HttpClient {
    */
   setURL(url) {
     this.requestConfig.url = url;
+
+    return this;
   }
 
   /**

--- a/src/model/clients/__tests__/HttpClient.js
+++ b/src/model/clients/__tests__/HttpClient.js
@@ -64,24 +64,16 @@ describe('HttpClient', () => {
       timeout: 30000,
     });
 
-    // Headers
-    client.setHeader('TestHeader');
-    client.setHeader('TestHeader2', config.headers.TestHeader2);
-    client.setHeader('TestHeader3', config.headers.TestHeader3);
-
-    // Authorization Token
-    client.setAuthorizationToken('testScheme', token);
-
-    // Request method
-    client.setRequestMethod('POST');
-
-    // Request body
-    client.setBody({
-      test: 'test',
-    });
-
-    // Request target url
-    client.setURL('/api/test');
+    client
+      .setHeader('TestHeader')
+      .setHeader('TestHeader2', config.headers.TestHeader2)
+      .setHeader('TestHeader3', config.headers.TestHeader3)
+      .setAuthorizationToken('testScheme', token)
+      .setRequestMethod('POST')
+      .setBody({
+        test: 'test',
+      })
+      .setURL('/api/test');
 
     expect(client.requestConfig).toStrictEqual(config);
   });


### PR DESCRIPTION
Just for our pleasure 😬 

**Before**
```javascript
client.setHeader('TestHeader');
client.setHeader('TestHeader2', config.headers.TestHeader2);
client.setHeader('TestHeader3', config.headers.TestHeader3);
client.setAuthorizationToken('testScheme', token);
client.setRequestMethod('POST');
client.setBody({
  test: 'test',
});
client.setURL('/api/test');
```

**After**
```javascript
client
  .setHeader('TestHeader')
  .setHeader('TestHeader2', config.headers.TestHeader2)
  .setHeader('TestHeader3', config.headers.TestHeader3)
  .setAuthorizationToken('testScheme', token)
  .setRequestMethod('POST')
  .setBody({
    test: 'test',
  })
  .setURL('/api/test');
```