### PR TITLE
Fix broken nod in cluster overview, when they were actually ready

### DIFF
--- a/src/components/Cluster/ClusterDetail/NodesRunning.js
+++ b/src/components/Cluster/ClusterDetail/NodesRunning.js
@@ -2,16 +2,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FallbackMessages } from 'shared/constants';
 import { Dot, FallbackSpan } from 'styles';
-import { isClusterCreating } from 'utils/clusterUtils';
 
 const NodesRunning = ({
-  cluster,
+  isClusterCreating,
   workerNodesRunning,
   RAM,
   CPUs,
   nodePools,
 }) => {
-  if (workerNodesRunning === 0 && isClusterCreating(cluster)) {
+  if (workerNodesRunning === 0 && isClusterCreating) {
     return (
       <div data-testid='nodes-running'>
         <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
@@ -42,7 +41,7 @@ const NodesRunning = ({
 };
 
 NodesRunning.propTypes = {
-  cluster: PropTypes.object,
+  isClusterCreating: PropTypes.bool,
   workerNodesRunning: PropTypes.number,
   // TODO Change this when cluster_utils functions are refactored
   RAM: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/components/Cluster/ClusterDetail/NodesRunning.js
+++ b/src/components/Cluster/ClusterDetail/NodesRunning.js
@@ -2,18 +2,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FallbackMessages } from 'shared/constants';
 import { Dot, FallbackSpan } from 'styles';
-import { isClusterYoungerThanOneHour } from 'utils/clusterUtils';
+import { isClusterCreating } from 'utils/clusterUtils';
 
 const NodesRunning = ({
+  cluster,
   workerNodesRunning,
-  createDate,
   RAM,
   CPUs,
   nodePools,
 }) => {
-  //  If it was created more than an hour ago, then we should not show this message
-  //  because something went wrong, so it's best to make it noticeable.
-  if (workerNodesRunning === 0 && isClusterYoungerThanOneHour(createDate)) {
+  if (workerNodesRunning === 0 && isClusterCreating(cluster)) {
     return (
       <div data-testid='nodes-running'>
         <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
@@ -44,8 +42,8 @@ const NodesRunning = ({
 };
 
 NodesRunning.propTypes = {
+  cluster: PropTypes.object,
   workerNodesRunning: PropTypes.number,
-  createDate: PropTypes.string,
   // TODO Change this when cluster_utils functions are refactored
   RAM: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   CPUs: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
@@ -154,7 +154,7 @@ class V4ClusterDetailTable extends React.Component {
           Object.keys(this.state.azureVMSizes).length > 0 && (
             <WorkerNodesAzure
               az={cluster.availability_zones}
-              createDate={cluster.create_date}
+              cluster={cluster}
               instanceType={
                 this.state.azureVMSizes[cluster.workers[0].azure.vm_size]
               }
@@ -164,7 +164,7 @@ class V4ClusterDetailTable extends React.Component {
           )}
         {provider === Providers.KVM && (
           <WorkerNodesKVM
-            createDate={cluster.create_date}
+            cluster={cluster}
             worker={cluster.workers[0]}
             nodes={numberOfNodes}
             showScalingModal={this.props.showScalingModal}
@@ -174,7 +174,7 @@ class V4ClusterDetailTable extends React.Component {
           Object.keys(this.state.awsInstanceTypes).length > 0 && (
             <WorkerNodesAWS
               az={cluster.availability_zones}
-              createDate={cluster.create_date}
+              cluster={cluster}
               instanceName={cluster.workers[0].aws.instance_type}
               instanceType={
                 this.state.awsInstanceTypes[

--- a/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
@@ -122,8 +122,8 @@ class V4ClusterDetailTable extends React.Component {
           </div>
           <div>
             <NodesRunning
+              cluster={cluster}
               workerNodesRunning={numberOfNodes}
-              createDate={create_date}
               RAM={memory}
               CPUs={cores}
             />

--- a/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
@@ -7,6 +7,7 @@ import { selectResourcesV4 } from 'selectors/clusterSelectors';
 import { CSSBreakpoints, Providers } from 'shared/constants';
 import { FlexRowWithTwoBlocksOnEdges, mq } from 'styles';
 import Button from 'UI/Button';
+import { isClusterCreating } from 'utils/clusterUtils';
 
 import CredentialInfoRow from './CredentialInfoRow';
 import NodesRunning from './NodesRunning';
@@ -106,6 +107,8 @@ class V4ClusterDetailTable extends React.Component {
     const { create_date, release_version, api_endpoint } = cluster;
     const { numberOfNodes, memory, cores } = resources;
 
+    const isCreating = isClusterCreating(cluster);
+
     return (
       <WrapperDiv>
         <FlexRowWithTwoBlocksOnEdges>
@@ -122,7 +125,7 @@ class V4ClusterDetailTable extends React.Component {
           </div>
           <div>
             <NodesRunning
-              cluster={cluster}
+              isClusterCreating={isClusterCreating(cluster)}
               workerNodesRunning={numberOfNodes}
               RAM={memory}
               CPUs={cores}
@@ -154,7 +157,7 @@ class V4ClusterDetailTable extends React.Component {
           Object.keys(this.state.azureVMSizes).length > 0 && (
             <WorkerNodesAzure
               az={cluster.availability_zones}
-              cluster={cluster}
+              isClusterCreating={isCreating}
               instanceType={
                 this.state.azureVMSizes[cluster.workers[0].azure.vm_size]
               }
@@ -164,7 +167,7 @@ class V4ClusterDetailTable extends React.Component {
           )}
         {provider === Providers.KVM && (
           <WorkerNodesKVM
-            cluster={cluster}
+            isClusterCreating={isCreating}
             worker={cluster.workers[0]}
             nodes={numberOfNodes}
             showScalingModal={this.props.showScalingModal}
@@ -174,7 +177,7 @@ class V4ClusterDetailTable extends React.Component {
           Object.keys(this.state.awsInstanceTypes).length > 0 && (
             <WorkerNodesAWS
               az={cluster.availability_zones}
-              cluster={cluster}
+              isClusterCreating={isCreating}
               instanceName={cluster.workers[0].aws.instance_type}
               instanceType={
                 this.state.awsInstanceTypes[

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -391,7 +391,7 @@ class V5ClusterDetailTable extends React.Component {
           <div>
             <NodesRunning
               workerNodesRunning={numberOfNodes}
-              cluster={cluster}
+              isClusterCreating={isClusterCreating(cluster)}
               RAM={memory}
               CPUs={cores}
               nodePools={nodePools}

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -391,7 +391,7 @@ class V5ClusterDetailTable extends React.Component {
           <div>
             <NodesRunning
               workerNodesRunning={numberOfNodes}
-              createDate={create_date}
+              cluster={cluster}
               RAM={memory}
               CPUs={cores}
               nodePools={nodePools}

--- a/src/components/Cluster/ClusterDetail/WorkerNodesAWS.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesAWS.js
@@ -8,13 +8,13 @@ import theme from 'styles/theme';
 import AvailabilityZonesLabels from 'UI/AvailabilityZonesLabels';
 import Button from 'UI/Button';
 import RefreshableLabel from 'UI/RefreshableLabel';
-import { isClusterYoungerThanOneHour } from 'utils/clusterUtils';
+import { isClusterCreating } from 'utils/clusterUtils';
 
 import { LineDiv, ScalingNodeCounter, WrapperDiv } from './WorkerNodesAzure';
 
 function WorkerNodesAWS({
   az,
-  createDate,
+  cluster,
   instanceName,
   instanceType,
   scaling,
@@ -71,8 +71,7 @@ function WorkerNodesAWS({
           </OverlayTrigger>
         </div>
         <RefreshableLabel value={workerNodesDesired}>
-          {workerNodesDesired === 0 &&
-          isClusterYoungerThanOneHour(createDate) ? (
+          {workerNodesDesired === 0 && isClusterCreating(cluster) ? (
             <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
           ) : (
             workerNodesDesired
@@ -82,8 +81,7 @@ function WorkerNodesAWS({
       <LineDiv data-testid='running-nodes'>
         <div>Current number</div>
         <RefreshableLabel value={workerNodesRunning}>
-          {workerNodesRunning === 0 &&
-          isClusterYoungerThanOneHour(createDate) ? (
+          {workerNodesRunning === 0 && isClusterCreating(cluster) ? (
             <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
           ) : (
             workerNodesRunning
@@ -96,9 +94,9 @@ function WorkerNodesAWS({
 
 WorkerNodesAWS.propTypes = {
   az: PropTypes.array,
+  cluster: PropTypes.object,
   instanceName: PropTypes.string,
   instanceType: PropTypes.object,
-  createDate: PropTypes.string,
   scaling: PropTypes.object,
   showScalingModal: PropTypes.func,
   workerNodesDesired: PropTypes.number,

--- a/src/components/Cluster/ClusterDetail/WorkerNodesAWS.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesAWS.js
@@ -8,13 +8,12 @@ import theme from 'styles/theme';
 import AvailabilityZonesLabels from 'UI/AvailabilityZonesLabels';
 import Button from 'UI/Button';
 import RefreshableLabel from 'UI/RefreshableLabel';
-import { isClusterCreating } from 'utils/clusterUtils';
 
 import { LineDiv, ScalingNodeCounter, WrapperDiv } from './WorkerNodesAzure';
 
 function WorkerNodesAWS({
   az,
-  cluster,
+  isClusterCreating,
   instanceName,
   instanceType,
   scaling,
@@ -71,7 +70,7 @@ function WorkerNodesAWS({
           </OverlayTrigger>
         </div>
         <RefreshableLabel value={workerNodesDesired}>
-          {workerNodesDesired === 0 && isClusterCreating(cluster) ? (
+          {workerNodesDesired === 0 && isClusterCreating ? (
             <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
           ) : (
             workerNodesDesired
@@ -81,7 +80,7 @@ function WorkerNodesAWS({
       <LineDiv data-testid='running-nodes'>
         <div>Current number</div>
         <RefreshableLabel value={workerNodesRunning}>
-          {workerNodesRunning === 0 && isClusterCreating(cluster) ? (
+          {workerNodesRunning === 0 && isClusterCreating ? (
             <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
           ) : (
             workerNodesRunning
@@ -94,7 +93,7 @@ function WorkerNodesAWS({
 
 WorkerNodesAWS.propTypes = {
   az: PropTypes.array,
-  cluster: PropTypes.object,
+  isClusterCreating: PropTypes.bool,
   instanceName: PropTypes.string,
   instanceType: PropTypes.object,
   scaling: PropTypes.object,

--- a/src/components/Cluster/ClusterDetail/WorkerNodesAzure.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesAzure.js
@@ -7,7 +7,6 @@ import theme from 'styles/theme';
 import AvailabilityZonesLabels from 'UI/AvailabilityZonesLabels';
 import Button from 'UI/Button';
 import RefreshableLabel from 'UI/RefreshableLabel';
-import { isClusterCreating } from 'utils/clusterUtils';
 
 export const WrapperDiv = styled.div`
   font-size: 16px;
@@ -31,7 +30,7 @@ export const ScalingNodeCounter = styled(RefreshableLabel)`
 
 function WorkerNodesAzure({
   az,
-  cluster,
+  isClusterCreating,
   instanceType,
   nodes,
   showScalingModal,
@@ -64,7 +63,7 @@ function WorkerNodesAzure({
       <LineDiv>
         <div>Nodes</div>
         <ScalingNodeCounter value={nodeCount}>
-          {nodeCount === 0 && isClusterCreating(cluster) ? (
+          {nodeCount === 0 && isClusterCreating ? (
             <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
           ) : (
             nodeCount
@@ -78,7 +77,7 @@ function WorkerNodesAzure({
 
 WorkerNodesAzure.propTypes = {
   az: PropTypes.array,
-  cluster: PropTypes.object,
+  isClusterCreating: PropTypes.bool,
   instanceType: PropTypes.object,
   nodes: PropTypes.number,
   showScalingModal: PropTypes.func,

--- a/src/components/Cluster/ClusterDetail/WorkerNodesAzure.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesAzure.js
@@ -7,7 +7,7 @@ import theme from 'styles/theme';
 import AvailabilityZonesLabels from 'UI/AvailabilityZonesLabels';
 import Button from 'UI/Button';
 import RefreshableLabel from 'UI/RefreshableLabel';
-import { isClusterYoungerThanOneHour } from 'utils/clusterUtils';
+import { isClusterCreating } from 'utils/clusterUtils';
 
 export const WrapperDiv = styled.div`
   font-size: 16px;
@@ -31,7 +31,7 @@ export const ScalingNodeCounter = styled(RefreshableLabel)`
 
 function WorkerNodesAzure({
   az,
-  createDate,
+  cluster,
   instanceType,
   nodes,
   showScalingModal,
@@ -64,7 +64,7 @@ function WorkerNodesAzure({
       <LineDiv>
         <div>Nodes</div>
         <ScalingNodeCounter value={nodeCount}>
-          {nodeCount === 0 && isClusterYoungerThanOneHour(createDate) ? (
+          {nodeCount === 0 && isClusterCreating(cluster) ? (
             <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
           ) : (
             nodeCount
@@ -78,7 +78,7 @@ function WorkerNodesAzure({
 
 WorkerNodesAzure.propTypes = {
   az: PropTypes.array,
-  createDate: PropTypes.string,
+  cluster: PropTypes.object,
   instanceType: PropTypes.object,
   nodes: PropTypes.number,
   showScalingModal: PropTypes.func,

--- a/src/components/Cluster/ClusterDetail/WorkerNodesKVM.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesKVM.js
@@ -4,11 +4,11 @@ import { FallbackMessages } from 'shared/constants';
 import { FallbackSpan } from 'styles';
 import Button from 'UI/Button';
 import RefreshableLabel from 'UI/RefreshableLabel';
-import { isClusterYoungerThanOneHour } from 'utils/clusterUtils';
+import { isClusterCreating } from 'utils/clusterUtils';
 
 import { LineDiv, ScalingNodeCounter, WrapperDiv } from './WorkerNodesAzure';
 
-function WorkerNodesKVM({ createDate, worker, nodes, showScalingModal }) {
+function WorkerNodesKVM({ cluster, worker, nodes, showScalingModal }) {
   const nodeSpecText = worker
     ? `${worker.cpu.cores} CPUs, ${worker.memory.size_gb} GB RAM`
     : '0 CPUs, 0 GB RAM';
@@ -24,7 +24,7 @@ function WorkerNodesKVM({ createDate, worker, nodes, showScalingModal }) {
       <LineDiv>
         <div>Nodes</div>
         <ScalingNodeCounter value={nodeCount}>
-          {nodeCount === 0 && isClusterYoungerThanOneHour(createDate) ? (
+          {nodeCount === 0 && isClusterCreating(cluster) ? (
             <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
           ) : (
             nodeCount
@@ -37,7 +37,7 @@ function WorkerNodesKVM({ createDate, worker, nodes, showScalingModal }) {
 }
 
 WorkerNodesKVM.propTypes = {
-  createDate: PropTypes.string,
+  cluster: PropTypes.object,
   worker: PropTypes.object,
   nodes: PropTypes.number,
   showScalingModal: PropTypes.func,

--- a/src/components/Cluster/ClusterDetail/WorkerNodesKVM.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesKVM.js
@@ -4,11 +4,15 @@ import { FallbackMessages } from 'shared/constants';
 import { FallbackSpan } from 'styles';
 import Button from 'UI/Button';
 import RefreshableLabel from 'UI/RefreshableLabel';
-import { isClusterCreating } from 'utils/clusterUtils';
 
 import { LineDiv, ScalingNodeCounter, WrapperDiv } from './WorkerNodesAzure';
 
-function WorkerNodesKVM({ cluster, worker, nodes, showScalingModal }) {
+function WorkerNodesKVM({
+  isClusterCreating,
+  worker,
+  nodes,
+  showScalingModal,
+}) {
   const nodeSpecText = worker
     ? `${worker.cpu.cores} CPUs, ${worker.memory.size_gb} GB RAM`
     : '0 CPUs, 0 GB RAM';
@@ -24,7 +28,7 @@ function WorkerNodesKVM({ cluster, worker, nodes, showScalingModal }) {
       <LineDiv>
         <div>Nodes</div>
         <ScalingNodeCounter value={nodeCount}>
-          {nodeCount === 0 && isClusterCreating(cluster) ? (
+          {nodeCount === 0 && isClusterCreating ? (
             <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
           ) : (
             nodeCount
@@ -37,7 +41,7 @@ function WorkerNodesKVM({ cluster, worker, nodes, showScalingModal }) {
 }
 
 WorkerNodesKVM.propTypes = {
-  cluster: PropTypes.object,
+  isClusterCreating: PropTypes.bool,
   worker: PropTypes.object,
   nodes: PropTypes.number,
   showScalingModal: PropTypes.func,

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -22,6 +22,7 @@ import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 import ErrorFallback from 'UI/ErrorFallback';
 import RefreshableLabel from 'UI/RefreshableLabel';
+import { isClusterCreating } from 'utils/clusterUtils';
 
 import ClusterDashboardResourcesV4 from './ClusterDashboardResourcesV4';
 import ClusterDashboardResourcesV5 from './ClusterDashboardResourcesV5';
@@ -144,6 +145,8 @@ function ClusterDashboardItem({
   // If the cluster has been deleted using gsctl, Happa doesn't know yet.
   if (!cluster) return null;
 
+  const isCreating = isClusterCreating(cluster);
+
   /**
    * Returns true if the cluster is younger than 30 days
    */
@@ -234,9 +237,13 @@ function ClusterDashboardItem({
               <ClusterDashboardResourcesV5
                 cluster={cluster}
                 nodePools={nodePools}
+                isClusterCreating={isCreating}
               />
             ) : (
-              <ClusterDashboardResourcesV4 cluster={cluster} />
+              <ClusterDashboardResourcesV4
+                cluster={cluster}
+                isClusterCreating={isCreating}
+              />
             )}
           </ClusterDetailsDiv>
         </ErrorFallback>

--- a/src/components/Home/ClusterDashboardNodes.tsx
+++ b/src/components/Home/ClusterDashboardNodes.tsx
@@ -2,31 +2,32 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FallbackMessages } from 'shared/constants';
 import { FallbackSpan } from 'styles';
-import { isClusterYoungerThanOneHour } from 'utils/clusterUtils';
+import { isClusterCreating } from 'utils/clusterUtils';
 
-interface IClusterDashboardNodes {
+interface IClusterDashboardNodesProps {
   numberOfNodes: number;
-  createDate: string;
+  cluster: Record<string, never>;
 }
 
 // This component outputs 'Nodes not ready' or the actual number of nodes in the cluster.
-function ClusterDashboardNodes({
+const ClusterDashboardNodes: React.FC<IClusterDashboardNodesProps> = ({
   numberOfNodes,
-  createDate,
-}: IClusterDashboardNodes): React.ReactElement {
+  cluster,
+}) => {
   // If it was created more than an hour ago, then we should not show this message
   // because something went wrong, so it's best to make it noticeable.
-  if (numberOfNodes === 0 && isClusterYoungerThanOneHour(createDate))
+  if (numberOfNodes === 0 && isClusterCreating(cluster))
     return <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>;
 
   return (
     <span>{`${numberOfNodes} ${numberOfNodes === 1 ? 'node' : 'nodes'}`}</span>
   );
-}
+};
 
 ClusterDashboardNodes.propTypes = {
-  createDate: PropTypes.string,
-  numberOfNodes: PropTypes.number,
+  numberOfNodes: PropTypes.number.isRequired,
+  // @ts-ignore
+  cluster: PropTypes.object.isRequired,
 };
 
 export default ClusterDashboardNodes;

--- a/src/components/Home/ClusterDashboardNodes.tsx
+++ b/src/components/Home/ClusterDashboardNodes.tsx
@@ -14,8 +14,6 @@ const ClusterDashboardNodes: React.FC<IClusterDashboardNodesProps> = ({
   numberOfNodes,
   cluster,
 }) => {
-  // If it was created more than an hour ago, then we should not show this message
-  // because something went wrong, so it's best to make it noticeable.
   if (numberOfNodes === 0 && isClusterCreating(cluster))
     return <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>;
 

--- a/src/components/Home/ClusterDashboardNodes.tsx
+++ b/src/components/Home/ClusterDashboardNodes.tsx
@@ -2,19 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FallbackMessages } from 'shared/constants';
 import { FallbackSpan } from 'styles';
-import { isClusterCreating } from 'utils/clusterUtils';
 
 interface IClusterDashboardNodesProps {
   numberOfNodes: number;
-  cluster: Record<string, never>;
+  isClusterCreating: boolean;
 }
 
 // This component outputs 'Nodes not ready' or the actual number of nodes in the cluster.
 const ClusterDashboardNodes: React.FC<IClusterDashboardNodesProps> = ({
   numberOfNodes,
-  cluster,
+  isClusterCreating,
 }) => {
-  if (numberOfNodes === 0 && isClusterCreating(cluster))
+  if (numberOfNodes === 0 && isClusterCreating)
     return <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>;
 
   return (
@@ -24,8 +23,7 @@ const ClusterDashboardNodes: React.FC<IClusterDashboardNodesProps> = ({
 
 ClusterDashboardNodes.propTypes = {
   numberOfNodes: PropTypes.number.isRequired,
-  // @ts-ignore
-  cluster: PropTypes.object.isRequired,
+  isClusterCreating: PropTypes.bool.isRequired,
 };
 
 export default ClusterDashboardNodes;

--- a/src/components/Home/ClusterDashboardResourcesV4.js
+++ b/src/components/Home/ClusterDashboardResourcesV4.js
@@ -14,6 +14,7 @@ import ClusterDashboardNodes from './ClusterDashboardNodes';
 
 function ClusterDashboardResourcesV4({
   cluster,
+  isClusterCreating,
   loadingClusters,
   loadingStatus,
   resources,
@@ -30,7 +31,7 @@ function ClusterDashboardResourcesV4({
       <RefreshableLabel value={numberOfNodes}>
         <ClusterDashboardNodes
           numberOfNodes={numberOfNodes}
-          cluster={cluster}
+          isClusterCreating={isClusterCreating}
         />
       </RefreshableLabel>
       {cluster.kvm && (
@@ -47,6 +48,7 @@ function ClusterDashboardResourcesV4({
 
 ClusterDashboardResourcesV4.propTypes = {
   cluster: PropTypes.object,
+  isClusterCreating: PropTypes.bool,
   nodePools: PropTypes.array,
   resources: PropTypes.object,
   loadingClusters: PropTypes.bool,

--- a/src/components/Home/ClusterDashboardResourcesV4.js
+++ b/src/components/Home/ClusterDashboardResourcesV4.js
@@ -21,15 +21,16 @@ function ClusterDashboardResourcesV4({
   const { storage, numberOfNodes } = resources;
   const loading = loadingClusters || loadingStatus;
 
-  if (loading)
+  if (loading) {
     return <ClusterDashboardLoadingPlaceholder isV5Cluster={false} />;
+  }
 
   return (
     <div data-testid='cluster-resources'>
       <RefreshableLabel value={numberOfNodes}>
         <ClusterDashboardNodes
           numberOfNodes={numberOfNodes}
-          createDate={cluster.create_date}
+          cluster={cluster}
         />
       </RefreshableLabel>
       {cluster.kvm && (

--- a/src/components/Home/ClusterDashboardResourcesV5.js
+++ b/src/components/Home/ClusterDashboardResourcesV5.js
@@ -23,7 +23,9 @@ function ClusterDashboardResourcesV5({
   const hasNodePools = numberOfNodes !== 0 && cluster?.nodePools?.length > 0;
   const loading = loadingClusters || loadingStatus || loadingNodePools;
 
-  if (loading) return <ClusterDashboardLoadingPlaceholder isV5Cluster={true} />;
+  if (loading) {
+    return <ClusterDashboardLoadingPlaceholder isV5Cluster={true} />;
+  }
 
   return (
     <div data-testid='cluster-resources'>
@@ -39,8 +41,8 @@ function ClusterDashboardResourcesV5({
       )}
       <RefreshableLabel value={numberOfNodes}>
         <ClusterDashboardNodes
+          cluster={cluster}
           numberOfNodes={numberOfNodes}
-          createDate={cluster.create_date}
         />
       </RefreshableLabel>
       {hasNodePools && (

--- a/src/components/Home/ClusterDashboardResourcesV5.js
+++ b/src/components/Home/ClusterDashboardResourcesV5.js
@@ -14,6 +14,7 @@ import ClusterDashboardNodes from './ClusterDashboardNodes';
 
 function ClusterDashboardResourcesV5({
   cluster,
+  isClusterCreating,
   loadingClusters,
   loadingNodePools,
   loadingStatus,
@@ -41,7 +42,7 @@ function ClusterDashboardResourcesV5({
       )}
       <RefreshableLabel value={numberOfNodes}>
         <ClusterDashboardNodes
-          cluster={cluster}
+          isClusterCreating={isClusterCreating}
           numberOfNodes={numberOfNodes}
         />
       </RefreshableLabel>
@@ -63,6 +64,7 @@ function ClusterDashboardResourcesV5({
 
 ClusterDashboardResourcesV5.propTypes = {
   cluster: PropTypes.object,
+  isClusterCreating: PropTypes.bool,
   isV5Cluster: PropTypes.bool,
   nodePools: PropTypes.array,
   resources: PropTypes.object,

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import cmp from 'semver-compare';
 import { Constants, Providers } from 'shared/constants';
 import FeatureFlags from 'shared/FeatureFlags';
@@ -168,12 +167,6 @@ export function computeCapabilities(releaseVersion, provider) {
     supportsHAMasters,
   };
 }
-
-export const isClusterYoungerThanOneHour = (createDate) => {
-  const creationPlusOneHour = moment(createDate).add(1, 'hour');
-
-  return moment().utc().isBefore(creationPlusOneHour);
-};
 
 export const filterLabels = (labels) => {
   if (!labels) {


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C0148R1G12N/p1592478994263500

This makes use of the actual `Creating` condition in the CR, as opposed to waiting an hour before checking if the nodes are there.