### PR TITLE
Listen for connections on local interface only.

### DIFF
--- a/scripts/webpack/proxyPlugin.js
+++ b/scripts/webpack/proxyPlugin.js
@@ -114,7 +114,7 @@ class ProxyPlugin {
         .pipe(res);
     });
 
-    proxy.listen(port);
+    proxy.listen(port, 'localhost');
   }
 
   /**


### PR DESCRIPTION
Makes sure we don't expose the proxy to whatever networks your dev machine is a part of.