### PR TITLE
Add the possibility to provide environmental variables with a configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Icon
 
 # Test Coverage (Jest)
 /coverage
+
+# Environmental variables
+.env

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "superagent": "5.2.2",
     "superagent-bluebird-promise": "4.2.0",
     "underscore": "1.10.2",
-    "validate.js": "0.13.1"
+    "validate.js": "0.13.1",
+    "dotenv": "8.2.0"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,24 +1,29 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 const path = require('path');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const webpack = require('webpack');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const process = require('process');
+const dotenv = require('dotenv');
 
 const makeEndpoints = () => {
-  const { HAPPA_API_ENDPOINT, HAPPA_PASSAGE_ENDPOINT } = process.env;
+  const defaults = {
+    HAPPA_API_ENDPOINT: 'http://localhost:8000',
+    HAPPA_PASSAGE_ENDPOINT: 'http://localhost:5001',
+  };
+  const envFileVars = JSON.stringify(dotenv.config().parsed);
+
+  const { HAPPA_API_ENDPOINT, HAPPA_PASSAGE_ENDPOINT } = Object.assign(
+    {},
+    defaults,
+    envFileVars,
+    process.env
+  );
 
   return {
-    apiEndpoint: HAPPA_API_ENDPOINT
-      ? HAPPA_API_ENDPOINT
-      : 'http://localhost:8000',
-    passageEndpoint: HAPPA_PASSAGE_ENDPOINT
-      ? HAPPA_PASSAGE_ENDPOINT
-      : 'http://localhost:5001',
+    apiEndpoint: HAPPA_API_ENDPOINT,
+    passageEndpoint: HAPPA_PASSAGE_ENDPOINT,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,6 +4816,11 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,7 +4816,7 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^8.2.0:
+dotenv@8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==


### PR DESCRIPTION
This makes adding environmental variables possible with a configuration file. It is very useful in my case (where the testing api doesn't work and I always have to use a testing api).

The configuration file consists in a file called `.env`, stored in the root of the project. (it is not stored in git)

Example `.env` file
```
HAPPA_API_ENDPOINT=https://api.someendpoint.com
HAPPA_PASSAGE_ENDPOINT=https://passage.someendpoint.com
```

Importance level (from less important to most important)
- defaults
- `.env` file
- variables taken from the environment

It is also possible to mix and match (for example, only providing the api endpoint in the `.env` file, and providing the passage endpoint through the command line)