### PR TITLE
Fix flickery ingress button states

### DIFF
--- a/src/components/Cluster/ClusterDetail/Ingress/InstallIngressButton.tsx
+++ b/src/components/Cluster/ClusterDetail/Ingress/InstallIngressButton.tsx
@@ -46,6 +46,7 @@ const InstallIngressButton: React.FC<IInstallIngressButtonProps> = ({
   ...rest
 }) => {
   const [isInstalling, setIsInstalling] = useState(false);
+  const [isNew, setIsNew] = useState(true);
 
   const isLoadingApps: boolean | null = useSelector((state) =>
     selectLoadingFlagByAction(state, CLUSTER_LOAD_APPS_REQUEST)
@@ -53,8 +54,8 @@ const InstallIngressButton: React.FC<IInstallIngressButtonProps> = ({
   const ingressApp:
     | Record<string, never>
     | undefined = selectIngressAppFromCluster(cluster);
-  const isLoading = isLoadingApps || isInstalling;
 
+  const isLoading = isLoadingApps || isInstalling || isNew;
   const clusterID: string = cluster.id;
 
   const dispatch: ThunkDispatch<IState, undefined, AnyAction> = useDispatch();
@@ -63,7 +64,8 @@ const InstallIngressButton: React.FC<IInstallIngressButtonProps> = ({
     const tryToLoadApps = async () => {
       try {
         await dispatch(loadApps(clusterID));
-      } catch {
+        setIsNew(false);
+      } catch (error) {
         // Do nothing, flash message is shown in action.
       }
     };

--- a/src/components/Cluster/ClusterDetail/Ingress/__tests__/Ingress.ts
+++ b/src/components/Cluster/ClusterDetail/Ingress/__tests__/Ingress.ts
@@ -2,6 +2,7 @@ import { screen, within } from '@testing-library/react';
 import { Providers } from 'shared/constants';
 import {
   appResponseWithCustomConfig,
+  getMockCall,
   v5ClusterResponse,
 } from 'testUtils/mockHttpCalls';
 import { getComponentWithTheme, renderWithStore } from 'testUtils/renderUtils';
@@ -99,6 +100,7 @@ describe('Ingress', () => {
   });
 
   it('displays ingress controller installation instructions, in case no ingress controller is installed', async () => {
+    getMockCall(`/v4/clusters/${v5ClusterResponse.id}/apps/`, []);
     const cluster = { ...v5ClusterResponse, apps: [] };
     renderWithStore(Ingress, { cluster });
 
@@ -107,8 +109,9 @@ describe('Ingress', () => {
         /in order to expose services via Ingress, you must have external-dns and an Ingress controller installed/i
       )
     ).toBeInTheDocument();
+
     expect(
-      screen.getByText(
+      await screen.findByText(
         /this will install the nginx ingress controller app on cluster/i
       )
     ).toBeInTheDocument();

--- a/src/components/Cluster/ClusterDetail/Ingress/__tests__/InstallIngressButton.ts
+++ b/src/components/Cluster/ClusterDetail/Ingress/__tests__/InstallIngressButton.ts
@@ -49,6 +49,8 @@ describe('InstallIngressButton', () => {
   });
 
   it('displays a message if an IC is already installed', async () => {
+    getMockCall(`/v4/clusters/${v4AWSClusterResponse.id}/apps/`, [icApp]);
+
     renderWithStore(InstallIngressButton, {
       cluster: { ...v4AWSClusterResponse, apps: [icApp] },
     });

--- a/src/lib/effects/useDelayedChange.js
+++ b/src/lib/effects/useDelayedChange.js
@@ -9,7 +9,7 @@ function useDelayedChange(value, delay) {
   const [delayedValue, setDelayedValue] = useState(value);
 
   const isComponentMounted = useRef(true);
-  const lastUpdateFinishTime = useRef(Date.now());
+  const lastUpdateRef = useRef(Date.now());
 
   useEffect(() => {
     return () => {
@@ -18,16 +18,22 @@ function useDelayedChange(value, delay) {
   }, []);
 
   useEffect(() => {
-    const currentTime = Date.now();
-    const lastUpdateTime = lastUpdateFinishTime.current;
+    const now = Date.now();
+    const lastUpdate = lastUpdateRef.current;
 
+    // Transition immediately the first time.
     let secondsToNextUpdate = 0;
 
-    if (currentTime - lastUpdateTime < 0) {
-      secondsToNextUpdate = delay + (lastUpdateTime - currentTime);
+    // BUT, if the last update is set to be in the future, i.e. we've already delayed
+    // a value, and we're trying to change the value again before that delay's
+    // timeout has triggered:
+    if (lastUpdate > now) {
+      // Then make sure we create a timeout with an appropriate delay:
+      secondsToNextUpdate = delay + (lastUpdate - now);
     }
 
-    lastUpdateFinishTime.current = currentTime + delay;
+    // Save when the next update should happen:
+    lastUpdateRef.current = now + (secondsToNextUpdate || delay);
 
     setTimeout(() => {
       if (isComponentMounted.current) {


### PR DESCRIPTION
- Fixes `useDelayedChange` when multiple changes come in sooner than the default delay.
- Make the ingress button start off in a loading state so that it doesnt flicker from green to gray to green again.

See this thread for videos: https://gigantic.slack.com/archives/CQ465CFG8/p1593759099004300