### PR TITLE
Set gs client back to master.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "copy-to-clipboard": "3.3.1",
     "deep-diff": "1.0.2",
     "emotion-theming": "10.0.27",
-    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git#generate-for-aws-ha-masters",
+    "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git",
     "history": "4.10.1",
     "immer": "6.0.9",
     "immutable": "3.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6077,9 +6077,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-"giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git#generate-for-aws-ha-masters":
+"giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git":
   version "4.0.1"
-  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#24de0aa4432eeb96e841f398bb7489eff3198d8e"
+  resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#ae85ec4ff8b4ac0e8dff5644d03d807c86df6a61"
   dependencies:
     superagent "3.8.3"
 


### PR DESCRIPTION
Putting it back now that https://github.com/giantswarm/giantswarm-js-client/pull/113 got merged and the branch is gone. Fixes CI error 

`error Couldn't find match for "24de0aa4432eeb96e841f398bb7489eff3198d8e" `