### PR TITLE
Implement smart truncation for strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ typecheck:
 	docker run --rm -t \
 		-v ${PWD}/src:/usr/src/app/src:z \
 		-v ${PWD}/dist:/usr/src/app/dist:z \
+		-v ${PWD}/testUtils:/usr/src/app/testUtils:z \
 		-v ${PWD}/node_modules_linux:/usr/src/app/node_modules:z \
 		-v ${PWD}/package.json:/usr/src/app/package.json:z \
 		-v ${PWD}/tsconfig.json:/usr/src/app/tsconfig.json:z \

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier": "yarn format --write",
     "validate-prettier": "yarn format --version; yarn format --no-color --check",
     "precommit": "./node_modules/.bin/lint-staged",
-    "typecheck": "./node_modules/.bin/tsc -p tsconfig.json"
+    "typecheck": "./node_modules/.bin/tsc"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier": "yarn format --write",
     "validate-prettier": "yarn format --version; yarn format --no-color --check",
     "precommit": "./node_modules/.bin/lint-staged",
-    "typecheck": "./node_modules/.bin/tsc"
+    "typecheck": "./node_modules/.bin/tsc -p tsconfig.json"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/InitialPane.js
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/InitialPane.js
@@ -4,6 +4,7 @@ import React from 'react';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import Button from 'UI/Button';
+import Truncated from 'UI/Truncated';
 import VersionPicker from 'UI/VersionPicker/VersionPicker';
 
 import YAMLFileUpload from './YamlFileUpload';
