### PR TITLE
remove bootstrap from existing dropdowns

### DIFF
--- a/src/components/Cluster/ClusterDetail/NodePoolDropdownMenu.js
+++ b/src/components/Cluster/ClusterDetail/NodePoolDropdownMenu.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import DropdownMenu from 'UI/DropdownMenu';
+import DropdownMenu, { DropdownTrigger, Link, List } from 'UI/DropdownMenu';
 
 const NodePoolDropdownMenu = (props) => {
   return (
@@ -13,20 +13,19 @@ const NodePoolDropdownMenu = (props) => {
         onKeyDownHandler,
       }) => (
         <div onBlur={onBlurHandler} onFocus={onFocusHandler}>
-          <button
+          <DropdownTrigger
             aria-expanded={isOpen}
             aria-haspopup='true'
-            className='dropdown-trigger'
             onClick={onClickHandler}
             onKeyDown={onKeyDownHandler}
             type='button'
           >
             •••
-          </button>
+          </DropdownTrigger>
           {isOpen && (
-            <ul aria-labelledby='node_pools_dropdown' role='menu'>
+            <List aria-labelledby='node_pools_dropdown' role='menu'>
               <li>
-                <a
+                <Link
                   href='#'
                   onClick={(e) => {
                     e.preventDefault();
@@ -34,10 +33,10 @@ const NodePoolDropdownMenu = (props) => {
                   }}
                 >
                   Rename
-                </a>
+                </Link>
               </li>
               <li>
-                <a
+                <Link
                   href='#'
                   onClick={(e) => {
                     e.preventDefault();
@@ -45,10 +44,10 @@ const NodePoolDropdownMenu = (props) => {
                   }}
                 >
                   Edit scaling limits
-                </a>
+                </Link>
               </li>
               <li>
-                <a
+                <Link
                   href='#'
                   onClick={(e) => {
                     e.preventDefault();
@@ -56,9 +55,9 @@ const NodePoolDropdownMenu = (props) => {
                   }}
                 >
                   Delete
-                </a>
+                </Link>
               </li>
-            </ul>
+            </List>
           )}
         </div>
       )}

--- a/src/components/UI/DropdownMenu.js
+++ b/src/components/UI/DropdownMenu.js
@@ -12,52 +12,54 @@ import React, { useState } from 'react';
  * component where it is being used
  */
 
+export const List = styled.ul`
+  position: absolute;
+  right: 7px;
+  list-style-type: none;
+  margin: 2px 0 0;
+  padding: 5px 0;
+  width: 180px;
+  background: ${(props) => props.theme.colors.shade2};
+  z-index: 1;
+  background-color: ${({ theme }) => theme.colors.dropdownBackground};
+  border: none;
+  border-radius: 5px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+`;
+
+export const Link = styled.a`
+  display: inline-block;
+  text-decoration: none;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 400;
+  padding: 7px 15px;
+  width: 100%;
+  &:hover {
+    background: ${(props) => props.theme.colors.shade9};
+  }
+`;
+
+export const DropdownTrigger = styled.button`
+  width: 40px;
+  height: 40px;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  background: unset;
+  transition: background 0.3s;
+  &:focus {
+    outline: 5px auto -webkit-focus-ring-color;
+  }
+  &:hover,
+  &:focus,
+  &:focus-within {
+    background: ${(props) => props.theme.colors.shade8};
+  }
+`;
+
 const MenuWrapper = styled.div`
   position: relative;
-  .dropdown-trigger {
-    width: 40px;
-    height: 40px;
-    /* Overrides for bootstrap */
-    margin: 0;
-    border-radius: 0;
-    padding: 0;
-    background: unset;
-    transition: background 0.3s;
-    &:focus {
-      outline: 5px auto -webkit-focus-ring-color;
-    }
-    &:hover,
-    &:focus,
-    &:focus-within {
-      background: ${(props) => props.theme.colors.shade8};
-    }
-  }
-  ul {
-    position: absolute;
-    right: 7px;
-    list-style-type: none;
-    margin: 2px 0 0;
-    padding: 5px 0;
-    width: 180px;
-    background: ${(props) => props.theme.colors.shade2};
-    z-index: 1;
-    background-color: #2a5874;
-    border: none;
-    border-radius: 5px;
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
-  }
-  a {
-    display: inline-block;
-    text-decoration: none;
-    color: #fff;
-    font-size: 14px;
-    font-weight: 400;
-    padding: 7px 15px;
-    width: 100%;
-    &:hover {
-      background: ${(props) => props.theme.colors.shade9};
-    }
-  }
 `;
 
 function DropdownMenu(props) {

--- a/src/components/UI/Navigation/Hamburger.js
+++ b/src/components/UI/Navigation/Hamburger.js
@@ -1,44 +1,38 @@
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { DropdownTrigger } from 'UI/DropdownMenu';
 
-const HamburgerDiv = styled.div`
-  height: 100%;
+const Bar = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  background: ${(props) => props.theme.colors.white3};
+  height: 2px;
+  margin: 2px 0;
+  border-radius: 3px;
+  transition: width 0.3s, transform 0.3s, opacity 0.3s;
+  will-change: transform;
+`;
+
+const HamburgerDiv = styled(DropdownTrigger)`
+  padding: 10px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   cursor: pointer;
 
-  div {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    height: 100%;
-  }
-
-  /* Hamburger bars */
-  .first,
-  .second,
-  .third {
-    background: ${(props) => props.theme.colors.white3};
-    height: 2px;
-    margin: 2px 0;
-    border-radius: 3px;
-    transition: all 0.3s;
-  }
-
   &.open {
-    .first,
-    .third {
+    ${Bar}:nth-of-type(1), ${Bar}:nth-of-type(3) {
       width: 17.5px;
     }
-    .first {
+    ${Bar}:nth-of-type(1) {
       transform: rotate(35deg) translate(4.2px, 5.5px);
     }
-    .second {
+    ${Bar}:nth-of-type(2) {
       opacity: 0;
     }
-    .third {
+    ${Bar}:nth-of-type(3) {
       transform: rotate(-35deg) translate(3.2px, -4px);
     }
   }
@@ -53,16 +47,14 @@ function Hamburger({ onClickHandler, onKeyDownHandler, isOpen }) {
     <HamburgerDiv
       aria-expanded={isOpen}
       aria-haspopup='true'
-      className={isOpen ? 'open dropdown-trigger' : 'dropdown-trigger'}
+      className={isOpen ? 'open' : ''}
       onClick={onClick}
       onKeyDown={onKeyDownHandler}
       type='button'
     >
-      <>
-        <div className='first' />
-        <div className='second' />
-        <div className='third' />
-      </>
+      <Bar />
+      <Bar />
+      <Bar />
     </HamburgerDiv>
   );
 }

--- a/src/components/UI/Navigation/MainMenu.js
+++ b/src/components/UI/Navigation/MainMenu.js
@@ -10,28 +10,28 @@ import {
   UsersRoutes,
 } from 'shared/constants/routes';
 import { mq } from 'styles';
-import DropdownMenu from 'UI/DropdownMenu';
+import DropdownMenu, { List } from 'UI/DropdownMenu';
 
 import Hamburger from './Hamburger';
+
+const StyledNavLink = styled(NavLink)`
+  text-decoration: none;
+  color: ${(props) => props.theme.colors.white4};
+  margin-right: 18px;
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  &:hover {
+    color: ${(props) => props.theme.colors.white1};
+  }
+`;
 
 const NavDiv = styled.div`
   float: left;
   padding-left: 20px;
   height: 40px;
-
-  & > a {
-    text-decoration: none;
-    color: ${(props) => props.theme.colors.white4};
-    margin-right: 18px;
-
-    &:last-child {
-      margin-right: 0;
-    }
-
-    &:hover {
-      color: ${(props) => props.theme.colors.white1};
-    }
-  }
 
   ${mq(CSSBreakpoints.Medium)} {
     display: none;
@@ -40,23 +40,11 @@ const NavDiv = styled.div`
 
 const DropdownMenuStyled = styled(DropdownMenu)`
   display: none;
-  left: reset;
+  left: unset;
   flex-direction: column;
   transform: translate(30px, 5px);
   position: fixed;
   width: 38px;
-
-  .dropdown-trigger {
-    width: 100%;
-    height: 100%;
-    padding: 10px;
-  }
-
-  ul {
-    right: unset;
-    line-height: 1.45em;
-    margin: 7px 0 0 -1px;
-  }
 
   .active {
     font-weight: 700;
@@ -65,39 +53,44 @@ const DropdownMenuStyled = styled(DropdownMenu)`
   ${mq(CSSBreakpoints.Medium)} {
     display: flex;
   }
-
-  ${mq(CSSBreakpoints.Medium)} {
-    ul {
-      width: calc(100vw - 8px);
-      left: -35px;
-    }
-
-    a {
-      font-size: 16px;
-      padding: 20px 30px;
-    }
-  }
 `;
+
+const DropdownList = styled(List)`
+  right: unset;
+  left: -35px;
+  line-height: 1.45em;
+  margin: 7px 0 0 -1px;
+  width: calc(100vw - 8px);
+`;
+
+const DropdownNavLink = styled(StyledNavLink)`
+  display: block;
+  font-size: 16px;
+  font-weight: 400;
+  padding: 20px 30px;
+`;
+
+const DropdownAnchor = DropdownNavLink.withComponent('a');
 
 function MainMenu({ showAppCatalog, isUserAdmin }) {
   return (
     <>
       <NavDiv>
-        <NavLink activeClassName='active' exact to={AppRoutes.Home}>
+        <StyledNavLink activeClassName='active' exact to={AppRoutes.Home}>
           Clusters
-        </NavLink>
-        <NavLink activeClassName='active' to={OrganizationsRoutes.Home}>
+        </StyledNavLink>
+        <StyledNavLink activeClassName='active' to={OrganizationsRoutes.Home}>
           Organizations
-        </NavLink>
+        </StyledNavLink>
         {showAppCatalog && (
-          <NavLink activeClassName='active' to={AppCatalogRoutes.Home}>
+          <StyledNavLink activeClassName='active' to={AppCatalogRoutes.Home}>
             App Catalogs
-          </NavLink>
+          </StyledNavLink>
         )}
         {isUserAdmin ? (
-          <NavLink activeClassName='active' to={UsersRoutes.Home}>
+          <StyledNavLink activeClassName='active' to={UsersRoutes.Home}>
             Users
-          </NavLink>
+          </StyledNavLink>
         ) : undefined}
         <a
           href='https://docs.giantswarm.io'
@@ -116,71 +109,66 @@ function MainMenu({ showAppCatalog, isUserAdmin }) {
           onBlurHandler,
           onKeyDownHandler,
         }) => (
-          <div
-            className='mobile-nav-div'
-            onBlur={onBlurHandler}
-            onFocus={onFocusHandler}
-            tabIndex='0'
-          >
+          <div onBlur={onBlurHandler} onFocus={onFocusHandler} tabIndex='0'>
             <Hamburger
               isOpen={isOpen}
               onClickHandler={onClickHandler}
               onKeyDownHandler={onKeyDownHandler}
             />
             {isOpen && (
-              <ul role='menu'>
+              <DropdownList role='menu'>
                 <li>
-                  <NavLink
+                  <DropdownNavLink
                     activeClassName='active'
                     exact
                     to={AppRoutes.Home}
                     onClick={onClickHandler}
                   >
                     Clusters
-                  </NavLink>
+                  </DropdownNavLink>
                 </li>
                 <li>
-                  <NavLink
+                  <DropdownNavLink
                     activeClassName='active'
                     to={OrganizationsRoutes.Home}
                     onClick={onClickHandler} // This closes the dropdown.
                   >
                     Organizations
-                  </NavLink>
+                  </DropdownNavLink>
                 </li>
                 {showAppCatalog && (
                   <li>
-                    <NavLink
+                    <DropdownNavLink
                       activeClassName='active'
                       to={AppCatalogRoutes.Home}
                       onClick={onClickHandler}
                     >
                       App Catalogs
-                    </NavLink>
+                    </DropdownNavLink>
                   </li>
                 )}
                 {isUserAdmin ? (
                   <li>
-                    <NavLink
+                    <DropdownNavLink
                       activeClassName='active'
                       to={UsersRoutes.Home}
                       onClick={onClickHandler}
                     >
                       Users
-                    </NavLink>
+                    </DropdownNavLink>
                   </li>
                 ) : undefined}
                 <li>
-                  <a
+                  <DropdownAnchor
                     href='https://docs.giantswarm.io'
                     rel='noopener noreferrer'
                     target='_blank'
                     onClick={onClickHandler}
                   >
                     Documentation <i className='fa fa-open-in-new' />
-                  </a>
+                  </DropdownAnchor>
                 </li>
-              </ul>
+              </DropdownList>
             )}
           </div>
         )}

--- a/src/components/UI/VersionPicker/VersionPicker.tsx
+++ b/src/components/UI/VersionPicker/VersionPicker.tsx
@@ -1,28 +1,28 @@
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import DropdownMenu from 'UI/DropdownMenu';
+import DropdownMenu, { DropdownTrigger, Link, List } from 'UI/DropdownMenu';
 
 const INNER_PADDING = '5px 15px';
 const WIDTH = '250px';
 const MAX_HEIGHT = '250px';
 
-const Wrapper = styled.div`
-  div > .dropdown-trigger {
-    background-color: ${(props) => props.theme.colors.shade5};
-    border: 1px solid ${(props) => props.theme.colors.shade6};
-    border-radius: ${(props) => props.theme.border_radius};
-    font-size: 14px;
-    line-height: normal;
-    padding: 8px 10px;
-    width: auto;
-    height: 34px;
+const VersionPickerDropdownTrigger = styled(DropdownTrigger)`
+  background-color: ${(props) => props.theme.colors.shade5};
+  border: 1px solid ${(props) => props.theme.colors.shade6};
+  border-radius: ${(props) => props.theme.border_radius};
+  font-size: 14px;
+  line-height: normal;
+  padding: 8px 10px;
+  width: auto;
+  height: 34px;
 
-    .caret {
-      margin-left: 10px;
-    }
+  .caret {
+    margin-left: 10px;
   }
 `;
+
+const Wrapper = styled.div``;
 
 const Menu = styled.form`
   width: ${WIDTH};
@@ -30,7 +30,7 @@ const Menu = styled.form`
   background-color: ${(props) => props.theme.colors.shade4};
   overflow: hidden;
   font-size: 14px;
-  box-shadow: 0px 0px 10px 5px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.2);
   position: absolute;
   top: 45px;
 `;
@@ -47,12 +47,12 @@ const Header = styled.div`
   label {
     border-top: 1px solid ${(props) => props.theme.colors.shade2};
 
-    padding: 0px;
+    padding: 0;
     cursor: pointer;
     font-weight: normal;
 
     &::selection {
-      color: none;
+      color: unset;
       background: none;
     }
 
@@ -65,7 +65,7 @@ const Header = styled.div`
 
     a {
       display: inline;
-      padding: 0px;
+      padding: 0;
 
       &:hover {
         background-color: inherit;
@@ -77,26 +77,25 @@ const Header = styled.div`
 const Body = styled.div`
   max-height: ${MAX_HEIGHT};
   overflow-y: scroll;
+`;
 
-  ul {
-    padding: 0px;
-    width: 100%;
-    position: relative;
-    right: 0px;
-  }
+const VersionPickerList = styled(List)`
+  padding: 0;
+  width: 100%;
+  position: relative;
+  right: 0;
+`;
 
-  li {
-    list-style-type: none;
-    border-bottom: 1px solid ${(props) => props.theme.colors.shade1};
-    cursor: pointer;
+const VersionPickerItem = styled.li`
+  list-style-type: none;
+  border-bottom: 1px solid ${(props) => props.theme.colors.shade1};
+  cursor: pointer;
+`;
 
-    a.selected {
-      font-weight: bold;
-    }
-
-    a {
-      padding: 10px 15px;
-    }
+const VersionPickerLink = styled(Link)`
+  padding: 10px 15px;
+  &.selected {
+    font-weight: bold;
   }
 `;
 
@@ -162,8 +161,7 @@ const VersionPicker: React.FC<IVersionPickerProps> = ({
           onFocusHandler,
         }) => (
           <div onBlur={onBlurHandler} onFocus={onFocusHandler}>
-            <button
-              className='dropdown-trigger'
+            <VersionPickerDropdownTrigger
               aria-expanded={isOpen}
               aria-haspopup='true'
               onClick={onClickHandler}
@@ -172,7 +170,7 @@ const VersionPicker: React.FC<IVersionPickerProps> = ({
             >
               {selectedVersion}
               <span className='caret' />
-            </button>
+            </VersionPickerDropdownTrigger>
             {isOpen && (
               <Menu {...props}>
                 <Header>
@@ -200,15 +198,15 @@ const VersionPicker: React.FC<IVersionPickerProps> = ({
                 </Header>
 
                 <Body role='menu' data-testid='menu'>
-                  <ul>
+                  <VersionPickerList>
                     {versions
                       ?.filter((version) => {
                         return includeTestVersions ? true : !version.test;
                       })
                       .map((version) => {
                         return (
-                          <li key={version.version}>
-                            <a
+                          <VersionPickerItem key={version.version}>
+                            <VersionPickerLink
                               className={
                                 version.version === selectedVersion
                                   ? 'selected'
@@ -222,11 +220,11 @@ const VersionPicker: React.FC<IVersionPickerProps> = ({
                               role='menuitem'
                             >
                               {version.version}
-                            </a>
-                          </li>
+                            </VersionPickerLink>
+                          </VersionPickerItem>
                         );
                       })}
-                  </ul>
+                  </VersionPickerList>
                 </Body>
               </Menu>
             )}

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -47,6 +47,7 @@ export interface IColorMap {
   gray: string;
   error: string;
   loadingForeground: string;
+  dropdownBackground: string;
   foreground: string;
   redOld: string;
   greenNew: string;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -59,6 +59,7 @@ const theme: ITheme = {
     loadingForeground: '#507184',
 
     foreground: '#375b70',
+    dropdownBackground: '#2a5874',
 
     redOld: '#f56262',
     greenNew: '#24A524',


### PR DESCRIPTION
While working on giantswarm/giantswarm#11928 I noticed we're having a Dropdown component. This PR changes the existing uses of this component to better re-use the styles defined in the Dropdown component. 

It also removes the bootstrap class `dropdown-trigger` and adds a new color to our theme which defines a `dropdownBackground` color.

<details>

<summary>Mobile Navigation Dropdown</summary>

## Old
![navigation_old](https://user-images.githubusercontent.com/1494211/87640867-a26ed780-c747-11ea-8628-0c82242cc524.png)

## New
![navigation_new](https://user-images.githubusercontent.com/1494211/87640859-a1d64100-c747-11ea-9438-ebb473cb1576.png)

</details>


<details>

<summary>Node pools Menu Dropdown</summary>

## Old
![nodepools_old](https://user-images.githubusercontent.com/1494211/87641028-d649fd00-c747-11ea-85f1-7f3a66b1f9e4.png)

## New
![nodepools_new](https://user-images.githubusercontent.com/1494211/87641048-de09a180-c747-11ea-92df-2b594453275f.png)

</details>

<details>

<summary>Version picker Dropdown</summary>

## Old
![versionpicker_old](https://user-images.githubusercontent.com/1494211/87641100-ee218100-c747-11ea-8fcf-5e51fc5e609a.png)

## New
![versionpicker_new](https://user-images.githubusercontent.com/1494211/87641117-f4176200-c747-11ea-9c27-b450209c9de8.png)

</details>
