### PR TITLE
Prevent upgrade when cluster not ready

### DIFF
--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -160,13 +160,8 @@ export const batchedRefreshClusterDetailView = (
           withLoadingFlags: false,
         })
       );
-    } else {
-      await dispatch(
-        clusterActions.clusterLoadStatus(clusterId, {
-          withLoadingFlags: false,
-        })
-      );
     }
+
     // If cluster is an empty object, it means that it has been removed.
     // We don't want to load apps in this scenario.
     if (Object.keys(cluster).length > 0) {

--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -160,10 +160,16 @@ export const batchedRefreshClusterDetailView = (
           withLoadingFlags: false,
         })
       );
+    } else {
+      await dispatch(
+        clusterActions.clusterLoadStatus(clusterId, {
+          withLoadingFlags: false,
+        })
+      );
     }
     // If cluster is an empty object, it means that it has been removed.
     // We don't want to load apps in this scenario.
-    if (!Object.keys(cluster).length === 0) {
+    if (Object.keys(cluster).length > 0) {
       dispatch(loadClusterApps({ clusterId: clusterId }));
     }
   } catch (err) {

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -294,7 +294,7 @@ export function clusterLoadDetails(
   };
 }
 
-function clusterLoadStatus(clusterId, { withLoadingFlags }) {
+export function clusterLoadStatus(clusterId, { withLoadingFlags }) {
   return function (dispatch) {
     // Does it  makes sense to leave it here just for let loadingReducer set/unset a flag?
     if (withLoadingFlags)

--- a/src/actions/clusterActions.js
+++ b/src/actions/clusterActions.js
@@ -294,7 +294,7 @@ export function clusterLoadDetails(
   };
 }
 
-export function clusterLoadStatus(clusterId, { withLoadingFlags }) {
+function clusterLoadStatus(clusterId, { withLoadingFlags }) {
   return function (dispatch) {
     // Does it  makes sense to leave it here just for let loadingReducer set/unset a flag?
     if (withLoadingFlags)

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -223,9 +223,13 @@ class UpgradeClusterModal extends React.Component {
         const targetReleaseVersion = this.props.targetRelease.version;
 
         this.props.clusterActions
-          .clusterPatch(this.props.cluster, {
-            release_version: targetReleaseVersion,
-          })
+          .clusterPatch(
+            this.props.cluster,
+            {
+              release_version: targetReleaseVersion,
+            },
+            true
+          )
           .then(() => {
             new FlashMessage(
               'Cluster upgrade initiated.',

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -225,9 +225,7 @@ class UpgradeClusterModal extends React.Component {
         this.props.clusterActions
           .clusterPatch(
             this.props.cluster,
-            {
-              release_version: targetReleaseVersion,
-            },
+            { release_version: targetReleaseVersion },
             true
           )
           .then(() => {

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -183,6 +183,8 @@ class UpgradeClusterModal extends React.Component {
   };
 
   inspectChangesPage = () => {
+    const { loading } = this.state;
+
     return (
       <div>
         <BootstrapModal.Header closeButton>
@@ -195,14 +197,18 @@ class UpgradeClusterModal extends React.Component {
         <BootstrapModal.Footer>
           <Button
             bsStyle='primary'
-            loading={this.state.loading}
+            loading={loading}
             onClick={this.submit}
+            loadingTimeout={0}
           >
             Start Upgrade
           </Button>
-          <Button bsStyle='link' onClick={this.close}>
-            Cancel
-          </Button>
+
+          {!loading && (
+            <Button bsStyle='link' onClick={this.close}>
+              Cancel
+            </Button>
+          )}
         </BootstrapModal.Footer>
       </div>
     );
@@ -212,7 +218,6 @@ class UpgradeClusterModal extends React.Component {
     this.setState(
       {
         loading: true,
-        page: 'closing',
       },
       () => {
         const targetReleaseVersion = this.props.targetRelease.version;

--- a/src/components/Home/UpgradeNotice.tsx
+++ b/src/components/Home/UpgradeNotice.tsx
@@ -3,33 +3,42 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { IState } from 'reducers/types';
-import { selectCanClusterUpgrade } from 'selectors/clusterSelectors';
+import {
+  selectCanClusterUpgrade,
+  selectIsClusterUpgrading,
+} from 'selectors/clusterSelectors';
 
-const UpgradeWrapperDiv = styled.div`
+const labelDisabledOpacity = 0.7;
+const UpgradeWrapperDiv = styled.div<{
+  disabled: boolean;
+  isHyperlink: boolean;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+}>`
   display: inline-block;
-  color: ${(props) => props.theme.colors.gold};
-  cursor: ${({ onClick }) => (onClick ? 'pointer' : 'inherit')};
+  color: ${({ theme }) => theme.colors.gold};
+  opacity: ${({ disabled }) => disabled && labelDisabledOpacity};
+  cursor: ${({ isHyperlink }) => isHyperlink && 'pointer'};
 
   span {
     white-space: normal !important;
     display: unset;
     font-size: 16px;
     font-weight: 300;
+
     &:hover {
-      text-decoration: ${({ onClick }) => {
-        return onClick ? 'underline' : 'inherit';
-      }};
+      text-decoration: ${({ isHyperlink }) => isHyperlink && 'underline'};
     }
   }
 
   i {
-    color: ${(props) => props.theme.colors.yellow1};
+    color: ${({ theme }) => theme.colors.gold};
     padding: 0 2px;
   }
 `;
 
 interface IUpgradeNoticeProps {
   canClusterUpgrade: boolean;
+  isClusterUpgrading: boolean;
   clusterId: string;
   className?: string;
   onClick?: () => void;
@@ -39,20 +48,30 @@ interface IUpgradeNoticeProps {
 // in case it is, outputs an upgrade notice,
 function UpgradeNotice({
   canClusterUpgrade,
-  onClick,
-  className,
+  isClusterUpgrading,
   clusterId,
+  className,
+  onClick,
 }: IUpgradeNoticeProps) {
-  if (!canClusterUpgrade) return null;
+  if (!canClusterUpgrade && !isClusterUpgrading) return null;
+
+  const iconClassName = isClusterUpgrading
+    ? 'fa fa-version-upgrade'
+    : 'fa fa-warning';
+  const message = isClusterUpgrading
+    ? 'Upgrade in progress…'
+    : 'Upgrade Available';
 
   return (
     <UpgradeWrapperDiv
       id={`upgrade-notice-${clusterId}`}
       className={className}
       onClick={onClick}
+      disabled={isClusterUpgrading}
+      isHyperlink={Boolean(onClick) && !isClusterUpgrading}
     >
-      <i className='fa fa-warning' />
-      <span>Upgrade Available</span>
+      <i className={iconClassName} />
+      <span>{message}</span>
     </UpgradeWrapperDiv>
   );
 }
@@ -60,13 +79,17 @@ function UpgradeNotice({
 UpgradeNotice.propTypes = {
   clusterId: PropTypes.string.isRequired,
   canClusterUpgrade: PropTypes.bool.isRequired,
+  isClusterUpgrading: PropTypes.bool.isRequired,
   onClick: PropTypes.func,
   className: PropTypes.string,
 };
 
 function mapStateToProps(state: IState, props: IUpgradeNoticeProps) {
+  const { clusterId } = props;
+
   return {
-    canClusterUpgrade: selectCanClusterUpgrade(state, props.clusterId),
+    canClusterUpgrade: selectCanClusterUpgrade(state, clusterId),
+    isClusterUpgrading: selectIsClusterUpgrading(state, clusterId),
   };
 }
 

--- a/src/components/Home/UpgradeNotice.tsx
+++ b/src/components/Home/UpgradeNotice.tsx
@@ -2,12 +2,14 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import { IState } from 'reducers/types';
 import { selectCanClusterUpgrade } from 'selectors/clusterSelectors';
 
 const UpgradeWrapperDiv = styled.div`
   display: inline-block;
   color: ${(props) => props.theme.colors.gold};
   cursor: ${({ onClick }) => (onClick ? 'pointer' : 'inherit')};
+
   span {
     white-space: normal !important;
     display: unset;
@@ -19,6 +21,7 @@ const UpgradeWrapperDiv = styled.div`
       }};
     }
   }
+
   i {
     color: ${(props) => props.theme.colors.yellow1};
     padding: 0 2px;
@@ -27,8 +30,8 @@ const UpgradeWrapperDiv = styled.div`
 
 interface IUpgradeNoticeProps {
   canClusterUpgrade: boolean;
-  className: string;
   clusterId: string;
+  className?: string;
   onClick?: () => void;
 }
 
@@ -46,7 +49,7 @@ function UpgradeNotice({
     <UpgradeWrapperDiv
       id={`upgrade-notice-${clusterId}`}
       className={className}
-      onClick={onClick ? onClick : undefined}
+      onClick={onClick}
     >
       <i className='fa fa-warning' />
       <span>Upgrade Available</span>
@@ -55,21 +58,16 @@ function UpgradeNotice({
 }
 
 UpgradeNotice.propTypes = {
-  clusterId: PropTypes.string,
-  canClusterUpgrade: PropTypes.bool,
+  clusterId: PropTypes.string.isRequired,
+  canClusterUpgrade: PropTypes.bool.isRequired,
   onClick: PropTypes.func,
   className: PropTypes.string,
 };
 
-function mapStateToProps(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  state: Record<string, any>,
-  props: IUpgradeNoticeProps
-) {
+function mapStateToProps(state: IState, props: IUpgradeNoticeProps) {
   return {
     canClusterUpgrade: selectCanClusterUpgrade(state, props.clusterId),
   };
 }
 
-// @ts-ignore
 export default connect(mapStateToProps)(UpgradeNotice);

--- a/src/components/Home/UpgradeNotice.tsx
+++ b/src/components/Home/UpgradeNotice.tsx
@@ -12,7 +12,6 @@ const labelDisabledOpacity = 0.7;
 const UpgradeWrapperDiv = styled.div<{
   disabled: boolean;
   isHyperlink: boolean;
-  onClick?: React.MouseEventHandler<HTMLDivElement>;
 }>`
   display: inline-block;
   color: ${({ theme }) => theme.colors.gold};
@@ -55,6 +54,13 @@ function UpgradeNotice({
 }: IUpgradeNoticeProps) {
   if (!canClusterUpgrade && !isClusterUpgrading) return null;
 
+  const handleUpgrade = () => {
+    if (isClusterUpgrading) return;
+
+    // eslint-disable-next-line no-unused-expressions
+    onClick?.();
+  };
+
   const iconClassName = isClusterUpgrading
     ? 'fa fa-version-upgrade'
     : 'fa fa-warning';
@@ -66,7 +72,7 @@ function UpgradeNotice({
     <UpgradeWrapperDiv
       id={`upgrade-notice-${clusterId}`}
       className={className}
-      onClick={onClick}
+      onClick={handleUpgrade}
       disabled={isClusterUpgrading}
       isHyperlink={Boolean(onClick) && !isClusterUpgrading}
     >

--- a/src/components/Home/UpgradeNotice.tsx
+++ b/src/components/Home/UpgradeNotice.tsx
@@ -14,7 +14,7 @@ const UpgradeWrapperDiv = styled.div<{
   isHyperlink: boolean;
 }>`
   display: inline-block;
-  color: ${({ theme }) => theme.colors.gold};
+  color: ${({ theme }) => theme.colors.yellow1};
   opacity: ${({ disabled }) => disabled && labelDisabledOpacity};
   cursor: ${({ isHyperlink }) => isHyperlink && 'pointer'};
 
@@ -30,7 +30,7 @@ const UpgradeWrapperDiv = styled.div<{
   }
 
   i {
-    color: ${({ theme }) => theme.colors.gold};
+    color: ${({ theme }) => theme.colors.yellow1};
     padding: 0 2px;
   }
 `;

--- a/src/components/Home/UpgradeNotice.tsx
+++ b/src/components/Home/UpgradeNotice.tsx
@@ -8,14 +8,13 @@ import {
   selectIsClusterUpgrading,
 } from 'selectors/clusterSelectors';
 
-const labelDisabledOpacity = 0.7;
 const UpgradeWrapperDiv = styled.div<{
   disabled: boolean;
   isHyperlink: boolean;
 }>`
   display: inline-block;
   color: ${({ theme }) => theme.colors.yellow1};
-  opacity: ${({ disabled }) => disabled && labelDisabledOpacity};
+  opacity: ${({ theme, disabled }) => disabled && theme.disabledOpacity};
   cursor: ${({ isHyperlink }) => isHyperlink && 'pointer'};
 
   span {

--- a/src/components/Organizations/Detail/View.js
+++ b/src/components/Organizations/Detail/View.js
@@ -19,6 +19,7 @@ import { OrganizationsRoutes } from 'shared/constants/routes';
 import { Ellipsis } from 'styles';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 import Section from 'UI/Section';
+import { isClusterUpdating } from 'utils/clusterUtils';
 
 import Credentials from './Credentials';
 
@@ -264,10 +265,14 @@ function upgradeNoticeIcon(_, cluster, orgId) {
     }
   );
 
+  const message = isClusterUpdating(cluster)
+    ? 'Upgrade in progress…'
+    : 'Upgrade Available';
+
   return (
     <Link to={clusterDetailPath}>
       <OverlayTrigger
-        overlay={<Tooltip id='tooltip'>Upgrade Available</Tooltip>}
+        overlay={<Tooltip id='tooltip'>{message}</Tooltip>}
         placement='top'
       >
         <UpgradeNoticeWrapperDiv>

--- a/src/selectors/clusterSelectors.js
+++ b/src/selectors/clusterSelectors.js
@@ -189,3 +189,10 @@ export const selectCanClusterUpgrade = (state, clusterID) => {
     state.main.info.general.provider
   );
 };
+
+export const selectIsClusterUpgrading = (state, clusterID) => {
+  const cluster = state.entities.clusters.items[clusterID];
+  if (!cluster) return false;
+
+  return isClusterUpdating(cluster);
+};

--- a/src/selectors/clusterSelectors.js
+++ b/src/selectors/clusterSelectors.js
@@ -8,6 +8,8 @@ import {
   getNumberOfNodePoolsNodes,
   getNumberOfNodes,
   getStorageTotal,
+  isClusterCreating,
+  isClusterUpdating,
 } from 'utils/clusterUtils';
 
 import { createDeepEqualSelector, typeWithoutSuffix } from './selectorUtils';
@@ -173,12 +175,14 @@ export const selectTargetRelease = (state, cluster) => {
 
 export const selectCanClusterUpgrade = (state, clusterID) => {
   const cluster = state.entities.clusters.items[clusterID];
-
   if (!cluster) return false;
+
+  if (isClusterCreating(cluster) || isClusterUpdating(cluster)) {
+    return false;
+  }
 
   const targetVersion = selectTargetRelease(state, cluster);
 
-  // eslint-disable-next-line consistent-return
   return canClusterUpgrade(
     cluster.release_version,
     targetVersion,

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -64,6 +64,7 @@ export interface ITheme {
   fontFamilies: IThemeFonts;
   border: string;
   spacingPx: number;
+  disabledOpacity: number;
 }
 
 /***** BASE STYLES ****/

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -75,6 +75,7 @@ const theme: ITheme = {
     console: 'Inconsolata, monospace',
   },
   border: '1px solid #3A5F7B',
+  disabledOpacity: 0.7,
 };
 
 export default theme;

--- a/src/utils/__tests__/clusterUtils.ts
+++ b/src/utils/__tests__/clusterUtils.ts
@@ -1,34 +1,52 @@
-import { v5ClusterResponse } from 'testUtils/mockHttpCalls';
 import {
+  v4AWSClusterResponse,
+  v4AWSClusterStatusResponse,
+  v5ClusterResponse,
+} from 'testUtils/mockHttpCalls';
+import {
+  getClusterLatestCondition,
   getInstanceTypesForProvider,
   guessProviderFromNodePools,
-  hasClusterLatestCondition,
   isClusterCreating,
   isClusterDeleting,
   isClusterUpdating,
 } from 'utils/clusterUtils';
 
 describe('clusterUtils', () => {
-  describe('hasClusterLatestCondition', () => {
-    it('gets the latest cluster condition', () => {
+  describe('getClusterLatestCondition', () => {
+    it('gets the latest cluster condition, on a v5 cluster', () => {
       const cluster = Object.assign({}, v5ClusterResponse);
 
-      expect(hasClusterLatestCondition(cluster, 'Creating')).toBeFalsy();
-      expect(hasClusterLatestCondition(cluster, 'Created')).toBeTruthy();
+      expect(getClusterLatestCondition(cluster)).toBe('Created');
     });
 
-    it(`doesn't break if there are no conditions in the cluster`, () => {
+    it('gets the latest cluster condition, on a v4 cluster', () => {
+      const cluster = Object.assign({}, v4AWSClusterResponse, {
+        status: v4AWSClusterStatusResponse,
+      });
+
+      expect(getClusterLatestCondition(cluster)).toBe('Created');
+    });
+
+    it(`doesn't break if there are no conditions in a v5 cluster`, () => {
       const cluster = Object.assign({}, v5ClusterResponse, {
         conditions: undefined,
       });
 
-      expect(hasClusterLatestCondition(cluster, 'Creating')).toBeFalsy();
-      expect(hasClusterLatestCondition(cluster, 'Created')).toBeFalsy();
+      expect(getClusterLatestCondition(cluster)).not.toBe('Created');
+    });
+
+    it(`doesn't break if there are no conditions in a v4 cluster`, () => {
+      const cluster = Object.assign({}, v4AWSClusterResponse, {
+        status: undefined,
+      });
+
+      expect(getClusterLatestCondition(cluster)).not.toBe('Created');
     });
   });
 
   describe('isClusterCreating', () => {
-    it('checks if the latest condition is the creating one', () => {
+    it('checks if the latest condition is the creating one, on a v5 cluster', () => {
       let cluster = Object.assign({}, v5ClusterResponse);
       expect(isClusterCreating(cluster)).toBeFalsy();
 
@@ -42,10 +60,33 @@ describe('clusterUtils', () => {
       });
       expect(isClusterCreating(cluster)).toBeTruthy();
     });
+
+    it('checks if the latest condition is the creating one, on a v4 cluster', () => {
+      const cluster = Object.assign({}, v4AWSClusterResponse, {
+        status: v4AWSClusterStatusResponse,
+      });
+      expect(isClusterCreating(cluster)).toBeFalsy();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cluster as any).status = {
+        ...cluster.status,
+        cluster: {
+          ...cluster.status.cluster,
+          conditions: [
+            {
+              lastTransitionTime: new Date().toISOString(),
+              type: 'Creating',
+            },
+          ],
+        },
+      };
+
+      expect(isClusterCreating(cluster)).toBeTruthy();
+    });
   });
 
   describe('isClusterUpdating', () => {
-    it('checks if the latest condition is the updating one', () => {
+    it('checks if the latest condition is the updating one, on a v5 cluster', () => {
       let cluster = Object.assign({}, v5ClusterResponse);
       expect(isClusterUpdating(cluster)).toBeFalsy();
 
@@ -59,10 +100,33 @@ describe('clusterUtils', () => {
       });
       expect(isClusterUpdating(cluster)).toBeTruthy();
     });
+
+    it('checks if the latest condition is the updating one, on a v4 cluster', () => {
+      const cluster = Object.assign({}, v4AWSClusterResponse, {
+        status: v4AWSClusterStatusResponse,
+      });
+      expect(isClusterUpdating(cluster)).toBeFalsy();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cluster as any).status = {
+        ...cluster.status,
+        cluster: {
+          ...cluster.status.cluster,
+          conditions: [
+            {
+              lastTransitionTime: new Date().toISOString(),
+              type: 'Updating',
+            },
+          ],
+        },
+      };
+
+      expect(isClusterUpdating(cluster)).toBeTruthy();
+    });
   });
 
   describe('isClusterDeleting', () => {
-    it('checks if the latest condition is the deleting one', () => {
+    it('checks if the latest condition is the deleting one, on a v5 cluster', () => {
       let cluster = Object.assign({}, v5ClusterResponse);
       expect(isClusterDeleting(cluster)).toBeFalsy();
 
@@ -74,6 +138,29 @@ describe('clusterUtils', () => {
           },
         ],
       });
+      expect(isClusterDeleting(cluster)).toBeTruthy();
+    });
+
+    it('checks if the latest condition is the deleting one, on a v4 cluster', () => {
+      const cluster = Object.assign({}, v4AWSClusterResponse, {
+        status: v4AWSClusterStatusResponse,
+      });
+      expect(isClusterDeleting(cluster)).toBeFalsy();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cluster as any).status = {
+        ...cluster.status,
+        cluster: {
+          ...cluster.status.cluster,
+          conditions: [
+            {
+              lastTransitionTime: new Date().toISOString(),
+              type: 'Deleting',
+            },
+          ],
+        },
+      };
+
       expect(isClusterDeleting(cluster)).toBeTruthy();
     });
   });

--- a/src/utils/clusterUtils.js
+++ b/src/utils/clusterUtils.js
@@ -231,15 +231,22 @@ export const filterLabels = (labels) => {
 };
 
 /**
- * Check whether the given condition is a cluster's latest condition.
+ * Get a cluster's latest condition
  * @param cluster {Object} - The cluster object.
- * @param conditionToCheck {string} - The name of the condition to check for.
- * @returns {boolean}
+ * @returns {string | undefined}
  */
-export function hasClusterLatestCondition(cluster, conditionToCheck) {
-  if (!cluster.conditions || cluster.conditions.length === 0) return false;
+export function getClusterLatestCondition(cluster) {
+  // It's a V5 cluster.
+  if (cluster.conditions?.length > 0) {
+    return cluster.conditions[0].condition;
+  }
 
-  return cluster.conditions[0].condition === conditionToCheck;
+  // It's a V4 cluster.
+  if (cluster.status?.cluster.conditions?.length > 0) {
+    return cluster.status.cluster.conditions[0].type;
+  }
+
+  return undefined;
 }
 
 /**
@@ -248,11 +255,10 @@ export function hasClusterLatestCondition(cluster, conditionToCheck) {
  * @returns {boolean}
  */
 export function isClusterCreating(cluster) {
-  if (!cluster.conditions || cluster.conditions.length === 0) return true;
+  const latestCondition = getClusterLatestCondition(cluster);
+  if (!latestCondition) return true;
 
-  const conditionToCheck = 'Creating';
-
-  return hasClusterLatestCondition(cluster, conditionToCheck);
+  return latestCondition === 'Creating';
 }
 
 /**
@@ -261,9 +267,9 @@ export function isClusterCreating(cluster) {
  * @returns {boolean}
  */
 export function isClusterUpdating(cluster) {
-  const conditionToCheck = 'Updating';
+  const latestCondition = getClusterLatestCondition(cluster);
 
-  return hasClusterLatestCondition(cluster, conditionToCheck);
+  return latestCondition === 'Updating';
 }
 
 /**
@@ -272,9 +278,9 @@ export function isClusterUpdating(cluster) {
  * @returns {boolean}
  */
 export function isClusterDeleting(cluster) {
-  const conditionToCheck = 'Deleting';
+  const latestCondition = getClusterLatestCondition(cluster);
 
-  return hasClusterLatestCondition(cluster, conditionToCheck);
+  return latestCondition === 'Deleting';
 }
 
 /**

--- a/testUtils/mockHttpCalls/status.js
+++ b/testUtils/mockHttpCalls/status.js
@@ -1,4 +1,5 @@
 import { Providers } from 'shared/constants';
+
 import { V4_CLUSTER } from './constantsAndHelpers';
 
 export const v4AWSClusterStatusResponse = {
@@ -19,7 +20,7 @@ export const v4AWSClusterStatusResponse = {
       {
         lastTransitionTime: '2019-11-15T15:54:05.711696992Z',
         status: 'True',
-        type: 'Creating',
+        type: 'Created',
       },
     ],
     network: { cidr: '10.1.2.0/24' },


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/12443

In this PR:
* Fix a bug that would make the upgrade cluster modal be in a broken state if an upgrade request failed
* Hide the upgrade cluster modal cancel button when an upgrade request is in progress
* Don't display the `Upgrade Available` button if a cluster is not ready
* Display whether a cluster has an upgrade in progress or not
* Handle cluster condition checks for V4 clusters, too (it was previously working just for V5 ones)

### Preview

<details>
<summary>Upgrade in progress - Cluster overview</summary>

![image](https://user-images.githubusercontent.com/13508038/89059215-0fe25100-d361-11ea-8648-ccb8e51b6c78.png)

</details>

<details>
<summary>Upgrade in progress - Cluster detail</summary>

![image](https://user-images.githubusercontent.com/13508038/89059175-fd681780-d360-11ea-9b99-d6af18ec9c92.png)

</details>

<details>
<summary>Upgrade in progress - Organization detail</summary>

![image](https://user-images.githubusercontent.com/13508038/89059192-048f2580-d361-11ea-9325-df1e3c4264c2.png)

</details>




