### PR TITLE
Use errors from the server, if they are available

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -268,8 +268,13 @@ export function clusterLoadDetails(
         error,
       });
 
+      let errorMessage = `Something went wrong while trying to load cluster details for <code>${clusterId}</code>.`;
+      if (error.message) {
+        errorMessage = `There was a problem loading cluster details: ${error.message}`;
+      }
+
       new FlashMessage(
-        `Something went wrong while trying to load cluster details for <code>${clusterId}</code>.`,
+        errorMessage,
         messageType.ERROR,
         messageTTL.LONG,
         'Please try again later or contact support: support@giantswarm.io'
@@ -305,8 +310,14 @@ function clusterLoadStatus(clusterId, { withLoadingFlags }) {
         } else {
           dispatch({ type: types.CLUSTER_LOAD_STATUS_ERROR, error });
 
+          let errorMessage =
+            'Something went wrong while trying to load the cluster status.';
+          if (error.message) {
+            errorMessage = `There was a problem loading cluster status: ${error.message}`;
+          }
+
           new FlashMessage(
-            'Something went wrong while trying to load the cluster status.',
+            errorMessage,
             messageType.ERROR,
             messageTTL.LONG,
             'Please try again later or contact support: support@giantswarm.io'

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -269,8 +269,10 @@ export function clusterLoadDetails(
       });
 
       let errorMessage = `Something went wrong while trying to load cluster details for <code>${clusterId}</code>.`;
-      if (error.message) {
-        errorMessage = `There was a problem loading cluster details: ${error.message}`;
+      if (error.response?.message || error.message) {
+        errorMessage = `There was a problem loading the cluster details: ${
+          error.response?.message ?? error.message
+        }`;
       }
 
       new FlashMessage(
@@ -312,8 +314,10 @@ function clusterLoadStatus(clusterId, { withLoadingFlags }) {
 
           let errorMessage =
             'Something went wrong while trying to load the cluster status.';
-          if (error.message) {
-            errorMessage = `There was a problem loading cluster status: ${error.message}`;
+          if (error.response?.message || error.message) {
+            errorMessage = `There was a problem loading the cluster status: ${
+              error.response?.message ?? error.message
+            }`;
           }
 
           new FlashMessage(

--- a/src/actions/nodePoolActions.js
+++ b/src/actions/nodePoolActions.js
@@ -57,8 +57,10 @@ export function clusterNodePoolsLoad(clusterId, { withLoadingFlags }) {
 
           let errorMessage =
             'Something went wrong while trying to load node pools on this cluster.';
-          if (error.message) {
-            errorMessage = `There was a problem loading node pools: ${error.message}`;
+          if (error.response?.message || error.message) {
+            errorMessage = `There was a problem loading node pools: ${
+              error.response?.message ?? error.message
+            }`;
           }
 
           new FlashMessage(

--- a/src/actions/nodePoolActions.js
+++ b/src/actions/nodePoolActions.js
@@ -55,8 +55,14 @@ export function clusterNodePoolsLoad(clusterId, { withLoadingFlags }) {
             error: error.message,
           });
 
+          let errorMessage =
+            'Something went wrong while trying to load node pools on this cluster.';
+          if (error.message) {
+            errorMessage = `There was a problem loading node pools: ${error.message}`;
+          }
+
           new FlashMessage(
-            'Something went wrong while trying to load node pools on this cluster.',
+            errorMessage,
             messageType.ERROR,
             messageTTL.LONG,
             'Please try again later or contact support: support@giantswarm.io'


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11389

This will include errors from the API, or from the failed request, or fallback to a generic error.

### Preview

![image](https://user-images.githubusercontent.com/13508038/84783751-d8565a00-afe9-11ea-99be-4680cff8888a.png)
