### PR TITLE
Adjust the guide to support optional ingress controller clusters.

### DIFF
--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -122,12 +122,7 @@ export function installApp(app, clusterID) {
         },
       }).catch((error) => {
         showAppInstallationErrorFlashMessage(app.name, clusterID, error);
-
-        dispatch({
-          type: types.CLUSTER_INSTALL_APP_ERROR,
-          id: clusterID,
-          error,
-        });
+        throw error;
       });
 
       dispatch({

--- a/src/components/GettingStarted/GettingStarted.js
+++ b/src/components/GettingStarted/GettingStarted.js
@@ -3,62 +3,143 @@ import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
+import { connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { OrganizationsRoutes } from 'shared/constants/routes';
 
-import Page1_ConfigureKubeCTL from './Steps/ConfigureKubectl';
-import Page3_NextSteps from './Steps/NextSteps';
-import Page0_Overview from './Steps/Overview';
-import Page2_SimpleExample from './Steps/SimpleExample';
+import ConfigureKubeCTL from './Steps/ConfigureKubectl';
+import InstallIngress from './Steps/InstallIngress';
+import NextSteps from './Steps/NextSteps';
+import Overview from './Steps/Overview';
+import SimpleExample from './Steps/SimpleExample';
 
-const GettingStarted = (props) => (
-  <DocumentTitle title='Getting Started'>
-    <Breadcrumb
-      data={{
-        title: 'GETTING STARTED',
-        pathname: RoutePath.createUsablePath(
-          OrganizationsRoutes.Clusters.GettingStarted.Overview,
-          {
-            clusterId: props.match.params.clusterId,
-            orgId: props.match.params.orgId,
-          }
-        ),
-      }}
-    >
-      <div>
-        <Switch>
-          <Route
-            component={Page0_Overview}
-            exact
-            path={OrganizationsRoutes.Clusters.GettingStarted.Overview}
-          />
-          <Route
-            component={Page1_ConfigureKubeCTL}
-            exact
-            path={OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl}
-          />
-          <Route
-            component={Page2_SimpleExample}
-            exact
-            path={OrganizationsRoutes.Clusters.GettingStarted.SimpleExample}
-          />
-          <Route
-            component={Page3_NextSteps}
-            exact
-            path={OrganizationsRoutes.Clusters.GettingStarted.NextSteps}
-          />
-          <Redirect
-            path='*'
-            to={OrganizationsRoutes.Clusters.GettingStarted.Overview}
-          />
-        </Switch>
-      </div>
-    </Breadcrumb>
-  </DocumentTitle>
-);
+const GettingStarted = (props) => {
+  const pathParams = {
+    orgId: props.match.params.orgId,
+    clusterId: props.match.params.clusterId,
+  };
+
+  const clusterGuideConfigurationPath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl,
+    pathParams
+  );
+
+  const clusterGuideExamplePath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
+    pathParams
+  );
+
+  const clusterGuideIngressPath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.GettingStarted.InstallIngress,
+    pathParams
+  );
+
+  const clusterGuideNextStepsPath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.GettingStarted.NextSteps,
+    pathParams
+  );
+
+  const steps = [
+    {
+      title: 'Get Access',
+      description:
+        'Enable your Kubernetes CLI to access your Kubernetes cluster at Giant Swarm',
+      url: clusterGuideConfigurationPath,
+      routePath: OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl,
+      component: ConfigureKubeCTL,
+    },
+
+    {
+      title: 'Run a simple example',
+      description:
+        'To make sure everything works as expected, let&apos;s start a hello world application',
+      url: clusterGuideExamplePath,
+      routePath: OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
+      component: SimpleExample,
+    },
+
+    {
+      title: 'Next steps',
+      description:
+        'We point you to some useful next best actions, like setting up the Kubernetes dashboard',
+      url: clusterGuideNextStepsPath,
+      routePath: OrganizationsRoutes.Clusters.GettingStarted.NextSteps,
+      component: NextSteps,
+    },
+  ];
+
+  // Insert the install ingress step if the cluster has optional ingress.
+  const ingressStep = {
+    title: 'Install an ingress controller',
+    description:
+      "We'll need an ingress controller before we can access any services from the browser",
+    url: clusterGuideIngressPath,
+    routePath: OrganizationsRoutes.Clusters.GettingStarted.InstallIngress,
+    component: InstallIngress,
+  };
+
+  if (props.hasOptionalIngress) {
+    steps.splice(1, 0, ingressStep);
+  }
+
+  return (
+    <DocumentTitle title='Getting Started'>
+      <Breadcrumb
+        data={{
+          title: 'GETTING STARTED',
+          pathname: RoutePath.createUsablePath(
+            OrganizationsRoutes.Clusters.GettingStarted.Overview,
+            {
+              clusterId: props.match.params.clusterId,
+              orgId: props.match.params.orgId,
+            }
+          ),
+        }}
+      >
+        <div>
+          <Switch>
+            <Route
+              render={() => <Overview steps={steps} {...props} />}
+              exact
+              path={OrganizationsRoutes.Clusters.GettingStarted.Overview}
+            />
+            {steps.map(({ component, routePath, title }, i) => (
+              <Route
+                render={() =>
+                  React.createElement(component, {
+                    steps: steps,
+                    stepIndex: i,
+                    ...props,
+                  })
+                }
+                exact
+                path={routePath}
+                key={title}
+              />
+            ))}
+            <Redirect
+              path='*'
+              to={OrganizationsRoutes.Clusters.GettingStarted.Overview}
+            />
+          </Switch>
+        </div>
+      </Breadcrumb>
+    </DocumentTitle>
+  );
+};
 
 GettingStarted.propTypes = {
   match: PropTypes.object,
+  hasOptionalIngress: PropTypes.bool,
 };
 