@@ -70,7 +71,7 @@ const InitialPane = (props) => {
             {props.app.status.app_version === '' ? (
               <span>Information pending...</span>
             ) : (
-              <span>{props.app.status.app_version}</span>
+              <Truncated as='span'>{props.app.status.app_version}</Truncated>
             )}
           </div>
         </div>

--- a/src/components/UI/AppContainer.js
+++ b/src/components/UI/AppContainer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { AppCatalogRoutes } from 'shared/constants/routes';
+import Truncated from 'UI/Truncated';
 
 export const APP_CONTAINER_HEIGHT = 200;
 export const APP_CONTAINER_IMAGE_HEIGHT = 100;
@@ -174,7 +175,7 @@ const AppContainer = ({
         </AppIcon>
         <AppDetails>
           <h3>{name}</h3>
-          <span>{version}</span>
+          <Truncated>{version}</Truncated>
         </AppDetails>
       </StyledLink>
     </Wrapper>

--- a/src/components/UI/AppDetails/AppDetails.js
+++ b/src/components/UI/AppDetails/AppDetails.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { AppCatalogRoutes } from 'shared/constants/routes';
+import Truncated from 'UI/Truncated';
 
 import AppDetailsBody from './AppDetailsBody';
 import AppDetailsItem from './AppDetailsItem';
@@ -152,7 +153,8 @@ const AppDetails = (props) => {
 
           <div className='version'>
             <small>Chart&nbsp;Version</small>&nbsp;
-            <code>{version}</code> <small>App&nbsp;Version</small>&nbsp;
+            <Truncated as='code'>{version}</Truncated>{' '}
+            <small>App&nbsp;Version</small>&nbsp;
             <code className='appVersion'>{appVersion}</code>
           </div>
         </Title>

--- a/src/components/UI/AppDetails/ChartVersionsTable.js
+++ b/src/components/UI/AppDetails/ChartVersionsTable.js
@@ -98,7 +98,9 @@ const ChartVersionsTable = (props) => {
 
                 <td className='appVersion'>
                   <StyledCopyable copyText={appVersionString}>
-                    <code>{appVersionString}</code>
+                    <Truncated numStart={8} as='code'>
+                      {appVersionString}
+                    </Truncated>
                   </StyledCopyable>
                 </td>
               </tr>

--- a/src/components/UI/AppDetails/ChartVersionsTable.js
+++ b/src/components/UI/AppDetails/ChartVersionsTable.js
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Copyable from 'shared/Copyable';
-import { Ellipsis } from 'styles/';
+import Truncated from 'UI/Truncated';
 
 const StyledCopyable = styled(Copyable)``;
 
@@ -17,7 +17,6 @@ const ChartVersionTable = styled.table`
   td {
     vertical-align: top;
     code {
-      ${Ellipsis}
       max-width: 150px;
       display: inline-block;
     }
@@ -89,7 +88,9 @@ const ChartVersionsTable = (props) => {
                         key={appVersionObject.version}
                         copyText={appVersionObject.version}
                       >
-                        <code>{appVersionObject.version}</code>
+                        <Truncated numStart={12} as='code'>
+                          {appVersionObject.version}
+                        </Truncated>
                       </StyledCopyable>
                     );
                   })}

--- a/src/components/UI/Truncated.tsx
+++ b/src/components/UI/Truncated.tsx
@@ -2,22 +2,35 @@ import styled from '@emotion/styled';
 import { truncate } from 'lib/helpers';
 import PropTypes from 'prop-types';
 import React from 'react';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
 
-interface ITruncatedProps {
+interface ITruncatedProps
+  extends React.ComponentPropsWithoutRef<React.ElementType> {
   children: string | number;
   replacer?: string;
   as?: React.ElementType;
   numStart?: number;
   numEnd?: number;
+  labelProps?: React.ComponentPropsWithoutRef<'span'>;
 }
 
-const StyledWrapper = styled.span``;
+const Wrapper = styled.span``;
 
+const Label = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+/**
+ * A component that truncates a string/number in a smart way
+ */
 const Truncated: React.FC<ITruncatedProps> = ({
   children,
   replacer,
   numStart,
   numEnd,
+  labelProps,
   ...rest
 }) => {
   let str = String(children);
@@ -25,7 +38,16 @@ const Truncated: React.FC<ITruncatedProps> = ({
   // Safe because we're using defaultProps in case these aren't defined
   str = truncate(str, replacer as string, numStart as number, numEnd as number);
 
-  return <StyledWrapper {...rest}>{str}</StyledWrapper>;
+  return (
+    <Wrapper {...rest}>
+      <OverlayTrigger
+        overlay={<Tooltip id='tooltip'>{children}</Tooltip>}
+        placement='top'
+      >
+        <Label {...labelProps}>{str}</Label>
+      </OverlayTrigger>
+    </Wrapper>
+  );
 };
 
 Truncated.propTypes = {
@@ -37,6 +59,7 @@ Truncated.propTypes = {
   as: PropTypes.string,
   numStart: PropTypes.number,
   numEnd: PropTypes.number,
+  labelProps: PropTypes.object,
 };
 
 Truncated.defaultProps = {
@@ -45,3 +68,5 @@ Truncated.defaultProps = {
   numStart: 15,
   numEnd: 5,
 };
+
+export default Truncated;

--- a/src/components/UI/Truncated.tsx
+++ b/src/components/UI/Truncated.tsx
@@ -16,11 +16,7 @@ interface ITruncatedProps
 }
 
 const Wrapper = styled.span``;
-
-const Label = styled.div`
-  width: 100%;
-  height: 100%;
-`;
+const Label = styled.span``;
 
 /**
  * A component that truncates a string/number in a smart way

--- a/src/components/UI/Truncated.tsx
+++ b/src/components/UI/Truncated.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled';
+import { truncate } from 'lib/helpers';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+interface ITruncatedProps {
+  children: string | number;
+  replacer?: string;
+  as?: React.ElementType;
+  numStart?: number;
+  numEnd?: number;
+}
+
+const StyledWrapper = styled.span``;
+
+const Truncated: React.FC<ITruncatedProps> = ({
+  children,
+  replacer,
+  numStart,
+  numEnd,
+  ...rest
+}) => {
+  let str = String(children);
+
+  // Safe because we're using defaultProps in case these aren't defined
+  str = truncate(str, replacer as string, numStart as number, numEnd as number);
+
+  return <StyledWrapper {...rest}>{str}</StyledWrapper>;
+};
+
+Truncated.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
+  replacer: PropTypes.string,
+  // Suppressing because there is no prop-type for HTML tag names
+  // @ts-ignore
+  as: PropTypes.string,
+  numStart: PropTypes.number,
+  numEnd: PropTypes.number,
+};
+
+Truncated.defaultProps = {
+  replacer: '...',
+  as: 'span',
+  numStart: 15,
+  numEnd: 5,
+};

--- a/src/components/UI/__tests__/Truncated.ts
+++ b/src/components/UI/__tests__/Truncated.ts
@@ -1,0 +1,98 @@
+import { fireEvent } from '@testing-library/react';
+import { renderWithTheme } from 'testUtils/renderUtils';
+import Truncated from 'UI/Truncated';
+
+describe('Truncated', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(Truncated, {
+      children: 'Test',
+    });
+  });
+
+  it('renders base text if the text is too short to be truncated', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'Test',
+    });
+
+    expect(getByText('Test')).toBeInTheDocument();
+  });
+
+  it('renders truncated text if the text is long', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'ATextThatIsTooLongToBeDisplayed',
+    });
+
+    expect(getByText('ATextThatIsTooL...layed')).toBeInTheDocument();
+  });
+
+  it('renders truncated text if the text is long', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'ATextThatIsTooLongToBeDisplayed',
+    });
+
+    expect(getByText('ATextThatIsTooL...layed')).toBeInTheDocument();
+  });
+
+  it('accepts zero values', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'ATextThatIsTooLongToBeDisplayed',
+      numStart: 0,
+      numEnd: 0,
+    });
+
+    expect(getByText('ATextThatIsTooLongToBeDisplayed')).toBeInTheDocument();
+  });
+
+  it('accepts different replacers', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'ATextThatIsTooLongToBeDisplayed',
+      replacer: 'NotHelpful',
+    });
+
+    expect(getByText('ATextThatIsTooLNotHelpfullayed')).toBeInTheDocument();
+  });
+
+  it('can be rendered as a different element', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'Test',
+      as: 'div',
+    });
+
+    const rootEl: HTMLDivElement = getByText('Test')
+      .parentNode as HTMLDivElement;
+    expect(rootEl.tagName).toBe('DIV');
+  });
+
+  it('displays a tooltip while hovering on the label', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'ATextThatIsTooLongToBeDisplayed',
+    });
+
+    const label: HTMLSpanElement = getByText('ATextThatIsTooL...layed');
+    fireEvent.mouseOver(label);
+    expect(getByText('ATextThatIsTooLongToBeDisplayed')).toBeInTheDocument();
+  });
+
+  it('can have props passed to the root component', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'Test',
+      className: 'test-class',
+    });
+
+    const rootEl: HTMLSpanElement = getByText('Test')
+      .parentNode as HTMLSpanElement;
+    expect(rootEl.matches('.test-class')).toBe(true);
+  });
+
+  it('can have props passed to the label component', () => {
+    const { getByText } = renderWithTheme(Truncated, {
+      children: 'Test',
+      labelProps: {
+        className: 'test-class',
+      },
+    });
+
+    const label: HTMLSpanElement = getByText('Test');
+    expect(label.matches('.test-class')).toBe(true);
+  });
+});

--- a/src/lib/__tests__/helpers.js
+++ b/src/lib/__tests__/helpers.js
@@ -21,7 +21,7 @@ describe('truncate', () => {
     // eslint-disable-next-line no-magic-numbers
     const result = truncate(initial, '...', 10, 8);
 
-    expect(result).toBe('someReall...Truncate');
+    expect(result).toBe('someReally...Truncate');
   });
 
   it('accepts different replacers', () => {
@@ -29,6 +29,6 @@ describe('truncate', () => {
     // eslint-disable-next-line no-magic-numbers
     const result = truncate(initial, 'NotReallyHelpful', 10, 8);
 
-    expect(result).toBe('someReallNotReallyHelpfulTruncate');
+    expect(result).toBe('someReallyNotReallyHelpfulTruncate');
   });
 });

--- a/src/lib/__tests__/helpers.js
+++ b/src/lib/__tests__/helpers.js
@@ -1,0 +1,34 @@
+import { truncate } from 'lib/helpers';
+
+describe('truncate', () => {
+  it('leaves string untouched if it is too short to be replaced', () => {
+    const initial = 'someString';
+    // eslint-disable-next-line no-magic-numbers
+    const result = truncate(initial, '...', 15, 5);
+
+    expect(result).toBe(initial);
+  });
+
+  it('accepts zero values', () => {
+    const initial = 'someString';
+    const result = truncate(initial, '...', 0, 0);
+
+    expect(result).toBe(initial);
+  });
+
+  it('truncates string', () => {
+    const initial = 'someReallyLongStringThatIWouldLikeToTruncate';
+    // eslint-disable-next-line no-magic-numbers
+    const result = truncate(initial, '...', 10, 8);
+
+    expect(result).toBe('someReall...Truncate');
+  });
+
+  it('accepts different replacers', () => {
+    const initial = 'someReallyLongStringThatIWouldLikeToTruncate';
+    // eslint-disable-next-line no-magic-numbers
+    const result = truncate(initial, 'NotReallyHelpful', 10, 8);
+
+    expect(result).toBe('someReallNotReallyHelpfulTruncate');
+  });
+});

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -155,7 +155,7 @@ export function truncate(str, replacer, numStartChars, numEndChars) {
   }
 
   const result = [
-    str.substring(0, numStartChars - 1),
+    str.substring(0, numStartChars),
     replacer,
     str.substring(str.length - numEndChars),
   ];

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -138,13 +138,29 @@ export function toTitleCase(str) {
   });
 }
 
-// eslint-disable-next-line no-magic-numbers
-export function truncate(string, maxLength = 20) {
-  if (string.length > maxLength) {
-    return `${string.substring(0, maxLength)}\u2026`;
+/**
+ * Truncate a string in a smart way
+ *
+ * @param {string} str - String to truncate
+ * @param {string} replacer - The symbol displayed between the start chars and the end chars
+ * @param {number} numStartChars - Chars to keep unmangled in the beginning
+ * @param {number} numEndChars - Chars to keep unmangled in the end
+ * @returns {string}
+ */
+export function truncate(str, replacer, numStartChars, numEndChars) {
+  const maxLength = numStartChars + numEndChars + replacer.length;
+
+  if (str.length <= maxLength) {
+    return str;
   }
 
-  return string;
+  const result = [
+    str.substring(0, numStartChars - 1),
+    replacer,
+    str.substring(str.length - numEndChars),
+  ];
+
+  return result.join('');
 }
 
 export function makeKubeConfigTextFile(cluster, keyPairResult, useInternalAPI) {

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -150,7 +150,7 @@ export function toTitleCase(str) {
 export function truncate(str, replacer, numStartChars, numEndChars) {
   const maxLength = numStartChars + numEndChars + replacer.length;
 
-  if (str.length <= maxLength) {
+  if (str.length <= maxLength || numEndChars === 0 || numEndChars === 0) {
     return str;
   }
 

--- a/testUtils/renderUtils.js
+++ b/testUtils/renderUtils.js
@@ -47,9 +47,9 @@ export function renderRouteWithStore(
 
 /**
  * Render component in the Theme context
- * @param {React.ReactType} component The React Component
- * @param {<P extends Record<string, any>>React.ComponentProps<P>} props Props to pass to the component
- * @param {<Q extends TestingLibrary.Queries>TestingLibrary.RenderOptions<Q>} [options] Testing library render options
+ * @param {React.ElementType} component The React Component
+ * @param {Object} props Props to pass to the component
+ * @param {Object} [options] Testing library render options
  */
 export function renderWithTheme(component, props, options) {
   return render(getComponentWithTheme(component, props), options);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     },
     "typeRoots": ["node_modules/@types", "src/@types"]
   },
-  "include": ["src", "testUtils", "__tests__"]
+  "include": ["./*.**","src", "testUtils", "__tests__"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,11 @@
     "jsx": "react",
     "baseUrl": ".",
     "paths": {
-      "*": ["./src/components/*", "./src/*"],
-      "testUtils/*": ["./testUtils/*"],
-      "__tests__/*": ["./__tests__/*"]
+      "*": ["src/components/*", "src/*"],
+      "testUtils/*": ["testUtils/*"],
+      "__tests__/*": ["__tests__/*"]
     },
     "typeRoots": ["node_modules/@types", "src/@types"]
   },
-  "include": ["./*.**","src", "testUtils", "__tests__"]
+  "include": ["./*.**", "src", "testUtils", "__tests__"]
 }


### PR DESCRIPTION
Provide more useful truncations.

For long similar strings, it's easier to find differences by looking at the beginning or at the end of each of them.

## Examples

**Before**

![image](https://user-images.githubusercontent.com/13508038/78382584-64560980-75d7-11ea-8c14-5c944df40ef6.png)

**After**

![image](https://user-images.githubusercontent.com/13508038/78382608-6b7d1780-75d7-11ea-917b-73578aa000c0.png)

**After, on hover**

![image](https://user-images.githubusercontent.com/13508038/78382669-7e8fe780-75d7-11ea-958c-d3921e77c9e0.png)

