### PR TITLE
Always redirect to the cluster overview page after changing organizations

### DIFF
--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -197,6 +197,7 @@ export const batchedOrganizationSelect = (orgId) => async (dispatch) => {
         withLoadingFlags: true,
       })
     );
+    dispatch(push(AppRoutes.Home));
   } catch (err) {
     ErrorReporter.getInstance().notify(err);
   }

--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -185,6 +185,7 @@ export const batchedClusterDeleteConfirmed = (cluster) => async (dispatch) => {
 export const batchedOrganizationSelect = (orgId) => async (dispatch) => {
   try {
     await dispatch(organizationActions.organizationSelect(orgId));
+    dispatch(push(AppRoutes.Home));
     dispatch(
       clusterActions.clustersDetails({
         filterBySelectedOrganization: true,
@@ -197,7 +198,6 @@ export const batchedOrganizationSelect = (orgId) => async (dispatch) => {
         withLoadingFlags: true,
       })
     );
-    dispatch(push(AppRoutes.Home));
   } catch (err) {
     ErrorReporter.getInstance().notify(err);
   }

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -53,10 +53,10 @@ class Layout extends React.Component {
     }
   }
 
-  selectOrganization = (orgId) => {
+  selectOrganization = async (orgId) => {
     const { dispatch } = this.props;
 
-    dispatch(batchedOrganizationSelect(orgId));
+    await dispatch(batchedOrganizationSelect(orgId));
     dispatch(push(AppRoutes.Home));
   };
 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -53,11 +53,10 @@ class Layout extends React.Component {
     }
   }
 
-  selectOrganization = async (orgId) => {
+  selectOrganization = (orgId) => {
     const { dispatch } = this.props;
 
-    await dispatch(batchedOrganizationSelect(orgId));
-    dispatch(push(AppRoutes.Home));
+    dispatch(batchedOrganizationSelect(orgId));
   };
 
   render() {

--- a/src/components/UI/Navigation/OrganizationDropdown.js
+++ b/src/components/UI/Navigation/OrganizationDropdown.js
@@ -206,7 +206,10 @@ const OrganizationDropdown = ({
                             href='#'
                             to='#'
                             activeClassName=''
-                            onClick={() => {
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+
                               onSelectOrganization(org);
                               onClickHandler();
                             }}


### PR DESCRIPTION
This PR prevents having a random page reload after selecting a new organization, which prevented redirecting to the cluster overview page.