### PR TITLE
Fix CVE 2019 20149

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "immutable": "3.8.2",
     "js-base64": "2.5.2",
     "js-yaml": "^3.12.1",
+    "kind-of": "6.0.3",
     "lunr": "^2.3.6",
     "moment": "2.24.0",
     "normalize.css": "8.0.1",
@@ -95,8 +96,8 @@
   "devDependencies": {
     "@babel/core": "7.9.0",
     "@babel/preset-env": "7.9.0",
-    "@babel/preset-typescript": "^7.9.0",
     "@babel/preset-react": "7.9.4",
+    "@babel/preset-typescript": "^7.9.0",
     "@testing-library/jest-dom": "5.3.0",
     "@testing-library/react": "10.0.1",
     "@testing-library/react-hooks": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
   },
   "resolutions": {
     "**/crypto-js": "^3.2.1",
-    "kind-of": ">= 6.0.3"
+    "kind-of": "^6.0.3"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "immutable": "3.8.2",
     "js-base64": "2.5.2",
     "js-yaml": "^3.12.1",
-    "kind-of": "6.0.3",
     "lunr": "^2.3.6",
     "moment": "2.24.0",
     "normalize.css": "8.0.1",
@@ -179,7 +178,8 @@
     "webpack-merge": "4.2.2"
   },
   "resolutions": {
-    "**/crypto-js": "^3.2.1"
+    "**/crypto-js": "^3.2.1",
+    "kind-of": ">= 6.0.3"
   },
   "husky": {
     "hooks": {

--- a/src/index.html
+++ b/src/index.html
@@ -28,8 +28,10 @@
 
     <script>
       var config = {
-        apiEndpoint: 'http://localhost:8000',
-        passageEndpoint: 'http://localhost:5001',
+        // apiEndpoint: 'http://localhost:8000',
+        apiEndpoint: 'https://api.g8s.ginger.eu-west-1.aws.gigantic.io',
+        // passageEndpoint: 'http://localhost:5001',
+        passageEndpoint: 'https://passage.g8s.ginger.eu-west-1.aws.gigantic.io',
         // environment is set to:
         // 'dev' while developing
         // 'kubernetes' when deployed in production

--- a/src/index.html
+++ b/src/index.html
@@ -28,10 +28,8 @@
 
     <script>
       var config = {
-        // apiEndpoint: 'http://localhost:8000',
-        apiEndpoint: 'https://api.g8s.ginger.eu-west-1.aws.gigantic.io',
-        // passageEndpoint: 'http://localhost:5001',
-        passageEndpoint: 'https://passage.g8s.ginger.eu-west-1.aws.gigantic.io',
+        apiEndpoint: 'http://localhost:8000',
+        passageEndpoint: 'http://localhost:5001',
         // environment is set to:
         // 'dev' while developing
         // 'kubernetes' when deployed in production

--- a/yarn.lock
+++ b/yarn.lock
@@ -6745,7 +6745,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.4, is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.4, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -7739,34 +7739,10 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
-kind-of@6.0.3:
+"kind-of@>= 6.0.3", kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
-
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
 kleur@^3.0.3:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7739,6 +7739,11 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
+kind-of@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
https://github.com/advisories/GHSA-6c8f-qphg-qjgp

Forcing all packages that have the `kind-of` dependency  to use the patched `6.0.3` version.