### PR TITLE
Make IC optional for KVM releases >= v12.2.0

### DIFF
--- a/src/utils/__tests__/computeCapabilities.js
+++ b/src/utils/__tests__/computeCapabilities.js
@@ -71,11 +71,25 @@ describe('computeCapabilities', () => {
     });
 
     describe('on kvm', () => {
-      it('is false for KVM at any version', () => {
+      it('is false for KVM below 12.2.0', () => {
         const capabilities = computeCapabilities(
           getEmptyStateWithProvider('kvm')
-        )('8.0.0', 'kvm');
+        )('11.0.0', 'kvm');
         expect(capabilities.hasOptionalIngress).toBe(false);
+      });
+
+      it('is true for KVM at 12.2.0', () => {
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('kvm')
+        )('12.2.0', 'kvm');
+        expect(capabilities.hasOptionalIngress).toBe(true);
+      });
+
+      it('is true for KVM above 12.2.0', () => {
+        const capabilities = computeCapabilities(
+          getEmptyStateWithProvider('kvm')
+        )('13.0.0', 'kvm');
+        expect(capabilities.hasOptionalIngress).toBe(true);
       });
     });
   });

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -200,6 +200,11 @@ export const computeCapabilities = (state) => (releaseVersion, provider) => {
       hasOptionalIngress = cmp(releaseVersion, '12.0.0') >= 0;
 
       break;
+
+    case Providers.KVM:
+      hasOptionalIngress = cmp(releaseVersion, '12.2.0') >= 0;
+
+      break;
   }
 
   return {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12326

Make Ingress Controller optional in KVM releases newer or equal to `v12.2.0`. 🥳 