### PR TITLE
Refactor Organization Dropdown & make it scrollable

### DIFF
--- a/src/components/UI/DropdownMenu.js
+++ b/src/components/UI/DropdownMenu.js
@@ -19,7 +19,6 @@ export const List = styled.ul`
   margin: 2px 0 0;
   padding: 5px 0;
   width: 180px;
-  background: ${(props) => props.theme.colors.shade2};
   z-index: 1;
   background-color: ${({ theme }) => theme.colors.dropdownBackground};
   border: none;

--- a/src/components/UI/Navigation/OrganizationDropdown.js
+++ b/src/components/UI/Navigation/OrganizationDropdown.js
@@ -1,192 +1,241 @@
 import styled from '@emotion/styled';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
-import React from 'react';
-import DropdownButton from 'react-bootstrap/lib/DropdownButton';
-import MenuItem from 'react-bootstrap/lib/MenuItem';
+import React, { useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
 import { OrganizationsRoutes } from 'shared/constants/routes';
-import { sortBy } from 'underscore';
+import DropdownMenu, { DropdownTrigger, List } from 'UI/DropdownMenu';
 
-const Wrapper = styled.div`
-  display: inline;
+const OrganizationDropdownTrigger = styled(DropdownTrigger)`
+  width: unset;
+  height: unset;
+  display: inline-block;
+  position: relative;
+  padding: 0 12px 0 0;
+  margin: 0;
+  text-decoration: none;
+  background-color: ${(props) => props.theme.colors.shade2};
+  border-radius: 5px;
+  border: none;
+  border-top: 1px solid #2e617f;
+  border-bottom: 1px solid #183343;
+  color: #ccd;
+  font-size: 14px;
+  line-height: 32px;
+  cursor: pointer;
+  text-align: center;
+  will-change: background-color;
+  transition: background-color 0.3s;
 
-  ul.dropdown-menu {
-    background-color: #2a5874;
-    border: none;
-    border-radius: 5px;
-
-    .dropdown-header {
-      color: #ccc;
-      margin-top: 10px;
-      padding: 3px 15px;
-    }
-
-    .divider {
-      background-color: transparent;
-      border-bottom: 1px solid ${(props) => props.theme.colors.shade6};
-      border-top: 1px solid ${(props) => props.theme.colors.shade3};
-      margin: 0px;
-    }
-
-    > li > a {
-      color: #ddd;
-      padding: 10px 20px;
-
-      &:hover {
-        background-color: transparent;
-        color: ${(props) => props.theme.colors.white1};
-      }
-    }
-  }
-
-  .open .dropdown-toggle.btn-default {
-    background-color: transparent;
-    color: ${(props) => props.theme.colors.white1};
-    box-shadow: none;
-  }
-
-  .dropdown-toggle.btn-default {
-    background-color: ${(props) => props.theme.colors.shade2};
-    border-radius: 5px;
-    border: none;
-    border-top: 1px solid #2e617f;
-    border-bottom: 1px solid #183343;
-    position: relative;
-    padding-left: 50px;
+  &:active {
     color: #ccd;
-
-    .label {
-      margin-right: 10px;
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      line-height: 29px;
-      border-radius: 0px;
-      border-top-left-radius: 5px;
-      border-bottom-left-radius: 5px;
-      background-color: #2e617f;
-      padding-left: 10px;
-      padding-right: 10px;
-      font-weight: normal;
-      letter-spacing: 0.5px;
-    }
-
-    &:active {
-      color: #ccd;
-      text-decoration: none;
-      box-shadow: none;
-      background-color: ${(props) => props.theme.colors.shade2};
-    }
-
-    &:focus {
-      background-color: ${(props) => props.theme.colors.shade2};
-      color: #ccd;
-    }
-
-    &:hover {
-      text-decoration: none;
-      background-color: ${(props) => props.theme.colors.shade5} !important;
-      color: ${(props) => props.theme.colors.white1};
-    }
-
-    &:active:focus {
-      background-color: ${(props) => props.theme.colors.shade5} !important;
-      color: ${(props) => props.theme.colors.white1};
-    }
-
-    ul.dropdown-menu {
-      background-color: ${(props) => props.theme.colors.shade2};
-      box-shadow: none;
-    }
+    background-color: ${(props) => props.theme.colors.shade2};
   }
 
-  .open {
-    .dropdown-toggle.btn-default {
-      background-color: ${(props) => props.theme.colors.shade2};
-      border-bottom: 1px solid #2e617f;
-      border-top: 1px solid #183343;
-    }
+  &:focus {
+    background-color: ${(props) => props.theme.colors.shade2};
+    color: #ccd;
+  }
+
+  &:hover {
+    background-color: ${(props) => props.theme.colors.shade5} !important;
+    color: ${(props) => props.theme.colors.white1};
+  }
+
+  &:active:focus {
+    background-color: ${(props) => props.theme.colors.shade5} !important;
+    color: ${(props) => props.theme.colors.white1};
+  }
+
+  &:before {
+    content: 'ORG';
+    border-radius: 5px 0px 0px 5px;
+    background-color: #2e617f;
+    position: absolute;
+    padding: 0 10px;
+    font-weight: normal;
+    letter-spacing: 0.5px;
+    color: #fff;
+    font-size: 75%;
+  }
+
+  .caret {
+    margin-left: 4px;
   }
 `;
 
