### PR TITLE
Fix trying to use an 'undefined' response in HttpClient

### DIFF
--- a/src/model/clients/HttpClient.js
+++ b/src/model/clients/HttpClient.js
@@ -241,8 +241,8 @@ export class HttpClient {
       res.status = 400;
       res.message = `This is embarrassing, we couldn't execute this request. Please try again in a few moments.`;
 
-      // We got a non-2xx status code
-      if (err.hasOwnProperty('response')) {
+      // We got a non-2xx status code.
+      if (err.response) {
         res.status = err.response.status;
         res.message = err.code;
         res.headers = err.response.headers;

--- a/src/model/clients/__tests__/HttpClient.js
+++ b/src/model/clients/__tests__/HttpClient.js
@@ -325,4 +325,22 @@ describe('HttpClient', () => {
       );
     }
   });
+
+  it(`accepts an undefined 'response' property in the error object`, async () => {
+    const client = new HttpClient();
+    client.onBeforeRequest = () => {
+      // eslint-disable-next-line no-throw-literal
+      throw {
+        response: undefined,
+      };
+    };
+
+    try {
+      await client.execute();
+    } catch (err) {
+      expect(err.message).toStrictEqual(
+        `This is embarrassing, we couldn't execute this request. Please try again in a few moments.`
+      );
+    }
+  });
 });


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C3MCF5EJK/p1595519133001200 and https://gigantic.slack.com/archives/C3MCF5EJK/p1595518780001100

So apparently the `response` property can exist, but have an `undefined` value (this comes from `axios`). We now take that into account.