### PR TITLE
Implement catalog visibility

### DIFF
--- a/__tests__/AppCatalog.js
+++ b/__tests__/AppCatalog.js
@@ -85,7 +85,7 @@ describe('Apps and App Catalog', () => {
           // They should not show up for non-admins.
           if (
             catalog.metadata.labels[
-              'application.giantswarm.io/catalog-type'
+              'application.giantswarm.io/catalog-visibility'
             ] === 'internal'
           ) {
             continue;

--- a/src/components/AppCatalog/AppList/AppListInner.js
+++ b/src/components/AppCatalog/AppList/AppListInner.js
@@ -129,6 +129,14 @@ class AppListInner extends React.Component {
             }
           />
 
+          <StyledCatalogTypeLabel
+            catalogType={
+              catalog.metadata.labels[
+                'application.giantswarm.io/catalog-visibility'
+              ]
+            }
+          />
+
           <AppListSearch
             value={searchQuery}
             onChange={this.updateSearchParams}

--- a/src/components/AppCatalog/AppList/AppListInner.js
+++ b/src/components/AppCatalog/AppList/AppListInner.js
@@ -14,6 +14,7 @@ const StyledCatalogTypeLabel = styled(CatalogTypeLabel)`
   position: relative;
   top: -4px;
   margin-left: 10px;
+  margin-right: 0px;
 `;
 
 class AppListInner extends React.Component {

--- a/src/components/AppCatalog/CatalogList/CatalogList.js
+++ b/src/components/AppCatalog/CatalogList/CatalogList.js
@@ -15,8 +15,10 @@ const CatalogList = (props) => {
 
     const labels = catalog.metadata.labels;
     const catalogType = labels['application.giantswarm.io/catalog-type'];
+    const catalogVisibility =
+      labels['application.giantswarm.io/catalog-visibility'];
 
-    return catalogType !== 'internal';
+    return catalogType !== 'internal' && catalogVisibility !== 'internal';
   };
 
   return (

--- a/src/components/AppCatalog/CatalogList/CatalogRepo.js
+++ b/src/components/AppCatalog/CatalogList/CatalogRepo.js
@@ -74,6 +74,9 @@ const CatalogRepo = ({ catalog, catalogLoadIndex }) => {
         <CatalogTypeLabel
           catalogType={labels['application.giantswarm.io/catalog-type']}
         />
+        <CatalogTypeLabel
+          catalogType={labels['application.giantswarm.io/catalog-visibility']}
+        />
         <ReactMarkdown renderers={markdownRenderers}>
           {description}
         </ReactMarkdown>

--- a/src/components/UI/CatalogTypeLabel.js
+++ b/src/components/UI/CatalogTypeLabel.js
@@ -8,6 +8,7 @@ const Wrapper = styled.div`
   font-size: 12px;
   display: inline-block;
   margin-bottom: 12px;
+  margin-right: 10px;
 
   span {
     background-color: #1e4156;

--- a/testUtils/mockHttpCalls/appCatalogs.js
+++ b/testUtils/mockHttpCalls/appCatalogs.js
@@ -4,7 +4,7 @@ export const appCatalogsResponse = [
       name: 'giantswarm-internal',
       labels: {
         'app-operator.giantswarm.io/version': '1.0.0',
-        'application.giantswarm.io/catalog-type': 'internal',
+        'application.giantswarm.io/catalog-visibility': 'internal',
       },
     },
     spec: {


### PR DESCRIPTION
Catalogs can be type:test, type:stable, and type:community, and until now type:internal

`type:internal` controlled the visibility of catalogs. However, we also have test catalogs that we do not want to be visible. So this implements the new `catalog-visibilty` label, with backwards compatibility.


<img width="1038" alt="Screenshot 2020-05-30 at 12 13 11 AM" src="https://user-images.githubusercontent.com/455309/83281476-b9468280-a20a-11ea-8ab4-bc6f92c83cea.png">

see also: https://gigantic.slack.com/archives/C76JX6YLQ/p1590710379008600