### PR TITLE
Remove jq from dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.16-alpine
 
-RUN apk --no-cache add jq findutils gzip && \
+RUN apk --no-cache add findutils gzip && \
   rm -r /etc/nginx/conf.d && \
   mkdir -p /etc/nginx/config
 


### PR DESCRIPTION
Noticed there was a CVE out for `jq` added in our production Dockerfile.

I don't think we use `jq` at all.. removing it to see what happens.

<img width="1109" alt="Screenshot 2020-07-14 at 4 14 29 PM" src="https://user-images.githubusercontent.com/455309/87401969-750e1680-c5ed-11ea-8360-35043d6698b8.png">
