### PR TITLE
Update GS API client to expose TypeScript types

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5892,7 +5892,7 @@ getpass@^0.1.1:
 
 "giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git":
   version "4.0.1"
-  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#f16fc646563e3d9d9d64f0a0d6d94ed3ede0d37c"
+  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#5ed0abe0644a0fb81ec0b58c5ab050d423f5eef6"
   dependencies:
     superagent "3.8.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5892,7 +5892,7 @@ getpass@^0.1.1:
 
 "giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git":
   version "4.0.1"
-  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#5ed0abe0644a0fb81ec0b58c5ab050d423f5eef6"
+  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#aba599459eec02d7c1b517eb5274c3c17cec0fd1"
   dependencies:
     superagent "3.8.3"
 


### PR DESCRIPTION
I've added types to the GS API client (60% generated, 40% by hand) -> they are mostly good
https://github.com/giantswarm/giantswarm-js-client/tree/master/%40types

This means we can have code completion and good interop with TypeScript, so we can migrate our store/actions to TypeScript.

Example

![image](https://user-images.githubusercontent.com/13508038/78349050-4a023880-75a3-11ea-87cf-1470aca920d0.png)
