### PR TITLE
Fix test router redirecting

### DIFF
--- a/__tests__/AdminLogin.js
+++ b/__tests__/AdminLogin.js
@@ -63,16 +63,18 @@ helpers.validateOrRaise = jest.fn();
 const renderRouteWithStore = (
   initialRoute = AppRoutes.Home,
   state = {},
-  storage = initialStorage,
-  history = createMemoryHistory()
+  storage = initialStorage
 ) => {
   localStorage.replaceWith(storage);
+
+  const history = createMemoryHistory({
+    initialEntries: [initialRoute],
+    initialIndex: 0,
+  });
 
   store = configureStore(state, history);
 
   const app = render(<App {...{ store, theme, history }} />);
-
-  store.dispatch(push(initialRoute));
 
   return app;
 };
@@ -97,7 +99,7 @@ describe('AdminLogin', () => {
       store.dispatch(push(`${AppRoutes.OAuthCallback}#response_type=id_token`));
     });
 
-    mockAuth0ParseHash.mockImplementation(callback => {
+    mockAuth0ParseHash.mockImplementation((callback) => {
       callback(null, mockSuccessfulAuthResponse);
     });
 
@@ -172,7 +174,7 @@ describe('AdminLogin', () => {
       store.dispatch(push(`${AppRoutes.OAuthCallback}#response_type=invalid`));
     });
 
-    mockAuth0ParseHash.mockImplementation(callback => {
+    mockAuth0ParseHash.mockImplementation((callback) => {
       callback(null, mockSuccessfulAuthResponse);
     });
 
@@ -188,7 +190,7 @@ describe('AdminLogin', () => {
       store.dispatch(push(`${AppRoutes.OAuthCallback}#response_type=id_token`));
     });
 
-    mockAuth0ParseHash.mockImplementation(callback => {
+    mockAuth0ParseHash.mockImplementation((callback) => {
       callback(new Error('u w0t m8?'), mockSuccessfulAuthResponse);
     });
 

--- a/__tests__/AdminLogin.js
+++ b/__tests__/AdminLogin.js
@@ -15,7 +15,6 @@ import theme from 'styles/theme';
 import {
   AWSInfoResponse,
   getMockCall,
-  getMockCallTimes,
   USER_EMAIL,
   userResponse,
 } from 'testUtils/mockHttpCalls';
@@ -113,12 +112,11 @@ describe('AdminLogin', () => {
   });
 
   it('redirects to homepage if the user has been previously logged in', async () => {
-    getMockCallTimes('/v4/user/', userResponse, 2);
+    getMockCall('/v4/user/', userResponse);
     getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);
-    getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);
-    getMockCallTimes('/v4/appcatalogs/', [], 2);
+    getMockCall('/v4/appcatalogs/', []);
     getMockCall('/v4/organizations/');
-    getMockCallTimes('/v4/clusters/', [], 2);
+    getMockCall('/v4/clusters/', []);
 
     helpers.isJwtExpired.mockReturnValue(false);
 
@@ -131,12 +129,11 @@ describe('AdminLogin', () => {
   });
 
   it('renews user token if the previously stored one is expired', async () => {
-    getMockCallTimes('/v4/user/', userResponse, 2);
+    getMockCall('/v4/user/', userResponse);
     getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);
-    getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);
-    getMockCallTimes('/v4/appcatalogs/', [], 2);
+    getMockCall('/v4/appcatalogs/', []);
     getMockCall('/v4/organizations/');
-    getMockCallTimes('/v4/clusters/', [], 2);
+    getMockCall('/v4/clusters/', []);
 
     const mockUserDataWithNewToken = Object.assign({}, mockUserData, {
       auth: {
@@ -204,12 +201,6 @@ describe('AdminLogin', () => {
     const originalConsoleError = console.error;
     // eslint-disable-next-line no-console
     console.error = jest.fn();
-
-    getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);
-    getMockCall('/v4/user/', userResponse);
-    getMockCall('/v4/appcatalogs/');
-    getMockCall('/v4/organizations/');
-    getMockCall('/v4/clusters/', []);
 
     const mockAuthResponseWithNewToken = Object.assign(
       {},

--- a/__tests__/ForgotPassword.js
+++ b/__tests__/ForgotPassword.js
@@ -266,12 +266,6 @@ describe('PasswordReset', () => {
     });
 
     it(`jumps to password setup automatically if there's an email saved in the local storage`, async () => {
-      getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);
-      getMockCall('/v4/user/', userResponse);
-      getMockCall('/v4/organizations/');
-      getMockCall('/v4/appcatalogs/');
-      getMockCall('/v4/clusters/');
-
       nock(global.config.passageEndpoint)
         .post(`/recovery/${token}/`, { email: USER_EMAIL })
         .reply(StatusCodes.Ok, {

--- a/__tests__/SignUp.js
+++ b/__tests__/SignUp.js
@@ -22,14 +22,6 @@ const verifyingRoute = RoutePath.createUsablePath(AppRoutes.SignUp, {
 });
 
 describe('Signup', () => {
-  beforeEach(() => {
-    getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);
-    getMockCall('/v4/user/', userResponse);
-    getMockCall('/v4/appcatalogs/');
-    getMockCall('/v4/clusters/');
-    getMockCall('/v4/organizations/');
-  });
-
   it('renders without crashing', async () => {
     const { findByText } = renderRouteWithStore(verifyingRoute);
 

--- a/testUtils/renderUtils.js
+++ b/testUtils/renderUtils.js
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import App from 'App';
-import { ConnectedRouter, push } from 'connected-react-router';
+import { ConnectedRouter } from 'connected-react-router';
 import { ThemeProvider } from 'emotion-theming';
 import { createMemoryHistory } from 'history';
 import React from 'react';
@@ -23,16 +23,18 @@ export const initialStorage = {
 export function renderRouteWithStore(
   initialRoute = AppRoutes.Home,
   state = {},
-  storage = initialStorage,
-  history = createMemoryHistory()
+  storage = initialStorage
 ) {
   localStorage.replaceWith(storage);
+
+  const history = createMemoryHistory({
+    initialEntries: [initialRoute],
+    initialIndex: 0,
+  });
 
   const store = configureStore(state, history);
 
   const app = render(<App {...{ store, theme, history }} />);
-
-  store.dispatch(push(initialRoute));
 
   return app;
 }

--- a/testUtils/setupTests.js
+++ b/testUtils/setupTests.js
@@ -27,10 +27,10 @@ afterEach(async () => {
     const done = nock.isDone();
 
     // Uncomment the next lines to debug hanging requests
-    const pendingMocks = nock.pendingMocks().map((mock) => `${mock}\n`);
-    if (!done) {
-      throw new Error(`You still have pending mocks bro:\n ${pendingMocks}`);
-    }
+    // const pendingMocks = nock.pendingMocks().map((mock) => `${mock}\n`);
+    // if (!done) {
+    //   throw new Error(`You still have pending mocks bro:\n ${pendingMocks}`);
+    // }
 
     expect(done).toBeTruthy();
   });

--- a/testUtils/setupTests.js
+++ b/testUtils/setupTests.js
@@ -27,10 +27,10 @@ afterEach(async () => {
     const done = nock.isDone();
 
     // Uncomment the next lines to debug hanging requests
-    // const pendingMocks = nock.pendingMocks().map(mock => `${mock}\n`);
-    // if (!done) {
-    //   throw new Error(`You still have pending mocks bro:\n ${pendingMocks}`);
-    // }
+    const pendingMocks = nock.pendingMocks().map((mock) => `${mock}\n`);
+    if (!done) {
+      throw new Error(`You still have pending mocks bro:\n ${pendingMocks}`);
+    }
 
     expect(done).toBeTruthy();
   });


### PR DESCRIPTION
This should fix the problem with the tests in https://github.com/giantswarm/happa/pull/1124/
This was branched off of that brach, and is meant to be merged back into it

The problem was when rendering a route during tests:
* The `/` path would be the initial path
* We would push to the desired path provided to the `renderRouteWithStore` function

The problem in the `SignUp` tests was that we would first push to `/` with an user in the storage, so the app would deserialize it and act like it was logged in, which would mount the `Layout` component and trigger the API calls. Then we would redirect to `SignUp`, but we would cut the test before the api calls were actually done.

The reason why this only surfaced now is that lazy rendering is asynchronous, which gave the API requests time to initialize.