### PR TITLE
Show a more appropriate error for certain cases of app creation failure.

### DIFF
--- a/src/actions/appActions.js
+++ b/src/actions/appActions.js
@@ -163,6 +163,12 @@ function showAppInstallationErrorFlashMessage(appName, clusterID, error) {
       messageType.ERROR,
       messageTTL.LONG
     );
+  } else if (error.status === StatusCodes.ServiceUnavailable) {
+    new FlashMessage(
+      `The cluster is not yet ready for app installation. Please try again in 5 to 10 minutes.`,
+      messageType.ERROR,
+      messageTTL.LONG
+    );
   } else if (error.status === StatusCodes.BadRequest) {
     new FlashMessage(
       `Your input appears to be invalid. Please make sure all fields are filled in correctly.`,

--- a/src/components/AppCatalog/AppDetail/InstallAppModal.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppModal.js
@@ -210,9 +210,8 @@ const InstallAppModal = (props) => {
         onClose();
         props.dispatch(push(clusterDetailPath));
       })
-      .catch((error) => {
+      .catch(() => {
         setLoading(false);
-        throw error;
       });
   };
 


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/9166
related: https://github.com/giantswarm/api/pull/1013

instead of "something went wrong" we now show a slightly more specific error message.

<img width="345" alt="Screenshot 2020-04-29 at 12 29 21 AM" src="https://user-images.githubusercontent.com/455309/80512714-7e092780-89b0-11ea-85e1-2e5e6843226e.png">