### PR TITLE
Fix trying to use apps before loading them in an app catalog

### DIFF
--- a/src/actions/catalogActions.js
+++ b/src/actions/catalogActions.js
@@ -125,8 +125,6 @@ export function catalogLoadIndex(catalog) {
           catalogName: catalog.metadata.name,
           id: catalog.metadata.name,
         });
-
-        throw error;
       });
   };
 }

--- a/src/components/AppCatalog/AppList/AppList.js
+++ b/src/components/AppCatalog/AppList/AppList.js
@@ -1,5 +1,6 @@
 import { CATALOG_LOAD_INDEX_REQUEST } from 'actions/actionTypes';
 import DocumentTitle from 'components/shared/DocumentTitle';
+import usePrevious from 'lib/effects/usePrevious';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
@@ -24,12 +25,19 @@ const AppList = ({
 }) => {
   const catalogName = catalog?.metadata?.name;
   const breadCrumbTitle = catalogName ? catalogName.toUpperCase() : '';
+  const previousCatalogName = usePrevious(catalogName);
 
   useEffect(() => {
-    if (catalogName) {
+    if (catalogName !== previousCatalogName) {
       catalogLoadIndex(catalog);
     }
-  }, [catalogName, loadingCatalogs, catalogLoadIndex, catalog]);
+  }, [
+    catalogName,
+    loadingCatalogs,
+    catalogLoadIndex,
+    catalog,
+    previousCatalogName,
+  ]);
 
   return (
     <Breadcrumb

--- a/src/components/AppCatalog/AppList/AppListInner.js
+++ b/src/components/AppCatalog/AppList/AppListInner.js
@@ -81,6 +81,10 @@ class AppListInner extends React.Component {
   }
 
   getAppsWithOrderedVersions = memoize((allApps) => {
+    if (!allApps) {
+      return [];
+    }
+
     const apps = Object.values(allApps);
 
     apps.map(this.sortVersionsByCreationDateDESC);


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C3MCF5EJK/p1595517097001000

If the apps are not loaded yet, then the property is `null`.
Now we're taking that into account.