### PR TITLE
Add components for displaying master nodes in the cluster detail page

### DIFF
--- a/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodes.tsx
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodes.tsx
@@ -1,0 +1,143 @@
+import styled from '@emotion/styled';
+import MasterNodeConverter from 'Cluster/ClusterDetail/MasterNodes/MasterNodesConverter';
+import MasterNodesInfo from 'Cluster/ClusterDetail/MasterNodes/MasterNodesInfo';
+import PropTypes from 'prop-types';
+import React, { useEffect, useRef, useState } from 'react';
+import { Constants } from 'shared/constants';
+import SlideTransition from 'styles/transitions/SlideTransition';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const TitleWrapper = styled.div`
+  flex: 0 1 203px;
+`;
+
+const InfoWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  flex: 1 0 calc(100% - 203px);
+  min-width: 300px;
+  max-width: 100%;
+`;
+
+interface IMasterNodesProps extends React.ComponentPropsWithoutRef<'div'> {
+  isHA?: boolean;
+  canBeConverted?: boolean;
+  availabilityZones?: string[] | null;
+  supportsReadyNodes?: boolean;
+  numOfReadyNodes?: number | null;
+  numOfMaxHANodes?: number;
+  onConvert?: () => Promise<void>;
+}
+
+const MasterNodes: React.FC<IMasterNodesProps> = ({
+  isHA,
+  canBeConverted,
+  availabilityZones,
+  supportsReadyNodes,
+  numOfReadyNodes,
+  numOfMaxHANodes,
+  onConvert,
+  ...rest
+}) => {
+  const [isConverting, setIsConverting] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // Account for nil slices in the server code.
+  let azs: string[] = availabilityZones || [];
+  if (azs.length > 0) {
+    azs = azs.sort();
+  }
+
+  const maxNumOfNodes: number = isHA ? (numOfMaxHANodes as number) : 1;
+
+  const handleConvertToHA = async () => {
+    setIsLoading(true);
+    try {
+      await onConvert?.();
+      if (isMounted.current) {
+        setIsConverting(false);
+      }
+    } catch {
+      // Skipping because we're handling the error in the action.
+    } finally {
+      if (isMounted.current) {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  return (
+    <Wrapper {...rest}>
+      <TitleWrapper>
+        <span>Master nodes:</span>
+      </TitleWrapper>
+      <InfoWrapper>
+        <SlideTransition
+          in={isConverting}
+          direction='up'
+          timeout={{
+            enter: 200,
+            exit: 0,
+          }}
+        >
+          <MasterNodeConverter
+            onApply={handleConvertToHA}
+            onCancel={() => setIsConverting(false)}
+            isLoading={isLoading}
+          />
+        </SlideTransition>
+        <SlideTransition
+          in={!isConverting}
+          direction='up'
+          timeout={{
+            enter: 200,
+            exit: 0,
+          }}
+        >
+          <MasterNodesInfo
+            canBeConverted={canBeConverted}
+            availabilityZones={azs}
+            supportsReadyNodes={supportsReadyNodes}
+            numOfReadyNodes={numOfReadyNodes}
+            maxNumOfNodes={maxNumOfNodes}
+            onConvert={() => setIsConverting(true)}
+          />
+        </SlideTransition>
+      </InfoWrapper>
+    </Wrapper>
+  );
+};
+
+MasterNodes.propTypes = {
+  isHA: PropTypes.bool,
+  canBeConverted: PropTypes.bool,
+  availabilityZones: PropTypes.arrayOf(PropTypes.string.isRequired),
+  supportsReadyNodes: PropTypes.bool,
+  numOfReadyNodes: PropTypes.number,
+  numOfMaxHANodes: PropTypes.number,
+  onConvert: PropTypes.func,
+};
+
+MasterNodes.defaultProps = {
+  isHA: false,
+  canBeConverted: false,
+  availabilityZones: [],
+  supportsReadyNodes: false,
+  numOfReadyNodes: null,
+  numOfMaxHANodes: Constants.AWS_HA_MASTERS_MAX_NODES,
+};
+
+export default MasterNodes;

--- a/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesConverter.tsx
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesConverter.tsx
@@ -1,0 +1,83 @@
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Button from 'UI/Button';
+
+const Strong = styled.strong`
+  font-weight: 700;
+`;
+
+const ButtonWrapper = styled.div`
+  margin: 16px 0 8px;
+`;
+
+interface IMasterNodeConverterProps
+  extends React.ComponentPropsWithoutRef<'div'> {
+  onApply?: () => void;
+  onCancel?: () => void;
+  isLoading?: boolean;
+}
+
+const MasterNodeConverter: React.FC<IMasterNodeConverterProps> = ({
+  onApply,
+  onCancel,
+  isLoading,
+  ...rest
+}) => {
+  const handleEventListener = (
+    callback?: () => void
+  ): ((e: React.MouseEvent<HTMLButtonElement>) => void) => {
+    return (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // eslint-disable-next-line no-unused-expressions
+      callback?.();
+    };
+  };
+
+  return (
+    <div {...rest}>
+      <p>
+        <Strong>
+          Do you want to convert this cluster to use three master nodes instead
+          of one?
+        </Strong>
+      </p>
+      <p>
+        This will improve the cluster&rsquo;s resilience against data center
+        failures and keep the Kubernetes API available during upgrades, and will
+        also increase the resource cost.
+      </p>
+      <p>
+        <Strong>Note:</Strong> there is no way to undo this switch.
+      </p>
+      <ButtonWrapper>
+        <Button
+          bsStyle='primary'
+          loading={isLoading}
+          loadingTimeout={0}
+          onClick={handleEventListener(onApply)}
+        >
+          Switch to high availability
+        </Button>
+
+        {!isLoading && (
+          <Button onClick={handleEventListener(onCancel)}>Cancel</Button>
+        )}
+      </ButtonWrapper>
+    </div>
+  );
+};
+
+MasterNodeConverter.propTypes = {
+  onApply: PropTypes.func,
+  onCancel: PropTypes.func,
+  isLoading: PropTypes.bool,
+};
+
+MasterNodeConverter.defaultProps = {
+  isLoading: false,
+};
+
+export default MasterNodeConverter;

--- a/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesInfo.tsx
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesInfo.tsx
@@ -1,0 +1,111 @@
+import styled from '@emotion/styled';
+import {
+  getAvailabilityZonesSectionLabel,
+  getReadinessLabel,
+} from 'Cluster/ClusterDetail/MasterNodes/MasterNodesUtils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import AvailabilityZonesLabels from 'UI/AvailabilityZonesLabels';
+import Button from 'UI/Button';
+
+const Group = styled.span`
+  & + & {
+    margin-left: 0.4rem;
+  }
+`;
+
+const AZGroup = styled(Group)`
+  flex-shrink: 0;
+  * + & {
+    margin-left: 0.4rem;
+  }
+`;
+
+const ConvertButton = styled(Button)`
+  padding-top: 4px;
+  padding-bottom: 4px;
+  margin-left: 12px;
+`;
+
+const AZLabel = styled.span`
+  margin-right: 0.8rem;
+`;
+
+interface IMasterNodesInfoProps extends React.ComponentPropsWithoutRef<'div'> {
+  canBeConverted?: boolean;
+  availabilityZones?: string[];
+  numOfReadyNodes?: number | null;
+  supportsReadyNodes?: boolean;
+  maxNumOfNodes?: number;
+  onConvert?: () => void;
+}
+
+const MasterNodesInfo: React.FC<IMasterNodesInfoProps> = ({
+  canBeConverted,
+  availabilityZones,
+  supportsReadyNodes,
+  numOfReadyNodes,
+  maxNumOfNodes,
+  onConvert,
+  ...rest
+}) => {
+  const azLabel = getAvailabilityZonesSectionLabel(
+    availabilityZones as string[]
+  );
+
+  const readinessLabel = getReadinessLabel(
+    numOfReadyNodes as number | null,
+    maxNumOfNodes as number
+  );
+
+  const handleOnConvert = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // eslint-disable-next-line no-unused-expressions
+    onConvert?.();
+  };
+
+  return (
+    <div {...rest}>
+      {supportsReadyNodes && (
+        <>
+          <Group>{readinessLabel}</Group>
+          <Group>&#183;</Group>
+        </>
+      )}
+
+      <AZGroup>
+        <AZLabel>{azLabel}</AZLabel>
+        <AvailabilityZonesLabels zones={availabilityZones} labelsChecked={[]} />
+      </AZGroup>
+
+      {numOfReadyNodes !== null && canBeConverted && (
+        <Group>
+          <ConvertButton onClick={handleOnConvert}>
+            Switch to high availability…
+          </ConvertButton>
+        </Group>
+      )}
+    </div>
+  );
+};
+
+MasterNodesInfo.propTypes = {
+  canBeConverted: PropTypes.bool,
+  availabilityZones: PropTypes.arrayOf(PropTypes.string.isRequired),
+  supportsReadyNodes: PropTypes.bool,
+  numOfReadyNodes: PropTypes.number,
+  maxNumOfNodes: PropTypes.number,
+  onConvert: PropTypes.func,
+};
+
+MasterNodesInfo.defaultProps = {
+  canBeConverted: false,
+  availabilityZones: [],
+  supportsReadyNodes: false,
+  numOfReadyNodes: null,
+  maxNumOfNodes: 0,
+};
+
+export default MasterNodesInfo;

--- a/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesUtils.ts
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesUtils.ts
@@ -1,0 +1,32 @@
+export function getAvailabilityZonesSectionLabel(azs: string[]): string {
+  let label = 'Availability zone';
+
+  if (azs.length > 1) {
+    label += 's';
+  }
+
+  return label;
+}
+
+export function getReadinessLabel(
+  currentNodeCount: number | null,
+  maxNodeCount: number
+): string {
+  if (currentNodeCount === null) {
+    return 'No status info';
+  }
+
+  if (currentNodeCount < maxNodeCount) {
+    if (maxNodeCount === 1) {
+      return 'Not ready';
+    }
+
+    return `${currentNodeCount} of ${maxNodeCount} master nodes ready`;
+  }
+
+  if (maxNodeCount === 1) {
+    return 'Ready';
+  }
+
+  return `All ${maxNodeCount} master nodes ready`;
+}

--- a/src/components/Cluster/ClusterDetail/MasterNodes/__tests__/MasterNodes.ts
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/__tests__/MasterNodes.ts
@@ -1,0 +1,169 @@
+import {
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import MasterNodes from 'Cluster/ClusterDetail/MasterNodes/MasterNodes';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+describe('MasterNodes', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(MasterNodes, {});
+  });
+
+  it('renders the correct information for a non-HA master node', () => {
+    renderWithTheme(MasterNodes, {
+      isHA: false,
+      canBeConverted: true,
+      availabilityZones: ['b'],
+      numOfReadyNodes: 1,
+      numOfMaxHANodes: 1,
+      supportsReadyNodes: true,
+    });
+
+    expect(screen.getByText(/ready/i)).toBeInTheDocument();
+    expect(screen.getByText(/availability zone/i)).toBeInTheDocument();
+    expect(screen.getByText(/^b$/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/switch to high availability…/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the correct information for a HA master node', () => {
+    renderWithTheme(MasterNodes, {
+      isHA: true,
+      availabilityZones: ['b', 'c', 'd'],
+      numOfReadyNodes: 3,
+      numOfMaxHANodes: 3,
+      supportsReadyNodes: true,
+    });
+
+    expect(screen.getByText(/all 3 master nodes ready/i)).toBeInTheDocument();
+    expect(screen.getByText(/availability zones/i)).toBeInTheDocument();
+    expect(screen.getByText(/^b$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^c$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^d$/i)).toBeInTheDocument();
+  });
+
+  it('displays availability zones as n/a if they are null in the input', () => {
+    renderWithTheme(MasterNodes, {
+      isHA: true,
+      availabilityZones: null,
+      numOfReadyNodes: 3,
+      numOfMaxHANodes: 3,
+      supportsReadyNodes: true,
+    });
+
+    expect(screen.getByText(/all 3 master nodes ready/i)).toBeInTheDocument();
+    expect(screen.getByText(/availability zone/i)).toBeInTheDocument();
+    expect(screen.getByText(/^n\/a$/i)).toBeInTheDocument();
+  });
+
+  it('can convert non-ha masters to ha', async () => {
+    const handleConvertToHAMock = jest.fn();
+    handleConvertToHAMock.mockResolvedValueOnce(true);
+
+    renderWithTheme(MasterNodes, {
+      isHA: false,
+      canBeConverted: true,
+      availabilityZones: ['b'],
+      numOfReadyNodes: 1,
+      numOfMaxHANodes: 1,
+      supportsReadyNodes: true,
+      onConvert: handleConvertToHAMock,
+    });
+
+    const switchButton = screen.getByText(/switch to high availability…/i);
+    fireEvent.click(switchButton);
+
+    const converterLabel = await screen.findByText(
+      /Do you want to convert this cluster to use three master nodes instead of one\?/i
+    );
+    expect(converterLabel).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/^switch to high availability$/i));
+    await waitForElementToBeRemoved(() =>
+      screen.getByText(/^switch to high availability$/i)
+    );
+
+    expect(handleConvertToHAMock).toBeCalled();
+  });
+
+  it('can cancel converting to HA', async () => {
+    const handleConvertToHAMock = jest.fn();
+    handleConvertToHAMock.mockResolvedValueOnce(true);
+
+    renderWithTheme(MasterNodes, {
+      isHA: false,
+      canBeConverted: true,
+      availabilityZones: ['b'],
+      numOfReadyNodes: 1,
+      numOfMaxHANodes: 1,
+      supportsReadyNodes: true,
+      onConvert: handleConvertToHAMock,
+    });
+
+    const switchButton = screen.getByText(/switch to high availability…/i);
+    fireEvent.click(switchButton);
+
+    expect(
+      await screen.findByText(
+        /Do you want to convert this cluster to use three master nodes instead of one\?/i
+      )
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/cancel/i));
+    await waitForElementToBeRemoved(() => screen.getByText(/cancel/i));
+
+    expect(handleConvertToHAMock).not.toBeCalled();
+  });
+
+  it(`doesn't display the conversion button if it cannot be converted`, () => {
+    renderWithTheme(MasterNodes, {
+      isHA: false,
+      canBeConverted: false,
+      availabilityZones: ['b'],
+      numOfReadyNodes: 1,
+      numOfMaxHANodes: 1,
+      supportsReadyNodes: true,
+    });
+
+    expect(
+      screen.queryByText(/switch to high availability…/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('sorts availability zones alphabetically in ascending order', () => {
+    const visibleAZs = ['b', 'a', 'v', 'd'];
+
+    renderWithTheme(MasterNodes, {
+      isHA: true,
+      availabilityZones: visibleAZs,
+      numOfReadyNodes: 4,
+      numOfMaxHANodes: 4,
+      supportsReadyNodes: true,
+    });
+
+    const azLabel = screen.getByText(/availability zones/i);
+
+    const azs = [];
+    for (const child of (azLabel.parentElement as HTMLElement).children) {
+      if (Object.is(child, azLabel)) continue;
+
+      azs.push(child.textContent?.toLowerCase());
+    }
+
+    expect(azs).toStrictEqual(visibleAZs);
+  });
+
+  it('hides the master node count if HA masters are not supported', () => {
+    renderWithTheme(MasterNodes, {
+      isHA: false,
+      availabilityZones: ['b'],
+      numOfMaxHANodes: 1,
+      supportsReadyNodes: false,
+    });
+
+    expect(screen.queryByText(/No status info/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Cluster/ClusterDetail/MasterNodes/__tests__/MasterNodesUtils.ts
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/__tests__/MasterNodesUtils.ts
@@ -1,0 +1,60 @@
+import {
+  getAvailabilityZonesSectionLabel,
+  getReadinessLabel,
+} from 'Cluster/ClusterDetail/MasterNodes/MasterNodesUtils';
+
+describe('MasterNodesUtils', () => {
+  describe('getAvailabilityZonesSectionLabel', () => {
+    it('returns the correct value for no AZ', () => {
+      const result = getAvailabilityZonesSectionLabel([]);
+      expect(result).toBe('Availability zone');
+    });
+
+    it('returns the correct value for a single AZ', () => {
+      const result = getAvailabilityZonesSectionLabel(['a']);
+      expect(result).toBe('Availability zone');
+    });
+
+    it('returns the correct value for multiple AZs', () => {
+      const result = getAvailabilityZonesSectionLabel(['a', 'b', 'c']);
+      expect(result).toBe('Availability zones');
+    });
+  });
+
+  describe('getReadinessLabel', () => {
+    it('returns the correct value for a maximum node count of 1 and a current value less than the maximum', () => {
+      const result = getReadinessLabel(0, 1);
+      expect(result).toBe('Not ready');
+    });
+
+    it('returns the correct value for a maximum node count of 1 and a current value equal to the maximum', () => {
+      const result = getReadinessLabel(1, 1);
+      expect(result).toBe('Ready');
+    });
+
+    it('returns the correct value for a maximum node count of 3 and a current value less than the maximum', () => {
+      // eslint-disable-next-line no-magic-numbers
+      let result = getReadinessLabel(0, 3);
+      expect(result).toBe('0 of 3 master nodes ready');
+
+      // eslint-disable-next-line no-magic-numbers
+      result = getReadinessLabel(1, 3);
+      expect(result).toBe('1 of 3 master nodes ready');
+
+      // eslint-disable-next-line no-magic-numbers
+      result = getReadinessLabel(2, 3);
+      expect(result).toBe('2 of 3 master nodes ready');
+    });
+
+    it('returns the correct value for a maximum node count of 3 and a current value equal to the maximum', () => {
+      // eslint-disable-next-line no-magic-numbers
+      const result = getReadinessLabel(3, 3);
+      expect(result).toBe('All 3 master nodes ready');
+    });
+
+    it('returns the correct value for an unknown current node count', () => {
+      const result = getReadinessLabel(null, 1);
+      expect(result).toBe('No status info');
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "downlevelIteration": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",


### PR DESCRIPTION
Part of #1486

## Preview

**Non-HA, with the master node not ready**

![image](https://user-images.githubusercontent.com/13508038/82992278-37ced480-9fff-11ea-8f0b-d2799d0063f6.png)

**Non-HA, switch to HA**

![image](https://user-images.githubusercontent.com/13508038/82991704-5e404000-9ffe-11ea-9972-e1cc2e71f5c8.png)

**Non-HA, switching to HA - loading state**

![image](https://user-images.githubusercontent.com/13508038/82991626-4072db00-9ffe-11ea-9cfd-b4e9fda58552.png)


**Non-HA, switching to HA - error state**

![image](https://user-images.githubusercontent.com/13508038/82992183-1372f800-9fff-11ea-8bc5-b24d5ad6a5ff.png)

**HA, not all master nodes ready**

![image](https://user-images.githubusercontent.com/13508038/82815446-84000480-9e99-11ea-8db1-0ab4afe4ed63.png)

**HA, all master node ready**

![image](https://user-images.githubusercontent.com/13508038/82815483-91b58a00-9e99-11ea-9085-74f70a81393f.png)

**HA, no info on number of master nodes ready**

![image](https://user-images.githubusercontent.com/13508038/82816124-dee62b80-9e9a-11ea-847f-84946e824f02.png)