### PR TITLE
Clarify app configuration fields.

### DIFF
--- a/__tests__/AppCatalog.js
+++ b/__tests__/AppCatalog.js
@@ -296,7 +296,7 @@ describe('Apps and App Catalog', () => {
       expect(getByLabelText(/namespace:/i).readOnly).toBeTruthy();
 
       // Upload a configmap file
-      let fileInput = getByLabelText(/User Values YAML:/i);
+      let fileInput = getByLabelText(/User level config values YAML:/i);
       let file = new Blob(
         [
           JSON.stringify({
@@ -316,7 +316,7 @@ describe('Apps and App Catalog', () => {
       });
 
       // Upload a secrets file
-      fileInput = getByLabelText(/User Secrets YAML:/i);
+      fileInput = getByLabelText(/User level secret values YAML:/i);
       file = new Blob(
         [
           JSON.stringify({

--- a/__tests__/AppCatalog.js
+++ b/__tests__/AppCatalog.js
@@ -296,7 +296,7 @@ describe('Apps and App Catalog', () => {
       expect(getByLabelText(/namespace:/i).readOnly).toBeTruthy();
 
       // Upload a configmap file
-      let fileInput = getByLabelText(/configmap:/i);
+      let fileInput = getByLabelText(/User Values YAML:/i);
       let file = new Blob(
         [
           JSON.stringify({
@@ -316,7 +316,7 @@ describe('Apps and App Catalog', () => {
       });
 
       // Upload a secrets file
-      fileInput = getByLabelText(/secret:/i);
+      fileInput = getByLabelText(/User Secrets YAML:/i);
       file = new Blob(
         [
           JSON.stringify({

--- a/__tests__/AppDetailPane.js
+++ b/__tests__/AppDetailPane.js
@@ -93,7 +93,9 @@ describe('Installed app detail pane', () => {
       fireEvent.click(appLabel);
 
       // Delete the existing file
-      const fileInputPlaceholder = getByText(/configmap has been set/i);
+      const fileInputPlaceholder = getByText(
+        /User level config values have been set/i
+      );
       const fileInput = fileInputPlaceholder.parentNode.querySelector('input');
       const file = new Blob(
         [
@@ -137,18 +139,22 @@ describe('Installed app detail pane', () => {
       fireEvent.click(appLabel);
 
       // Upload a configmap file
-      const fileInputPlaceholder = getByText(/configmap has been set/i);
+      const fileInputPlaceholder = getByText(
+        /User level config values have been set/i
+      );
       let deleteButton = fileInputPlaceholder.parentNode.querySelector(
         '.btn-danger'
       );
       fireEvent.click(deleteButton);
 
       // Confirm deletion
-      deleteButton = getByText(/^delete configmap$/i);
+      deleteButton = getByText(/^Delete user level config values$/i);
       fireEvent.click(deleteButton);
 
       await waitFor(() => {
-        expect(queryByText(/delete configmap/i)).not.toBeInTheDocument();
+        expect(
+          queryByText(/Delete user level config values/i)
+        ).not.toBeInTheDocument();
       });
 
       await findByText(/has been deleted./i);
@@ -174,7 +180,9 @@ describe('Installed app detail pane', () => {
       fireEvent.click(appLabel);
 
       // Upload a secrets file
-      const fileInputPlaceholder = getByText(/secret has been set/i);
+      const fileInputPlaceholder = getByText(
+        /user level secret values have been set/i
+      );
       const fileInput = fileInputPlaceholder.parentNode.querySelector('input');
       const file = new Blob(
         [
@@ -195,7 +203,9 @@ describe('Installed app detail pane', () => {
       });
 
       await waitFor(() => {
-        expect(queryByText(/delete secret/i)).not.toBeInTheDocument();
+        expect(
+          queryByText(/delete user level secret values/i)
+        ).not.toBeInTheDocument();
       });
 
       await findByText(/has successfully been updated./i);
@@ -221,18 +231,22 @@ describe('Installed app detail pane', () => {
       fireEvent.click(appLabel);
 
       // Delete the existing file
-      const fileInputPlaceholder = getByText(/secret has been set/i);
+      const fileInputPlaceholder = getByText(
+        /user level secret values have been set/i
+      );
       let deleteButton = fileInputPlaceholder.parentNode.querySelector(
         '.btn-danger'
       );
       fireEvent.click(deleteButton);
 
       // Confirm deletion
-      deleteButton = getByText(/^delete secret$/i);
+      deleteButton = getByText(/^delete user level secret values$/i);
       fireEvent.click(deleteButton);
 
       await waitFor(() => {
-        expect(queryByText(/delete secret/i)).not.toBeInTheDocument();
+        expect(
+          queryByText(/delete user level secret values/i)
+        ).not.toBeInTheDocument();
       });
 
       await findByText(/has been deleted./i);

--- a/src/actions/appConfigActions.js
+++ b/src/actions/appConfigActions.js
@@ -45,7 +45,7 @@ export function updateAppConfig(appName, clusterID, values) {
         });
 
         new FlashMessage(
-          `The configuration of <code>${appName}</code> on <code>${clusterID}</code> has successfully been updated.`,
+          `The ConfigMap containing the user level config values of <code>${appName}</code> on <code>${clusterID}</code> has successfully been updated.`,
           messageType.SUCCESS,
           messageTTL.LONG
         );
@@ -59,7 +59,7 @@ export function updateAppConfig(appName, clusterID, values) {
 
         if (error.status === StatusCodes.NotFound) {
           new FlashMessage(
-            `Could not find an app or app config to update for <code>${appName}</code> on cluster <code>${clusterID}</code>`,
+            `Could not find an app or ConfigMap containing user level config values to update for <code>${appName}</code> on cluster <code>${clusterID}</code>`,
             messageType.ERROR,
             messageTTL.LONG
           );
@@ -71,7 +71,7 @@ export function updateAppConfig(appName, clusterID, values) {
           );
         } else {
           new FlashMessage(
-            `Something went wrong while trying to update the ConfigMap. Please try again later or contact support: support@giantswarm.io`,
+            `Something went wrong while trying to update the ConfigMap containing user level config values. Please try again later or contact support: support@giantswarm.io`,
             messageType.ERROR,
             messageTTL.LONG
           );
@@ -121,7 +121,7 @@ export function createAppConfig(appName, clusterID, values) {
         });
 
         new FlashMessage(
-          `The ConfigMap for <code>${appName}</code> on <code>${clusterID}</code> has successfully been created.`,
+          `A ConfigMap containing user level config values for <code>${appName}</code> on <code>${clusterID}</code> has successfully been created.`,
           messageType.SUCCESS,
           messageTTL.LONG
         );
@@ -135,7 +135,7 @@ export function createAppConfig(appName, clusterID, values) {
 
         if (error.status === StatusCodes.NotFound) {
           new FlashMessage(
-            `Could not find an app to create a ConfigMap for <code>${appName}</code> on cluster <code>${clusterID}</code>`,
+            `Could not find app <code>${appName}</code> on cluster <code>${clusterID}</code>`,
             messageType.ERROR,
             messageTTL.LONG
           );
@@ -147,7 +147,7 @@ export function createAppConfig(appName, clusterID, values) {
           );
         } else {
           new FlashMessage(
-            `Something went wrong while trying to create the ConfigMap. Please try again later or contact support: support@giantswarm.io`,
+            `Something went wrong while trying to create a ConfigMap to store your values. Please try again later or contact support: support@giantswarm.io`,
             messageType.ERROR,
             messageTTL.LONG
           );
@@ -194,7 +194,7 @@ export function deleteAppConfig(appName, clusterID) {
         });
 
         new FlashMessage(
-          `The ConfigMap for <code>${appName}</code> on <code>${clusterID}</code> has been deleted.`,
+          `The ConfigMap containing user level config values for <code>${appName}</code> on <code>${clusterID}</code> has been deleted.`,
           messageType.SUCCESS,
           messageTTL.MEDIUM
         );
@@ -208,7 +208,7 @@ export function deleteAppConfig(appName, clusterID) {
 
         if (error.status === StatusCodes.NotFound) {
           new FlashMessage(
-            `Could not find ConfigMap for an app called <code>${appName}</code> on cluster <code>${clusterID}</code>`,
+            `Could not find the ConfigMap containing user level config values for the app called <code>${appName}</code> on cluster <code>${clusterID}</code>`,
             messageType.ERROR,
             messageTTL.LONG
           );
@@ -220,7 +220,7 @@ export function deleteAppConfig(appName, clusterID) {
           );
         } else {
           new FlashMessage(
-            `Something went wrong while trying to delete the ConfigMap. Please try again later or contact support: support@giantswarm.io`,
+            `Something went wrong while trying to delete the ConfigMap containing your values. Please try again later or contact support: support@giantswarm.io`,
             messageType.ERROR,
             messageTTL.LONG
           );

--- a/src/actions/appSecretActions.js
+++ b/src/actions/appSecretActions.js
@@ -45,7 +45,7 @@ export function updateAppSecret(appName, clusterID, values) {
         });
 
         new FlashMessage(
-          `The Secret of <code>${appName}</code> on <code>${clusterID}</code> has successfully been updated.`,
+          `The Secret containing user level secret values of <code>${appName}</code> on <code>${clusterID}</code> has successfully been updated.`,
           messageType.SUCCESS,
           messageTTL.LONG
         );
@@ -59,7 +59,7 @@ export function updateAppSecret(appName, clusterID, values) {
 
         if (error.status === StatusCodes.NotFound) {
           new FlashMessage(
-            `Could not find an app or app secret to update for <code>${appName}</code> on cluster <code>${clusterID}</code>`,
+            `Could not find an app or Secret containing user level secret values to update for <code>${appName}</code> on cluster <code>${clusterID}</code>`,
             messageType.ERROR,
             messageTTL.LONG
           );
@@ -71,7 +71,7 @@ export function updateAppSecret(appName, clusterID, values) {
           );
         } else {
           new FlashMessage(
-            `Something went wrong while trying to update the Secret. Please try again later or contact support: support@giantswarm.io`,
+            `Something went wrong while trying to update the Secret containing user level secret values. Please try again later or contact support: support@giantswarm.io`,
             messageType.ERROR,
             messageTTL.LONG
           );
@@ -121,7 +121,7 @@ export function createAppSecret(appName, clusterID, values) {
         });
 
         new FlashMessage(
-          `A Secret for <code>${appName}</code> on <code>${clusterID}</code> has successfully been created.`,
+          `A Secret containing user level secret values for <code>${appName}</code> on <code>${clusterID}</code> has successfully been created.`,
           messageType.SUCCESS,
           messageTTL.LONG
         );
@@ -147,7 +147,7 @@ export function createAppSecret(appName, clusterID, values) {
           );
         } else {
           new FlashMessage(
-            `Something went wrong while trying to create the Secret. Please try again later or contact support: support@giantswarm.io`,
+            `Something went wrong while trying to create the Secret containing your values. Please try again later or contact support: support@giantswarm.io`,
             messageType.ERROR,
             messageTTL.LONG
           );
@@ -194,7 +194,7 @@ export function deleteAppSecret(appName, clusterID) {
         });
 
         new FlashMessage(
-          `The Secret for <code>${appName}</code> on <code>${clusterID}</code> has been deleted.`,
+          `The Secret containing user level secret values for <code>${appName}</code> on <code>${clusterID}</code> has been deleted.`,
           messageType.SUCCESS,
           messageTTL.MEDIUM
         );
@@ -208,7 +208,7 @@ export function deleteAppSecret(appName, clusterID) {
 
         if (error.status === StatusCodes.NotFound) {
           new FlashMessage(
-            `Could not find the Secret for an app called <code>${appName}</code> on cluster <code>${clusterID}</code>`,
+            `Could not find the Secret containing user level secret values for an app called <code>${appName}</code> on cluster <code>${clusterID}</code>`,
             messageType.ERROR,
             messageTTL.LONG
           );

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -131,7 +131,7 @@ const InstallAppForm = ({
       <FileInput
         description='Apps can be configured using a yaml file with values. If you have one, you can upload it here already.'
         hint={<>&nbsp;</>}
-        label='User Values YAML:'
+        label='User level config values YAML:'
         onChange={updateValuesYAML}
         validationError={valuesYAMLError}
         value={valuesYAML}
@@ -140,7 +140,7 @@ const InstallAppForm = ({
       <FileInput
         description='Sensitive configuration can be uploaded separately as a secret.'
         hint={<>&nbsp;</>}
-        label='User Secrets YAML:'
+        label='User level secret values YAML:'
         onChange={updateSecretsYAML}
         validationError={secretsYAMLError}
         value={secretsYAML}

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -138,7 +138,7 @@ const InstallAppForm = ({
       />
 
       <FileInput
-        description='Sensitive configuration can be uploaded separately as a secret.'
+        description='Sensitive configuration values can be uploaded separately.'
         hint={<>&nbsp;</>}
         label='User level secret values YAML:'
         onChange={updateSecretsYAML}

--- a/src/components/AppCatalog/AppDetail/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppForm.js
@@ -129,9 +129,9 @@ const InstallAppForm = ({
       )}
 
       <FileInput
-        description='Apps can be configured using a values.yaml file. If you have one, you can upload it here already.'
+        description='Apps can be configured using a yaml file with values. If you have one, you can upload it here already.'
         hint={<>&nbsp;</>}
-        label='ConfigMap:'
+        label='User Values YAML:'
         onChange={updateValuesYAML}
         validationError={valuesYAMLError}
         value={valuesYAML}
@@ -140,7 +140,7 @@ const InstallAppForm = ({
       <FileInput
         description='Sensitive configuration can be uploaded separately as a secret.'
         hint={<>&nbsp;</>}
-        label='Secret:'
+        label='User Secrets YAML:'
         onChange={updateSecretsYAML}
         validationError={secretsYAMLError}
         value={secretsYAML}

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.js
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.js
@@ -203,14 +203,14 @@ const AppDetailsModal = (props) => {
     case modalPanes.deleteAppConfig:
       modalTitle = (
         <>
-          Delete ConfigMap for {props.app.metadata.name} on{' '}
+          Delete user level config values for {props.app.metadata.name} on{' '}
           <ClusterIDLabel clusterID={props.clusterId} />
         </>
       );
 
       modalBody = (
         <>
-          Are you sure you want to delete the ConfigMap for{' '}
+          Are you sure you want to delete user level config values for{' '}
           {props.app.metadata.name} on{' '}
           <ClusterIDLabel clusterID={props.clusterId} />?
           <br />
@@ -219,21 +219,24 @@ const AppDetailsModal = (props) => {
         </>
       );
 
-      modalFooter = deleteConfirmFooter('Delete ConfigMap', deleteAppConfig);
+      modalFooter = deleteConfirmFooter(
+        'Delete user level config values',
+        deleteAppConfig
+      );
 
       break;
 
     case modalPanes.deleteAppSecret:
       modalTitle = (
         <>
-          Delete Secret for {props.app.metadata.name} on{' '}
+          Delete user level secret values for {props.app.metadata.name} on{' '}
           <ClusterIDLabel clusterID={props.clusterId} />
         </>
       );
 
       modalBody = (
         <>
-          Are you sure you want to delete the Secret for{' '}
+          Are you sure you want to delete user level secret values for{' '}
           {props.app.metadata.name} on{' '}
           <ClusterIDLabel clusterID={props.clusterId} />?
           <br />

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.js
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.js
@@ -245,7 +245,10 @@ const AppDetailsModal = (props) => {
         </>
       );
 
-      modalFooter = deleteConfirmFooter('Delete Secret', deleteAppSecret);
+      modalFooter = deleteConfirmFooter(
+        'Delete user level secret values',
+        deleteAppSecret
+      );
 
       break;
 

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/InitialPane.js
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/InitialPane.js
@@ -77,16 +77,16 @@ const InitialPane = (props) => {
       </div>
 
       <div className='labelvaluepair'>
-        <div className='labelvaluepair--label'>CONFIGMAP</div>
+        <div className='labelvaluepair--label'>user level config values</div>
 
         <div className='appdetails--userconfiguration'>
           {props.app.spec.user_config.configmap.name !== '' ? (
             <>
-              <span>ConfigMap has been set</span>
+              <span>User level config values have been set</span>
 
               <div className='actions'>
                 <YAMLFileUpload
-                  buttonText='Replace ConfigMap'
+                  buttonText='Replace values'
                   onInputChange={props.dispatchUpdateAppConfig}
                 />
 
@@ -100,11 +100,11 @@ const InitialPane = (props) => {
             </>
           ) : (
             <>
-              <span>No ConfigMap</span>
+              <span>No user level config values</span>
 
               <div className='actions'>
                 <YAMLFileUpload
-                  buttonText='Upload ConfigMap'
+                  buttonText='Upload user level config values'
                   onInputChange={props.dispatchCreateAppConfig}
                 />
               </div>
@@ -114,16 +114,16 @@ const InitialPane = (props) => {
       </div>
 
       <div className='labelvaluepair'>
-        <div className='labelvaluepair--label'>SECRET</div>
+        <div className='labelvaluepair--label'>user level secret values</div>
 
         <div className='appdetails--userconfiguration'>
           {props.app.spec.user_config.secret.name !== '' ? (
             <>
-              <span>Secret has been set</span>
+              <span>User level secret values have been set</span>
 
               <div className='actions'>
                 <YAMLFileUpload
-                  buttonText='Replace Secret'
+                  buttonText='Replace user level secret values'
                   onInputChange={props.dispatchUpdateAppSecret}
                 />
 
@@ -137,11 +137,11 @@ const InitialPane = (props) => {
             </>
           ) : (
             <>
-              <span>No Secret.</span>
+              <span>No user level secret values</span>
 
               <div className='actions'>
                 <YAMLFileUpload
-                  buttonText='Upload Secret'
+                  buttonText='Upload user level secret values'
                   onInputChange={props.dispatchCreateAppSecret}
                 />
               </div>


### PR DESCRIPTION
I've been working on some documentation around app configuration and some domain language is emerging that I'd like to carry through in the UI as well.

The way I labeled the configuration fields was confusing at best and misleading at worst.

This might be a lot more verbose, but the intention is to explain that you are uploading a file containing values for a specific configuration level. I will eventually add something like "click here for an example file" or "click here for docs" to explain that further.

The toasts are also adjusted to be very explicit about what is happening.