### PR TITLE
On the App Detail Page, hide most chart versions, but make them expandable.

### DIFF
--- a/src/components/UI/AppDetails/ChartVersionsTable.js
+++ b/src/components/UI/AppDetails/ChartVersionsTable.js
@@ -7,13 +7,13 @@ import VersionsRow from './VersionsRow';
 const ChartVersionTable = styled.table`
   border: 1px solid ${(props) => props.theme.colors.shade4};
   margin-top: 10px;
-  max-width: 320px;
+  max-width: 325px;
   table-layout: fixed;
-  white-space: nowrap;
   float: right;
 
   td {
-    vertical-align: top;
+    vertical-align: middle;
+    line-height: 30px;
     code {
       max-width: 150px;
       display: inline-block;
@@ -25,6 +25,7 @@ const ChartVersionTable = styled.table`
   }
 
   td.appVersion {
+    vertical-align: top;
     border-left: 1px dashed ${(props) => props.theme.colors.shade1};
     text-align: center;
   }

--- a/src/components/UI/AppDetails/ChartVersionsTable.js
+++ b/src/components/UI/AppDetails/ChartVersionsTable.js
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Copyable from 'shared/Copyable';
-import Truncated from 'UI/Truncated';
 
-const StyledCopyable = styled(Copyable)``;
+import VersionsRow from './VersionsRow';
 
 const ChartVersionTable = styled.table`
   border: 1px solid ${(props) => props.theme.colors.shade4};
@@ -20,11 +18,6 @@ const ChartVersionTable = styled.table`
       max-width: 150px;
       display: inline-block;
     }
