### PR TITLE
run all ci jobs for vX.X.X tags & all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,11 @@ defaults: &defaults
     - image: circleci/node:12-buster
 
 job_filters: &job_filters
-  tags:
-    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-  branches:
-    only: /.*/
+  filters:
+    tags:
+      only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+    branches:
+      only: /.*/
 
 whitelist: &whitelist
   paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,12 @@ defaults: &defaults
   docker:
     - image: circleci/node:12-buster
 
+job_filters: &job_filters
+  tags:
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+  branches:
+    only: /.*/
+
 whitelist: &whitelist
   paths:
     - dist/*
@@ -19,26 +25,27 @@ workflows:
   build:
     jobs:
       - checkout:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-            branches:
-              only: /.*/
+          <<: *job_filters
       - test:
           requires:
             - checkout
+          <<: *job_filters
       - lint:
           requires:
             - checkout
+          <<: *job_filters
       - prettier:
           requires:
             - checkout
+          <<: *job_filters
       - typecheck:
           requires:
             - checkout
+          <<: *job_filters
       - build:
           requires:
             - checkout
+          <<: *job_filters
       - build-container:
           requires:
             - test
@@ -46,6 +53,7 @@ workflows:
             - prettier
             - typecheck
             - build
+          <<: *job_filters
 
       - architect/push-to-docker-legacy:
           name: push-happa-to-aliyun-master


### PR DESCRIPTION
This should fix tags not deployed. 

This is caused by me not reading the [circle ci docs].

> CircleCI does not run workflows for tags unless you explicitly specify tag filters. Additionally, if a job requires any other jobs (directly or indirectly), you must specify tag filters for those jobs.

[circle ci docs]: https://circleci.com/docs/2.0/configuration-reference/#tags