### PR TITLE
azure v5: add support for modifying node pools

### DIFF
--- a/src/components/Cluster/ClusterDetail/NodePool.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePool.tsx
@@ -10,7 +10,7 @@ import Tooltip from 'react-bootstrap/lib/Tooltip';
 import { connect, DispatchProp } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { Providers } from 'shared';
-import { INodePool } from 'shared/types';
+import { INodePool, PropertiesOf } from 'shared/types';
 import { Code, Ellipsis } from 'styles/';
 import ViewAndEditName from 'UI/ViewEditName';
 
@@ -82,7 +82,7 @@ interface IDispatchProps extends DispatchProp {
 interface INodePoolsProps extends IStateProps, IDispatchProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   cluster: any;
-  provider: string;
+  provider: PropertiesOf<typeof Providers>;
 }
 
 interface INodePoolsState {
@@ -248,9 +248,7 @@ class NodePool extends Component<INodePoolsProps, INodePoolsState> {
             <div>
               <AvailabilityZonesWrapper zones={availability_zones} />
             </div>
-            {provider === Providers.AWS && (
-              <NodePoolScaling nodePool={nodePool} provider={provider} />
-            )}
+            <NodePoolScaling nodePool={nodePool} provider={provider} />
             <StyledNodePoolDropdownMenu
               provider={provider}
               clusterId={cluster.id}

--- a/src/components/Cluster/ClusterDetail/NodePoolDropdownMenu.js
+++ b/src/components/Cluster/ClusterDetail/NodePoolDropdownMenu.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import * as Providers from 'shared/constants/providers';
 import DropdownMenu, { DropdownTrigger, Link, List } from 'UI/DropdownMenu';
 
 const NodePoolDropdownMenu = ({
@@ -44,21 +43,17 @@ const NodePoolDropdownMenu = ({
                   Rename
                 </Link>
               </li>
-
-              {provider === Providers.AWS && (
-                <li>
-                  <Link
-                    href='#'
-                    onClick={(e) => {
-                      e.preventDefault();
-                      showNodePoolScalingModal(nodePool);
-                    }}
-                  >
-                    Edit scaling limits
-                  </Link>
-                </li>
-              )}
-
+              <li>
+                <Link
+                  href='#'
+                  onClick={(e) => {
+                    e.preventDefault();
+                    showNodePoolScalingModal(nodePool);
+                  }}
+                >
+                  Edit scaling limits
+                </Link>
+              </li>
               <li>
                 <Link
                   href='#'

--- a/src/components/Cluster/ClusterDetail/NodePoolScaling.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePoolScaling.tsx
@@ -54,10 +54,16 @@ const NodePoolScaling: React.FC<INodePoolScalingProps> = ({
 
   return (
     <>
-      <NodesWrapper data-testid='scaling-min'>{scaling.min}</NodesWrapper>
+      {provider === Providers.AWS && (
+        <NodesWrapper data-testid='scaling-min'>{scaling.min}</NodesWrapper>
+      )}
+
       <NodesWrapper data-testid='scaling-max'>{scaling.max}</NodesWrapper>
-      <NodesWrapper>{desired}</NodesWrapper>
+
+      {provider === Providers.AWS && <NodesWrapper>{desired}</NodesWrapper>}
+
       <NodesWrapper highlight={current < desired}>{current}</NodesWrapper>
+
       {provider === Providers.AWS ? (
         <OverlayTrigger
           overlay={

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -91,12 +91,12 @@ const GridRowNodePoolsNodes = styled.div`
   padding-bottom: 0;
   transform: translateY(12px);
   div {
-    grid-column: 5 / span 5;
+    grid-column: ${({ compact }) => (compact ? '5 / span 2' : '5 / span 5')};
     font-size: 12px;
     position: relative;
     width: 100%;
     text-align: center;
-    transform: translateX(0.8vw);
+    transform: ${({ compact }) => !compact && 'translateX(0.8vw)'};
     span {
       display: inline-block;
       padding: 0 10px;
@@ -429,13 +429,11 @@ class V5ClusterDetailTable extends React.Component {
           <h2>Node Pools</h2>
           {!zeroNodePools && !loadingNodePools && (
             <>
-              {provider === Providers.AWS && (
-                <GridRowNodePoolsNodes>
-                  <div>
-                    <span>NODES</span>
-                  </div>
-                </GridRowNodePoolsNodes>
-              )}
+              <GridRowNodePoolsNodes compact={provider === Providers.AZURE}>
+                <div>
+                  <span>NODES</span>
+                </div>
+              </GridRowNodePoolsNodes>
               <GridRowNodePoolsHeaders>
                 <NodePoolsColumnHeader>Id</NodePoolsColumnHeader>
                 <NodePoolsNameColumn>Name</NodePoolsNameColumn>
@@ -443,11 +441,7 @@ class V5ClusterDetailTable extends React.Component {
                 <NodePoolsColumnHeader>
                   Availability Zones
                 </NodePoolsColumnHeader>
-
-                {provider === Providers.AWS && (
-                  <V5ClusterDetailTableNodePoolScaling />
-                )}
-
+                <V5ClusterDetailTableNodePoolScaling provider={provider} />
                 <NodePoolsColumnHeader>&nbsp;</NodePoolsColumnHeader>
               </GridRowNodePoolsHeaders>
               <TransitionGroup>

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTableNodePoolScaling.tsx
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTableNodePoolScaling.tsx
@@ -1,40 +1,68 @@
 import { NodePoolsColumnHeader } from 'Cluster/ClusterDetail/V5ClusterDetailTable';
+import PropTypes from 'prop-types';
 import React from 'react';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
-import { Constants } from 'shared';
+import { Constants, Providers } from 'shared';
+import { PropertiesOf } from 'shared/types';
 
-interface IV5ClusterDetailTableNodePoolScalingProps {}
+interface IV5ClusterDetailTableNodePoolScalingProps {
+  provider: PropertiesOf<typeof Providers>;
+}
 
-const V5ClusterDetailTableNodePoolScaling: React.FC<IV5ClusterDetailTableNodePoolScalingProps> = () => {
+const V5ClusterDetailTableNodePoolScaling: React.FC<IV5ClusterDetailTableNodePoolScalingProps> = ({
+  provider,
+}) => {
   return (
     <>
-      <OverlayTrigger
-        overlay={
-          <Tooltip id='min-tooltip'>{Constants.MIN_NODES_EXPLANATION}</Tooltip>
-        }
-        placement='top'
-      >
-        <NodePoolsColumnHeader>Min</NodePoolsColumnHeader>
-      </OverlayTrigger>
-      <OverlayTrigger
-        overlay={
-          <Tooltip id='max-tooltip'>{Constants.MAX_NODES_EXPLANATION}</Tooltip>
-        }
-        placement='top'
-      >
-        <NodePoolsColumnHeader>Max</NodePoolsColumnHeader>
-      </OverlayTrigger>
-      <OverlayTrigger
-        overlay={
-          <Tooltip id='desired-tooltip'>
-            {Constants.DESIRED_NODES_EXPLANATION}
-          </Tooltip>
-        }
-        placement='top'
-      >
-        <NodePoolsColumnHeader>Desired</NodePoolsColumnHeader>
-      </OverlayTrigger>
+      {provider === Providers.AWS && (
+        <>
+          <OverlayTrigger
+            overlay={
+              <Tooltip id='min-tooltip'>
+                {Constants.MIN_NODES_EXPLANATION}
+              </Tooltip>
+            }
+            placement='top'
+          >
+            <NodePoolsColumnHeader>Min</NodePoolsColumnHeader>
+          </OverlayTrigger>
+          <OverlayTrigger
+            overlay={
+              <Tooltip id='max-tooltip'>
+                {Constants.MAX_NODES_EXPLANATION}
+              </Tooltip>
+            }
+            placement='top'
+          >
+            <NodePoolsColumnHeader>Max</NodePoolsColumnHeader>
+          </OverlayTrigger>
+          <OverlayTrigger
+            overlay={
+              <Tooltip id='desired-tooltip'>
+                {Constants.DESIRED_NODES_EXPLANATION}
+              </Tooltip>
+            }
+            placement='top'
+          >
+            <NodePoolsColumnHeader>Desired</NodePoolsColumnHeader>
+          </OverlayTrigger>
+        </>
+      )}
+
+      {provider === Providers.AZURE && (
+        <OverlayTrigger
+          overlay={
+            <Tooltip id='min-tooltip'>
+              {Constants.NODES_COUNT_EXPLANATION}
+            </Tooltip>
+          }
+          placement='top'
+        >
+          <NodePoolsColumnHeader>Count</NodePoolsColumnHeader>
+        </OverlayTrigger>
+      )}
+
       <OverlayTrigger
         overlay={
           <Tooltip id='current-tooltip'>
@@ -45,20 +73,25 @@ const V5ClusterDetailTableNodePoolScaling: React.FC<IV5ClusterDetailTableNodePoo
       >
         <NodePoolsColumnHeader>Current</NodePoolsColumnHeader>
       </OverlayTrigger>
-      <OverlayTrigger
-        overlay={
-          <Tooltip id='spot-tooltip'>
-            {Constants.SPOT_NODES_EXPLNANATION}
-          </Tooltip>
-        }
-        placement='top'
-      >
-        <NodePoolsColumnHeader>Spot</NodePoolsColumnHeader>
-      </OverlayTrigger>
+
+      {provider === Providers.AWS && (
+        <OverlayTrigger
+          overlay={
+            <Tooltip id='spot-tooltip'>
+              {Constants.SPOT_NODES_EXPLNANATION}
+            </Tooltip>
+          }
+          placement='top'
+        >
+          <NodePoolsColumnHeader>Spot</NodePoolsColumnHeader>
+        </OverlayTrigger>
+      )}
     </>
   );
 };
 
-V5ClusterDetailTableNodePoolScaling.propTypes = {};
+V5ClusterDetailTableNodePoolScaling.propTypes = {
+  provider: PropTypes.oneOf(Object.values(Providers)).isRequired,
+};
 
 export default V5ClusterDetailTableNodePoolScaling;

--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -33,6 +33,7 @@ export const Constants = {
   // UI labels
   CURRENT_NODES_INPOOL_EXPLANATION:
     'Current number of worker nodes in the node pool',
+  NODES_COUNT_EXPLANATION: 'Desired number of worker nodes in the node pool',
   DESIRED_NODES_EXPLANATION:
     'Autoscaler’s idea of how many nodes would be required for the workloads',
   MIN_NODES_EXPLANATION:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12535

This PR:
* Adds support for scaling node pools (also displaying the number of nodes, which I disabled some time ago)
* Adds support for renaming node pools

Autoscaling is disabled on purpose. It's not supported on Azure at the moment.
Needs API branch from main issue.

### Preview

<details>
<summary>Node pool overview</summary>

![image](https://user-images.githubusercontent.com/13508038/89287118-a3fb3380-d653-11ea-9f81-c2e93e361ab0.png)

</details>

<details>

<summary>Edit scaling limits</summary>

![image](https://user-images.githubusercontent.com/13508038/89287156-b9705d80-d653-11ea-9eb5-6246d2739a5d.png)

</details>