### PR TITLE
Set lodash to 4.17.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
   "resolutions": {
     "**/crypto-js": "^3.2.1",
     "kind-of": "^6.0.3",
-    "lodash": "^4.17.16"
+    "lodash": "^4.17.19"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Dependabot is still complaining about it not being at 4.17.19, even though in the lockfile it looks to me like it resolved to 4.17.19.. anyways, forcing it now to 4.17.19 in the package.json file, to see if that clears the warning.