-export default GettingStarted;
+function mapStateToProps(state, ownProps) {
+  const selectedCluster =
+    state.entities.clusters.items[ownProps.match.params.clusterId];
+
+  return {
+    hasOptionalIngress: selectedCluster?.capabilities?.hasOptionalIngress,
+  };
+}
+
+export default connect(mapStateToProps)(GettingStarted);

--- a/src/components/GettingStarted/GettingStarted.js
+++ b/src/components/GettingStarted/GettingStarted.js
@@ -52,7 +52,7 @@ const GettingStarted = (props) => {
     {
       title: 'Run a simple example',
       description:
-        'To make sure everything works as expected, let&apos;s start a hello world application',
+        "To make sure everything works as expected, let's start a hello world application",
       url: clusterGuideExamplePath,
       routePath: OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
       component: SimpleExample,
@@ -103,15 +103,11 @@ const GettingStarted = (props) => {
               exact
               path={OrganizationsRoutes.Clusters.GettingStarted.Overview}
             />
-            {steps.map(({ component, routePath, title }, i) => (
+            {steps.map(({ component: Component, routePath, title }, i) => (
               <Route
-                render={() =>
-                  React.createElement(component, {
-                    steps: steps,
-                    stepIndex: i,
-                    ...props,
-                  })
-                }
+                render={() => (
+                  <Component steps={steps} stepIndex={i} {...props} />
+                )}
                 exact
                 path={routePath}
                 key={title}

--- a/src/components/GettingStarted/Steps/ConfigureKubectl.js
+++ b/src/components/GettingStarted/Steps/ConfigureKubectl.js
@@ -147,11 +147,6 @@ class ConfigKubeCtl extends React.Component {
       pathParams
     );
 
-    const clusterGuideExamplePath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
-      pathParams
-    );
-
     const clusterGuideOverviewPath = RoutePath.createUsablePath(
       OrganizationsRoutes.Clusters.GettingStarted.Overview,
       pathParams
@@ -335,7 +330,7 @@ class ConfigKubeCtl extends React.Component {
               </button>
             </Link>
 
-            <Link to={clusterGuideExamplePath}>
+            <Link to={this.props.steps[this.props.stepIndex + 1].url}>
               <button className='primary' type='button'>
                 Continue <i className='fa fa-chevron-right' />
               </button>
@@ -355,6 +350,8 @@ ConfigKubeCtl.propTypes = {
   match: PropTypes.object,
   selectedCluster: PropTypes.object,
   user: PropTypes.object,
+  steps: PropTypes.array,
+  stepIndex: PropTypes.number,
 };
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/GettingStarted/Steps/InstallIngress.js
+++ b/src/components/GettingStarted/Steps/InstallIngress.js
@@ -18,9 +18,11 @@ import { OrganizationsRoutes } from 'shared/constants/routes';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 
 const InstallIngress = (props) => {
+  const clusterId = props.cluster.id;
+
   useEffect(() => {
     props.dispatch(loadApps(props.cluster.id));
-  }, [props.cluster.id]);
+  }, [clusterId]);
 
   const pathParams = {
     orgId: props.match.params.orgId,
@@ -46,7 +48,8 @@ const InstallIngress = (props) => {
     const appsLoading =
       'Checking if an ingress controller is already installed.';
     const installingIngress = 'Installing your ingress controller now.';
-    const ingressInstalled = '✅ Ingress controller already installed!';
+    const ingressInstalled =
+      '🎉 Ingress controller installed. Please continue to the next step.';
     const noIngressYet = (
       <>
         Click this button to install an ingress controller on{' '}
@@ -54,12 +57,14 @@ const InstallIngress = (props) => {
       </>
     );
 
-    if (prps.appsLoading) return { message: appsLoading, disabled: true };
+    if (prps.ingressApp)
+      return { message: ingressInstalled, disabled: true, visible: false };
+    if (prps.appsLoading)
+      return { message: appsLoading, disabled: true, visible: true };
     if (prps.ingressInstalling)
-      return { message: installingIngress, disabled: true };
-    if (prps.ingressApp) return { message: ingressInstalled, disabled: true };
+      return { message: installingIngress, disabled: true, visible: true };
 
-    return { message: noIngressYet, disabled: false };
+    return { message: noIngressYet, disabled: false, visible: true };
   };
 
   const installIngressController = async () => {
@@ -92,71 +97,46 @@ const InstallIngress = (props) => {
         <h1>Install an ingress controller</h1>
 
         <p>
-          Your cluster ({props.cluster.name}{' '}
-          <ClusterIDLabel clusterID={props.cluster.id} />) does not come with an
-          ingress controller installed by default. Without an ingress controller
-          you won&apos;t be able to access any services running on the cluster
-          from the browser. Once you have an ingress controller you&apos;ll be
-          able to create Ingress resources which specify how external traffic
-          should get routed to services running on you cluster.
+          Your cluster does not come with an ingress controller installed by
+          default. Without an ingress controller you won&apos;t be able to
+          access any services running on the cluster from the browser.
         </p>
 
         <h3>Using the Giant Swarm App Platform</h3>
         <p>
-          You can use our app platform to install the popular{' '}
-          <code>nginx-ingress-controller</code>. We provide a tuned
-          implementation of the <code>nginx-ingress-controller</code> in the
-          &quot;Giant Swarm Catalog&quot;
+          You can use our app platform to install the popular nginx ingress
+          controller. We provide a tuned implementation in the &quot;Giant Swarm
+          Catalog&quot;, which you can browse by clicking &quot;App
+          Catalogs&quot; in the navigation above.
         </p>
 
         <p>
-          For convenience, you can click on the &apos;Install Ingress
-          Controller&apos; button below to immediately install the{' '}
-          <code>nginx-ingress-controller</code>
-          on your cluster.
+          For convenience however, you can click on the &apos;Install Ingress
+          Controller&apos; button below to immediately install the nginx ingress
+          controller on your cluster.
         </p>
 
         <div
           className='well'
           style={{ verticalAlign: 'middle', overflow: 'auto' }}
         >
-          <button
-            type='button'
-            className='primary'
-            disabled={buttonState(props).disabled}
-            style={{ marginBottom: '0px', float: 'left', marginRight: '18px' }}
-            onClick={installIngressController}
-          >
-            Install Ingress Controller
-          </button>
+          {buttonState(props).visible ? (
+            <button
+              type='button'
+              className='primary'
+              disabled={buttonState(props).disabled}
+              style={{
+                marginBottom: '0px',
+                float: 'left',
+                marginRight: '18px',
+              }}
+              onClick={installIngressController}
+            >
+              Install Ingress Controller
+            </button>
+          ) : undefined}
           <p style={{ marginTop: '9px' }}>{buttonState(props).message}</p>
         </div>
-        <hr />
-
-        <small>
-          <i>
-            Alternatively, you can click on &quot;App Catalogs&quot; in the
-            navigation above, then pick &quot;Giant Swarm Catalog&quot;.
-          </i>
-
-          <br />
-          <br />
-          <i>Here you&apos;ll find all the apps we provide.</i>
-
-          <br />
-          <br />
-          <i>
-            Pick <code>nginx-ingress-controller-app</code> and click on
-            &quot;Configure & Install&quot; to bring up a modal where you can
-            pick which cluster you want to install it to.
-            <br />
-            <br />
-            Pick your cluster <ClusterIDLabel
-              clusterID={props.cluster.id}
-            />{' '}
-            from the list and go through the steps presented in the modal.
-          </i>
-        </small>
 
         <div className='component_slider--nav'>
           <Link to={clusterGuideConfigurationPath}>

--- a/src/components/GettingStarted/Steps/InstallIngress.js
+++ b/src/components/GettingStarted/Steps/InstallIngress.js
@@ -72,32 +72,34 @@ const InstallIngress = (props) => {
   };
 
   const installIngressController = async () => {
-    setInstalling(true);
+    try {
+      setInstalling(true);
 
-    await props.dispatch(
-      installApp(
-        {
-          catalog: 'giantswarm',
-          chartName: 'nginx-ingress-controller-app',
-          namespace: 'kube-system',
-          name: 'nginx-ingress-controller-app',
-          valuesYAML: '',
-          secretsYAML: '',
-          version: '1.6.9',
-        },
-        props.cluster.id
-      )
-    );
+      await props.dispatch(
+        installApp(
+          {
+            catalog: 'giantswarm',
+            chartName: 'nginx-ingress-controller-app',
+            namespace: 'kube-system',
+            name: 'nginx-ingress-controller-app',
+            valuesYAML: '',
+            secretsYAML: '',
+            version: '1.6.9',
+          },
+          props.cluster.id
+        )
+      );
 
-    await props.dispatch(loadApps(props.cluster.id));
-
-    setInstalling(false);
+      await props.dispatch(loadApps(props.cluster.id));
+    } finally {
+      setInstalling(false);
+    }
   };
 
   return (
     <Breadcrumb
       data={{
-        title: 'INSTALL_INGRESS',
+        title: 'INSTALL INGRESS',
         pathname: clusterGuideIngressPath,
       }}
     >

--- a/src/components/GettingStarted/Steps/InstallIngress.js
+++ b/src/components/GettingStarted/Steps/InstallIngress.js
@@ -2,7 +2,7 @@ import {
   CLUSTER_INSTALL_APP_REQUEST,
   CLUSTER_LOAD_APPS_REQUEST,
 } from 'actions/actionTypes';
-import { loadApps } from 'actions/appActions';
+import { installApp, loadApps } from 'actions/appActions';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
@@ -62,7 +62,24 @@ const InstallIngress = (props) => {
     return { message: noIngressYet, disabled: false };
   };
 
-  const installIngressController = () => {};
+  const installIngressController = async () => {
+    await props.dispatch(
+      installApp(
+        {
+          catalog: 'giantswarm',
+          chartName: 'nginx-ingress-controller-app',
+          namespace: 'kube-system',
+          name: 'nginx-ingress-controller-app',
+          valuesYAML: '',
+          secretsYAML: '',
+          version: '1.6.9',
+        },
+        props.cluster.id
+      )
+    );
+
+    await props.dispatch(loadApps(props.cluster.id));
+  };
 
   return (
     <Breadcrumb
@@ -94,8 +111,9 @@ const InstallIngress = (props) => {
 
         <p>
           For convenience, you can click on the &apos;Install Ingress
-          Controller&apos; button below to bring up a modal which will guide you
-          through the process.
+          Controller&apos; button below to immediately install the{' '}
+          <code>nginx-ingress-controller</code>
+          on your cluster.
         </p>
 
         <div

--- a/src/components/GettingStarted/Steps/InstallIngress.js
+++ b/src/components/GettingStarted/Steps/InstallIngress.js
@@ -4,7 +4,9 @@ import React from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { selectClusterById } from 'selectors/clusterSelectors';
 import { OrganizationsRoutes } from 'shared/constants/routes';
+import ClusterIDLabel from 'UI/ClusterIDLabel';
 
 const InstallIngress = (props) => {
   const pathParams = {
@@ -35,7 +37,68 @@ const InstallIngress = (props) => {
       }}
     >
       <div className='centered col-9'>
-        Install an ingress yo.
+        <h1>Install an ingress controller</h1>
+
+        <p>
+          Your cluster ({props.cluster.name}{' '}
+          <ClusterIDLabel clusterID={props.cluster.id} />) does not come with an
+          ingress controller installed by default. Without an ingress controller
+          you won&apos;t be able to access any services running on the cluster
+          from the browser. Once you have an ingress controller you&apos;ll be
+          able to create Ingress resources which specify how external traffic
+          should get routed to services running on you cluster.
+        </p>
+
+        <h3>Using the Giant Swarm App Platform</h3>
+        <p>
+          You can use our app platform to install the popular{' '}
+          <code>nginx-ingress-controller</code>. We provide a tuned
+          implementation of the <code>nginx-ingress-controller</code> in the
+          &quot;Giant Swarm Catalog&quot;
+        </p>
+
+        <p>
+          For convenience, you can click on the &apos;Install Ingress
+          Controller&apos; button below to bring up a modal which will guide you
+          through the process.
+        </p>
+
+        <div className='well' style={{ textAlign: 'center' }}>
+          <button
+            type='button'
+            className='primary'
+            style={{ marginBottom: '0px' }}
+          >
+            Install Ingress Controller
+          </button>
+        </div>
+        <hr />
+
+        <small>
+          <i>
+            Alternatively, you can click on &quot;App Catalogs&quot; in the
+            navigation above, then pick &quot;Giant Swarm Catalog&quot;.
+          </i>
+
+          <br />
+          <br />
+          <i>Here you&apos;ll find all the apps we provide.</i>
+
+          <br />
+          <br />
+          <i>
+            Pick <code>nginx-ingress-controller-app</code> and click on
+            &quot;Configure & Install&quot; to bring up a modal where you can
+            pick which cluster you want to install it to.
+            <br />
+            <br />
+            Pick your cluster <ClusterIDLabel
+              clusterID={props.cluster.id}
+            />{' '}
+            from the list and go through the steps presented in the modal.
+          </i>
+        </small>
+
         <div className='component_slider--nav'>
           <Link to={clusterGuideConfigurationPath}>
             <button type='button'>
@@ -61,8 +124,10 @@ InstallIngress.propTypes = {
 };
 
 function mapStateToProps(state, ownProps) {
-  const selectedCluster =
-    state.entities.clusters.items[ownProps.match.params.clusterId];
+  const selectedCluster = selectClusterById(
+    state,
+    ownProps.match.params.clusterId
+  );
 
   return {
     cluster: selectedCluster,

--- a/src/components/GettingStarted/Steps/InstallIngress.js
+++ b/src/components/GettingStarted/Steps/InstallIngress.js
@@ -1,0 +1,72 @@
+import RoutePath from 'lib/routePath';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Breadcrumb } from 'react-breadcrumbs';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { OrganizationsRoutes } from 'shared/constants/routes';
+
+const InstallIngress = (props) => {
+  const pathParams = {
+    orgId: props.match.params.orgId,
+    clusterId: props.match.params.clusterId,
+  };
+
+  const clusterGuideIngressPath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.GettingStarted.InstallIngress,
+    pathParams
+  );
+
+  const clusterGuideConfigurationPath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl,
+    pathParams
+  );
+
+  const clusterGuideExamplePath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
+    pathParams
+  );
+
+  return (
+    <Breadcrumb
+      data={{
+        title: 'INSTALL_INGRESS',
+        pathname: clusterGuideIngressPath,
+      }}
+    >
+      <div className='centered col-9'>
+        Install an ingress yo.
+        <div className='component_slider--nav'>
+          <Link to={clusterGuideConfigurationPath}>
+            <button type='button'>
+              <i className='fa fa-chevron-left' /> Back
+            </button>
+          </Link>
+
+          <Link to={clusterGuideExamplePath}>
+            <button className='primary' type='button'>
+              Continue <i className='fa fa-chevron-right' />
+            </button>
+          </Link>
+        </div>
+      </div>
+    </Breadcrumb>
+  );
+};
+
+InstallIngress.propTypes = {
+  goToSlide: PropTypes.func,
+  match: PropTypes.object,
+  cluster: PropTypes.object,
+};
+
+function mapStateToProps(state, ownProps) {
+  const selectedCluster =
+    state.entities.clusters.items[ownProps.match.params.clusterId];
+
+  return {
+    cluster: selectedCluster,
+  };
+}
+
+export default connect(mapStateToProps)(InstallIngress);

--- a/src/components/GettingStarted/Steps/InstallIngress.js
+++ b/src/components/GettingStarted/Steps/InstallIngress.js
@@ -3,9 +3,10 @@ import {
   CLUSTER_LOAD_APPS_REQUEST,
 } from 'actions/actionTypes';
 import { installApp, loadApps } from 'actions/appActions';
+import { spinner } from 'images';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -23,6 +24,8 @@ const InstallIngress = (props) => {
   useEffect(() => {
     props.dispatch(loadApps(props.cluster.id));
   }, [clusterId]);
+
+  const [installing, setInstalling] = useState(false);
 
   const pathParams = {
     orgId: props.match.params.orgId,
@@ -45,9 +48,9 @@ const InstallIngress = (props) => {
   );
 
   const buttonState = (prps) => {
-    const appsLoading =
-      'Checking if an ingress controller is already installed.';
-    const installingIngress = 'Installing your ingress controller now.';
+    const loading = (
+      <img style={{ width: '20px' }} className='loader' src={spinner} />
+    );
     const ingressInstalled =
       '🎉 Ingress controller installed. Please continue to the next step.';
     const noIngressYet = (
@@ -57,17 +60,20 @@ const InstallIngress = (props) => {
       </>
     );
 
+    if (installing) return { message: loading, disabled: true, visible: true };
+
     if (prps.ingressApp)
       return { message: ingressInstalled, disabled: true, visible: false };
+
     if (prps.appsLoading)
-      return { message: appsLoading, disabled: true, visible: true };
-    if (prps.ingressInstalling)
-      return { message: installingIngress, disabled: true, visible: true };
+      return { message: loading, disabled: true, visible: true };
 
     return { message: noIngressYet, disabled: false, visible: true };
   };
 
   const installIngressController = async () => {
+    setInstalling(true);
+
     await props.dispatch(
       installApp(
         {
@@ -84,6 +90,8 @@ const InstallIngress = (props) => {
     );
 
     await props.dispatch(loadApps(props.cluster.id));
+
+    setInstalling(false);
   };
 
   return (

--- a/src/components/GettingStarted/Steps/Overview.js
+++ b/src/components/GettingStarted/Steps/Overview.js
@@ -1,82 +1,28 @@
-import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { OrganizationsRoutes } from 'shared/constants/routes';
 
 class Overview extends React.Component {
-  static testFileContent() {
-    return `
-      The contents of the file
-
-      Indentation
-      -----------
-        Indentation should be preserved based on where the first line
-        started in the code.
-    `;
-  }
-
   render() {
-    const pathParams = {
-      orgId: this.props.match.params.orgId,
-      clusterId: this.props.match.params.clusterId,
-    };
-
-    const clusterGuideConfigurationPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl,
-      pathParams
-    );
-
-    const clusterGuideExamplePath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
-      pathParams
-    );
-
-    const clusterGuideNextStepsPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.GettingStarted.NextSteps,
-      pathParams
-    );
-
     return (
       <div className='centered col-10'>
         <h1>Get started with your Kubernetes cluster</h1>
         <ol className='step_selector'>
-          <li>
-            <Link to={clusterGuideConfigurationPath}>
-              <span className='step_selector--step-number'>1.</span>
-              <span className='step_selector--step-title'>Get access</span>
-              <span className='step_selector--step-description'>
-                Enable your Kubernetes CLI to access your Kubernetes cluster at
-                Giant Swarm
-              </span>
-            </Link>
-          </li>
-          <li>
-            <Link to={clusterGuideExamplePath}>
-              <span className='step_selector--step-number'>2.</span>
-              <span className='step_selector--step-title'>
-                Run a simple example
-              </span>
-              <span className='step_selector--step-description'>
-                To make sure everything works as expected, let&apos;s start a
-                hello world application
-              </span>
-            </Link>
-          </li>
-          <li>
-            <Link to={clusterGuideNextStepsPath}>
-              <span className='step_selector--step-number'>3.</span>
-              <span className='step_selector--step-title'>Next steps</span>
-              <span className='step_selector--step-description'>
-                We point you to some useful next best actions, like setting up
-                the Kubernetes dashboard
-              </span>
-            </Link>
-          </li>
+          {this.props.steps.map(({ url, title, description }, i) => (
+            <li key={title}>
+              <Link to={url}>
+                <span className='step_selector--step-number'>{i + 1}.</span>
+                <span className='step_selector--step-title'>{title}</span>
+                <span className='step_selector--step-description'>
+                  {description}
+                </span>
+              </Link>
+            </li>
+          ))}
         </ol>
 
         <div className='component_slider--nav'>
-          <Link to={clusterGuideConfigurationPath}>
+          <Link to={this.props.steps[0].url}>
             <button className='primary' type='button'>
               Start <i className='fa fa-chevron-right' />
             </button>
@@ -90,6 +36,7 @@ class Overview extends React.Component {
 Overview.propTypes = {
   match: PropTypes.object,
   goToSlide: PropTypes.func,
+  steps: PropTypes.array,
 };
 
 export default Overview;

--- a/src/components/GettingStarted/Steps/SimpleExample.js
+++ b/src/components/GettingStarted/Steps/SimpleExample.js
@@ -80,11 +80,6 @@ class SimpleExample extends React.Component {
       clusterId: this.props.match.params.clusterId,
     };
 
-    const clusterGuideConfigurationPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl,
-      pathParams
-    );
-
     const clusterGuideExamplePath = RoutePath.createUsablePath(
       OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
       pathParams
@@ -313,7 +308,7 @@ class SimpleExample extends React.Component {
           </CodeBlock>
 
           <div className='component_slider--nav'>
-            <Link to={clusterGuideConfigurationPath}>
+            <Link to={this.props.steps[this.props.stepIndex - 1].url}>
               <button type='button'>
                 <i className='fa fa-chevron-left' /> Back
               </button>
@@ -337,6 +332,8 @@ SimpleExample.propTypes = {
   dispatch: PropTypes.func,
   goToSlide: PropTypes.func,
   match: PropTypes.object,
+  steps: PropTypes.array,
+  stepIndex: PropTypes.number,
 };
 
 function mapStateToProps(state, ownProps) {

--- a/src/components/UI/ClusterIDLabel.js
+++ b/src/components/UI/ClusterIDLabel.js
@@ -8,7 +8,7 @@ import Tooltip from 'react-bootstrap/lib/Tooltip';
 
 const colorHashCache = {};
 
-const Wrapper = styled.div`
+const Wrapper = styled.span`
   display: inline-block;
 
   &:hover {

--- a/src/selectors/clusterSelectors.js
+++ b/src/selectors/clusterSelectors.js
@@ -17,6 +17,16 @@ export const selectClusterById = (state, id) => {
   return state.entities.clusters.items[id];
 };
 
+export const selectIngressAppFromCluster = (cluster) => {
+  const apps = cluster.apps || [];
+
+  const ingressApp = apps.find((app) => {
+    return app.spec.name === 'nginx-ingress-controller-app';
+  });
+
+  return ingressApp;
+};
+
 const selectOrganizationClusterNames = (state) => {
   const clusters = state.entities.clusters.items;
   const clusterIds = Object.keys(clusters);

--- a/src/shared/constants/routes.js
+++ b/src/shared/constants/routes.js
@@ -35,6 +35,8 @@ const OrganizationsRoutes = {
       Overview: '/organizations/:orgId/clusters/:clusterId/getting-started',
       ConfigureKubeCtl:
         '/organizations/:orgId/clusters/:clusterId/getting-started/configure',
+      InstallIngress:
+        '/organizations/:orgId/clusters/:clusterId/getting-started/ingress',
       SimpleExample:
         '/organizations/:orgId/clusters/:clusterId/getting-started/example',
       NextSteps:

--- a/src/styles/components/_step_selector.sass
+++ b/src/styles/components/_step_selector.sass
@@ -9,15 +9,13 @@
   li
     margin: 10px
     flex-grow: 1
-    width: 30%
+    width: 100%
 
     a
       display: block
       background-color: lighten($darkblue, 10%)
       border-radius: 5px
       height: 100%
-      text-align: center
-      margin-bottom: 20px
       padding: 15px 20px
 
       &:hover
@@ -33,7 +31,9 @@
         font-size: 30px
         font-weight: 800
         display: block
+        float: left
         color: lighten($darkblue, 40%)
+        margin-right: 15px;
 
       .step_selector--step-title
         font-weight: 800


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/7783

A step gets inserted into the getting started guide for clusters that have an optional ingress controller:

<img width="1058" alt="Screenshot 2020-04-27 at 3 40 01 PM" src="https://user-images.githubusercontent.com/455309/80347207-98eb7700-889e-11ea-9ad7-b644af126722.png">

Which presents a bit of an explanation and a convenient button for installing the ingress controller immediately.

<img width="1045" alt="Screenshot 2020-04-27 at 3 50 05 PM" src="https://user-images.githubusercontent.com/455309/80347416-dbad4f00-889e-11ea-9678-1566ca2267b5.png">

<img width="1064" alt="Screenshot 2020-04-27 at 3 50 26 PM" src="https://user-images.githubusercontent.com/455309/80347442-e10a9980-889e-11ea-9646-cc87c702aff3.png">

