### PR TITLE
Clear a delayed value if another one comes in before the current one …

### DIFF
--- a/src/lib/effects/useDelayedChange.js
+++ b/src/lib/effects/useDelayedChange.js
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react';
  */
 function useDelayedChange(value, delay) {
   const [delayedValue, setDelayedValue] = useState(value);
+  const [timeoutRef, setTimeoutRef] = useState(undefined);
 
   const isComponentMounted = useRef(true);
   const lastUpdateFinishTime = useRef(Date.now());
@@ -29,11 +30,15 @@ function useDelayedChange(value, delay) {
 
     lastUpdateFinishTime.current = currentTime + delay;
 
-    setTimeout(() => {
+    clearTimeout(timeoutRef);
+
+    const ref = setTimeout(() => {
       if (isComponentMounted.current) {
         setDelayedValue(value);
       }
     }, secondsToNextUpdate);
+
+    setTimeoutRef(ref);
   }, [value, delay]);
 
   return delayedValue;


### PR DESCRIPTION
I noticed that the loading spinner next to the `install ingress controller` button was always spinning.

After a bit of investigating, it looked like the useDelayedChange effect was firing a 'true' value for the loading flag after a `false` value, so somehow out of sequence. 

My hunch is that it was the setTimeout firing in a sequence we didn't expect.

But still weird that they would happen out of sequence, since there should be some nanoseconds between the loading flag going from false, to true, back to false again. But maybe not enough time for it to matter.

This feels like a regression to me after a refactoring @axbarsan , Im not sure what it is though about the refactoring that made this bug appear though.