-// eslint-disable-next-line react/prefer-stateless-function
-class OrganizationDropdown extends React.Component {
-  render() {
-    const organizationDetailPath = RoutePath.createUsablePath(
-      OrganizationsRoutes.Detail,
-      {
-        orgId: this.props.selectedOrganization,
-      }
-    );
+const TriggerLabel = styled.span`
+  margin-left: 50px;
+`;
 
-    return (
-      <Wrapper>
-        {Object.entries(this.props.organizations.items).length === 0 &&
-        !this.props.organizations.isFetching ? (
-          <DropdownButton
-            id='org_dropdown'
-            key='2'
-            title={
-              <span>
-                <span className='label label-default'>ORG</span>No organizations
-              </span>
-            }
-          >
-            <MenuItem
-              componentClass={NavLink}
-              href={OrganizationsRoutes.List}
-              to={OrganizationsRoutes.List}
-            >
-              Manage organizations
-            </MenuItem>
-          </DropdownButton>
-        ) : (
-          <DropdownButton
-            id='org_dropdown'
-            key='2'
-            title={
-              <span>
-                <span className='label label-default'>ORG</span>{' '}
-                {this.props.selectedOrganization}
-              </span>
-            }
-          >
-            <MenuItem
-              componentClass={NavLink}
-              href={OrganizationsRoutes.List}
-              to={organizationDetailPath}
-            >
-              Details for {this.props.selectedOrganization}
-            </MenuItem>
-            <MenuItem divider />
-            <MenuItem
-              componentClass={NavLink}
-              href={OrganizationsRoutes.List}
-              to={OrganizationsRoutes.List}
-            >
-              Manage organizations
-            </MenuItem>
-            <MenuItem divider />
-            <MenuItem header>Switch Organization</MenuItem>
-            {sortBy(this.props.organizations.items, 'id').map((org) => {
-              return (
-                <MenuItem
-                  eventKey={org.id}
-                  key={org.id}
-                  onSelect={this.props.onSelectOrganization}
-                >
-                  {org.id}
-                </MenuItem>
-              );
-            })}
-          </DropdownButton>
-        )}
-      </Wrapper>
-    );
+const OrganizationMenu = styled(DropdownMenu)`
+  display: inline;
+`;
+
+const InlineDiv = styled.div`
+  display: inline;
+`;
+
+const OrganizationList = styled(List)`
+  right: 0;
+  left: 0;
+  top: 24px;
+`;
+
+const MenuItem = styled(NavLink)`
+  color: ${(props) => props.theme.colors.white1};
+  padding: 8px 15px;
+  display: block;
+  clear: both;
+  font-weight: 400;
+  line-height: 1.42857143;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.shade9};
+    color: ${(props) => props.theme.colors.white1};
   }
-}
+`;
+
+const Divider = styled.li`
+  height: 1px;
+  overflow: hidden;
+  background-color: transparent;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.shade6};
+  border-top: 1px solid ${({ theme }) => theme.colors.shade3};
+  margin: 0;
+`;
+
+const MenuHeader = styled.div`
+  color: #ccc;
+  margin-top: 10px;
+  padding: 3px 15px;
+  display: block;
+  font-size: 12px;
+  line-height: 1.42857143;
+  white-space: nowrap;
+`;
+
+const OrganizationItem = styled.li`
+  color: ${({ theme }) => theme.colors.white1};
+  padding: 8px 15px;
+  display: block;
+  clear: both;
+  font-weight: 400;
+  line-height: 1.42857143;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.shade9};
+    color: ${({ theme }) => theme.colors.white1};
+  }
+`;
+
+const ScrollableOrganizations = styled.div`
+  overflow: auto;
+  max-height: 50vh;
+  overscroll-behavior: contain;
+`;
+
+const OrganizationDropdown = ({
+  organizations,
+  selectedOrganization,
+  onSelectOrganization,
+}) => {
+  const organizationDetailPath = useMemo(
+    () =>
+      RoutePath.createUsablePath(OrganizationsRoutes.Detail, {
+        orgId: selectedOrganization,
+      }),
+    [selectedOrganization]
+  );
+
+  const sortedOrganizations = useMemo(() => {
+    if (organizations.isFetching) {
+      return [];
+    }
+
+    return Object.values(organizations.items)
+      .map(({ id }) => id)
+      .sort((a, b) => a.localeCompare(b));
+  }, [organizations.items, organizations.isFetching]);
+
+  return (
+    <InlineDiv>
+      <OrganizationMenu
+        render={({
+          isOpen,
+          onClickHandler,
+          onFocusHandler,
+          onBlurHandler,
+          onKeyDownHandler,
+        }) => (
+          <InlineDiv onBlur={onBlurHandler} onFocus={onFocusHandler}>
+            <OrganizationDropdownTrigger
+              aria-expanded={isOpen}
+              aria-haspopup='true'
+              onClick={onClickHandler}
+              onKeyDown={onKeyDownHandler}
+              type='button'
+            >
+              <TriggerLabel>
+                {sortedOrganizations.length !== 0
+                  ? selectedOrganization
+                  : 'No Organizations'}
+              </TriggerLabel>
+              <span className='caret' />
+            </OrganizationDropdownTrigger>
+            {isOpen && (
+              <OrganizationList role='menu'>
+                {sortedOrganizations.length !== 0 && (
+                  <>
+                    <li role='presentation'>
+                      <MenuItem
+                        href={organizationDetailPath}
+                        to={organizationDetailPath}
+                      >
+                        Details for {selectedOrganization}
+                      </MenuItem>
+                    </li>
+                    <Divider role='separator' />
+                  </>
+                )}
+                <li role='presentation'>
+                  <MenuItem
+                    href={OrganizationsRoutes.List}
+                    to={OrganizationsRoutes.List}
+                  >
+                    Manage organizations
+                  </MenuItem>
+                </li>
+                {sortedOrganizations.length !== 0 && (
+                  <>
+                    <Divider role='separator' />
+                    <MenuHeader role='heading'>Switch Organization</MenuHeader>
+                    <ScrollableOrganizations>
+                      {sortedOrganizations.map((org) => (
+                        <OrganizationItem
+                          key={org}
+                          onClick={() => {
+                            onSelectOrganization(org);
+                            onClickHandler();
+                          }}
+                        >
+                          {org}
+                        </OrganizationItem>
+                      ))}
+                    </ScrollableOrganizations>
+                  </>
+                )}
+              </OrganizationList>
+            )}
+          </InlineDiv>
+        )}
+      />
+    </InlineDiv>
+  );
+};
 
 OrganizationDropdown.propTypes = {
   organizations: PropTypes.object,


### PR DESCRIPTION
Towards giantswarm/giantswarm#11928

This PR refactors the OrganizationSelector 

- to use the DropdownMenu of Happa
- remove lodash & Bootstrap 
- make it scrollable

![scroll_organization](https://user-images.githubusercontent.com/1494211/87689768-e59d6a80-c788-11ea-9569-aa9c917ba4a8.gif)
