### PR TITLE
Remove escaped html character from reset password error

### DIFF
--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -54,14 +54,11 @@ class ForgotPassword extends React.Component {
             break;
           default: {
             const heading = 'Unable to reset password';
-            let message =
-              'Something went wrong. Our servers might be down, or perhaps you&apos;ve made too many requests in a row. Please try again in 5 minutes.';
+            let message = `Something went wrong. Our servers might be down, or perhaps you've made too many requests in a row. Please try again in 5 minutes.`;
 
-            if (error.message) {
-              if (error.message.includes('Access-Control-Allow-Origin')) {
-                message =
-                  'Please ensure you have installed the required certificates to talk to the API server.';
-              }
+            if (error.message?.includes('Access-Control-Allow-Origin')) {
+              message =
+                'Please ensure you have installed the required certificates to talk to the API server.';
             }
 
             new FlashMessage(


### PR DESCRIPTION
As seen in https://gigantic.slack.com/archives/CQ465CFG8/p1592250996010600