### PR TITLE
Use alternative unused expressions typescript-eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -111,7 +111,7 @@ module.exports = {
     'no-sequences': 2,
     'no-throw-literal': 2,
     'no-unmodified-loop-condition': 2,
-    'no-unused-expressions': 2,
+    'no-unused-expressions': 0,
     'no-unused-labels': 2,
     'no-useless-call': 2,
     'no-useless-catch': 1,
@@ -222,6 +222,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 0,
     '@typescript-eslint/no-use-before-define': [2, { functions: false }],
     '@typescript-eslint/unbound-method': 0,
+    '@typescript-eslint/no-unused-expressions': 2,
   },
   extends: [
     'eslint:recommended',

--- a/src/actions/metadataActions.ts
+++ b/src/actions/metadataActions.ts
@@ -103,7 +103,6 @@ export const checkForUpdates = (
     } catch {
       // Do nothing
     } finally {
-      // eslint-disable-next-line no-unused-expressions
       callback?.();
     }
   };

--- a/src/components/AppCatalog/CatalogList/CatalogExternalLink.js
+++ b/src/components/AppCatalog/CatalogList/CatalogExternalLink.js
@@ -11,7 +11,6 @@ const CatalogExternalLink = (props) => {
   const onClick = (e) => {
     e.stopPropagation();
 
-    // eslint-disable-next-line no-unused-expressions
     props.onClick?.();
   };
 

--- a/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesConverter.tsx
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesConverter.tsx
@@ -31,7 +31,6 @@ const MasterNodeConverter: React.FC<IMasterNodeConverterProps> = ({
       e.preventDefault();
       e.stopPropagation();
 
-      // eslint-disable-next-line no-unused-expressions
       callback?.();
     };
   };

--- a/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesInfo.tsx
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesInfo.tsx
@@ -63,7 +63,6 @@ const MasterNodesInfo: React.FC<IMasterNodesInfoProps> = ({
     e.preventDefault();
     e.stopPropagation();
 
-    // eslint-disable-next-line no-unused-expressions
     onConvert?.();
   };
 

--- a/src/components/Cluster/ClusterDetail/NodePool.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePool.tsx
@@ -137,7 +137,6 @@ class NodePool extends Component<INodePoolsProps, INodePoolsState> {
   };
 
   triggerEditName = () => {
-    // eslint-disable-next-line no-unused-expressions
     this.viewEditNameRef?.activateEditMode();
   };
 
@@ -166,11 +165,8 @@ class NodePool extends Component<INodePoolsProps, INodePoolsState> {
   };
 
   showNodePoolScalingModal = (nodePool: INodePool): void => {
-    // eslint-disable-next-line no-unused-expressions
     this.scaleNodePoolModal?.reset();
-    // eslint-disable-next-line no-unused-expressions
     this.scaleNodePoolModal?.show();
-    // eslint-disable-next-line no-unused-expressions
     this.scaleNodePoolModal?.setNodePool(nodePool);
   };
 

--- a/src/components/Cluster/NewCluster/MasterNodes.tsx
+++ b/src/components/Cluster/NewCluster/MasterNodes.tsx
@@ -23,7 +23,6 @@ const MasterNodes: React.FC<IMasterNodesProps> = ({
   onChange,
 }) => {
   const handleChange = (isHA: boolean) => () => {
-    // eslint-disable-next-line no-unused-expressions
     onChange?.(isHA);
   };
 

--- a/src/components/Home/UpgradeNotice.tsx
+++ b/src/components/Home/UpgradeNotice.tsx
@@ -56,7 +56,6 @@ function UpgradeNotice({
   const handleUpgrade = () => {
     if (isClusterUpgrading) return;
 
-    // eslint-disable-next-line no-unused-expressions
     onClick?.();
   };
 

--- a/src/components/UI/Inputs/FileInput.tsx
+++ b/src/components/UI/Inputs/FileInput.tsx
@@ -5,7 +5,6 @@ import Input, { IInput, InputElement } from './Input';
 
 const FileInput: FC<IInput<FileList>> = (props) => {
   const onChange = (e: ChangeEvent<ElementRef<'input'>>) => {
-    // eslint-disable-next-line no-unused-expressions
     props.onChange?.(e.target.files);
   };
 

--- a/src/components/UI/Inputs/Input.tsx
+++ b/src/components/UI/Inputs/Input.tsx
@@ -76,7 +76,6 @@ export interface IInput<T> {
 
 const Input: FC<IInput<string | FileList>> = (props) => {
   const onChange = (e: ChangeEvent<ElementRef<'input'>>) => {
-    // eslint-disable-next-line no-unused-expressions
     props.onChange?.(e.target.value);
   };
 

--- a/src/components/UI/ViewEditName.tsx
+++ b/src/components/UI/ViewEditName.tsx
@@ -125,7 +125,6 @@ class ViewAndEditName extends Component<
     });
 
     const { onToggleEditingState } = this.props;
-    // eslint-disable-next-line no-unused-expressions
     onToggleEditingState?.(state);
   }
 
@@ -152,7 +151,6 @@ class ViewAndEditName extends Component<
   };
 
   handleSubmit = (e?: FormEvent<HTMLFormElement>) => {
-    // eslint-disable-next-line no-unused-expressions
     e?.preventDefault();
 
     const { value } = this.state;

--- a/src/lib/errors/ErrorReporter.js
+++ b/src/lib/errors/ErrorReporter.js
@@ -32,7 +32,6 @@ export class ErrorReporter {
    * @param {string | Object} error - The error to report
    */
   notify(error) {
-    // eslint-disable-next-line no-unused-expressions
     this.notifier?.notify(error);
   }
 }

--- a/src/lib/flashMessage.js
+++ b/src/lib/flashMessage.js
@@ -101,7 +101,6 @@ export function forceRemoveAll() {
   clearQueues();
 
   const notificationWrapper = document.querySelector('.noty_layout');
-  // eslint-disable-next-line no-unused-expressions
   notificationWrapper?.remove();
 }
 


### PR DESCRIPTION
This PR uses the alternative `@typescript-eslint/no-unused-expressions` linter rule, instead of the built-in `no-unused-expressions`, to add support for optional chaining, so we won't need to disable the rule every time.