### PR TITLE
Happa home mobile changes

### DIFF
--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -121,6 +121,10 @@ const ClusterDetailsDiv = styled.div`
   ${mq(CSSBreakpoints.Medium)} {
     height: unset;
   }
+  ${mq(CSSBreakpoints.Small)} {
+    display: inline-block;
+    transform: translateY(-1px);
+  }
 `;
 
 function ClusterDashboardItem({

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -99,7 +99,10 @@ const ButtonsWrapper = styled.div`
     padding-left: 98px;
   }
   ${mq(CSSBreakpoints.Small)} {
-    padding-left: 9px;
+    position: absolute;
+    right: 0;
+    width: auto !important;
+    transform: translateX(15px) scale(0.9);
   }
 `;
 

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -61,7 +61,13 @@ const WrapperStyles = (props) => css`
       width: 100%;
     }
     ${LabelWrapper} {
-      margin-bottom: 5px;
+      position: absolute;
+      i {
+        display: none;
+      }
+    }
+    ${TitleWrapper} {
+      margin-left: 60px;
     }
     /* Font sizes */
     font-size: 0.9em;
@@ -99,10 +105,7 @@ const ButtonsWrapper = styled.div`
     padding-left: 98px;
   }
   ${mq(CSSBreakpoints.Small)} {
-    position: absolute;
-    right: 0;
-    width: auto !important;
-    transform: translateX(15px) scale(0.9);
+    display: none;
   }
 `;
 

--- a/src/styles/_base.sass
+++ b/src/styles/_base.sass
@@ -43,6 +43,9 @@ body
 #app
 	flex: 1 0 auto
 	padding-top: 120px
+	@media only screen and (max-width: $breakpoint-small)
+		padding-top: 68px
+
 
 footer
 	flex-shrink: 0

--- a/src/styles/_base.sass
+++ b/src/styles/_base.sass
@@ -43,7 +43,7 @@ body
 #app
 	flex: 1 0 auto
 	padding-top: 120px
-	@media only screen and (max-width: $breakpoint-small)
+	@media only screen and (max-width: $breakpoint-large)
 		padding-top: 68px
 
 


### PR DESCRIPTION
Just a couple of minor changes in mobile view to make better use of available view height:

- I've moved the _get started_ button to the top and to the right, and have made it smaller
- I've reduced the space above the _launch new cluster_ button

Before:

![image](https://user-images.githubusercontent.com/14203438/78255039-0e119980-74f7-11ea-8cf5-32fc529e9e1d.png)

After:

![image](https://user-images.githubusercontent.com/14203438/78255089-22ee2d00-74f7-11ea-8637-dff2d2278a21.png)
