### PR TITLE
Optimistic update on cluster name change

### DIFF
--- a/__tests__/V4AWSClusterManagement.js
+++ b/__tests__/V4AWSClusterManagement.js
@@ -273,12 +273,9 @@ it('patches v4 cluster name correctly', async () => {
   const submitButton = getByText(/ok/i);
   fireEvent.click(submitButton);
 
-  //Wait for the Flash message to appear
   await waitFor(() => {
-    getByText(/succesfully edited cluster name/i);
+    expect(getByText(newClusterName)).toBeInTheDocument();
   });
-
-  expect(getByText(newClusterName)).toBeInTheDocument();
 });
 
 /******************** PENDING TESTS ********************/

--- a/__tests__/V5ClusterManagement.js
+++ b/__tests__/V5ClusterManagement.js
@@ -149,13 +149,10 @@ it('patches node pool name correctly and re-sort node pools accordingly', async 
   const submitButton = getByText(/ok/i);
   fireEvent.click(submitButton);
 
-  //Wait for the Flash message to appear
   await waitFor(() => {
-    getByText(/succesfully edited node pool name/i);
+    // Is the new NP name in the document?
+    expect(getByText(newNodePoolName)).toBeInTheDocument();
   });
-
-  // Is the new NP name in the document?
-  expect(getByText(newNodePoolName)).toBeInTheDocument();
 
   // Is it now the 2nd node pool in list?
   const reSortedNodePools = getAllByTestId('node-pool-id');

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.js
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.js
@@ -119,6 +119,7 @@ const AppDetailsModal = props => {
     done();
   }
 
+  // eslint-disable-next-line react/no-multi-comp
   function deleteConfirmFooter(cta, onConfirm) {
     return (
       <DeleteConfirmFooter

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -11,6 +11,7 @@ import {
 import * as clusterActions from 'actions/clusterActions';
 import * as nodePoolActions from 'actions/nodePoolActions';
 import * as releaseActions from 'actions/releaseActions';
+import { errorReporter } from 'components';
 import DocumentTitle from 'components/shared/DocumentTitle';
 import { push } from 'connected-react-router';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
@@ -196,8 +197,9 @@ class ClusterDetailView extends React.Component {
       this.props.dispatch(
         clusterActions.clusterPatch(this.props.cluster, { name: value })
       );
-    } catch {
-      // Do nothing on purpose, flash message is already displayed inside the action
+    } catch (err) {
+      // eslint-disable-next-line no-unused-expressions
+      errorReporter?.notify(err);
     }
   };
 

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -192,23 +192,13 @@ class ClusterDetailView extends React.Component {
   };
 
   editClusterName = value => {
-    return new Promise((resolve, reject) => {
-      this.props
-        .dispatch(
-          clusterActions.clusterPatch(this.props.cluster, { name: value })
-        )
-        .then(() => {
-          new FlashMessage(
-            'Succesfully edited cluster name.',
-            messageType.SUCCESS,
-            messageTTL.MEDIUM
-          );
-          resolve();
-        })
-        .catch(error => {
-          reject(error);
-        });
-    });
+    try {
+      this.props.dispatch(
+        clusterActions.clusterPatch(this.props.cluster, { name: value })
+      );
+    } catch {
+      // Do nothing on purpose, flash message is already displayed inside the action
+    }
   };
 
   render() {

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -241,8 +241,8 @@ class ClusterDetailView extends React.Component {
                   <h1 style={{ marginLeft: '-10px' }}>
                     <ClusterIDLabel clusterID={cluster.id} copyEnabled />{' '}
                     <ViewAndEditName
-                      entity={cluster}
-                      entityType='cluster'
+                      name={cluster.name}
+                      type='cluster'
                       onSubmit={this.editClusterName}
                     />{' '}
                   </h1>

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -11,9 +11,9 @@ import {
 import * as clusterActions from 'actions/clusterActions';
 import * as nodePoolActions from 'actions/nodePoolActions';
 import * as releaseActions from 'actions/releaseActions';
-import { errorReporter } from 'components';
 import DocumentTitle from 'components/shared/DocumentTitle';
 import { push } from 'connected-react-router';
+import ErrorReporter from 'lib/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import PageVisibilityTracker from 'lib/pageVisibilityTracker';
 import RoutePath from 'lib/routePath';
@@ -198,8 +198,7 @@ class ClusterDetailView extends React.Component {
         clusterActions.clusterPatch(this.props.cluster, { name: value })
       );
     } catch (err) {
-      // eslint-disable-next-line no-unused-expressions
-      errorReporter?.notify(err);
+      ErrorReporter.getInstance().notify(err);
     }
   };
 

--- a/src/components/Cluster/ClusterDetail/NodePool.js
+++ b/src/components/Cluster/ClusterDetail/NodePool.js
@@ -14,6 +14,21 @@ import AvailabilityZonesWrapper from './AvailabilityZonesWrapper';
 import NodePoolDropdownMenu from './NodePoolDropdownMenu';
 import ScaleNodePoolModal from './ScaleNodePoolModal';
 
+const NPViewAndEditName = styled(ViewAndEditName)`
+  input[type='text'] {
+    font-size: 15px;
+    line-height: 1.8em;
+    margin-bottom: 0;
+  }
+  .btn-group {
+    top: 0;
+  }
+  button {
+    font-size: 13px;
+    padding: 4px 10px;
+  }
+`;
+
 const NodesWrapper = styled.div`
   width: 36px;
   height: 30px;
@@ -108,13 +123,12 @@ class NodePool extends Component {
         <NameWrapperDiv
           style={{ gridColumn: isNameBeingEdited ? '2 / 9' : null }}
         >
-          <ViewAndEditName
-            cssClass='np'
-            entity={nodePool}
-            entityType='node pool'
+          <NPViewAndEditName
+            name={nodePool.name}
+            type='node pool'
             onSubmit={this.editNodePoolName}
             ref={viewEditName => (this.viewEditNameRef = viewEditName)}
-            toggleEditingState={this.toggleEditingState}
+            onToggleEditingState={this.toggleEditingState}
           />
         </NameWrapperDiv>
         {/* Hide the rest of fields when editing name */}

--- a/src/components/Cluster/ClusterDetail/NodePool.js
+++ b/src/components/Cluster/ClusterDetail/NodePool.js
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import * as nodePoolActions from 'actions/nodePoolActions';
 import { spinner } from 'images';
-import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -68,28 +67,13 @@ class NodePool extends Component {
   editNodePoolName = name => {
     const { cluster, nodePool } = this.props;
 
-    return new Promise((resolve, reject) => {
-      // Early return in case the name is not changed.
-      if (nodePool.name === name) return resolve();
-
-      return this.props
-        .dispatch(nodePoolActions.nodePoolPatch(cluster.id, nodePool, { name }))
-        .then(() => {
-          new FlashMessage(
-            'Succesfully edited node pool name.',
-            messageType.SUCCESS,
-            messageTTL.MEDIUM
-          );
-
-          return resolve();
-        })
-        .catch(error => {
-          // eslint-disable-next-line no-console
-          console.error(error);
-
-          return reject(error);
-        });
-    });
+    try {
+      this.props.dispatch(
+        nodePoolActions.nodePoolPatch(cluster.id, nodePool, { name })
+      );
+    } catch {
+      // Do nothing on purpose, flash message is already displayed inside the action
+    }
   };
 
   deleteNodePool = () => {

--- a/src/components/Cluster/ClusterDetail/NodePool.js
+++ b/src/components/Cluster/ClusterDetail/NodePool.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import * as nodePoolActions from 'actions/nodePoolActions';
-import { errorReporter } from 'components';
 import { spinner } from 'images';
+import ErrorReporter from 'lib/ErrorReporter';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -73,8 +73,7 @@ class NodePool extends Component {
         nodePoolActions.nodePoolPatch(cluster.id, nodePool, { name })
       );
     } catch (err) {
-      // eslint-disable-next-line no-unused-expressions
-      errorReporter?.notify(err);
+      ErrorReporter.getInstance().notify(err);
     }
   };
 

--- a/src/components/Cluster/ClusterDetail/NodePool.js
+++ b/src/components/Cluster/ClusterDetail/NodePool.js
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import * as nodePoolActions from 'actions/nodePoolActions';
+import { errorReporter } from 'components';
 import { spinner } from 'images';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -71,8 +72,9 @@ class NodePool extends Component {
       this.props.dispatch(
         nodePoolActions.nodePoolPatch(cluster.id, nodePool, { name })
       );
-    } catch {
-      // Do nothing on purpose, flash message is already displayed inside the action
+    } catch (err) {
+      // eslint-disable-next-line no-unused-expressions
+      errorReporter?.notify(err);
     }
   };
 

--- a/src/components/UI/ViewEditName.js
+++ b/src/components/UI/ViewEditName.js
@@ -103,8 +103,9 @@ class ViewAndEditName extends React.Component {
     this.setState({ inputFieldValue: e.target.value });
   };
 
-  handleSubmit = evt => {
-    evt.preventDefault();
+  handleSubmit = e => {
+    // eslint-disable-next-line no-unused-expressions
+    e?.preventDefault();
 
     const { onSubmit, toggleEditingState } = this.props;
 
@@ -127,16 +128,23 @@ class ViewAndEditName extends React.Component {
       () => {
         // eslint-disable-next-line no-unused-expressions
         toggleEditingState?.(false);
-        onSubmit(this.state.inputFieldValue);
+        // eslint-disable-next-line no-unused-expressions
+        onSubmit?.(this.state.inputFieldValue);
       }
     );
   };
 
-  handleKey = evt => {
-    // 27 = Escape key
-    // eslint-disable-next-line no-magic-numbers
-    if (evt.keyCode === 27) {
-      this.deactivateEditMode();
+  handleKey = e => {
+    switch (e.key) {
+      case 'Escape':
+        this.deactivateEditMode();
+
+        break;
+
+      case 'Enter':
+        this.handleSubmit();
+
+        break;
     }
   };
 
@@ -199,7 +207,6 @@ class ViewAndEditName extends React.Component {
 
 ViewAndEditName.propTypes = {
   cssClass: PropTypes.string,
-  dispatch: PropTypes.func,
   entity: PropTypes.object,
   // Used by flash message and tooltip.
   entityType: PropTypes.string,
@@ -207,4 +214,6 @@ ViewAndEditName.propTypes = {
   toggleEditingState: PropTypes.func,
 };
 
-export default ViewAndEditName;
+export default React.forwardRef((props, ref) => (
+  <ViewAndEditName ref={ref} {...props} />
+));

--- a/src/components/UI/ViewEditName.js
+++ b/src/components/UI/ViewEditName.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
-import { connect } from 'react-redux';
 
 import Button from './Button';
 
@@ -208,6 +207,4 @@ ViewAndEditName.propTypes = {
   toggleEditingState: PropTypes.func,
 };
 
-export default connect(undefined, undefined, undefined, { forwardRef: true })(
-  ViewAndEditName
-);
+export default ViewAndEditName;

--- a/src/components/UI/ViewEditName.js
+++ b/src/components/UI/ViewEditName.js
@@ -200,7 +200,7 @@ class ViewAndEditName extends React.Component {
 
     // View mode
     return (
-      <span>
+      <span {...rest}>
         <OverlayTrigger
           overlay={<Tooltip id='tooltip'>Click to edit {type} name</Tooltip>}
           placement='top'

--- a/src/components/UI/__tests__/ViewEditName.js
+++ b/src/components/UI/__tests__/ViewEditName.js
@@ -11,8 +11,8 @@ const renderComponent = (props = {}) => {
   const propsWithDefault = Object.assign(
     {},
     {
-      entity: defaultEntity,
-      entityType: defaultEntity.type,
+      name: defaultEntity.name,
+      type: defaultEntity.type,
     },
     props
   );
@@ -151,7 +151,7 @@ describe('ViewEditName', () => {
 
     const { getByText, getByDisplayValue } = renderComponent({
       onSubmit: onSubmitMock,
-      toggleEditingState: onToggleEditingStateMock,
+      onToggleEditingState: onToggleEditingStateMock,
     });
 
     const label = getByText(/some value/i);
@@ -177,7 +177,7 @@ describe('ViewEditName', () => {
 
     const { getByText, getByDisplayValue } = renderComponent({
       onSubmit: onSubmitMock,
-      toggleEditingState: onToggleEditingStateMock,
+      onToggleEditingState: onToggleEditingStateMock,
     });
 
     const label = getByText(/some value/i);

--- a/src/components/UI/__tests__/ViewEditName.js
+++ b/src/components/UI/__tests__/ViewEditName.js
@@ -145,7 +145,7 @@ describe('ViewEditName', () => {
     expect(input).toBeInTheDocument();
   });
 
-  it('executes callbacks from props on events', () => {
+  it('executes callbacks from props on submit', () => {
     const onSubmitMock = jest.fn();
     const onToggleEditingStateMock = jest.fn();
 
@@ -167,6 +167,32 @@ describe('ViewEditName', () => {
     const submitButton = getByText(/ok/i);
     fireEvent.click(submitButton);
     expect(onSubmitMock).toHaveBeenCalledWith('some other value');
+
+    expect(onToggleEditingStateMock).toBeCalledWith(false);
+  });
+
+  it('executes callbacks from props on cancel', () => {
+    const onSubmitMock = jest.fn();
+    const onToggleEditingStateMock = jest.fn();
+
+    const { getByText, getByDisplayValue } = renderComponent({
+      onSubmit: onSubmitMock,
+      toggleEditingState: onToggleEditingStateMock,
+    });
+
+    const label = getByText(/some value/i);
+
+    // Click to edit
+    fireEvent.click(label);
+    expect(onToggleEditingStateMock).toBeCalledWith(true);
+    const input = getByDisplayValue(/some value/i);
+    fireEvent.change(input, {
+      target: { value: 'some other value' },
+    });
+
+    const submitButton = getByText(/cancel/i);
+    fireEvent.click(submitButton);
+    expect(onSubmitMock).not.toBeCalled();
 
     expect(onToggleEditingStateMock).toBeCalledWith(false);
   });

--- a/src/components/UI/__tests__/ViewEditName.js
+++ b/src/components/UI/__tests__/ViewEditName.js
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import ViewEditName from 'UI/ViewEditName';
+
+const renderComponent = (props = {}) => {
+  return render(<ViewEditName {...props} />);
+};
+
+describe('ViewEditName', () => {
+  it('renders without crashing', () => {
+    renderComponent();
+  });
+});

--- a/src/components/UI/__tests__/ViewEditName.js
+++ b/src/components/UI/__tests__/ViewEditName.js
@@ -1,13 +1,173 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import ViewEditName from 'UI/ViewEditName';
 
+const defaultEntity = {
+  name: 'Some value',
+  type: 'test-type',
+};
+
 const renderComponent = (props = {}) => {
-  return render(<ViewEditName {...props} />);
+  const propsWithDefault = Object.assign(
+    {},
+    {
+      entity: defaultEntity,
+      entityType: defaultEntity.type,
+    },
+    props
+  );
+
+  return render(<ViewEditName {...propsWithDefault} />);
 };
 
 describe('ViewEditName', () => {
   it('renders without crashing', () => {
     renderComponent();
+  });
+
+  it('edits content on click', () => {
+    const { getByText, getByDisplayValue } = renderComponent();
+
+    let label = getByText(/some value/i);
+    expect(label).toBeInTheDocument();
+    expect(label.tagName.toLowerCase()).toBe('a');
+
+    // Hover to see helping tooltip
+    fireEvent.mouseOver(label);
+    expect(getByText(/Click to edit test-type name/i)).toBeInTheDocument();
+
+    // Click to edit
+    fireEvent.click(label);
+    const input = getByDisplayValue(/some value/i);
+    expect(input).toBeInTheDocument();
+
+    fireEvent.change(input, {
+      target: { value: 'some other value' },
+    });
+
+    const submitButton = getByText(/ok/i);
+    fireEvent.click(submitButton);
+
+    // Value was changed
+    label = getByText(/some other value/i);
+    expect(label).toBeInTheDocument();
+    expect(label.tagName.toLowerCase()).toBe('a');
+  });
+
+  it('cancels edit on pressing cancel', () => {
+    const { getByText, getByDisplayValue } = renderComponent();
+
+    let label = getByText(/some value/i);
+
+    // Click to edit
+    fireEvent.click(label);
+    const input = getByDisplayValue(/some value/i);
+    fireEvent.change(input, {
+      target: { value: 'some other value' },
+    });
+
+    // Press cancel
+    const cancelButton = getByText(/cancel/i);
+    fireEvent.click(cancelButton);
+
+    // Value was not changed
+    label = getByText(/some value/i);
+    expect(label).toBeInTheDocument();
+  });
+
+  it(`can be saved by pressing the 'enter' key`, () => {
+    const { getByText, getByDisplayValue } = renderComponent();
+
+    let label = getByText(/some value/i);
+    expect(label.tagName.toLowerCase()).toBe('a');
+
+    // Click to edit
+    fireEvent.click(label);
+    const input = getByDisplayValue(/some value/i);
+    fireEvent.change(input, {
+      target: { value: 'some other value' },
+    });
+
+    // Press enter
+    fireEvent.keyUp(input, {
+      key: 'Enter',
+    });
+
+    // Value has been changed
+    label = getByText(/some other value/i);
+    expect(label).toBeInTheDocument();
+    expect(label.tagName.toLowerCase()).toBe('a');
+  });
+
+  it(`cancels input by pressing the 'escape' key`, () => {
+    const { getByText, getByDisplayValue } = renderComponent();
+
+    let label = getByText(/some value/i);
+
+    // Click to edit
+    fireEvent.click(label);
+    const input = getByDisplayValue(/some value/i);
+    fireEvent.change(input, {
+      target: { value: 'some other value' },
+    });
+
+    // Press escape
+    fireEvent.keyUp(input, {
+      key: 'Escape',
+    });
+
+    // Value was not changed
+    label = getByText(/some value/i);
+    expect(label).toBeInTheDocument();
+  });
+
+  it('validates input on submit', () => {
+    const { getByText, getByDisplayValue } = renderComponent();
+
+    const label = getByText(/some value/i);
+
+    // Click to edit
+    fireEvent.click(label);
+    const input = getByDisplayValue(/some value/i);
+    fireEvent.change(input, {
+      target: { value: 'no' },
+    });
+
+    const submitButton = getByText(/ok/i);
+    fireEvent.click(submitButton);
+
+    // A warning is shown
+    expect(
+      getByText(/please use a name with at least 3 characters/i)
+    ).toBeInTheDocument();
+
+    // Input is still here, data not saved
+    expect(input).toBeInTheDocument();
+  });
+
+  it('executes callbacks from props on events', () => {
+    const onSubmitMock = jest.fn();
+    const onToggleEditingStateMock = jest.fn();
+
+    const { getByText, getByDisplayValue } = renderComponent({
+      onSubmit: onSubmitMock,
+      toggleEditingState: onToggleEditingStateMock,
+    });
+
+    const label = getByText(/some value/i);
+
+    // Click to edit
+    fireEvent.click(label);
+    expect(onToggleEditingStateMock).toBeCalledWith(true);
+    const input = getByDisplayValue(/some value/i);
+    fireEvent.change(input, {
+      target: { value: 'some other value' },
+    });
+
+    const submitButton = getByText(/ok/i);
+    fireEvent.click(submitButton);
+    expect(onSubmitMock).toHaveBeenCalledWith('some other value');
+
+    expect(onToggleEditingStateMock).toBeCalledWith(false);
   });
 });

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -33,7 +33,7 @@ export let errorReporter = null;
 
 // Configure an airbrake notifier for excption notification.
 // But only when not in development.
-if (window.config.environment === 'development') {
+if (window.config.environment !== 'development') {
   // We use the airbrake notifier here instead of rolling our own notification
   // client, it is a stable project used by many. Though instead of sending our
   // exception reports to airbrake we send it to an endpoint of our own API, to

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -29,14 +29,16 @@ const store = configureStore({}, history);
 // update the store with the new token.
 monkeyPatchGiantSwarmClient(store);
 
-// Configure an airbrake notifier for exception notification.
+export let errorReporter = null;
+
+// Configure an airbrake notifier for excption notification.
 // But only when not in development.
-if (window.config.environment !== 'development') {
+if (window.config.environment === 'development') {
   // We use the airbrake notifier here instead of rolling our own notification
   // client, it is a stable project used by many. Though instead of sending our
   // exception reports to airbrake we send it to an endpoint of our own API, to
   // ensure no customer data is being shared with a third party.
-  const airbrake = new Notifier({
+  errorReporter = new Notifier({
     // projectId and projectKey are not relevant to our exception notification endpoint, but are required to create a valid notifier.
     projectId: 1,
     projectKey: 'happa',
@@ -47,11 +49,11 @@ if (window.config.environment !== 'development') {
   // _requester attributes since the constructor does not allow us to edit the
   // url or the headers used during the request easily. We need to set headers so
   // that we can authenticate against our API endpoint.
-  airbrake._url = `${window.config.apiEndpoint}/v5/exception-notifications/`;
-  airbrake._requester = new Requester(store).request;
+  errorReporter._url = `${window.config.apiEndpoint}/v5/exception-notifications/`;
+  errorReporter._requester = new Requester(store).request;
 
   // set up a filter for reporting addtional information (happa version)
-  airbrake.addFilter(notice => ({
+  errorReporter.addFilter(notice => ({
     ...notice,
     context: { ...notice.context, version: window.config.happaVersion },
   }));

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ import 'react-datepicker/dist/react-datepicker.css';
 import 'styles/app.sass';
 
 import { Notifier } from '@airbrake/browser';
+import ErrorReporter from 'lib/ErrorReporter';
 import monkeyPatchGiantSwarmClient from 'lib/giantswarmClientPatcher';
 import { Requester } from 'lib/patchedAirbrakeRequester';
 import React from 'react';
@@ -29,8 +30,6 @@ const store = configureStore({}, history);
 // update the store with the new token.
 monkeyPatchGiantSwarmClient(store);
 
-export let errorReporter = null;
-
 // Configure an airbrake notifier for excption notification.
 // But only when not in development.
 if (window.config.environment !== 'development') {
@@ -38,7 +37,7 @@ if (window.config.environment !== 'development') {
   // client, it is a stable project used by many. Though instead of sending our
   // exception reports to airbrake we send it to an endpoint of our own API, to
   // ensure no customer data is being shared with a third party.
-  errorReporter = new Notifier({
+  const airbrake = new Notifier({
     // projectId and projectKey are not relevant to our exception notification endpoint, but are required to create a valid notifier.
     projectId: 1,
     projectKey: 'happa',
@@ -49,14 +48,17 @@ if (window.config.environment !== 'development') {
   // _requester attributes since the constructor does not allow us to edit the
   // url or the headers used during the request easily. We need to set headers so
   // that we can authenticate against our API endpoint.
-  errorReporter._url = `${window.config.apiEndpoint}/v5/exception-notifications/`;
-  errorReporter._requester = new Requester(store).request;
+  airbrake._url = `${window.config.apiEndpoint}/v5/exception-notifications/`;
+  airbrake._requester = new Requester(store).request;
 
   // set up a filter for reporting addtional information (happa version)
-  errorReporter.addFilter(notice => ({
+  airbrake.addFilter(notice => ({
     ...notice,
     context: { ...notice.context, version: window.config.happaVersion },
   }));
+
+  const errorReporter = ErrorReporter.getInstance();
+  errorReporter.notifier = airbrake;
 }
 
 // Scroll to the top when we change the URL.

--- a/src/lib/ErrorReporter.js
+++ b/src/lib/ErrorReporter.js
@@ -1,0 +1,20 @@
+class ErrorReporter {
+  static _instance = null;
+
+  static getInstance() {
+    if (!ErrorReporter._instance) {
+      ErrorReporter._instance = new ErrorReporter();
+    }
+
+    return ErrorReporter._instance;
+  }
+
+  notifier = null;
+
+  notify(error) {
+    // eslint-disable-next-line no-unused-expressions
+    this.notifier?.notify(error);
+  }
+}
+
+export default ErrorReporter;

--- a/testUtils/setupTests.js
+++ b/testUtils/setupTests.js
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom/extend-expect';
+
 import { configure, waitFor } from '@testing-library/react';
 import { forceRemoveAll } from 'lib/flashMessage';
 import nock from 'nock';


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/9428

### Changes
* Wrote unit tests for initial component, to not refactor blindly
* Refactored the component, disconnected it from the store
* Made the `OK` button have the success look (to be different from the cancel button)
* Removed the success message after editing cluster/node pool names, we're going full optimistic here (if the request fails, an error flash message would be shown, and the value will be reverted to the one before the change)
* Updated the tests that asserted those messages
* Instead of displaying a flash message with an error if the input validation fails, we're displaying a tooltip with the error message, giving the input a red border, and disabling the submit button

### How it looks
* **Error state**
![image](https://user-images.githubusercontent.com/13508038/76940617-e5847f80-68fa-11ea-9cab-c1ad6ace2216.png)

* **All bueno**
![image](https://user-images.githubusercontent.com/13508038/76940694-01882100-68fb-11ea-8d6e-11be488652ab.png)


