### PR TITLE
azure v5: hide CAPI cluster name label

### DIFF
--- a/__tests__/V5ClusterManagement.js
+++ b/__tests__/V5ClusterManagement.js
@@ -9,7 +9,7 @@ import RoutePath from 'lib/routePath';
 import { getInstallationInfo } from 'model/services/giantSwarm';
 import { getConfiguration } from 'model/services/metadata';
 import nock from 'nock';
-import { Constants, StatusCodes } from 'shared/constants';
+import { StatusCodes } from 'shared/constants';
 import { OrganizationsRoutes } from 'shared/constants/routes';
 import {
   API_ENDPOINT,
@@ -33,6 +33,7 @@ import {
 } from 'testUtils/mockHttpCalls';
 import { renderRouteWithStore } from 'testUtils/renderUtils';
 import { filterLabels, getNumberOfNodePoolsNodes } from 'utils/clusterUtils';
+import { validateLabelKey } from 'utils/labelUtils';
 
 describe('V5ClusterManagement', () => {
   // Responses to requests
@@ -584,9 +585,7 @@ scales node pools correctly`, async () => {
     await findByText('Labels:');
 
     for (const [key, value] of Object.entries(v5ClusterResponse.labels)) {
-      if (
-        key.includes(Constants.RESTRICTED_CLUSTER_LABEL_KEY_SUBSTRING) === false
-      ) {
+      if (validateLabelKey(key).isValid) {
         expect(getByText(key)).toBeInTheDocument();
         expect(getByText(value)).toBeInTheDocument();
       } else {

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
@@ -55,6 +55,8 @@ const ErrorText = styled(BottomAreaText)`
 
 const NoLabels = styled.div`
   grid-area: labels;
+  display: flex;
+  align-items: center;
 `;
 
 const NoLabelsEditLabelTooltip = styled(EditLabelTooltip)`

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -1,6 +1,7 @@
 import { getMinHAMastersVersion } from 'selectors/featureSelectors';
 import cmp from 'semver-compare';
 import { Constants, Providers } from 'shared/constants';
+import { validateLabelKey } from 'utils/labelUtils';
 
 // Here we can store functions that don't return markup/UI and are used in more
 // than one component.
@@ -221,9 +222,7 @@ export const filterLabels = (labels) => {
   const filteredLabels = {};
 
   for (const key of Object.keys(labels)) {
-    if (
-      key.includes(Constants.RESTRICTED_CLUSTER_LABEL_KEY_SUBSTRING) === false
-    ) {
+    if (validateLabelKey(key).isValid) {
       filteredLabels[key] = labels[key];
     }
   }

--- a/src/utils/labelUtils.ts
+++ b/src/utils/labelUtils.ts
@@ -152,6 +152,10 @@ export const validateLabelKey: IValidationFunction = (key) => {
     };
   }
 
+  /**
+   * Hide CAPI cluster name label, because we don't allow editing it at this time.
+   * https://github.com/giantswarm/giantswarm/issues/12431
+   */
   if (strKey.toLowerCase() === 'cluster.x-k8s.io/cluster-name') {
     return {
       isValid: false,

--- a/src/utils/labelUtils.ts
+++ b/src/utils/labelUtils.ts
@@ -152,5 +152,12 @@ export const validateLabelKey: IValidationFunction = (key) => {
     };
   }
 
+  if (strKey.toLowerCase() === 'cluster.x-k8s.io/cluster-name') {
+    return {
+      isValid: false,
+      validationError: `Key cannot be 'cluster.x-k8s.io/cluster-name'`,
+    };
+  }
+
   return isQualifiedName(strKey);
 };


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/12431

This PR:
* hides and blocks the creation of the cluster API cluster name label (`cluster.x-k8s.io/cluster-name`) from the label editor - this is used by Azure V5
* centers the `This cluster has no labels` placeholder vertically

### Preview

<details>
<summary>Before - no labels placeholder</summary>

![image](https://user-images.githubusercontent.com/13508038/89025657-85c9c680-d327-11ea-9cb9-6e3d49d51d56.png)

</details>

<details>
<summary>Before - with the CAPI label</summary>

![image](https://user-images.githubusercontent.com/13508038/89025504-456a4880-d327-11ea-8a37-e36a9adfda37.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/13508038/89025521-4bf8c000-d327-11ea-9755-85aa357431fc.png)

</details>