### PR TITLE
Delete old label on label key change

### DIFF
--- a/src/@types/clusterLabels.d.ts
+++ b/src/@types/clusterLabels.d.ts
@@ -1,6 +1,7 @@
 interface ILabelChange {
   key: string;
   value: string | null;
+  replaceLabelWithKey?: string;
 }
 
 interface ILabelChangeRequest extends ILabelChange {

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/EditLabelTooltip.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/EditLabelTooltip.tsx
@@ -109,7 +109,14 @@ const EditLabelTooltip: FC<IEditLabelTooltip> = ({
   };
 
   const save = () => {
-    onSave({ key: internalKeyValue, value: internalValueValue });
+    const savePayload: ILabelChange = {
+      key: internalKeyValue,
+      value: internalValueValue,
+    };
+    if (internalKeyValue !== label) {
+      savePayload.replaceLabelWithKey = label;
+    }
+    onSave(savePayload);
     onClose();
   };
 

--- a/src/stores/clusterlabels/actions.ts
+++ b/src/stores/clusterlabels/actions.ts
@@ -16,9 +16,16 @@ export const updateClusterLabels = createAsynchronousAction<
   actionTypePrefix: 'UPDATE_CLUSTER_LABELS',
   perform: async (_, payload) => {
     if (payload) {
+      const labelsPayload = {
+        [payload.key]: payload.value,
+      };
+      if (payload.replaceLabelWithKey) {
+        labelsPayload[payload.replaceLabelWithKey] = null;
+      }
+
       const api = new GiantSwarm.ClusterLabelsApi();
       const resp = await api.setClusterLabels(payload.clusterId, {
-        labels: { [payload.key]: payload.value },
+        labels: labelsPayload,
       });
 
       return {


### PR DESCRIPTION
I've noticed that label key change added a new label but did not clean up the label with the old key.