### PR TITLE
Faster rebuilds by changing the dev sourcemap generator

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -18,7 +18,7 @@ const ProxyPlugin = require('./scripts/webpack/proxyPlugin');
 
 module.exports = merge(common, {
   mode: 'development',
-  devtool: 'inline-source-map',
+  devtool: 'eval-cheap-module-source-map',
   output: {
     filename: 'assets/[name].[hash].js',
   },


### PR DESCRIPTION
This speeds up dev rebuilds a whole lot, at the cost of a bit less information I think in the console when an error happens. But it still shows the filename and line number, and I think it is generally speaking enough info compared to the other method.

Curious what you guys think, and if you have any opinions about that.

Related docs: https://webpack.js.org/configuration/devtool/