### PR TITLE
Account for having no conditions when cluster is creating

### DIFF
--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -211,6 +211,8 @@ export function hasClusterLatestCondition(cluster, conditionToCheck) {
  * @returns {boolean}
  */
 export function isClusterCreating(cluster) {
+  if (!cluster.conditions || cluster.conditions.length === 0) return true;
+
   const conditionToCheck = 'Creating';
 
   return hasClusterLatestCondition(cluster, conditionToCheck);


### PR DESCRIPTION
Missed this in https://github.com/giantswarm/happa/pull/1568

When cluster is really early in its creation phase, there will not be any `conditions` field to check, and this accounts for that.