### PR TITLE
Fix empty release rows in cluster creation for non-admins

### DIFF
--- a/__tests__/ClusterManagement.js
+++ b/__tests__/ClusterManagement.js
@@ -256,13 +256,20 @@ it('it does not show disabled releases in release selection modal for regular us
 
   const table = container.querySelector('table');
 
+  let numActiveReleases = 0;
+
   for (const { version, active } of releasesResponse) {
     if (active === true) {
       expect(within(table).getByText(version)).toBeInTheDocument();
+      numActiveReleases++;
     } else {
       expect(queryByText(version)).not.toBeInTheDocument();
     }
   }
+
+  const tableRows = table.querySelectorAll('tbody tr');
+
+  expect(tableRows).toHaveLength(numActiveReleases);
 });
 
 it('it displays disabled releases in release selection modal for admin users', async () => {

--- a/src/selectors/releaseSelectors.ts
+++ b/src/selectors/releaseSelectors.ts
@@ -1,4 +1,5 @@
 import { IState } from 'reducers/types';
+import cmp from 'semver-compare';
 
 import { createDeepEqualSelector } from './selectorUtils';
 
@@ -7,9 +8,6 @@ export const getReleasesIsFetching = (state: IState): boolean =>
 
 export const getAllReleases = (state: IState): IReleases =>
   state.entities.releases.items;
-
-export const getSortedReleaseVersions = (state: IState): string[] =>
-  state.entities.releases.sortedVersions;
 
 export const getReleasesError = (state: IState): Error | null =>
   state.entities.releases.error;
@@ -32,4 +30,9 @@ export const getReleases = createDeepEqualSelector(
 
     return activeReleases;
   }
+);
+
+export const getSortedReleaseVersions = createDeepEqualSelector(
+  [getReleases],
+  (releases) => Object.keys(releases).sort(cmp).reverse()
 );

--- a/src/stores/releases/actions.ts
+++ b/src/stores/releases/actions.ts
@@ -1,7 +1,6 @@
 import GiantSwarm from 'giantswarm';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { IState } from 'reducers/types';
-import cmp from 'semver-compare';
 
 import { createAsynchronousAction } from '../asynchronousAction';
 import { IReleaseActionResponse } from './types';
@@ -14,7 +13,6 @@ export const loadReleases = createAsynchronousAction<
   actionTypePrefix: 'RELEASES_LOAD',
   perform: async (state) => {
     const releases: IReleases = {};
-    let sortedReleaseVersions: string[] = [];
 
     const api = new GiantSwarm.ReleasesApi();
     const response = await api.getReleases();
@@ -35,11 +33,9 @@ export const loadReleases = createAsynchronousAction<
       }
     }
 
-    sortedReleaseVersions = Object.keys(releases).sort(cmp).reverse();
-
     const userIsAdmin = state.main.loggedInUser.isAdmin;
 
-    if (sortedReleaseVersions.length === 0 && !userIsAdmin) {
+    if (Object.keys(releases).length === 0 && !userIsAdmin) {
       new FlashMessage(
         'No active releases available at the moment.',
         messageType.INFO,
@@ -48,7 +44,7 @@ export const loadReleases = createAsynchronousAction<
       );
     }
 
-    return { releases, sortedReleaseVersions };
+    return { releases };
   },
   shouldPerform: () => true,
   throwOnError: false,

--- a/src/stores/releases/reducer.ts
+++ b/src/stores/releases/reducer.ts
@@ -7,14 +7,12 @@ interface IState {
   error?: Error;
   isFetching: boolean;
   items: IReleases;
-  sortedVersions: string[];
 }
 
 const initialState: IState = {
   error: undefined,
   isFetching: false,
   items: {},
-  sortedVersions: [],
 };
 
 const releasesReducer = produce(
@@ -34,7 +32,6 @@ const releasesReducer = produce(
         draft.isFetching = false;
         draft.error = undefined;
         draft.items = action.response.releases;
-        draft.sortedVersions = action.response.sortedReleaseVersions;
 
         break;
 

--- a/src/stores/releases/types.ts
+++ b/src/stores/releases/types.ts
@@ -1,4 +1,3 @@
 export interface IReleaseActionResponse {
   releases: IReleases;
-  sortedReleaseVersions: string[];
 }


### PR DESCRIPTION
Fixes giantswarm/giantswarm#12526

This makes the sorted list of release dependant on the available releases which is already filtered for admins/non-admins.