### PR TITLE
Show flatcar in release selection modal

### DIFF
--- a/__tests__/ClusterManagement.js
+++ b/__tests__/ClusterManagement.js
@@ -16,6 +16,7 @@ import {
   getMockCallTimes,
   metadataResponse,
   nodePoolsResponse,
+  nodePoolWithFlatcarRelease,
   ORGANIZATION,
   orgResponse,
   orgsResponse,
@@ -255,4 +256,33 @@ it(`it does not show disabled releases in release selection modal`, async () => 
       expect(queryByTestId(`release-${version}`)).not.toBeInTheDocument();
     }
   }
+});
+
+it(`it shows 'flatcar' for containerlinux versions >= 2345.3.1 in release selection modal`, async () => {
+  getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
+  getMockCall('/v4/clusters/');
+  getMockCall('/v4/releases/', releasesResponse);
+
+  const newClusterPath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.New,
+    {
+      orgId: ORGANIZATION,
+    }
+  );
+
+  const { findByText, findByTestId } = renderRouteWithStore(newClusterPath);
+
+  fireEvent.click(await findByText('Details and Alternatives'));
+
+  // Wait for the modal to pop up.
+  await findByText('Release Details');
+
+  const flatcarRelease = await findByTestId(
+    `release-${nodePoolWithFlatcarRelease.version}`
+  );
+
+  expect(flatcarRelease.textContent).toEqual(
+    expect.not.stringMatching('containerlinux')
+  );
+  expect(flatcarRelease.textContent).toEqual(expect.stringMatching('flatcar'));
 });

--- a/__tests__/ClusterManagement.js
+++ b/__tests__/ClusterManagement.js
@@ -226,3 +226,33 @@ it('Cluster list shows all clusters, each one with its details, for the selected
   expect(v5ClusterResources.getByText(/6 nodes/i)).toBeInTheDocument();
   expect(v5ClusterResources.getByText(/24 CPU cores/i)).toBeInTheDocument();
 });
+
+it(`it does not show disabled releases in release selection modal`, async () => {
+  getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
+  getMockCall('/v4/clusters/');
+  getMockCall('/v4/releases/', releasesResponse);
+
+  const newClusterPath = RoutePath.createUsablePath(
+    OrganizationsRoutes.Clusters.New,
+    {
+      orgId: ORGANIZATION,
+    }
+  );
+
+  const { findByText, getByTestId, queryByTestId } = renderRouteWithStore(
+    newClusterPath
+  );
+
+  fireEvent.click(await findByText('Details and Alternatives'));
+
+  // Wait for the modal to pop up.
+  await findByText('Release Details');
+
+  for (const { version, active } of releasesResponse) {
+    if (active === true) {
+      expect(getByTestId(`release-${version}`)).toBeInTheDocument();
+    } else {
+      expect(queryByTestId(`release-${version}`)).not.toBeInTheDocument();
+    }
+  }
+});