-
-    ${StyledCopyable} {
-      float: left;
-      margin-bottom: 10px;
-    }
   }
 
   th.appVersion {
@@ -34,17 +27,6 @@ const ChartVersionTable = styled.table`
   td.appVersion {
     border-left: 1px dashed ${(props) => props.theme.colors.shade1};
     text-align: center;
-
-    ${StyledCopyable} {
-      display: inline-block;
-      float: none;
-      position: relative;
-      left: 8px;
-      code {
-        background-color: ${(props) => props.theme.colors.darkBlueLighter8};
-        color: ${(props) => props.theme.colors.darkBlue};
-      }
-    }
   }
 
   tr:nth-of-type(even) {
@@ -80,30 +62,11 @@ const ChartVersionsTable = (props) => {
         {Object.entries(groupedAppVersions).map(
           ([appVersionString, entries]) => {
             return (
-              <tr key={appVersionString}>
-                <td>
-                  {entries.map((appVersionObject) => {
-                    return (
-                      <StyledCopyable
-                        key={appVersionObject.version}
-                        copyText={appVersionObject.version}
-                      >
-                        <Truncated numStart={12} as='code'>
-                          {appVersionObject.version}
-                        </Truncated>
-                      </StyledCopyable>
-                    );
-                  })}
-                </td>
-
-                <td className='appVersion'>
-                  <StyledCopyable copyText={appVersionString}>
-                    <Truncated numStart={8} as='code'>
-                      {appVersionString}
-                    </Truncated>
-                  </StyledCopyable>
-                </td>
-              </tr>
+              <VersionsRow
+                appVersion={appVersionString}
+                entries={entries}
+                key={appVersionString}
+              />
             );
           }
         )}

--- a/src/components/UI/AppDetails/VersionsRow.js
+++ b/src/components/UI/AppDetails/VersionsRow.js
@@ -1,0 +1,87 @@
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import Copyable from 'shared/Copyable';
+import Truncated from 'UI/Truncated';
+
+const INITIAL_MAX_CHART_VERSIONS = 2;
+
+const ChartVersion = styled(Copyable)`
+  margin-bottom: 10px;
+  float: left;
+`;
+
+const AppVersion = styled(Copyable)`
+  display: inline-block;
+  float: none;
+  position: relative;
+  left: 8px;
+  code {
+    background-color: ${(props) => props.theme.colors.darkBlueLighter8};
+    color: ${(props) => props.theme.colors.darkBlue};
+  }
+`;
+
+const ExpandVersions = styled.button`
+  padding: 0px;
+  background-color: inherit;
+  font-size: 14px;
+  color: ${(props) => props.theme.colors.darkBlueLighter6};
+
+  &:hover {
+    background-color: inherit;
+  }
+`;
+
+const VersionsRow = ({ appVersion, entries, className }) => {
+  const [expandVersions, setExpandVersions] = useState(
+    INITIAL_MAX_CHART_VERSIONS
+  );
+
+  const toggleExpandVersion = () => {
+    setExpandVersions(entries.length);
+  };
+
+  return (
+    <tr className={className}>
+      <td>
+        <div>
+          {entries.slice(0, expandVersions).map((appVersionObject) => {
+            return (
+              <ChartVersion
+                key={appVersionObject.version}
+                copyText={appVersionObject.version}
+              >
+                <Truncated numStart={12} as='code'>
+                  {appVersionObject.version}
+                </Truncated>
+              </ChartVersion>
+            );
+          })}
+        </div>
+        <br style={{ clear: 'both' }} />
+        {entries.length > expandVersions ? (
+          <ExpandVersions onClick={toggleExpandVersion}>
+            {`+ ${(entries.length - expandVersions).toString()} more ...`}
+          </ExpandVersions>
+        ) : undefined}
+      </td>
+
+      <td className='appVersion'>
+        <AppVersion copyText={appVersion}>
+          <Truncated numStart={8} as='code'>
+            {appVersion}
+          </Truncated>
+        </AppVersion>
+      </td>
+    </tr>
+  );
+};
+
+VersionsRow.propTypes = {
+  appVersion: PropTypes.string,
+  entries: PropTypes.array,
+  className: PropTypes.string,
+};
+
+export default VersionsRow;

--- a/src/components/UI/AppDetails/VersionsRow.js
+++ b/src/components/UI/AppDetails/VersionsRow.js
@@ -7,11 +7,13 @@ import Truncated from 'UI/Truncated';
 const INITIAL_MAX_CHART_VERSIONS = 2;
 
 const ChartVersion = styled(Copyable)`
-  margin-bottom: 10px;
-  float: left;
+  display: inline-block;
+  white-space: nowrap;
+  line-height: 18px;
 `;
 
 const AppVersion = styled(Copyable)`
+  line-height: 18px;
   display: inline-block;
   float: none;
   position: relative;
@@ -25,6 +27,7 @@ const AppVersion = styled(Copyable)`
 const ExpandVersions = styled.button`
   padding: 0px;
   background-color: inherit;
+  margin-bottom: 0px;
   font-size: 14px;
   color: ${(props) => props.theme.colors.darkBlueLighter6};
 
@@ -45,21 +48,19 @@ const VersionsRow = ({ appVersion, entries, className }) => {
   return (
     <tr className={className}>
       <td>
-        <div>
-          {entries.slice(0, expandVersions).map((appVersionObject) => {
-            return (
-              <ChartVersion
-                key={appVersionObject.version}
-                copyText={appVersionObject.version}
-              >
-                <Truncated numStart={12} as='code'>
-                  {appVersionObject.version}
-                </Truncated>
-              </ChartVersion>
-            );
-          })}
-        </div>
-        <br style={{ clear: 'both' }} />
+        {entries.slice(0, expandVersions).map((appVersionObject) => {
+          return (
+            <ChartVersion
+              key={appVersionObject.version}
+              copyText={appVersionObject.version}
+            >
+              <Truncated numStart={12} as='code'>
+                {appVersionObject.version}
+              </Truncated>
+            </ChartVersion>
+          );
+        })}
+
         {entries.length > expandVersions ? (
           <ExpandVersions onClick={expand}>
             {`+ ${(entries.length - expandVersions).toString()} more ...`}

--- a/src/components/UI/AppDetails/VersionsRow.js
+++ b/src/components/UI/AppDetails/VersionsRow.js
@@ -38,7 +38,7 @@ const VersionsRow = ({ appVersion, entries, className }) => {
     INITIAL_MAX_CHART_VERSIONS
   );
 
-  const toggleExpandVersion = () => {
+  const expand = () => {
     setExpandVersions(entries.length);
   };
 
@@ -61,7 +61,7 @@ const VersionsRow = ({ appVersion, entries, className }) => {
         </div>
         <br style={{ clear: 'both' }} />
         {entries.length > expandVersions ? (
-          <ExpandVersions onClick={toggleExpandVersion}>
+          <ExpandVersions onClick={expand}>
             {`+ ${(entries.length - expandVersions).toString()} more ...`}
           </ExpandVersions>
         ) : undefined}

--- a/src/components/UI/AppDetails/VersionsRow.js
+++ b/src/components/UI/AppDetails/VersionsRow.js
@@ -63,7 +63,7 @@ const VersionsRow = ({ appVersion, entries, className }) => {
 
         {entries.length > expandVersions ? (
           <ExpandVersions onClick={expand}>
-            {`+ ${(entries.length - expandVersions).toString()} more ...`}
+            + {(entries.length - expandVersions).toString()} more &hellip;
           </ExpandVersions>
         ) : undefined}
       </td>


### PR DESCRIPTION
Clicking on the "+ 7 more" label expands them all. With no way to 'recollapse' them. I think this is something that very few people will interact with and once it's open they probably don't want to close it again.

<img width="308" alt="Screenshot 2020-04-20 at 9 57 25 AM" src="https://user-images.githubusercontent.com/455309/79706902-5d283e80-82ed-11ea-990f-f2f9dcdbd7e3.png">
