### PR TITLE
Make add labels button label all caps

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterLabels/EditLabelTooltip.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/EditLabelTooltip.tsx
@@ -53,6 +53,7 @@ const AddLabelButton = styled(Button)`
   padding: 6px 8px;
   font-size: 12px;
   line-height: 12px;
+  text-transform: uppercase;
 `;
 
 const KeyInputLabel = styled.label`


### PR DESCRIPTION
Changing the `Add labels` button label to all caps makes it more in line with other buttons present in happa.