### PR TITLE
Fix for undefined API endpoint in cluster details view

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -224,13 +224,16 @@ class ClusterDetailView extends React.Component {
       region,
       genericLoadingCluster,
       loadingNodePools,
+      loadingCluster,
     } = this.props;
+
+    const loading = genericLoadingCluster || loadingNodePools || loadingCluster;
 
     return (
       <>
-        <LoadingOverlay loading={genericLoadingCluster || loadingNodePools} />
+        <LoadingOverlay loading={loading} />
 
-        {!genericLoadingCluster && !loadingNodePools && (
+        {!loading && (
           <DocumentTitle title={`Cluster Details | ${this.clusterName()}`}>
             <WrapperDiv
               className='cluster-details'


### PR DESCRIPTION
Fix for `undefined` `api_endpoint` in cluster details view: https://gigantic.slack.com/archives/C3MCF5EJK/p1584444878000300

Adding the specific cluster flag for the cluster because when accessing it directly it doesn't exists in the store, so this:

```javascript
<LoadingOverlay loading={this.props.loadingCluster}>
  <KeyPairs cluster={cluster} />
</LoadingOverlay>
```

can't do its job.