### PR TITLE
Redirect user to homepage after they deleted a cluster

### DIFF
--- a/__tests__/V4AWSClusterManagement.js
+++ b/__tests__/V4AWSClusterManagement.js
@@ -178,8 +178,6 @@ scales correctly`, async () => {
 });
 
 it('deletes a v4 cluster', async () => {
-  getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
-
   const cluster = v4AWSClusterResponse;
   const clusterDeleteResponse = {
     code: 'RESOURCE_DELETION_STARTED',

--- a/__tests__/V5ClusterManagement.js
+++ b/__tests__/V5ClusterManagement.js
@@ -279,8 +279,6 @@ scales node pools correctly`, async () => {
       .intercept(`/v4/clusters/${V5_CLUSTER.id}/`, 'DELETE')
       .reply(StatusCodes.Ok, clusterDeleteResponse);
 
-    getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
-
     const clusterDetailPath = RoutePath.createUsablePath(
       OrganizationsRoutes.Clusters.Detail.Home,
       {

--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -1,7 +1,7 @@
 import { push } from 'connected-react-router';
 import { ErrorReporter } from 'lib/errors';
 import RoutePath from 'lib/routePath';
-import { OrganizationsRoutes } from 'shared/constants/routes';
+import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import { listCatalogs } from 'stores/appcatalog/actions';
 
 import * as appActions from './appActions';
@@ -173,15 +173,8 @@ export const batchedRefreshClusterDetailView = (
 
 export const batchedClusterDeleteConfirmed = (cluster) => async (dispatch) => {
   try {
-    const organizationDetailPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Detail,
-      {
-        orgId: cluster.owner,
-      }
-    );
-
     await dispatch(clusterActions.clusterDeleteConfirmed(cluster));
-    dispatch(push(organizationDetailPath));
+    dispatch(push(AppRoutes.Home));
     dispatch(modalActions.modalHide());
   } catch (err) {
     ErrorReporter.getInstance().notify(err);


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/CQ465CFG8/p1592483898013600

Redirecting users to the homepage after deleting a cluster, instead of redirecting them to the organization details page.