### PR TITLE
Remove HA Masters feature flag and use server-side feature flag

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,6 @@ module.exports = {
   },
   testPathIgnorePatterns: ['/node_modules/', 'node_modules_linux'],
   globals: {
-    FEATURE_HA_MASTERS: true,
     // window.config object will now be available in all tests
     config: {
       apiEndpoint: 'http://1.2.3.4',

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,2 +1,5 @@
-// Feature flags.
-declare var FEATURE_HA_MASTERS: boolean;
+/**
+ * Declare feature flags here, with the format:
+ *
+ * declare var FEATURE_SOME_FEATURE: boolean;
+ */

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -17,7 +17,7 @@ const clustersApi = new GiantSwarm.ClustersApi();
 
 // This is a helper function that transforms an array of clusters into an object
 // of clusters with its ids as keys. Also we add some data to the clusters objects.
-function clustersLoadArrayToObject(clusters, provider) {
+function clustersLoadArrayToObject(state, clusters, provider) {
   return clusters
     .map((cluster) => {
       return {
@@ -29,7 +29,10 @@ function clustersLoadArrayToObject(clusters, provider) {
         // Since we only load cluster details for clusters that are in the
         // currently selected org, we also need to computeCapabilities here.
         // The install app modal lists all clusters and needs to know the capabiltiies.
-        capabilities: computeCapabilities(cluster.release_version, provider),
+        capabilities: computeCapabilities(state)(
+          cluster.release_version,
+          provider
+        ),
         labels: filterLabels(cluster.labels),
       };
     })
@@ -53,7 +56,7 @@ export function clustersList({ withLoadingFlags }) {
     return clustersApi
       .getClusters()
       .then((data) => {
-        const clusters = clustersLoadArrayToObject(data, provider);
+        const clusters = clustersLoadArrayToObject(getState())(data, provider);
 
         const allIds = data.map((cluster) => cluster.id);
 
@@ -101,7 +104,11 @@ export function refreshClustersList() {
 
         // If there are new clusters...
         if (addedClusters.length > 0) {
-          clusters = clustersLoadArrayToObject(addedClusters, provider);
+          clusters = clustersLoadArrayToObject(
+            getState(),
+            addedClusters,
+            provider
+          );
 
           v5ClusterIds = addedClusters
             .filter((cluster) => cluster.path.startsWith('/v5'))
@@ -197,7 +204,7 @@ export function clusterLoadDetails(
       if (isV5Cluster && initializeNodePools) cluster.nodePools = [];
 
       const provider = getState().main.info.general.provider;
-      cluster.capabilities = computeCapabilities(
+      cluster.capabilities = computeCapabilities(getState())(
         cluster.release_version,
         provider
       );

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -19,7 +19,6 @@ import {
   selectResourcesV5,
 } from 'selectors/clusterSelectors';
 import { Constants, CSSBreakpoints } from 'shared/constants';
-import FeatureFlags from 'shared/FeatureFlags';
 import { FlexRowWithTwoBlocksOnEdges, mq, Row } from 'styles';
 import BaseTransition from 'styles/transitions/BaseTransition';
 import SlideTransition from 'styles/transitions/SlideTransition';
@@ -396,7 +395,7 @@ class V5ClusterDetailTable extends React.Component {
           </div>
         </FlexRowWithTwoBlocksOnEdges>
 
-        {FeatureFlags.FEATURE_HA_MASTERS && master_nodes && (
+        {master_nodes && (
           <MasterNodesRow
             isHA={master_nodes.high_availability}
             availabilityZones={master_nodes.availability_zones}

--- a/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
+++ b/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
@@ -59,7 +59,7 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = ({
     setClusterName,
   ] = useValidatingInternalValue('Unnamed cluster', clusterNameLengthValidator);
   const [selectedRelease, setSelectedRelease] = useState('');
-  const capabilitiesFactory = useSelector(computeCapabilities);
+  const makeCapabilities = useSelector(computeCapabilities);
 
   const CreationForm = useMemo(() => {
     let semVerCompare = -1;
@@ -75,7 +75,7 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = ({
   }, [provider, firstNodePoolsRelease, selectedRelease]);
 
   const creationCapabilities = useMemo(
-    () => capabilitiesFactory(selectedRelease, provider),
+    () => makeCapabilities(selectedRelease, provider),
     [selectedRelease, provider]
   );
 

--- a/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
+++ b/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
@@ -59,6 +59,7 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = ({
     setClusterName,
   ] = useValidatingInternalValue('Unnamed cluster', clusterNameLengthValidator);
   const [selectedRelease, setSelectedRelease] = useState('');
+  const capabilitiesFactory = useSelector(computeCapabilities);
 
   const CreationForm = useMemo(() => {
     let semVerCompare = -1;
@@ -74,7 +75,7 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = ({
   }, [provider, firstNodePoolsRelease, selectedRelease]);
 
   const creationCapabilities = useMemo(
-    () => computeCapabilities(selectedRelease, provider),
+    () => capabilitiesFactory(selectedRelease, provider),
     [selectedRelease, provider]
   );
 

--- a/src/selectors/featureSelectors.ts
+++ b/src/selectors/featureSelectors.ts
@@ -1,0 +1,21 @@
+import { IState } from 'reducers/types';
+import { getProvider } from 'selectors/mainInfoSelectors';
+import { Constants, Providers } from 'shared/constants';
+
+export function getMinHAMastersVersion(state: IState): string {
+  const provider = getProvider(state);
+  let releaseVersion = '';
+
+  switch (provider) {
+    case Providers.AWS:
+      releaseVersion = Constants.AWS_HA_MASTERS_VERSION;
+      break;
+  }
+
+  if (state.main.info.features?.ha_masters?.release_version_minimum) {
+    releaseVersion =
+      state.main.info.features.ha_masters.release_version_minimum;
+  }
+
+  return releaseVersion;
+}

--- a/src/selectors/mainInfoSelectors.ts
+++ b/src/selectors/mainInfoSelectors.ts
@@ -1,13 +1,8 @@
 import { IState } from 'reducers/types';
 import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
 
-enum Provider {
-  AWS = 'aws',
-  AZURE = 'azure',
-  KVM = 'kvm',
-}
-
-export const getProvider = (state: IState): Provider =>
+export const getProvider = (state: IState): PropertiesOf<typeof Providers> =>
   state.main.info.general.provider;
 
 export const getFirstNodePoolsRelease = (state: IState): string =>

--- a/src/shared/FeatureFlags.ts
+++ b/src/shared/FeatureFlags.ts
@@ -1,10 +1,5 @@
-/* global FEATURE_HA_MASTERS:true */
+interface IFeatureFlags {}
 
-interface IFeatureFlags {
-  FEATURE_HA_MASTERS: boolean;
-}
-const FeatureFlags: IFeatureFlags = {
-  FEATURE_HA_MASTERS,
-};
+const FeatureFlags: IFeatureFlags = {};
 
 export default FeatureFlags;

--- a/src/utils/__tests__/computeCapabilities.js
+++ b/src/utils/__tests__/computeCapabilities.js
@@ -1,44 +1,80 @@
+import preloginState from 'testUtils/preloginState';
+
 import { computeCapabilities } from '../clusterUtils';
+
+/**
+ * @param provider
+ * @returns {IState}
+ */
+function getEmptyStateWithProvider(provider) {
+  return {
+    ...preloginState,
+    main: {
+      ...preloginState.main,
+      info: {
+        ...preloginState.main.info,
+        general: {
+          ...preloginState.main.info.general,
+          provider,
+        },
+      },
+    },
+  };
+}
 
 describe('computeCapabilities', () => {
   describe('hasOptionalIngress', () => {
     describe('on azure', () => {
       it('is false for Azure below 12.0.0', () => {
-        const capabilities = computeCapabilities('11.0.0', 'azure');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('azure')
+        )('11.0.0', 'azure');
         expect(capabilities.hasOptionalIngress).toBe(false);
       });
 
       it('is true for Azure at 12.0.0', () => {
-        const capabilities = computeCapabilities('12.0.0', 'azure');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('azure')
+        )('12.0.0', 'azure');
         expect(capabilities.hasOptionalIngress).toBe(true);
       });
 
       it('is true for Azure above 12.0.0', () => {
-        const capabilities = computeCapabilities('13.0.0', 'azure');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('azure')
+        )('13.0.0', 'azure');
         expect(capabilities.hasOptionalIngress).toBe(true);
       });
     });
 
     describe('on aws', () => {
       it('is false for AWS below 10.1.0', () => {
-        const capabilities = computeCapabilities('9.0.0', 'aws');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('aws')
+        )('9.0.0', 'aws');
         expect(capabilities.hasOptionalIngress).toBe(false);
       });
 
       it('is true for AWS at 10.1.0', () => {
-        const capabilities = computeCapabilities('10.1.0', 'aws');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('aws')
+        )('10.1.0', 'aws');
         expect(capabilities.hasOptionalIngress).toBe(true);
       });
 
       it('is true for AWS above 10.1.0', () => {
-        const capabilities = computeCapabilities('11.1.0', 'aws');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('aws')
+        )('11.1.0', 'aws');
         expect(capabilities.hasOptionalIngress).toBe(true);
       });
     });
 
     describe('on kvm', () => {
       it('is false for KVM at any version', () => {
-        const capabilities = computeCapabilities('8.0.0', 'kvm');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('kvm')
+        )('8.0.0', 'kvm');
         expect(capabilities.hasOptionalIngress).toBe(false);
       });
     });
@@ -47,31 +83,41 @@ describe('computeCapabilities', () => {
   describe('supportsHAMasters', () => {
     describe('on azure', () => {
       it('is false for Azure at any version', () => {
-        const capabilities = computeCapabilities('8.1.0', 'azure');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('azure')
+        )('8.1.0', 'azure');
         expect(capabilities.supportsHAMasters).toBe(false);
       });
     });
 
     describe('on aws', () => {
       it('is false for AWS below 9.0.0', () => {
-        const capabilities = computeCapabilities('9.0.0', 'aws');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('aws')
+        )('9.0.0', 'aws');
         expect(capabilities.supportsHAMasters).toBe(false);
       });
 
       it('is true for AWS at 11.4.0', () => {
-        const capabilities = computeCapabilities('11.4.0', 'aws');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('aws')
+        )('11.4.0', 'aws');
         expect(capabilities.supportsHAMasters).toBe(true);
       });
 
       it('is true for AWS above 13.0.0', () => {
-        const capabilities = computeCapabilities('13.0.0', 'aws');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('aws')
+        )('13.0.0', 'aws');
         expect(capabilities.supportsHAMasters).toBe(true);
       });
     });
 
     describe('on kvm', () => {
       it('is false for KVM at any version', () => {
-        const capabilities = computeCapabilities('8.0.0', 'kvm');
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('kvm')
+        )('8.0.0', 'kvm');
         expect(capabilities.supportsHAMasters).toBe(false);
       });
     });

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -145,17 +145,18 @@ export function getCpusTotalNodePools(nodePools = []) {
  * This function takes a release version and provider and returns a
  * capabilities object with the features that this cluster supports.
  * @param state {IState} - The app's global state.
+ * @returns {function (string, string): {hasOptionalIngress: boolean, supportsHAMasters: boolean}}
  */
 export const computeCapabilities = (state) => (releaseVersion, provider) => {
   let hasOptionalIngress = false;
   let supportsHAMasters = false;
 
-  const minHAMAstersVersion = getMinHAMastersVersion(state);
+  const minHAMastersVersion = getMinHAMastersVersion(state);
 
   switch (provider) {
     case Providers.AWS:
       hasOptionalIngress = cmp(releaseVersion, '10.0.99') === 1;
-      supportsHAMasters = cmp(releaseVersion, minHAMAstersVersion) >= 0;
+      supportsHAMasters = cmp(releaseVersion, minHAMastersVersion) >= 0;
 
       break;
 

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -1,6 +1,6 @@
+import { getMinHAMastersVersion } from 'selectors/featureSelectors';
 import cmp from 'semver-compare';
 import { Constants, Providers } from 'shared/constants';
-import FeatureFlags from 'shared/FeatureFlags';
 
 // Here we can store functions that don't return markup/UI and are used in more
 // than one component.
@@ -144,20 +144,18 @@ export function getCpusTotalNodePools(nodePools = []) {
 /**
  * This function takes a release version and provider and returns a
  * capabilities object with the features that this cluster supports.
- * @param releaseVersion {string} - The cluster's release version.
- * @param provider {"aws"|"azure"|"kvm"} - Possible service providers.
- * @returns {{supportsHAMasters: boolean, hasOptionalIngress: boolean}}
+ * @param state {IState} - The app's global state.
  */
-export function computeCapabilities(releaseVersion, provider) {
+export const computeCapabilities = (state) => (releaseVersion, provider) => {
   let hasOptionalIngress = false;
   let supportsHAMasters = false;
+
+  const minHAMAstersVersion = getMinHAMastersVersion(state);
 
   switch (provider) {
     case Providers.AWS:
       hasOptionalIngress = cmp(releaseVersion, '10.0.99') === 1;
-      supportsHAMasters =
-        FeatureFlags.FEATURE_HA_MASTERS &&
-        cmp(releaseVersion, Constants.AWS_HA_MASTERS_VERSION) >= 0;
+      supportsHAMasters = cmp(releaseVersion, minHAMAstersVersion) >= 0;
 
       break;
 
@@ -171,7 +169,7 @@ export function computeCapabilities(releaseVersion, provider) {
     hasOptionalIngress,
     supportsHAMasters,
   };
-}
+};
 
 export const filterLabels = (labels) => {
   if (!labels) {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -71,9 +71,7 @@ const makeEndpoints = () => {
 };
 
 const makeFeatureFlags = () => {
-  const defaults = {
-    FEATURE_HA_MASTERS: true,
-  };
+  const defaults = {};
 
   const dirtyFlags = Object.assign({}, defaults, envFileVars, process.env);
 


### PR DESCRIPTION
This PR:

* Removes the HA Masters feature flag
* Uses the minimum version coming from the server for computing the `supports HA Masters` capability, instead of a hard-coded one.