### PR TITLE
Upgrade cluster modal: avoid rerendering after dispatching the action

### DIFF
--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -204,6 +204,7 @@ class UpgradeClusterModal extends React.Component {
     this.setState(
       {
         loading: true,
+        page: 'closing',
       },
       () => {
         const targetReleaseVersion = this.props.targetRelease.version;


### PR DESCRIPTION
Fixes this https://gigantic.slack.com/archives/C3MCF5EJK/p1583932105000800

The problem is that the modal is rerendewring without props after the dispatching/submitting. 

The quick and dirty solution is this one in this PR, but we should refactor it following the new data flow. Will try to do it tomorrow.