### PR TITLE
Catch only errors from renewing the token.

### DIFF
--- a/src/lib/giantswarmClientPatcher.js
+++ b/src/lib/giantswarmClientPatcher.js
@@ -38,6 +38,13 @@ function monkeyPatchGiantSwarmClient(store) {
       if (isJwtExpired(defaultClientAuth.apiKey)) {
         return auth
           .renewToken()
+          .catch((err) => {
+            err.status = 401; // Add 'status: 401' to the error object
+            // so the layout component can treat auth0
+            // login required errors correctly.
+
+            throw err;
+          })
           .then(async (result) => {
             // Update state with new token.
             await store.dispatch(auth0Login(result));
@@ -60,12 +67,6 @@ function monkeyPatchGiantSwarmClient(store) {
               accepts,
               returnType
             );
-          })
-          .catch((err) => {
-            err.status = 401; // Add 'status: 401' to the error object
-            // so the layout component can treat auth0
-            // login required errors correctly.
-            throw err;
           });
       }
     }


### PR DESCRIPTION
This fixes the odd case of seeing an error with a status of 401 internally in Happa even though there was no 401 in the network tab.