### PR TITLE
Always display the cluster creation date

### DIFF
--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -230,9 +230,6 @@ export function clusterLoadDetails(
         );
       }
 
-      // Remove cluster's create_date because we are loading it in clustersList()
-      delete cluster.create_date;
-
       if (cluster.labels) {
         cluster.labels = filterLabels(cluster.labels);
       }


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C0148R1G12N/p1592337017206400

Since we're overwriting the existing cluster while fetching cluster details, deleting the creation date means we actually won't have any date to show