### PR TITLE
Use templated endpoints in index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,8 +28,8 @@
 
     <script>
       var config = {
-        apiEndpoint: 'http://localhost:8000',
-        passageEndpoint: 'http://localhost:5001',
+        apiEndpoint: '<%= apiEndpoint %>',
+        passageEndpoint: '<%= passageEndpoint %>',
         // environment is set to:
         // 'dev' while developing
         // 'kubernetes' when deployed in production

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,12 +6,27 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const process = require('process');
+
+const makeEndpoints = () => {
+  const { HAPPA_API_ENDPOINT, HAPPA_PASSAGE_ENDPOINT } = process.env;
+
+  return {
+    apiEndpoint: HAPPA_API_ENDPOINT
+      ? HAPPA_API_ENDPOINT
+      : 'http://localhost:8000',
+    passageEndpoint: HAPPA_PASSAGE_ENDPOINT
+      ? HAPPA_PASSAGE_ENDPOINT
+      : 'http://localhost:5001',
+  };
+};
 
 module.exports = {
   entry: ['react-hot-loader/patch', './src/components/index.tsx'],
   context: __dirname,
   node: {
-    fs: 'empty'
+    fs: 'empty',
   },
   output: {
     publicPath: '/',
@@ -93,6 +108,9 @@ module.exports = {
     new CleanWebpackPlugin(),
     new HtmlWebpackPlugin({
       template: 'src/index.html',
+      templateParameters: {
+        ...makeEndpoints(),
+      },
     }),
     // Ignore locale data from the moment package, which we don't use.
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),


### PR DESCRIPTION
I noticed sometimes commits which changed `apiEndpoint` and `passageEndpoit` sneaked past human review. 

This PR should make it easier to change the andpoints in development by setting `HAPPA_API_ENDPOINT` and `HAPPA_PASSAGE_ENDPOINTS`. Webpack will now take care of setting the desired values. If the environment variables are missing, default values will be used.