### PR TITLE
Node pools messages in delete modal

### DIFF
--- a/__tests__/V5ClusterManagement.js
+++ b/__tests__/V5ClusterManagement.js
@@ -91,7 +91,7 @@ it('renders all node pools in store', async () => {
 
   await waitFor(() => findAllByTestId('node-pool-id'));
 
-  nodePoolsResponse.forEach(nodePool => {
+  nodePoolsResponse.forEach((nodePool) => {
     expect(getByText(nodePool.id)).toBeInTheDocument();
   });
 });
@@ -306,6 +306,7 @@ it('deletes a v5 cluster', async () => {
 
 it('deletes a node pool', async () => {
   const nodePool = nodePoolsResponse[0];
+  const lastNodePool = nodePoolsResponse[1];
   const nodePoolDeleteResponse = {
     code: 'RESOURCE_DELETION_STARTED',
     message: `Deletion of node pool with ID '${nodePool.id}' is in progress.`,
@@ -315,6 +316,13 @@ it('deletes a node pool', async () => {
   nock(API_ENDPOINT)
     .intercept(
       `/v5/clusters/${V5_CLUSTER.id}/nodepools/${nodePool.id}/`,
+      'DELETE'
+    )
+    .reply(StatusCodes.Ok, nodePoolDeleteResponse);
+
+  nock(API_ENDPOINT)
+    .intercept(
+      `/v5/clusters/${V5_CLUSTER.id}/nodepools/${lastNodePool.id}/`,
       'DELETE'
     )
     .reply(StatusCodes.Ok, nodePoolDeleteResponse);
@@ -342,16 +350,16 @@ it('deletes a node pool', async () => {
   fireEvent.click(getByText('Delete'));
 
   // Is the modal in the document?
-  const titleText = /are you sure you want to delete/i;
+  const titleText = /do you want to delete this node pool?/i;
+  const bodyTextMultipleNP = /do you want to delete this node pool/i;
+
   await waitFor(() => getByText(titleText));
-  const modalTitle = getByText(titleText);
-  expect(modalTitle).toBeInTheDocument();
-  expect(modalTitle.textContent.includes(nodePool.id)).toBeTruthy();
+  expect(getByText(titleText)).toBeInTheDocument();
+  expect(getByText(bodyTextMultipleNP)).toBeInTheDocument();
 
   // Click delete button.
   const deleteButtonText = 'Delete Node Pool';
-  const deleteButton = getByText(deleteButtonText);
-  fireEvent.click(deleteButton);
+  fireEvent.click(getByText(deleteButtonText));
 
   // Flash message confirming deletion.
   await waitFor(() => {
@@ -365,6 +373,14 @@ it('deletes a node pool', async () => {
   await waitFor(() => {
     expect(queryByTestId(nodePool.id)).not.toBeInTheDocument();
   });
+
+  // Test that last nodepool warning appears.
+  const bodyTextLastNP = /do you want to delete this cluster\'s only node pool?/i;
+
+  fireEvent.click(getByText('•••'));
+  fireEvent.click(getByText('Delete'));
+  fireEvent.click(getByText(deleteButtonText));
+  expect(getByText(bodyTextLastNP)).toBeInTheDocument();
 });
 
 it('adds a node pool with default values', async () => {

--- a/__tests__/V5ClusterManagement.js
+++ b/__tests__/V5ClusterManagement.js
@@ -306,7 +306,6 @@ it('deletes a v5 cluster', async () => {
 
 it('deletes a node pool', async () => {
   const nodePool = nodePoolsResponse[0];
-  const lastNodePool = nodePoolsResponse[1];
   const nodePoolDeleteResponse = {
     code: 'RESOURCE_DELETION_STARTED',
     message: `Deletion of node pool with ID '${nodePool.id}' is in progress.`,
@@ -316,13 +315,6 @@ it('deletes a node pool', async () => {
   nock(API_ENDPOINT)
     .intercept(
       `/v5/clusters/${V5_CLUSTER.id}/nodepools/${nodePool.id}/`,
-      'DELETE'
-    )
-    .reply(StatusCodes.Ok, nodePoolDeleteResponse);
-
-  nock(API_ENDPOINT)
-    .intercept(
-      `/v5/clusters/${V5_CLUSTER.id}/nodepools/${lastNodePool.id}/`,
       'DELETE'
     )
     .reply(StatusCodes.Ok, nodePoolDeleteResponse);
@@ -379,7 +371,6 @@ it('deletes a node pool', async () => {
 
   fireEvent.click(getByText('•••'));
   fireEvent.click(getByText('Delete'));
-  fireEvent.click(getByText(deleteButtonText));
   expect(getByText(bodyTextLastNP)).toBeInTheDocument();
 });
 

--- a/src/components/Modals/Modals.js
+++ b/src/components/Modals/Modals.js
@@ -23,8 +23,8 @@ const NodePoolTextDiv = styled.div`
   strong {
     font-weight: 700;
   }
-
   .details {
+    margin-bottom: 10px;
     > * {
       margin-left: 15px;
     }
@@ -385,9 +385,17 @@ class Modals extends React.Component {
         const isLastNodePool =
           this.props.clusters[clusterId].nodePools.length === 1;
 
+        const details = (
+          <div className='details'>
+            <ClusterIDLabel clusterID={nodePoolId} />{' '}
+            <strong>{nodePoolName}</strong>
+          </div>
+        );
+
         const bodyText = isLastNodePool ? (
           <NodePoolTextDiv>
             <p>Do you want to delete this cluster&apos;s only node pool?</p>
+            {details}
             <p>
               <strong>Warning</strong>: There are no other node pools. When
               deleting this node pool, all workloads will be terminated and
@@ -397,17 +405,13 @@ class Modals extends React.Component {
         ) : (
           <NodePoolTextDiv>
             <p>Do you want to delete this node pool?</p>
-            <div className='details'>
-              <ClusterIDLabel clusterID={nodePoolId} />{' '}
-              <strong>{nodePoolName}</strong>
-            </div>
+            {details}
             <p>
               Nodes will be drained and workloads re-scheduled, if possible, to
               nodes from other pools.
             </p>
             <p>
-              <strong>Note</strong>: This node pool is not sharing any node
-              labels with other node pools. Make sure your scheduling rules are
+              <strong>Note</strong>: Make sure your scheduling rules are
               tolerant enough so that workloads can be re-assigned.
             </p>
           </NodePoolTextDiv>


### PR DESCRIPTION
This is something requested by a user: [check the slack thread](https://gigantic.slack.com/archives/C03LYSJL0/p1586276256002400) where this was discussed.

Before (no matter how many node pools the cluster has):

![image](https://user-images.githubusercontent.com/14203438/78775594-c11a4100-7996-11ea-8c3b-b2f277bf9c52.png)

After with two or more node pools:

![image](https://user-images.githubusercontent.com/14203438/78780014-405f4300-799e-11ea-9129-2c316b89c1a4.png)

With just one node pool:

![image](https://user-images.githubusercontent.com/14203438/78779945-2291de00-799e-11ea-9f39-fb14635f4356.png)



