### PR TITLE
Show the readme if it is there and make it look ok.

### DIFF
--- a/src/components/UI/AppDetails/AppDetails.js
+++ b/src/components/UI/AppDetails/AppDetails.js
@@ -126,9 +126,9 @@ function flatten(text, child) {
 }
 
 function HeadingRenderer(headingProps) {
-  var children = React.Children.toArray(headingProps.children);
-  var text = children.reduce(flatten, '');
-  var slug = text.toLowerCase().replace(/\W/g, '-');
+  const children = React.Children.toArray(headingProps.children);
+  const text = children.reduce(flatten, '');
+  const slug = text.toLowerCase().replace(/\W/g, '-');
 
   return React.createElement(
     `h${headingProps.level}`,

--- a/src/components/UI/AppDetails/AppDetails.js
+++ b/src/components/UI/AppDetails/AppDetails.js
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 import { Link } from 'react-router-dom';
 import { AppCatalogRoutes } from 'shared/constants/routes';
 import Truncated from 'UI/Truncated';
@@ -95,6 +96,47 @@ const Install = styled.div`
   }
 `;
 
+const Readme = styled.div`
+  max-width: 800px;
+
+  .markdown pre {
+    background-color: ${(props) => props.theme.colors.darkBlueDarker6};
+    border: none;
+    font-size: 16px;
+    color: ${(props) => props.theme.colors.white2};
+  }
+
+  .markdown h1 {
+    margin-top: 40px;
+    margin-bottom: 10px;
+    font-size: 24px;
+    font-weight: 500;
+  }
+
+  .markdown h2 {
+    margin-top: 40px;
+    font-size: 20px;
+  }
+`;
+
+function flatten(text, child) {
+  return typeof child === 'string'
+    ? text + child
+    : React.Children.toArray(child.props.children).reduce(flatten, text);
+}
+
+function HeadingRenderer(headingProps) {
+  var children = React.Children.toArray(headingProps.children);
+  var text = children.reduce(flatten, '');
+  var slug = text.toLowerCase().replace(/\W/g, '-');
+
+  return React.createElement(
+    `h${headingProps.level}`,
+    { id: slug },
+    headingProps.children
+  );
+}
+
 const AppDetails = (props) => {
   const {
     app,
@@ -117,6 +159,7 @@ const AppDetails = (props) => {
     home,
     sources,
     urls,
+    readme,
   } = app;
 
   const appCatalogAppListPath = RoutePath.createUsablePath(
@@ -163,6 +206,18 @@ const AppDetails = (props) => {
       </Header>
 
       <ChartVersionsTable appVersions={appVersions} />
+
+      {readme && (
+        <Readme>
+          <ReactMarkdown
+            className='markdown'
+            renderers={{ heading: HeadingRenderer }}
+          >
+            {readme}
+          </ReactMarkdown>
+          <hr />
+        </Readme>
+      )}
 
       <AppDetailsBody description={description}>
         {home && home !== '' && <AppDetailsItem data={home} label='Home' />}


### PR DESCRIPTION
The chart versions table length is being fixed in: https://github.com/giantswarm/happa/pull/1351

![localhost_7000_app-catalogs_giantswarm-test_nginx-ingress-controller-app_1 6 8-a70edadceed0c36c9ea933df39ba8e796fc6b057__q=](https://user-images.githubusercontent.com/455309/79717365-054d0000-830c-11ea-9369-f91d4be6deb5.png)
