### PR TITLE
make dev cors headers more production alike

### DIFF
--- a/scripts/webpack/proxyPlugin.js
+++ b/scripts/webpack/proxyPlugin.js
@@ -84,17 +84,35 @@ class ProxyPlugin {
    */
   startProxy(port, proxyUrl, credentials, origin, service) {
     let proxy = express();
-    proxy.use(cors({ credentials: credentials, origin: origin }));
-    proxy.options('*', cors({ credentials: credentials, origin: origin }));
+    proxy.use(
+      cors({
+        credentials: credentials,
+        origin: origin,
+        exposedHeaders: 'Location',
+        maxAge: 86400,
+      })
+    );
+    proxy.options(
+      '*',
+      cors({
+        credentials: credentials,
+        origin: origin,
+        exposedHeaders: 'Location',
+        maxAge: 86400,
+      })
+    );
 
     // remove trailing slash
-    var cleanProxyUrl = proxyUrl.replace(/\/$/, '');
+    let cleanProxyUrl = proxyUrl.replace(/\/$/, '');
 
     let log = this.log.bind(this);
 
     proxy.use('/', function (req, res) {
       try {
-        log('Request Proxied -> ' + req.url, service);
+        log(
+          `Request Proxied -> ${req.method.toUpperCase()} ${req.url}`,
+          service
+        );
       } catch (e) {}
 
       req


### PR DESCRIPTION
This PR adds `access-control-expose-headers: Location` & `access-control-max-age: 86400` headers to proxied requests.