### PR TITLE
Show '1 node pool' instead of '1 node pools' in cluster overview

### DIFF
--- a/src/components/Home/ClusterDashboardResourcesV5.js
+++ b/src/components/Home/ClusterDashboardResourcesV5.js
@@ -29,7 +29,12 @@ function ClusterDashboardResourcesV5({
     <div data-testid='cluster-resources'>
       {hasNodePools && (
         <RefreshableLabel value={numberOfNodes}>
-          <span>{cluster.nodePools.length} node pools, </span>
+          <span>
+            {cluster.nodePools.length === 1
+              ? '1 node pool'
+              : `${cluster.nodePools.length} node pools`}
+            ,{' '}
+          </span>
         </RefreshableLabel>
       )}
       <RefreshableLabel value={numberOfNodes}>


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/11230

Cluster overview will show '1 node pool' instead of '1 node pools' for single node pool.