### PR TITLE
Revert moment dependency upgrade.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "js-base64": "2.5.2",
     "js-yaml": "^3.12.1",
     "lunr": "^2.3.6",
-    "moment": "2.25.0",
+    "moment": "2.24.0",
     "normalize.css": "8.0.1",
     "noty": "^3.1.4",
     "platform": "1.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8528,10 +8528,10 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "^1.2.5"
 
-moment@2.25.0:
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.25.0.tgz#e961ab9a5848a1cf2c52b1af4e6c82a8401e7fe9"
-  integrity sha512-vbrf6kJGpevOxmDRvCCvGuCSXvRj93264WcFzjm3Z3pV4lfjrXll8rvSP+EbmCte64udj1LkJMILxQnjXAQBzg==
+moment@2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Something is not working will with the latest version of moment introduced here: https://github.com/giantswarm/happa/pull/1418

Reverting it.

I'd like to analyse why the tests passed and what we can do to fix it. 