### PR TITLE
Fix instance type position inside the create node pool form

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterApps.js
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.js
@@ -37,6 +37,11 @@ const BrowseButton = styled(Button)`
   margin-bottom: 10px;
 `;
 
+const Disclaimer = styled.p`
+  margin: 0 0 20px;
+  line-height: 1.2;
+`;
+
 class ClusterApps extends React.Component {
   static getDerivedStateFromProps(newProps, prevState) {
     if (prevState.appDetailsModal.visible) {
@@ -314,10 +319,10 @@ class ClusterApps extends React.Component {
 
         <div className='row cluster-apps'>
           <h3 className='table-label'>Preinstalled Apps</h3>
-          <p>
+          <Disclaimer>
             These apps and services are preinstalled on your cluster and managed
             by Giant Swarm.
-          </p>
+          </Disclaimer>
           <div className='row'>
             {this.props.release ? (
               <>
@@ -349,7 +354,7 @@ class ClusterApps extends React.Component {
                   <SmallHeading>ingress</SmallHeading>
                   {this.props.hasOptionalIngress && (
                     <OptionalIngressNotice>
-                      <p>
+                      <Disclaimer>
                         The ingress controller is optional on this cluster.
                         <br />
                         You can install one using our app catalog.
@@ -363,7 +368,7 @@ class ClusterApps extends React.Component {
                         >
                           installing an ingress controller guide.
                         </a>
-                      </p>
+                      </Disclaimer>
                     </OptionalIngressNotice>
                   )}
                   {preinstalledApps.ingress.map((app) => (

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -48,11 +48,13 @@ const WrapperDiv = styled.div`
     font-size: 22px;
     margin: 0 0 15px;
   }
-  p {
-    margin: 0 0 20px;
-    line-height: 1.2;
-  }
 `;
+
+const Disclaimer = styled.p`
+  margin: 0 0 20px;
+  line-height: 1.2;
+`;
+
 class ClusterDetailView extends React.Component {
   loadDataInterval = null;
 
@@ -276,11 +278,11 @@ class ClusterDetailView extends React.Component {
                           <h3 className='table-label'>Delete This Cluster</h3>
                         </div>
                         <div className='row'>
-                          <p>
+                          <Disclaimer>
                             All workloads on this cluster will be terminated.
                             Data stored on the worker nodes will be lost. There
                             is no way to undo this action.
-                          </p>
+                          </Disclaimer>
                           <Button
                             bsStyle='danger'
                             onClick={this.showDeleteClusterModal.bind(

--- a/src/components/Cluster/ClusterDetail/KeyPairs.js
+++ b/src/components/Cluster/ClusterDetail/KeyPairs.js
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { CLUSTER_LOAD_KEY_PAIRS_REQUEST } from 'actions/actionTypes';
 import * as clusterActions from 'actions/clusterActions';
 import { spinner } from 'images';
@@ -15,6 +16,11 @@ import Button from 'UI/Button';
 import CertificateOrgsLabel from './CertificateOrgsLabel';
 import KeypairCreateModal from './KeyPairCreateModal';
 import KeyPairDetailsModal from './KeyPairDetailsModal';
+
+const Disclaimer = styled.p`
+  margin: 0 0 20px;
+  line-height: 1.2;
+`;
 
 class KeyPairs extends React.Component {
   static createdCellFormatter(_cell, row) {
@@ -167,11 +173,11 @@ class KeyPairs extends React.Component {
     return (
       <div className='row cluster_key_pairs col-12'>
         <div className='row'>
-          <p>
+          <Disclaimer>
             Key pairs consist of an RSA private key and certificate, signed by
             the certificate authority (CA) belonging to this cluster. They are
             used for access to the cluster via the Kubernetes API.
-          </p>
+          </Disclaimer>
         </div>
 
         <div className='row'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7739,7 +7739,7 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
-"kind-of@>= 6.0.3", kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==


### PR DESCRIPTION
As seen on slack: https://gigantic.slack.com/archives/CQ465CFG8/p1585817925007000

This was happening inside of `V5 Cluster Details` -> `Add new node pool`

![image (2)](https://user-images.githubusercontent.com/13508038/78241238-60938b80-74e0-11ea-87e5-5c02e6565cb8.png)

This also adds an ordering fix to `yarn.lock`, which I forgot to push in my previous vulnerability fix PR.