### PR TITLE
Fix an error when deleting an app.

### DIFF
--- a/__tests__/AppCatalog.js
+++ b/__tests__/AppCatalog.js
@@ -654,9 +654,14 @@ describe('Apps and App Catalog', () => {
         v4AWSClusterStatusResponse,
         2
       );
-      getMockCallTimes(`/v4/clusters/${V4_CLUSTER.id}/apps/`, appsResponse, 2);
       getMockCall(`/v4/clusters/${V4_CLUSTER.id}/key-pairs/`);
       getMockCall('/v4/releases/', releasesResponse);
+
+      // Before deleting the app, there are apps.
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/apps/`, appsResponse);
+
+      // After deleting the app, there are no apps.
+      getMockCall(`/v4/clusters/${V4_CLUSTER.id}/apps/`, []);
 
       const clusterDetailPath = RoutePath.createUsablePath(
         OrganizationsRoutes.Clusters.Detail,

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.js
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.js
@@ -69,8 +69,8 @@ const AppDetailsModal = props => {
   }
 
   async function loadAppsAndClose() {
-    await props.dispatch(loadAppsAction(clusterId));
     onClose();
+    await props.dispatch(loadAppsAction(clusterId));
   }
 
   async function editChartVersion() {


### PR DESCRIPTION
Fixes the order in which we close the app detail modal and fetch an updated list of apps.

Otherwise we run into a problem after deleting an app, if the app is gone before the modal closes, the modal will throw an error as it tries to render a non existing app.

Also edits the tests to recreate what actually happens. (Made it fail like in production, then fixed it.)