### PR TITLE
Fix borked organization dropdown

### DIFF
--- a/src/components/UI/Navigation/OrganizationDropdown.js
+++ b/src/components/UI/Navigation/OrganizationDropdown.js
@@ -194,6 +194,7 @@ const OrganizationDropdown = ({
                       <MenuItem
                         href={organizationDetailPath}
                         to={organizationDetailPath}
+                        activeClassName=''
                       >
                         Details for {selectedOrganization}
                       </MenuItem>
@@ -205,6 +206,7 @@ const OrganizationDropdown = ({
                   <MenuItem
                     href={OrganizationsRoutes.List}
                     to={OrganizationsRoutes.List}
+                    activeClassName=''
                   >
                     Manage organizations
                   </MenuItem>

--- a/src/components/UI/Navigation/OrganizationDropdown.js
+++ b/src/components/UI/Navigation/OrganizationDropdown.js
@@ -116,22 +116,6 @@ const MenuHeader = styled.div`
   white-space: nowrap;
 `;
 
-const OrganizationItem = styled.li`
-  color: ${({ theme }) => theme.colors.white1};
-  padding: 8px 15px;
-  display: block;
-  clear: both;
-  font-weight: 400;
-  line-height: 1.42857143;
-  white-space: nowrap;
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.shade9};
-    color: ${({ theme }) => theme.colors.white1};
-  }
-`;
-
 const ScrollableOrganizations = styled.div`
   overflow: auto;
   max-height: 50vh;
@@ -217,15 +201,20 @@ const OrganizationDropdown = ({
                     <MenuHeader role='heading'>Switch Organization</MenuHeader>
                     <ScrollableOrganizations>
                       {sortedOrganizations.map((org) => (
-                        <OrganizationItem
-                          key={org}
-                          onClick={() => {
-                            onSelectOrganization(org);
-                            onClickHandler();
-                          }}
-                        >
-                          {org}
-                        </OrganizationItem>
+                        <li role='presentation' key={org}>
+                          <MenuItem
+                            href='#'
+                            to='#'
+                            activeClassName=''
+                            onClick={() => {
+                              onSelectOrganization(org);
+                              onClickHandler();
+                            }}
+                            title={`Switch to ${org}`}
+                          >
+                            {org}
+                          </MenuItem>
+                        </li>
                       ))}
                     </ScrollableOrganizations>
                   </>


### PR DESCRIPTION
These changes should fix [the issues identified](https://github.com/giantswarm/happa/pull/1654#issuecomment-660617434) in #1654 

- No more highlighting of "active" links
- Switching organizations through clicking of items actually works now