### PR TITLE
Use 'RadioInput' instead of the previous implementation

### DIFF
--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -12,10 +12,10 @@ import { connect } from 'react-redux';
 import { TransitionGroup } from 'react-transition-group';
 import { selectErrorByAction } from 'selectors/clusterSelectors';
 import { Constants, Providers } from 'shared/constants';
-import { Input } from 'styles';
 import SlideTransition from 'styles/transitions/SlideTransition';
 import Button from 'UI/Button';
 import ErrorFallback from 'UI/ErrorFallback';
+import RadioInput from 'UI/Inputs/RadioInput';
 import ValidationErrorMessage from 'UI/ValidationErrorMessage';
 
 import AddNodePool from '../ClusterDetail/AddNodePool';
@@ -25,6 +25,10 @@ import {
   AddNodePoolWrapper,
 } from '../ClusterDetail/V5ClusterDetailTable';
 import ReleaseSelector from './ReleaseSelector';
+
+const InputGroup = styled.fieldset`
+  margin-bottom: 4px;
+`;
 
 export const Wrapper = css`
   h1 {
@@ -48,7 +52,8 @@ export const FlexColumnDiv = styled.div`
   flex-direction: column;
   margin: 0 auto;
   max-width: 650px;
-  label {
+
+  label:not(.skip-format) {
     display: flex;
     justify-content: space-between;
     flex-direction: column;
@@ -60,6 +65,7 @@ export const FlexColumnDiv = styled.div`
       line-height: 1.4;
     }
   }
+
   .label-span {
     color: ${(props) => props.theme.colors.white1};
   }
@@ -70,7 +76,19 @@ export const FlexColumnDiv = styled.div`
     margin-bottom: 13px;
     font-weight: 400;
   }
-  ${Input};
+
+  input:not(.skip-format) {
+    box-sizing: border-box;
+    width: 100%;
+    background-color: ${({ theme }) => theme.colors.shade5};
+    padding: 11px 10px 11px 15px;
+    outline: 0;
+    color: ${({ theme }) => theme.colors.whiteInput};
+    border-radius: 4px;
+    border: ${({ theme }) => theme.border};
+    line-height: normal;
+  }
+
   p {
     margin: 0;
     font-size: 14px;
@@ -129,12 +147,6 @@ export const RadioWrapper = (props) => css`
         background-color: ${props.theme.colors.shade2};
       }
     }
-  }
-`;
-
-const RadioWrapperDiv = styled.div`
-  div {
-    ${RadioWrapper};
   }
 `;
 
@@ -387,56 +399,28 @@ class CreateNodePoolsCluster extends Component {
                 <span className='label-span'>
                   Master node availability zones selection
                 </span>
-                <RadioWrapperDiv>
-                  {/* Automatically */}
-                  <div>
-                    <div className='fake-radio'>
-                      <div
-                        className={`fake-radio-checked ${
-                          hasAZLabels === false && 'visible'
-                        }`}
-                      />
-                    </div>
-                    <input
-                      type='radio'
+                <div>
+                  <InputGroup>
+                    <RadioInput
                       id='automatic'
-                      value={false}
-                      checked={hasAZLabels === false}
+                      checked={!hasAZLabels}
+                      label='Automatic'
                       onChange={() => this.toggleMasterAZSelector(false)}
-                      tabIndex='0'
+                      rootProps={{ className: 'skip-format' }}
+                      className='skip-format'
                     />
-                    <label
-                      htmlFor='automatic'
-                      onClick={() => this.toggleMasterAZSelector(false)}
-                    >
-                      Automatic
-                    </label>
-                  </div>
-                  {/* Manual */}
-                  <div>
-                    <div className='fake-radio'>
-                      <div
-                        className={`fake-radio-checked ${
-                          hasAZLabels === true && 'visible'
-                        }`}
-                      />
-                    </div>
-                    <input
-                      type='radio'
+                  </InputGroup>
+                  <InputGroup>
+                    <RadioInput
                       id='manual'
-                      value={true}
-                      checked={hasAZLabels === true}
-                      tabIndex='0'
+                      checked={hasAZLabels}
+                      label='Manual'
                       onChange={() => this.toggleMasterAZSelector(true)}
+                      rootProps={{ className: 'skip-format' }}
+                      className='skip-format'
                     />
-                    <label
-                      htmlFor='manual'
-                      onClick={() => this.toggleMasterAZSelector(true)}
-                    >
-                      Manual
-                    </label>
-                  </div>
-                </RadioWrapperDiv>
+                  </InputGroup>
+                </div>
 
                 <AZWrapperDiv>
                   {hasAZLabels && (

--- a/src/components/UI/Inputs/RadioInput.tsx
+++ b/src/components/UI/Inputs/RadioInput.tsx
@@ -11,6 +11,7 @@ const Label = styled.label`
 const StyledInput = styled.input`
   visibility: hidden;
   opacity: 0;
+  position: absolute;
 `;
 
 const Bullet = styled.span<{ disabled?: boolean }>`
@@ -23,7 +24,7 @@ const Bullet = styled.span<{ disabled?: boolean }>`
   width: 16px;
   height: 16px;
   z-index: 0;
-  margin-right: 8px;
+  margin-right: 12px;
 
   &:after {
     content: '';
@@ -52,6 +53,7 @@ const Bullet = styled.span<{ disabled?: boolean }>`
 
 const LabelText = styled.span<{ disabled?: boolean }>`
   font-weight: 300;
+  font-size: 0.9rem;
   color: ${({ theme, disabled }) => disabled && theme.colors.gray};
 `;
 

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/core';
-import styled, { WithTheme } from '@emotion/styled';
+import styled from '@emotion/styled';
 import { CSSBreakpoints } from 'shared/constants';
 
 import theme from './theme';
@@ -83,21 +83,6 @@ export const FlexRowBase = css`
   display: flex;
   justify-content: space-between;
   align-items: center;
-`;
-
-export const Input = (props: WithTheme<{}, ITheme>) => css`
-  input {
-    box-sizing: border-box;
-    width: 100%;
-    background-color: ${props.theme.colors.shade5};
-    padding: 11px 10px;
-    outline: 0;
-    color: ${props.theme.colors.whiteInput};
-    border-radius: 4px;
-    border: ${props.theme.border};
-    padding-left: 15px;
-    line-height: normal;
-  }
 `;
 
 export const Ellipsis = css`


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10831

Replace the `Master node availability zones selection` radio inputs with the new implementation:
* Further improve the styling of the `RadioInput` component to be the same as it was before

## Preview

![image](https://user-images.githubusercontent.com/13508038/82464212-18472180-9abe-11ea-983b-b16bbb67ef32.png)
