### PR TITLE
Redirect from details after deletion

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -1,9 +1,7 @@
-import { push } from 'connected-react-router';
 import GiantSwarm from 'giantswarm';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import moment from 'moment';
 import { StatusCodes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
 import { computeCapabilities } from 'utils/clusterUtils';
 
 import * as types from './actionTypes';
@@ -259,7 +257,6 @@ export function clusterLoadDetails(
           clusterId,
           isV5Cluster,
         });
-        dispatch(push(AppRoutes.Home));
 
         return {};
       }

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -27,7 +27,7 @@ import {
   selectLoadingFlagByIdAndAction,
 } from 'selectors/clusterSelectors';
 import { Providers } from 'shared/constants';
-import { OrganizationsRoutes } from 'shared/constants/routes';
+import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 import LoadingOverlay from 'UI/LoadingOverlay';
@@ -78,16 +78,9 @@ class ClusterDetailView extends React.Component {
     );
   };
 
-  // It is not in your orgs or it has been deleted.
+  // It is not in user orgs or it has been deleted.
   doesNotExist = (isDeleted) => {
-    const { clusterId, organizationId, dispatch } = this.props;
-
-    const organizationDetailPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Detail,
-      {
-        orgId: organizationId,
-      }
-    );
+    const { clusterId, dispatch } = this.props;
 
     const text = isDeleted
       ? 'This cluster has been deleted'
@@ -102,7 +95,7 @@ class ClusterDetailView extends React.Component {
 
     this.props.clearInterval(this.loadDataInterval);
 
-    dispatch(push(organizationDetailPath));
+    dispatch(push(AppRoutes.Home));
   };
 
   loadDetails = () => {

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -78,7 +78,8 @@ class ClusterDetailView extends React.Component {
     );
   };
 
-  itDoesntExist = (isDeleted) => {
+  // It is not in your orgs or it has been deleted.
+  doesNotExist = (isDeleted) => {
     const { clusterId, organizationId, dispatch } = this.props;
 
     const organizationDetailPath = RoutePath.createUsablePath(
@@ -108,7 +109,7 @@ class ClusterDetailView extends React.Component {
     const { cluster, dispatch, organizationId } = this.props;
 
     if (typeof cluster === 'undefined' || cluster.delete_date) {
-      this.itDoesntExist(Boolean(cluster?.delete_date));
+      this.doesNotExist(Boolean(cluster?.delete_date));
     }
 
     dispatch(
@@ -124,7 +125,7 @@ class ClusterDetailView extends React.Component {
     const { cluster, dispatch, isV5Cluster } = this.props;
 
     if (typeof cluster === 'undefined' || cluster.delete_date) {
-      this.itDoesntExist(Boolean(cluster?.delete_date));
+      this.doesNotExist(Boolean(cluster?.delete_date));
     }
 
     dispatch(batchedRefreshClusterDetailView(cluster.id, isV5Cluster));


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/9879

I added support for the case when the cluster is deleted: it is not `undefined`, but we don't want the user to access the details view. 

Now, on delete, the user will be redirected and a toast will notify him that the cluster has been deleted or it is not in her organizations.

Also removed redirection from `clusterActions` because I think this is not the place for this, as this action can be dispatched in different contexts.