### PR TITLE
Remove noty top right overlapping user & org components

### DIFF
--- a/src/styles/components/_flash_messages.sass
+++ b/src/styles/components/_flash_messages.sass
@@ -11,7 +11,6 @@
     background-color: #fff
     color: #000
 
-
 #noty_layout__topRight
   top: 52px
 

--- a/src/styles/components/_flash_messages.sass
+++ b/src/styles/components/_flash_messages.sass
@@ -11,6 +11,10 @@
     background-color: #fff
     color: #000
 
+
+#noty_layout__topRight
+  top: 52px
+
 // closing animation for noty messages
 .flash_message_close
   animation: noty_anim_out 0.2s cubic-bezier(0.68, 0, 0.265, 1.55)


### PR DESCRIPTION
This PR moves the topRight noty notification a little bit lower so it does not overlap with user and org controls on small displays:

Before:
![image](https://user-images.githubusercontent.com/1494211/77911278-d30e2c80-7290-11ea-9dd3-42a535a3c9b7.png)

After:

![image](https://user-images.githubusercontent.com/1494211/77911240-c689d400-7290-11ea-8000-f6fd38ab9afe.png)