--- a/__tests__/ClusterManagement.js
+++ b/__tests__/ClusterManagement.js
@@ -19,6 +19,7 @@ import {
   ORGANIZATION,
   orgResponse,
   orgsResponse,
+  preNodePoolRelease,
   releasesResponse,
   userResponse,
   V4_CLUSTER,
@@ -150,18 +151,9 @@ details view`, async () => {
 
   fireEvent.click(await findByText('Details and Alternatives'));
 
-  // Wait for the modal to pop up.
-  await findByText('Release Details');
-
-  // Find the second button which is the 8.5.0
-  // TODO Improve this, check with cmp that this is not a node pools release
-  const button = document
-    .querySelectorAll(
-      `.modal-content .release-selector-modal--release-details h2`
-    )[1]
-    .querySelector('button');
-
-  fireEvent.click(button);
+  fireEvent.click(
+    await findByTestId(`select-release-${preNodePoolRelease.version}`)
+  );
 
   // Click the create cluster button.
   fireEvent.click(await findByText('Create Cluster'));

--- a/__tests__/V4AzureClusterManagement.js
+++ b/__tests__/V4AzureClusterManagement.js
@@ -18,6 +18,7 @@ import {
   ORGANIZATION,
   orgResponse,
   orgsResponse,
+  preNodePoolRelease,
   releasesResponse,
   userResponse,
   V4_CLUSTER,
@@ -104,16 +105,7 @@ describe('V4AzureClusterManagement', () => {
   });
 
   it('prevents availability zones customization for an unsupported release version', async () => {
-    // Cloning to not break the releases list for the next tests
-    const unsupportedReleaseResponse = releasesResponse.slice();
-    unsupportedReleaseResponse[2] = Object.assign(
-      {},
-      unsupportedReleaseResponse[2],
-      {
-        version: '8.4.0',
-      }
-    );
-    getMockCall('/v4/releases/', unsupportedReleaseResponse);
+    getMockCall('/v4/releases/', [preNodePoolRelease]);
     getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
 
     const clusterCreationPath = RoutePath.createUsablePath(

--- a/src/components/Modals/ReleaseDetailsModal.js
+++ b/src/components/Modals/ReleaseDetailsModal.js
@@ -2,6 +2,8 @@ import { relativeDate } from 'lib/helpers';
 import PropTypes from 'prop-types';
 import React from 'react';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
+import cmp from 'semver-compare';
+import { Constants } from 'shared/constants';
 import theme from 'styles/theme';
 import Button from 'UI/Button';
 import ComponentChangelog from 'UI/ComponentChangelog';
@@ -79,10 +81,19 @@ class ReleaseDetailsModal extends React.Component {
 
                   <div className='release-selector-modal--components'>
                     {_.sortBy(release.components, 'name').map((component) => {
+                      const componentName =
+                        component.name === 'containerlinux' &&
+                        cmp(
+                          component.version,
+                          Constants.FLATCAR_CONTAINERLINUX_SINCE
+                        ) >= 0
+                          ? 'flatcar'
+                          : component.name;
+
                       return (
                         <ReleaseComponentLabel
                           key={component.name}
-                          name={component.name}
+                          name={componentName}
                           version={component.version}
                         />
                       );

--- a/src/components/Modals/ReleaseDetailsModal.js
+++ b/src/components/Modals/ReleaseDetailsModal.js
@@ -49,6 +49,7 @@ class ReleaseDetailsModal extends React.Component {
                 <div
                   className='release-selector-modal--release-details'
                   key={release.version}
+                  data-testid={`release-${release.version}`}
                 >
                   <h2>
                     Version {release.version}{' '}

--- a/src/components/Modals/ReleaseDetailsModal.js
+++ b/src/components/Modals/ReleaseDetailsModal.js
@@ -64,6 +64,7 @@ class ReleaseDetailsModal extends React.Component {
                             onClick={() =>
                               this.props.selectRelease(release.version)
                             }
+                            data-testid={`select-release-${release.version}`}
                           >
                             Select
                           </Button>

--- a/testUtils/mockHttpCalls/releases.js
+++ b/testUtils/mockHttpCalls/releases.js
@@ -1,335 +1,442 @@
+export const disabledRelease = {
+  active: false,
+  changelog: [
+    {
+      component: 'cloudformation',
+      description: 'Duplicate etcd record set into public hosted zone.',
+    },
+    {
+      component: 'cloudformation',
+      description: 'Add ingress internal load-balancer in private hosted zone.',
+    },
+    {
+      component: 'cloudformation',
+      description:
+        'Use private subnets for internal Kubernetes API loadbalancer.',
+    },
+  ],
+  components: [
+    {
+      name: 'app-operator',
+      version: '1.0.0',
+    },
+    {
+      name: 'aws-operator',
+      version: '5.3.1',
+    },
+    {
+      name: 'calico',
+      version: '3.8.2',
+    },
+    {
+      name: 'cert-operator',
+      version: '0.1.0',
+    },
+    {
+      name: 'chart-operator',
+      version: '0.7.0',
+    },
+    {
+      name: 'cluster-autoscaler',
+      version: '1.14.0',
+    },
+    {
+      name: 'cluster-operator',
+      version: '0.19.0',
+    },
+    {
+      name: 'containerlinux',
+      version: '2135.4.0',
+    },
+    {
+      name: 'coredns',
+      version: '1.6.2',
+    },
+    {
+      name: 'docker',
+      version: '18.06.1',
+    },
+    {
+      name: 'etcd',
+      version: '3.3.13',
+    },
+    {
+      name: 'kube-state-metrics',
+      version: '1.7.2',
+    },
+    {
+      name: 'kubernetes',
+      version: '1.14.6',
+    },
+    {
+      name: 'metrics-server',
+      version: '0.3.1',
+    },
+    {
+      name: 'nginx-ingress-controller',
+      version: '0.25.1',
+    },
+    {
+      name: 'node-exporter',
+      version: '0.18.0',
+    },
+    {
+      name: 'vault',
+      version: '0.10.3',
+    },
+  ],
+  timestamp: '2019-09-24T11:00:00Z',
+  version: '8.4.1',
+};
+
+export const preNodePoolRelease = {
+  active: true,
+  changelog: [
+    {
+      component: 'cloudformation',
+      description:
+        'Use private subnets for internal Kubernetes API loadbalancer.',
+    },
+    {
+      component: 'cloudformation',
+      description: 'Add ingress internal load-balancer in private hosted zone.',
+    },
+    {
+      component: 'cloudformation',
+      description: 'Duplicate etcd record set into public hosted zone.',
+    },
+    {
+      component: 'cloudformation',
+      description:
+        'Add public internal-api record set for Kubernetes API private load balancer.',
+    },
+    {
+      component: 'cloudformation',
+      description: 'Add whitelisting for internal Kubernetes API.',
+    },
+    {
+      component: 'cluster-operator',
+      description:
+        'Add internal Kubernetes API domain into API certificate alternative names.',
+    },
+    {
+      component: 'chart-operator',
+      description: 'Install chart-operator from default catalog.',
+    },
+  ],
+  components: [
+    {
+      name: 'app-operator',
+      version: '1.0.0',
+    },
+    {
+      name: 'aws-operator',
+      version: '5.4.0',
+    },
+    {
+      name: 'calico',
+      version: '3.8.2',
+    },
+    {
+      name: 'cert-exporter',
+      version: '1.2.3',
+    },
+    {
+      name: 'net-exporter',
+      version: '2.3.4',
+    },
+    {
+      name: 'cert-operator',
+      version: '0.1.0',
+    },
+    {
+      name: 'chart-operator',
+      version: '0.7.0',
+    },
+    {
+      name: 'cluster-autoscaler',
+      version: '1.14.0',
+    },
+    {
+      name: 'cluster-operator',
+      version: '0.20.0',
+    },
+    {
+      name: 'containerlinux',
+      version: '2135.4.0',
+    },
+    {
+      name: 'coredns',
+      version: '1.6.2',
+    },
+    {
+      name: 'docker',
+      version: '18.06.1',
+    },
+    {
+      name: 'etcd',
+      version: '3.3.13',
+    },
+    {
+      name: 'kube-state-metrics',
+      version: '1.7.2',
+    },
+    {
+      name: 'kubernetes',
+      version: '1.14.6',
+    },
+    {
+      name: 'metrics-server',
+      version: '0.3.1',
+    },
+    {
+      name: 'nginx-ingress-controller',
+      version: '0.25.1',
+    },
+    {
+      name: 'node-exporter',
+      version: '0.18.0',
+    },
+    {
+      name: 'vault',
+      version: '0.10.3',
+    },
+  ],
+  timestamp: '2019-09-02T13:30:00Z',
+  version: '8.5.0',
+};
+
+export const nodePoolRelease = {
+  active: true,
+  changelog: [
+    {
+      component: 'cloudformation',
+      description: 'Add IAMManager IAM role for kiam managed app.',
+    },
+    {
+      component: 'cloudformation',
+      description: 'Add Route53Manager IAM role for external-dns managed app.',
+    },
+    {
+      component: 'kubernetes',
+      description: 'Updated from v1.14.6 to v1.15.5.',
+    },
+    {
+      component: 'clusterapi',
+      description:
+        'Add cleanuprecordsets resource to cleanup non-managed route53 records.',
+    },
+    {
+      component: 'nodepools',
+      description:
+        'Add Node Pools functionality. See https://docs.giantswarm.io/basics/nodepools/ for details.',
+    },
+    {
+      component: 'kiam',
+      description: 'Add managed kiam app into default app catalog(aws only).',
+    },
+    {
+      component: 'external-dns',
+      description: 'Add managed external-dns app into default app catalog.',
+    },
+    {
+      component: 'cert-manager',
+      description: 'Add managed cert-manager app into default app catalog.',
+    },
+  ],
+  components: [
+    {
+      name: 'app-operator',
+      version: '1.0.0',
+    },
+    {
+      name: 'aws-operator',
+      version: '7.0.0',
+    },
+    {
+      name: 'calico',
+      version: '3.9.1',
+    },
+    {
+      name: 'cert-manager',
+      version: '0.9.0',
+    },
+    {
+      name: 'cert-operator',
+      version: '0.1.0',
+    },
+    {
+      name: 'chart-operator',
+      version: '0.7.0',
+    },
+    {
+      name: 'cluster-autoscaler',
+      version: '1.15.2',
+    },
+    {
+      name: 'cluster-operator',
+      version: '1.0.0',
+    },
+    {
+      name: 'containerlinux',
+      version: '2191.5.0',
+    },
+    {
+      name: 'coredns',
+      version: '1.6.4',
+    },
+    {
+      name: 'docker',
+      version: '18.06.1',
+    },
+    {
+      name: 'etcd',
+      version: '3.3.15',
+    },
+    {
+      name: 'external-dns',
+      version: '0.5.11',
+    },
+    {
+      name: 'kiam',
+      version: '3.4.0',
+    },
+    {
+      name: 'kube-state-metrics',
+      version: '1.8.0',
+    },
+    {
+      name: 'kubernetes',
+      version: '1.15.5',
+    },
+    {
+      name: 'metrics-server',
+      version: '0.4.1',
+    },
+    {
+      name: 'nginx-ingress-controller',
+      version: '0.26.1',
+    },
+    {
+      name: 'node-exporter',
+      version: '0.18.0',
+    },
+    {
+      name: 'vault',
+      version: '0.10.3',
+    },
+  ],
+  timestamp: '2019-10-31T11:00:00Z',
+  version: '11.1.0',
+};
+
+export const nodePoolWithFlatcarRelease = {
+  active: true,
+  changelog: [
+    {
+      component: 'See release notes',
+      description:
+        'https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.3.0.md',
+    },
+  ],
+  components: [
+    {
+      name: 'app-operator',
+      version: '1.0.0',
+    },
+    {
+      name: 'aws-cni',
+      version: '1.6.0',
+    },
+    {
+      name: 'aws-operator',
+      version: '8.5.0',
+    },
+    {
+      name: 'cert-operator',
+      version: '0.1.0',
+    },
+    {
+      name: 'cluster-operator',
+      version: '2.1.10',
+    },
+    {
+      name: 'kubernetes',
+      version: '1.16.9',
+    },
+    {
+      name: 'containerlinux',
+      version: '2345.3.1',
+    },
+    {
+      name: 'calico',
+      version: '3.10.1',
+    },
+    {
+      name: 'etcd',
+      version: '3.3.17',
+    },
+    {
+      name: 'cert-exporter',
+      version: '1.2.1',
+    },
+    {
+      name: 'cert-manager',
+      version: '0.9.0',
+    },
+    {
+      name: 'chart-operator',
+      version: '0.12.4',
+    },
+    {
+      name: 'cluster-autoscaler',
+      version: '1.16.2',
+    },
+    {
+      name: 'coredns',
+      version: '1.6.5',
+    },
+    {
+      name: 'external-dns',
+      version: '0.5.18',
+    },
+    {
+      name: 'kiam',
+      version: '3.5.0',
+    },
+    {
+      name: 'kube-state-metrics',
+      version: '1.9.5',
+    },
+    {
+      name: 'metrics-server',
+      version: '0.3.3',
+    },
+    {
+      name: 'net-exporter',
+      version: '1.7.0',
+    },
+    {
+      name: 'node-exporter',
+      version: '0.18.1',
+    },
+  ],
+  timestamp: '2020-05-11T15:00:00Z',
+  version: '11.3.0',
+};
 // Just thre of them: a false release, a pre node pools release and a node pools release
+// A releases response with four responses:
+// - (A) a disabled one
+// - (B) enabled pre node pools
+// - (C) enabled node pools
+// - (D) enabled with flatcar (containerlinux >= 2345.3.1)
 export const releasesResponse = [
-  {
-    active: false,
-    changelog: [
-      {
-        component: 'cloudformation',
-        description: 'Duplicate etcd record set into public hosted zone.',
-      },
-      {
-        component: 'cloudformation',
-        description:
-          'Add ingress internal load-balancer in private hosted zone.',
-      },
-      {
-        component: 'cloudformation',
-        description:
-          'Use private subnets for internal Kubernetes API loadbalancer.',
-      },
-    ],
-    components: [
-      {
-        name: 'app-operator',
-        version: '1.0.0',
-      },
-      {
-        name: 'aws-operator',
-        version: '5.3.1',
-      },
-      {
-        name: 'calico',
-        version: '3.8.2',
-      },
-      {
-        name: 'cert-operator',
-        version: '0.1.0',
-      },
-      {
-        name: 'chart-operator',
-        version: '0.7.0',
-      },
-      {
-        name: 'cluster-autoscaler',
-        version: '1.14.0',
-      },
-      {
-        name: 'cluster-operator',
-        version: '0.19.0',
-      },
-      {
-        name: 'containerlinux',
-        version: '2135.4.0',
-      },
-      {
-        name: 'coredns',
-        version: '1.6.2',
-      },
-      {
-        name: 'docker',
-        version: '18.06.1',
-      },
-      {
-        name: 'etcd',
-        version: '3.3.13',
-      },
-      {
-        name: 'kube-state-metrics',
-        version: '1.7.2',
-      },
-      {
-        name: 'kubernetes',
-        version: '1.14.6',
-      },
-      {
-        name: 'metrics-server',
-        version: '0.3.1',
-      },
-      {
-        name: 'nginx-ingress-controller',
-        version: '0.25.1',
-      },
-      {
-        name: 'node-exporter',
-        version: '0.18.0',
-      },
-      {
-        name: 'vault',
-        version: '0.10.3',
-      },
-    ],
-    timestamp: '2019-09-24T11:00:00Z',
-    version: '8.4.1',
-  },
-  {
-    active: true,
-    changelog: [
-      {
-        component: 'cloudformation',
-        description:
-          'Use private subnets for internal Kubernetes API loadbalancer.',
-      },
-      {
-        component: 'cloudformation',
-        description:
-          'Add ingress internal load-balancer in private hosted zone.',
-      },
-      {
-        component: 'cloudformation',
-        description: 'Duplicate etcd record set into public hosted zone.',
-      },
-      {
-        component: 'cloudformation',
-        description:
-          'Add public internal-api record set for Kubernetes API private load balancer.',
-      },
-      {
-        component: 'cloudformation',
-        description: 'Add whitelisting for internal Kubernetes API.',
-      },
-      {
-        component: 'cluster-operator',
-        description:
-          'Add internal Kubernetes API domain into API certificate alternative names.',
-      },
-      {
-        component: 'chart-operator',
-        description: 'Install chart-operator from default catalog.',
-      },
-    ],
-    components: [
-      {
-        name: 'app-operator',
-        version: '1.0.0',
-      },
-      {
-        name: 'aws-operator',
-        version: '5.4.0',
-      },
-      {
-        name: 'calico',
-        version: '3.8.2',
-      },
-      {
-        name: 'cert-exporter',
-        version: '1.2.3',
-      },
-      {
-        name: 'net-exporter',
-        version: '2.3.4',
-      },
-      {
-        name: 'cert-operator',
-        version: '0.1.0',
-      },
-      {
-        name: 'chart-operator',
-        version: '0.7.0',
-      },
-      {
-        name: 'cluster-autoscaler',
-        version: '1.14.0',
-      },
-      {
-        name: 'cluster-operator',
-        version: '0.20.0',
-      },
-      {
-        name: 'containerlinux',
-        version: '2135.4.0',
-      },
-      {
-        name: 'coredns',
-        version: '1.6.2',
-      },
-      {
-        name: 'docker',
-        version: '18.06.1',
-      },
-      {
-        name: 'etcd',
-        version: '3.3.13',
-      },
-      {
-        name: 'kube-state-metrics',
-        version: '1.7.2',
-      },
-      {
-        name: 'kubernetes',
-        version: '1.14.6',
-      },
-      {
-        name: 'metrics-server',
-        version: '0.3.1',
-      },
-      {
-        name: 'nginx-ingress-controller',
-        version: '0.25.1',
-      },
-      {
-        name: 'node-exporter',
-        version: '0.18.0',
-      },
-      {
-        name: 'vault',
-        version: '0.10.3',
-      },
-    ],
-    timestamp: '2019-09-02T13:30:00Z',
-    version: '8.5.0',
-  },
-  {
-    active: true,
-    changelog: [
-      {
-        component: 'cloudformation',
-        description: 'Add IAMManager IAM role for kiam managed app.',
-      },
-      {
-        component: 'cloudformation',
-        description:
-          'Add Route53Manager IAM role for external-dns managed app.',
-      },
-      {
-        component: 'kubernetes',
-        description: 'Updated from v1.14.6 to v1.15.5.',
-      },
-      {
-        component: 'clusterapi',
-        description:
-          'Add cleanuprecordsets resource to cleanup non-managed route53 records.',
-      },
-      {
-        component: 'nodepools',
-        description:
-          'Add Node Pools functionality. See https://docs.giantswarm.io/basics/nodepools/ for details.',
-      },
-      {
-        component: 'kiam',
-        description: 'Add managed kiam app into default app catalog(aws only).',
-      },
-      {
-        component: 'external-dns',
-        description: 'Add managed external-dns app into default app catalog.',
-      },
-      {
-        component: 'cert-manager',
-        description: 'Add managed cert-manager app into default app catalog.',
-      },
-    ],
-    components: [
-      {
-        name: 'app-operator',
-        version: '1.0.0',
-      },
-      {
-        name: 'aws-operator',
-        version: '7.0.0',
-      },
-      {
-        name: 'calico',
-        version: '3.9.1',
-      },
-      {
-        name: 'cert-manager',
-        version: '0.9.0',
-      },
-      {
-        name: 'cert-operator',
-        version: '0.1.0',
-      },
-      {
-        name: 'chart-operator',
-        version: '0.7.0',
-      },
-      {
-        name: 'cluster-autoscaler',
-        version: '1.15.2',
-      },
-      {
-        name: 'cluster-operator',
-        version: '1.0.0',
-      },
-      {
-        name: 'containerlinux',
-        version: '2191.5.0',
-      },
-      {
-        name: 'coredns',
-        version: '1.6.4',
-      },
-      {
-        name: 'docker',
-        version: '18.06.1',
-      },
-      {
-        name: 'etcd',
-        version: '3.3.15',
-      },
-      {
-        name: 'external-dns',
-        version: '0.5.11',
-      },
-      {
-        name: 'kiam',
-        version: '3.4.0',
-      },
-      {
-        name: 'kube-state-metrics',
-        version: '1.8.0',
-      },
-      {
-        name: 'kubernetes',
-        version: '1.15.5',
-      },
-      {
-        name: 'metrics-server',
-        version: '0.4.1',
-      },
-      {
-        name: 'nginx-ingress-controller',
-        version: '0.26.1',
-      },
-      {
-        name: 'node-exporter',
-        version: '0.18.0',
-      },
-      {
-        name: 'vault',
-        version: '0.10.3',
-      },
-    ],
-    timestamp: '2019-10-31T11:00:00Z',
-    version: '11.1.0',
-  },
+  // (A)
+  disabledRelease,
+  // (B)
+  preNodePoolRelease,
+  // (C)
+  nodePoolRelease,
+  // (D)
+  nodePoolWithFlatcarRelease,
 ];


### PR DESCRIPTION
this is a follow up to #1448 

The release selection modal now shows `flatcar` for releases containing container linux >= 2345.3.1

also very little test refactoring