### PR TITLE
More keypair tests.

### DIFF
--- a/__tests__/KeyPairs.js
+++ b/__tests__/KeyPairs.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/extend-expect';
 
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, within } from '@testing-library/react';
 import RoutePath from 'lib/routePath';
 import { getInstallationInfo } from 'model/services/giantSwarm';
 import { OrganizationsRoutes } from 'shared/constants/routes';
@@ -8,12 +8,15 @@ import {
   appCatalogsResponse,
   appsResponse,
   AWSInfoResponse,
+  emptyKeyPairsResponse,
   getMockCall,
   getMockCallTimes,
+  keyPairsResponse,
   nodePoolsResponse,
   ORGANIZATION,
   orgResponse,
   orgsResponse,
+  postPayloadMockCall,
   releasesResponse,
   userResponse,
   V5_CLUSTER,
@@ -39,12 +42,20 @@ beforeEach(() => {
     2
   );
   getMockCall('/v4/appcatalogs/', appCatalogsResponse);
-  getMockCall(`/v4/clusters/${V5_CLUSTER.id}/key-pairs/`);
 });
 
 /************ TESTS ************/
 
-it('lets me open and close the keypair create modal', async () => {
+it('lets me create a keypair', async () => {
+  // Given the cluster has no keypairs.
+  // But on the second call it returns some keypairs.
+  getMockCall(
+    `/v4/clusters/${V5_CLUSTER.id}/key-pairs/`,
+    emptyKeyPairsResponse
+  );
+  getMockCall(`/v4/clusters/${V5_CLUSTER.id}/key-pairs/`, keyPairsResponse);
+
+  // And the app is on the cluster detail page.
   const clusterDetailPath = RoutePath.createUsablePath(
     OrganizationsRoutes.Clusters.Detail,
     {
@@ -52,14 +63,23 @@ it('lets me open and close the keypair create modal', async () => {
       clusterId: V5_CLUSTER.id,
     }
   );
-  // Given the app is on the cluster detail page.
-  const { findByText, getByText, queryByTestId } = renderRouteWithStore(
-    clusterDetailPath
-  );
+
+  const {
+    findByText,
+    getByText,
+    queryByTestId,
+    getByLabelText,
+  } = renderRouteWithStore(clusterDetailPath);
 
   // And it is done loading.
   const clusterName = await findByText(V5_CLUSTER.name);
   expect(clusterName).toBeInTheDocument();
+
+  // Then I should see also that there are no keypairs yet.
+  const message = getByText(
+    "No key pairs yet. Why don't you create your first?"
+  );
+  expect(message).toBeInTheDocument();
 
   // When I click the Key Pairs tab button.
   const keyPairTab = getByText('Key Pairs');
@@ -73,10 +93,77 @@ it('lets me open and close the keypair create modal', async () => {
   const modal = await queryByTestId('create-key-pair-modal');
   expect(modal).toBeInTheDocument();
 
-  // And when I click the cancel button.
-  const cancelButton = getByText('Cancel');
-  fireEvent.click(cancelButton);
+  // And type in a common name prefix.
+  const commonNamePrefixField = getByLabelText('Common Name Prefix:');
+  fireEvent.change(commonNamePrefixField, {
+    target: { value: 'my-own-cn-prefix' },
+  });
+
+  // And type in Organizations.
+  const organizationsField = getByLabelText('Organizations:');
+  fireEvent.change(organizationsField, {
+    target: { value: 'my-own-organizations' },
+  });
+
+  // (I'm expecting a specific POST request to be made.)
+  const oneMonth = 720;
+  postPayloadMockCall(
+    `/v4/clusters/${V5_CLUSTER.id}/key-pairs/`,
+    body =>
+      body.certificate_organizations === 'my-own-organizations' &&
+      body.cn_prefix === 'my-own-cn-prefix' &&
+      body.ttl_hours === oneMonth
+  );
+
+  // (Mock window.URL.createObjectURL because it doesn't exist in a test context)
+  window.URL.createObjectURL = jest.fn();
+
+  // When I click the create keypair button in the modal
+  const confirmKeyPairButton = getByText('Create Key Pair');
+  fireEvent.click(confirmKeyPairButton);
+
+  // Then I should see some text confirming the keypair got made.
+  const confirmText = await within(modal).findByText(
+    'Your key pair and kubeconfig has been created.'
+  );
+  expect(confirmText).toBeInTheDocument();
+
+  // And when I click the close button.
+  const modalFooter = await queryByTestId('create-key-pair-modal-footer');
+  const closeButton = within(modalFooter).getByText('Close');
+  fireEvent.click(closeButton);
 
   // Then the modal should be gone.
   expect(modal).not.toBeInTheDocument();
+});
+
+it('lists existing keypairs', async () => {
+  // Given the cluster has some keypairs.
+  getMockCall(`/v4/clusters/${V5_CLUSTER.id}/key-pairs/`, keyPairsResponse);
+
+  const clusterDetailPath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.Detail,
+    {
+      orgId: ORGANIZATION,
+      clusterId: V5_CLUSTER.id,
+    }
+  );
+
+  // And the app is on the cluster detail page.
+  const { findByText, getByText } = renderRouteWithStore(clusterDetailPath);
+
+  // And it is done loading.
+  const clusterName = await findByText(V5_CLUSTER.name);
+  expect(clusterName).toBeInTheDocument();
+
+  // When I click the Key Pairs tab button.
+  const keyPairTab = getByText('Key Pairs');
+  fireEvent.click(keyPairTab);
+
+  // Then I should see existing key pairs.
+  const firstKeypair = getByText(/first-key-pair-cn.*/i);
+  expect(firstKeypair).toBeInTheDocument();
+
+  const secondKeypair = getByText(/second-key-pair-cn.*/i);
+  expect(secondKeypair).toBeInTheDocument();
 });

--- a/src/components/Cluster/ClusterDetail/KeyPairCreateModal.js
+++ b/src/components/Cluster/ClusterDetail/KeyPairCreateModal.js
@@ -226,8 +226,9 @@ const KeyPairCreateModal = props => {
                     </p>
                     <div className='row'>
                       <div className='col-6'>
-                        <label>Common Name Prefix:</label>
+                        <label htmlFor='cnPrefix'>Common Name Prefix:</label>
                         <input
+                          id='cnPrefix'
                           autoFocus
                           onChange={handleCNPrefixChange}
                           type='text'
@@ -244,8 +245,9 @@ const KeyPairCreateModal = props => {
                         </div>
                       </div>
                       <div className='col-6'>
-                        <label>Organizations:</label>
+                        <label htmlFor='organizations'>Organizations:</label>
                         <input
+                          id='organizations'
                           onChange={handleCertificateOrganizationsChange}
                           type='text'
                           value={certificateOrganizations}
@@ -324,6 +326,7 @@ const KeyPairCreateModal = props => {
           case 'addKeyPairSuccess':
             return (
               <BootstrapModal
+                data-testid='create-key-pair-modal'
                 className='create-key-pair-modal--success'
                 onHide={close}
                 show={modal.visible}
@@ -363,7 +366,7 @@ const KeyPairCreateModal = props => {
 
                   {downloadAsFileLink()}
                 </BootstrapModal.Body>
-                <BootstrapModal.Footer>
+                <BootstrapModal.Footer data-testid='create-key-pair-modal-footer'>
                   <Button bsStyle='link' onClick={close}>
                     Close
                   </Button>

--- a/testUtils/mockHttpCalls/index.js
+++ b/testUtils/mockHttpCalls/index.js
@@ -38,3 +38,6 @@ export * from './catalogIndex';
 
 // User Invites
 export * from './invites';
+
+// Keypairs
+export * from './keypairs';

--- a/testUtils/mockHttpCalls/keypairs.js
+++ b/testUtils/mockHttpCalls/keypairs.js
@@ -1,0 +1,24 @@
+export const emptyKeyPairsResponse = [];
+
+export const keyPairsResponse = [
+  {
+    common_name:
+      'first-key-pair-cn@giantswarm.io.user.api.m0ckd.k8s.testing.gigantic.io',
+    create_date: '2020-03-12T23:02:39.083721342Z',
+    description:
+      "First key pair added by user testing@giantswarm.io using 'gsctl create kubeconfig'",
+    certificate_organizations: 'system:masters',
+    id: '58:98:a5:64:da:39:b1:4c:43:da:2f:51:4b:db:cb:8f:a8:fe:64:05',
+    ttl_hours: 720,
+  },
+  {
+    common_name:
+      'second-key-pair-cn@giantswarm.io.user.api.m0ckd.k8s.testing.gigantic.io',
+    create_date: '2020-03-13T00:26:51.830329047Z',
+    description:
+      "Second key pair added by user testing@giantswarm.io using 'gsctl create kubeconfig'",
+    certificate_organizations: 'system:masters',
+    id: '28:b6:21:7a:ac:ba:2b:8b:4e:01:24:dd:3a:0d:a0:79:4b:52:11:f5',
+    ttl_hours: 720,
+  },
+];


### PR DESCRIPTION
Towards: https://github.com/giantswarm/happa/issues/759

To check off `Key pairs tab: renders data correctly` and `Creating a keypair`

I don't think we need to copy the test for a v4 cluster, since it's the same tab and would exercise pretty much the same code... what do you guys think?