### PR TITLE
Improve Error Handling when fetching Readmes

### DIFF
--- a/src/actions/__tests__/appActions.js
+++ b/src/actions/__tests__/appActions.js
@@ -141,7 +141,7 @@ describe('readme loading', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  it.only('is able to fetch READMEs from test apps that arent tagged yet, but contain the SHA in the url, also if they start with v', async () => {
+  it('is able to fetch READMEs from test apps that arent tagged yet, but contain the SHA in the url, also if they start with v', async () => {
     const initialState = {};
     const store = mockStore(initialState);
 

--- a/src/actions/__tests__/appActions.js
+++ b/src/actions/__tests__/appActions.js
@@ -76,23 +76,23 @@ describe('readme loading', () => {
         'This is a sample readme, fetched from http://mockserver.fake/README.md'
       );
 
-    const appVersionWithEmptySources = {
+    const appVersionWithReadmeInSources = {
       sources: ['http://mockserver.fake/README.md'],
     };
 
     await store.dispatch(
-      loadAppReadme('notUnderTest', appVersionWithEmptySources)
+      loadAppReadme('notUnderTest', appVersionWithReadmeInSources)
     );
 
     const expectedActions = [
       {
         type: types.CLUSTER_LOAD_APP_README_REQUEST,
-        appVersion: appVersionWithEmptySources,
+        appVersion: appVersionWithReadmeInSources,
         catalogName: 'notUnderTest',
       },
       {
         type: types.CLUSTER_LOAD_APP_README_SUCCESS,
-        appVersion: appVersionWithEmptySources,
+        appVersion: appVersionWithReadmeInSources,
         catalogName: 'notUnderTest',
         readmeText:
           'This is a sample readme, fetched from http://mockserver.fake/README.md',
@@ -113,25 +113,64 @@ describe('readme loading', () => {
         'This is a sample readme, fetched from http://mockserver.fake/REALLY-LONG-COMMIT-SHA/README.md'
       );
 
-    const appVersionWithEmptySources = {
+    const appVersionWithTestVersionReadmeInSources = {
       sources: [
         'http://mockserver.fake/1.2.3-REALLY-LONG-COMMIT-SHA/README.md',
       ],
     };
 
     await store.dispatch(
-      loadAppReadme('notUnderTest', appVersionWithEmptySources)
+      loadAppReadme('notUnderTest', appVersionWithTestVersionReadmeInSources)
     );
 
     const expectedActions = [
       {
         type: types.CLUSTER_LOAD_APP_README_REQUEST,
-        appVersion: appVersionWithEmptySources,
+        appVersion: appVersionWithTestVersionReadmeInSources,
         catalogName: 'notUnderTest',
       },
       {
         type: types.CLUSTER_LOAD_APP_README_SUCCESS,
-        appVersion: appVersionWithEmptySources,
+        appVersion: appVersionWithTestVersionReadmeInSources,
+        catalogName: 'notUnderTest',
+        readmeText:
+          'This is a sample readme, fetched from http://mockserver.fake/REALLY-LONG-COMMIT-SHA/README.md',
+      },
+    ];
+
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it.only('is able to fetch READMEs from test apps that arent tagged yet, but contain the SHA in the url, also if they start with v', async () => {
+    const initialState = {};
+    const store = mockStore(initialState);
+
+    nock('http://mockserver.fake')
+      .get('/REALLY-LONG-COMMIT-SHA/README.md')
+      .reply(
+        StatusCodes.Ok,
+        'This is a sample readme, fetched from http://mockserver.fake/REALLY-LONG-COMMIT-SHA/README.md'
+      );
+
+    const appVersionWithTestVersionReadmeInSources = {
+      sources: [
+        'http://mockserver.fake/v1.2.3-REALLY-LONG-COMMIT-SHA/README.md',
+      ],
+    };
+
+    await store.dispatch(
+      loadAppReadme('notUnderTest', appVersionWithTestVersionReadmeInSources)
+    );
+
+    const expectedActions = [
+      {
+        type: types.CLUSTER_LOAD_APP_README_REQUEST,
+        appVersion: appVersionWithTestVersionReadmeInSources,
+        catalogName: 'notUnderTest',
+      },
+      {
+        type: types.CLUSTER_LOAD_APP_README_SUCCESS,
+        appVersion: appVersionWithTestVersionReadmeInSources,
         catalogName: 'notUnderTest',
         readmeText:
           'This is a sample readme, fetched from http://mockserver.fake/REALLY-LONG-COMMIT-SHA/README.md',

--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -368,7 +368,8 @@ function fixTestAppReadmeURLs(readmeURL) {
   // Test app urls will have a semver version followed by a hyphen followed by
   // a long commit sha. We need to remove the version part. If the regex
   // doesn't match, then the string is returned as is.
-  const regexMatcher = /^(.*)\/[0-9]+\.[0-9]+\.[0-9]+-(.*)\/README\.md$/;
+  // https://regex101.com/r/K2dxdN/1
+  const regexMatcher = /^(.*)\/v?[0-9]+\.[0-9]+\.[0-9]+-(.*)\/README\.md$/;
   const fixedReadmeURL = readmeURL.replace(regexMatcher, '$1/$2/README.md');
 
   return fixedReadmeURL;

--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -335,6 +335,11 @@ export function loadAppReadme(catalogName, appVersion) {
 
     try {
       const response = await fetch(readmeURL, { mode: 'cors' });
+      if (response.status !== StatusCodes.Ok) {
+        throw new Error(
+          `Error fetching Readme. Response Status: ${response.status}`
+        );
+      }
       const readmeText = await response.text();
 
       dispatch({

--- a/src/actions/errorActions.js
+++ b/src/actions/errorActions.js
@@ -1,0 +1,15 @@
+import { typeWithoutSuffix } from 'selectors/selectorUtils';
+
+import * as types from './actionTypes';
+
+/**
+ * Clears an error
+ *
+ * @param {String} errorType The type of the error to clear.
+ */
+export function clearError(errorType) {
+  return {
+    type: types.SINGLE_ERROR_CLEAR,
+    errorType: typeWithoutSuffix(errorType),
+  };
+}

--- a/src/components/AppCatalog/AppDetail/AppDetail.js
+++ b/src/components/AppCatalog/AppDetail/AppDetail.js
@@ -1,12 +1,19 @@
-import { CLUSTER_LOAD_APP_README_REQUEST } from 'actions/actionTypes';
+import {
+  CLUSTER_LOAD_APP_README_ERROR,
+  CLUSTER_LOAD_APP_README_REQUEST,
+} from 'actions/actionTypes';
 import { loadAppReadme } from 'actions/appActions';
+import { clearError } from 'actions/errorActions';
 import DocumentTitle from 'components/shared/DocumentTitle';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
-import { selectLoadingFlagByAction } from 'selectors/clusterSelectors';
+import {
+  selectErrorByAction,
+  selectLoadingFlagByAction,
+} from 'selectors/clusterSelectors';
 import { AppCatalogRoutes } from 'shared/constants/routes';
 import AppDetails from 'UI/AppDetails/AppDetails';
 import LoadingOverlay from 'UI/LoadingOverlay';
@@ -41,6 +48,7 @@ class AppDetail extends React.Component {
   }
 
   componentDidMount() {
+    this.props.dispatch(clearError(CLUSTER_LOAD_APP_README_ERROR));
     this.loadReadme();
   }
 
@@ -53,7 +61,16 @@ class AppDetail extends React.Component {
    * it hasn't been loaded yet.
    */
   loadReadme() {
-    const { catalog, selectedAppVersion, dispatch, loadingReadme } = this.props;
+    const {
+      catalog,
+      selectedAppVersion,
+      dispatch,
+      loadingReadme,
+      errorLoadingReadme,
+    } = this.props;
+
+    // Skip if there was an error loading the readme.
+    if (errorLoadingReadme) return;
 
     // Skip if there is no readme source to load.
     if (!hasReadmeSource(selectedAppVersion)) return;
@@ -135,6 +152,7 @@ AppDetail.propTypes = {
   loadingCluster: PropTypes.bool,
   dispatch: PropTypes.func,
   loadingReadme: PropTypes.bool,
+  errorLoadingReadme: PropTypes.string,
 };
 
 function mapStateToProps(state, ownProps) {
@@ -165,6 +183,10 @@ function mapStateToProps(state, ownProps) {
     loadingReadme: selectLoadingFlagByAction(
       state,
       CLUSTER_LOAD_APP_README_REQUEST
+    ),
+    errorLoadingReadme: selectErrorByAction(
+      state,
+      CLUSTER_LOAD_APP_README_ERROR
     ),
   };
 }

--- a/src/components/UI/AppDetails/AppDetails.js
+++ b/src/components/UI/AppDetails/AppDetails.js
@@ -238,7 +238,7 @@ const AppDetails = (props) => {
           <About>
             {readme && (
               <Readme>
-                <small style={{ 'font-weight': 'bold' }}>Readme</small>
+                <small style={{ fontWeight: 'bold' }}>Readme</small>
                 <ReactMarkdown
                   className='markdown'
                   renderers={{ heading: HeadingRenderer }}


### PR DESCRIPTION
This PR ensures we don't show a blank readme when there is a 404 or other error while loading a readme.

It also handles an edge case created by me when I incorrectly created some app releases where the 'v' is missing from the URL.

I added a error clearing action, instead of using the hook I made last time, because in this case the component I want to use it in is not a pure functional component, and I opted to create a new action instead of refactoring the component :) 