### PR TITLE
Add a guard in dashboard item

### DIFF
--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -135,6 +135,9 @@ function ClusterDashboardItem({
   dispatch,
   nodePoolsLoadError,
 }) {
+  // If the cluster has been deleted using gsctl, Happa doesn't know yet.
+  if (!cluster) return null;
+
   /**
    * Returns true if the cluster is younger than 30 days
    */


### PR DESCRIPTION
Fix for `TypeError: Cannot read property 'delete_date' of undefined`. 

I can't reproduce the issue. I think this is something that happens when the cluster is deleted using `gstl`. This fix is based in this assumption.
 
[Error log](https://gigantic.slack.com/archives/C3MCF5EJK/p1586258998001700) in slack #exceptions channel.