### PR TITLE
add 'Cancel' button to v4 cluster creation & wire it up

### DIFF
--- a/src/components/Cluster/NewCluster/ClusterCreationDuration.js
+++ b/src/components/Cluster/NewCluster/ClusterCreationDuration.js
@@ -11,7 +11,7 @@ const ClusterCreationDuration = (props) => {
     submitted.`
       : `Clusters usually take between 10 and 30 minutes to come up.`;
 
-  return <p style={{ marginTop: '23px' }}>{message}</p>;
+  return <p>{message}</p>;
 };
 
 ClusterCreationDuration.propTypes = {

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -100,7 +100,7 @@ export const FlexColumnDiv = styled.div`
   }
 `;
 
-const FlexRowDiv = styled.div`
+export const FlexRowDiv = styled.div`
   display: flex;
   margin: 0 auto 23px;
   max-width: 650px;

--- a/src/components/Cluster/NewCluster/CreateRegularCluster.js
+++ b/src/components/Cluster/NewCluster/CreateRegularCluster.js
@@ -19,7 +19,7 @@ import NumberPicker from 'UI/NumberPicker';
 import AWSInstanceTypeSelector from './AWSInstanceTypeSelector';
 import AzureVMSizeSelector from './AzureVMSizeSelector';
 import ClusterCreationDuration from './ClusterCreationDuration';
-import { FlexColumnDiv, Wrapper } from './CreateNodePoolsCluster';
+import { FlexColumnDiv, FlexRowDiv, Wrapper } from './CreateNodePoolsCluster';
 import ProviderCredentials from './ProviderCredentials';
 import ReleaseSelector from './ReleaseSelector';
 import V4AvailabilityZonesSelector from './V4AvailabilityZonesSelector';
@@ -581,7 +581,7 @@ class CreateRegularCluster extends React.Component {
 
             <hr style={{ margin: '37px 0 31px' }} />
 
-            <FlexColumnDiv style={{ marginBottom: '23px' }}>
+            <FlexRowDiv>
               <ErrorFallbackStyled error={noReleasesErrorText} />
               <ErrorFallback error={this.props.clusterCreateError}>
                 <Button
@@ -595,6 +595,19 @@ class CreateRegularCluster extends React.Component {
                   Create Cluster
                 </Button>
               </ErrorFallback>
+              {!this.state.submitting && (
+                <Button
+                  bsSize='large'
+                  bsStyle='default'
+                  loading={this.state.submitting}
+                  onClick={this.props.closeForm}
+                  type='button'
+                >
+                  Cancel
+                </Button>
+              )}
+            </FlexRowDiv>
+            <FlexColumnDiv>
               <ClusterCreationDuration
                 stats={this.props.clusterCreationStats}
               />
@@ -632,6 +645,7 @@ CreateRegularCluster.propTypes = {
   defaultMemorySize: PropTypes.number,
   defaultDiskSize: PropTypes.number,
   match: PropTypes.object,
+  closeForm: PropTypes.func,
   clusterCreationStats: PropTypes.object,
   informParent: PropTypes.func,
   selectableReleases: PropTypes.array,

--- a/src/components/Cluster/NewCluster/NewCluster.js
+++ b/src/components/Cluster/NewCluster/NewCluster.js
@@ -1,4 +1,5 @@
 import { loadReleases } from 'actions/releaseActions';
+import { push } from 'connected-react-router';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
@@ -7,7 +8,7 @@ import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import cmp from 'semver-compare';
 import { Providers } from 'shared/constants';
-import { OrganizationsRoutes } from 'shared/constants/routes';
+import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import LoadingOverlay from 'UI/LoadingOverlay';
 import { computeCapabilities } from 'utils/clusterUtils';
 
@@ -111,6 +112,10 @@ class NewCluster extends React.Component {
       this.props.provider
     );
 
+    const closeForm = () => {
+      this.props.dispatch(push(AppRoutes.Home));
+    };
+
     return (
       <Component
         {...props}
@@ -123,6 +128,7 @@ class NewCluster extends React.Component {
         clusterName={this.state.clusterName}
         updateClusterNameInParent={this.updateClusterName}
         capabilities={capabilities}
+        closeForm={closeForm}
       />
     );
   };


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/11052

This PR adds a 'Cancel' button to the v4 cluster creation page & wires up both the new and the existing one to navigate to the cluster overview.