### PR TITLE
Underscore cleanup

### DIFF
--- a/src/actions/invitationActions.js
+++ b/src/actions/invitationActions.js
@@ -1,6 +1,5 @@
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import Passage from 'lib/passageClient';
-import _ from 'underscore';
 
 import * as types from './actionTypes';
 
@@ -30,10 +29,10 @@ export function invitationsLoad() {
       .then((invitesArray) => {
         const invites = {};
 
-        _.each(invitesArray, (invite) => {
+        for (const invite of invitesArray) {
           invite.emaildomain = invite.email.split('@')[1];
           invites[invite.email] = invite;
-        });
+        }
 
         dispatch({
           type: types.INVITATIONS_LOAD_SUCCESS,

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -12,7 +12,6 @@ import { getInstallationInfo } from 'model/services/giantSwarm';
 import { selectAuthToken } from 'selectors/authSelectors';
 import { AuthorizationTypes, StatusCodes } from 'shared/constants';
 import { AppRoutes } from 'shared/constants/routes';
-import _ from 'underscore';
 
 import * as types from './actionTypes';
 
@@ -294,10 +293,10 @@ export function usersLoad() {
       .then((usersArray) => {
         const users = {};
 
-        _.each(usersArray, (user) => {
+        for (const user of usersArray) {
           user.emaildomain = user.email.split('@')[1];
           users[user.email] = user;
-        });
+        }
 
         dispatch({
           type: types.USERS_LOAD_SUCCESS,

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -9,7 +9,7 @@ import { bindActionCreators } from 'redux';
 import Button from 'UI/Button';
 import ComponentChangelog from 'UI/ComponentChangelog';
 import ReleaseComponentLabel from 'UI/ReleaseComponentLabel';
-import _ from 'underscore';
+import { groupBy, sortBy } from 'underscore';
 
 class UpgradeClusterModal extends React.Component {
   state = {
@@ -57,7 +57,7 @@ class UpgradeClusterModal extends React.Component {
 
     const changedComponents = diff.diff(components, targetComponents);
 
-    const changes = _.groupBy(this.props.targetRelease.changelog, (item) => {
+    const changes = groupBy(this.props.targetRelease.changelog, (item) => {
       return item.component;
     });
     const changedComponentNames = Object.keys(changes).sort();
@@ -75,7 +75,7 @@ class UpgradeClusterModal extends React.Component {
           <b>Component Changes</b>
         </p>
         <div className='release-selector-modal--components'>
-          {_.sortBy(changedComponents, 'name').map((diffEdit) => {
+          {sortBy(changedComponents, 'name').map((diffEdit) => {
             if (diffEdit.kind === 'E') {
               const component = components[diffEdit.path[0]];
 

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -20,7 +20,6 @@ import {
 import { OrganizationsRoutes } from 'shared/constants/routes';
 import Button from 'UI/Button';
 import ClusterEmptyState from 'UI/ClusterEmptyState';
-import _ from 'underscore';
 
 import ClusterDashboardItem from './ClusterDashboardItem';
 

--- a/src/components/Modals/ReleaseDetailsModal.js
+++ b/src/components/Modals/ReleaseDetailsModal.js
@@ -6,7 +6,7 @@ import theme from 'styles/theme';
 import Button from 'UI/Button';
 import ComponentChangelog from 'UI/ComponentChangelog';
 import ReleaseComponentLabel from 'UI/ReleaseComponentLabel';
-import _ from 'underscore';
+import { groupBy, sortBy } from 'underscore';
 
 class ReleaseDetailsModal extends React.Component {
   state = {
@@ -39,7 +39,7 @@ class ReleaseDetailsModal extends React.Component {
           <BootstrapModal.Body>
             {this.props.releases.map((release) => {
               // group changes by component
-              const changes = _.groupBy(release.changelog, (item) => {
+              const changes = groupBy(release.changelog, (item) => {
                 return item.component;
               });
 
@@ -78,7 +78,7 @@ class ReleaseDetailsModal extends React.Component {
                   </p>
 
                   <div className='release-selector-modal--components'>
-                    {_.sortBy(release.components, 'name').map((component) => (
+                    {sortBy(release.components, 'name').map((component) => (
                       <ReleaseComponentLabel
                         key={component.name}
                         name={component.name}

--- a/src/components/UI/Navigation/OrganizationDropdown.js
+++ b/src/components/UI/Navigation/OrganizationDropdown.js
@@ -6,7 +6,7 @@ import DropdownButton from 'react-bootstrap/lib/DropdownButton';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
 import { NavLink } from 'react-router-dom';
 import { OrganizationsRoutes } from 'shared/constants/routes';
-import _ from 'underscore';
+import { sortBy } from 'underscore';
 
 const Wrapper = styled.div`
   display: inline;
@@ -170,7 +170,7 @@ class OrganizationDropdown extends React.Component {
             </MenuItem>
             <MenuItem divider />
             <MenuItem header>Switch Organization</MenuItem>
-            {_.sortBy(this.props.organizations.items, 'id').map((org) => {
+            {sortBy(this.props.organizations.items, 'id').map((org) => {
               return (
                 <MenuItem
                   eventKey={org.id}

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -2,7 +2,6 @@ import moment from 'moment';
 import React from 'react';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
-import _ from 'underscore';
 import validate from 'validate.js';
 
 export function dedent(strings, ...values) {
@@ -204,13 +203,9 @@ export function makeKubeConfigTextFile(cluster, keyPairResult, useInternalAPI) {
 // clustersForOrg takes a orgId and a list of clusters and returns just the clusters
 // that are owned by that orgId
 export function clustersForOrg(orgId, allClusters) {
-  let clusters = [];
-
-  clusters = _.filter(allClusters, (cluster) => {
-    return cluster.owner === orgId;
-  });
-
-  return clusters;
+  return allClusters
+    ? Object.values(allClusters).filter((cluster) => cluster.owner === orgId)
+    : [];
 }
 
 // isJwtExpired expired takes a JWT token and will return true if it is expired.


### PR DESCRIPTION
This PR refactors some ocurrences of `underscore` usage in happa. The import name `_` prevented our eslint rules from picking up that it wasn't used in the `Home` component.