### PR TITLE
Render internal catalogs for admins.

### DIFF
--- a/src/components/AppCatalog/AppCatalog.js
+++ b/src/components/AppCatalog/AppCatalog.js
@@ -8,7 +8,7 @@ import { AppCatalogRoutes } from 'shared/constants/routes';
 
 import Detail from './AppDetail/AppDetail';
 import AppList from './AppList/AppList';
-import Catalogs from './CatalogList/CatalogList';
+import CatalogList from './CatalogList/CatalogList';
 
 class AppCatalog extends React.Component {
   catalogLoadIndex = (catalog) => {
@@ -42,7 +42,7 @@ class AppCatalog extends React.Component {
             <Route
               path={AppCatalogRoutes.Home}
               render={() => (
-                <Catalogs
+                <CatalogList
                   {...this.props}
                   catalogLoadIndex={this.catalogLoadIndex}
                 />
@@ -65,6 +65,7 @@ AppCatalog.propTypes = {
 function mapStateToProps(state) {
   return {
     catalogs: state.entities.catalogs,
+    isAdmin: state.main.loggedInUser.isAdmin,
   };
 }
 

--- a/src/components/AppCatalog/AppList/AppListInner.js
+++ b/src/components/AppCatalog/AppList/AppListInner.js
@@ -1,12 +1,20 @@
+import styled from '@emotion/styled';
 import { replace } from 'connected-react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
+import CatalogTypeLabel from 'UI/CatalogTypeLabel';
 import { memoize } from 'underscore';
 
 import AppListItems from './AppListItems';
 import AppListSearch from './AppListSearch';
 
 const SEARCH_URL_PARAM = 'q';
+
+const StyledCatalogTypeLabel = styled(CatalogTypeLabel)`
+  position: relative;
+  top: -4px;
+  margin-left: 10px;
+`;
 
 class AppListInner extends React.Component {
   static filterApps(searchQuery, allApps) {
@@ -114,6 +122,13 @@ class AppListInner extends React.Component {
       <>
         <h1>
           {catalog.spec.title}
+
+          <StyledCatalogTypeLabel
+            catalogType={
+              catalog.metadata.labels['application.giantswarm.io/catalog-type']
+            }
+          />
+
           <AppListSearch
             value={searchQuery}
             onChange={this.updateSearchParams}

--- a/src/components/AppCatalog/CatalogList/CatalogList.js
+++ b/src/components/AppCatalog/CatalogList/CatalogList.js
@@ -4,35 +4,57 @@ import React from 'react';
 
 import CatalogRepo from './CatalogRepo';
 
-const CatalogList = (props) => (
-  <DocumentTitle title='App Catalogs'>
-    <>
-      <h1>App Catalogs</h1>
-      <p>Pick an App Catalog to browse all the Apps in it.</p>
-      {Object.keys(props.catalogs.items).length === 0 ? (
-        <p className='well'>
-          <b>Could not find any appcatalogs:</b>
-          <br />
-          It appears we haven&apos;t configured the <code>appcatalog</code>{' '}
-          resources yet for your installation. Please come back later!
-        </p>
-      ) : (
-        <div className='app-catalog--repos'>
-          {Object.values(props.catalogs.items).map((catalog) => (
-            <CatalogRepo
-              key={catalog.metadata.name}
-              catalog={catalog}
-              catalogLoadIndex={props.catalogLoadIndex}
-            />
-          ))}
-        </div>
-      )}
-    </>
-  </DocumentTitle>
-);
+const CatalogList = (props) => {
+  const catalogs = props.catalogs.items;
+  const isAdmin = props.isAdmin;
+
+  const filterFunc = (catalog) => {
+    if (isAdmin) {
+      return true;
+    }
+
+    const labels = catalog.metadata.labels;
+    const catalogType = labels['application.giantswarm.io/catalog-type'];
+
+    return catalogType !== 'internal';
+  };
+
+  return (
+    <DocumentTitle title='App Catalogs'>
+      <>
+        <h1>App Catalogs</h1>
+        <p>Pick an App Catalog to browse all the Apps in it.</p>
+        {Object.keys(props.catalogs.items).length === 0 ? (
+          <p className='well'>
+            <b>Could not find any appcatalogs:</b>
+            <br />
+            It appears we haven&apos;t configured the <code>
+              appcatalog
+            </code>{' '}
+            resources yet for your installation. Please come back later!
+          </p>
+        ) : (
+          <div className='app-catalog--repos'>
+            {Object.values(catalogs)
+              .filter(filterFunc)
+              .map((catalog) => (
+                <CatalogRepo
+                  key={catalog.metadata.name}
+                  catalog={catalog}
+                  catalogLoadIndex={props.catalogLoadIndex}
+                />
+              ))}
+          </div>
+        )}
+      </>
+    </DocumentTitle>
+  );
+};
 
 CatalogList.propTypes = {
+  isAdmin: PropTypes.bool,
   catalogs: PropTypes.object,
+  adminCatalogs: PropTypes.object,
   catalogLoadIndex: PropTypes.func,
   match: PropTypes.object,
 };

--- a/src/components/UI/CatalogTypeLabel.js
+++ b/src/components/UI/CatalogTypeLabel.js
@@ -27,21 +27,27 @@ const Wrapper = styled.div`
  * CatalogTypeLabel shows some information about a catalog depending on its type.
  */
 const CatalogTypeLabel = (props) => {
+  const { catalogType, className } = props;
   let icon = '';
   let message = '';
 
-  const validCatalogTypes = ['community', 'incubator', 'test'];
+  const validCatalogTypes = ['community', 'incubator', 'test', 'internal'];
 
   // Early return if we're dealing with a unknown catalog type.
-  if (!validCatalogTypes.includes(props.catalogType)) {
+  if (!validCatalogTypes.includes(catalogType)) {
     return null;
   }
 
-  switch (props.catalogType) {
+  switch (catalogType) {
+    case 'internal':
+      icon = 'eye-with-line';
+      message =
+        'Only Giant Swarm admins are able to see these catalogs. They usually contain apps for the control plane.';
+      break;
     case 'community':
       icon = 'warning';
       message =
-        'Apps from this catalog will not work on your cluster without some alterations to the security settings.';
+        'Apps from this catalog will most likely not work on your cluster without some alterations to the security settings.';
       break;
     case 'incubator':
       icon = 'info';
@@ -58,13 +64,13 @@ const CatalogTypeLabel = (props) => {
   }
 
   return (
-    <Wrapper>
+    <Wrapper className={className}>
       <OverlayTrigger
         overlay={<Tooltip id='tooltip'>{message}</Tooltip>}
         placement='top'
       >
         <div>
-          <span>{props.catalogType}</span> <i className={`fa fa-${icon}`} />
+          <span>{catalogType}</span> <i className={`fa fa-${icon}`} />
         </div>
       </OverlayTrigger>
     </Wrapper>
@@ -73,6 +79,7 @@ const CatalogTypeLabel = (props) => {
 
 CatalogTypeLabel.propTypes = {
   catalogType: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default CatalogTypeLabel;

--- a/src/stores/appcatalog/actions.ts
+++ b/src/stores/appcatalog/actions.ts
@@ -10,17 +10,8 @@ export const listCatalogs = createAsynchronousAction<any, any, any>({
     const appsApi = new GiantSwarm.AppsApi();
     const catalogs = await appsApi.getAppCatalogs(); // Use model layer?
 
-    // Filter out 'internal' catalogs and turn it into a hash where the keys
-    // are catalog names.
+    // Turn the array response into a hash where the keys are the catalog names.
     const catalogsHash = Array.from(catalogs).reduce((agg, currCatalog) => {
-      const labels = currCatalog?.metadata?.labels;
-      const catalogType = labels?.['application.giantswarm.io/catalog-type'];
-
-      // Skip if the catalog is internal.
-      if (catalogType === 'internal') {
-        return agg;
-      }
-
       currCatalog.isFetchingIndex = false;
       agg[currCatalog.metadata.name] = currCatalog;
 


### PR DESCRIPTION
Internal catalogs now show up for admins.

Added an icon so it's hopefully clear that this does not show up for customers.

<img width="1138" alt="Screenshot 2020-05-29 at 10 18 35 AM" src="https://user-images.githubusercontent.com/455309/83214493-4cde6b80-a197-11ea-9a08-640990c3f6e0.png">


<img width="1128" alt="Screenshot 2020-05-29 at 10 18 42 AM" src="https://user-images.githubusercontent.com/455309/83214487-49e37b00-a197-11ea-9191-d602795cb305.png">


FYI @sslavic 