### PR TITLE
Dont fetch all catalog indexes from the catalog listing page

### DIFF
--- a/__tests__/AppCatalog.js
+++ b/__tests__/AppCatalog.js
@@ -48,19 +48,6 @@ describe('Apps and App Catalog', () => {
         );
         getMockCall(`/v4/organizations/${ORGANIZATION}/`, orgResponse);
         getMockCall(`/v4/organizations/${ORGANIZATION}/credentials/`);
-
-        nock('https://catalogshost')
-          .get('/giantswarm-incubator-catalog/index.yaml')
-          .reply(StatusCodes.Ok, catalogIndexResponse);
-        nock('https://catalogshost')
-          .get('/giantswarm-test-catalog/index.yaml')
-          .reply(StatusCodes.Ok, catalogIndexResponse);
-        nock('https://catalogshost')
-          .get('/helmstable/index.yaml')
-          .reply(StatusCodes.Ok, catalogIndexResponse);
-        nock('https://catalogshost')
-          .get('/giantswarm-catalog/index.yaml')
-          .reply(StatusCodes.Ok, catalogIndexResponse);
       });
 
       it('renders all non internal app catalogs in the app catalogs overview for non admins', async () => {
@@ -97,10 +84,6 @@ describe('Apps and App Catalog', () => {
       });
 
       it('renders all app catalogs in the app catalogs overview for admins', async () => {
-        nock('https://catalogshost')
-          .get('/giantswarm-internal-catalog/index.yaml')
-          .reply(StatusCodes.Ok, catalogIndexResponse);
-
         const adminUserInStorage = {
           user:
             '{"email":"developer@giantswarm.io","auth":{"scheme":"giantswarm","token":"a-valid-token"},"isAdmin":true}',

--- a/src/components/AppCatalog/AppCatalog.js
+++ b/src/components/AppCatalog/AppCatalog.js
@@ -41,12 +41,7 @@ class AppCatalog extends React.Component {
             />
             <Route
               path={AppCatalogRoutes.Home}
-              render={() => (
-                <CatalogList
-                  {...this.props}
-                  catalogLoadIndex={this.catalogLoadIndex}
-                />
-              )}
+              render={() => <CatalogList {...this.props} />}
             />
           </Switch>
         </div>

--- a/src/components/AppCatalog/CatalogList/CatalogList.js
+++ b/src/components/AppCatalog/CatalogList/CatalogList.js
@@ -72,11 +72,7 @@ const CatalogList = (props) => {
               .filter(filterFunc)
               .sort(sortFunc)
               .map((catalog) => (
-                <CatalogRepo
-                  key={catalog.metadata.name}
-                  catalog={catalog}
-                  catalogLoadIndex={props.catalogLoadIndex}
-                />
+                <CatalogRepo key={catalog.metadata.name} catalog={catalog} />
               ))}
           </div>
         )}
@@ -89,7 +85,6 @@ CatalogList.propTypes = {
   isAdmin: PropTypes.bool,
   catalogs: PropTypes.object,
   adminCatalogs: PropTypes.object,
-  catalogLoadIndex: PropTypes.func,
   match: PropTypes.object,
 };
 

--- a/src/components/AppCatalog/CatalogList/CatalogRepo.js
+++ b/src/components/AppCatalog/CatalogList/CatalogRepo.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Link } from 'react-router-dom';
 import { AppCatalogRoutes } from 'shared/constants/routes';
@@ -75,13 +75,9 @@ const markdownRenderers = {
   link: CatalogExternalLink,
 };
 
-const CatalogRepo = ({ catalog, catalogLoadIndex }) => {
+const CatalogRepo = ({ catalog }) => {
   const { name, labels } = catalog.metadata;
   const { logoURL, title, description } = catalog.spec;
-
-  useEffect(() => {
-    catalogLoadIndex(catalog);
-  }, [name, catalog, catalogLoadIndex]);
 
   const appCatalogListPath = RoutePath.createUsablePath(
     AppCatalogRoutes.AppList,
@@ -109,7 +105,6 @@ const CatalogRepo = ({ catalog, catalogLoadIndex }) => {
 
 CatalogRepo.propTypes = {
   catalog: PropTypes.object,
-  catalogLoadIndex: PropTypes.func,
 };
 
 export default CatalogRepo;


### PR DESCRIPTION
We did this as a kind of preloading, but I think it is too aggressive, especially now that the list of catalogs can get pretty log when you are logged in as an admin.

This avoid making a ton of requests and hitting github pages too hard.

Downside is opening the helm-stable catalog takes longer the first time. The other catalogs all load fast enough to not need to preload them.

I think that's an acceptable trade off to avoid downloading many megabytes of index.yamls that most users will probably not use.