### PR TITLE
Display Get Started button label on cluster list page in all caps

### DIFF
--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -110,6 +110,10 @@ const ButtonsWrapper = styled.div`
   }
 `;
 
+const GetStartedButton = styled(Button)`
+  text-transform: uppercase;
+`;
+
 const DeleteDateWrapper = styled.div`
   color: ${(props) => props.theme.colors.darkBlueLighter5};
 `;
@@ -241,10 +245,10 @@ function ClusterDashboardItem({
       <ButtonsWrapper>
         {clusterYoungerThan30Days() ? (
           <ButtonGroup>
-            <Button onClick={accessCluster}>
+            <GetStartedButton onClick={accessCluster}>
               <i className='fa fa-start' />
               Get Started
-            </Button>
+            </GetStartedButton>
           </ButtonGroup>
         ) : (
           ''


### PR DESCRIPTION
Following #1564 , this PR changes the label of the "Get Started" button to all caps in the cluster list overview.

On the cluster detail page, it is already in all caps.