### PR TITLE
Redirect user to the login page if initial data fetch fails

### DIFF
--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -1,5 +1,6 @@
 import { push } from 'connected-react-router';
 import { ErrorReporter } from 'lib/errors';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import RoutePath from 'lib/routePath';
 import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import { listCatalogs } from 'stores/appcatalog/actions';
@@ -16,6 +17,17 @@ export const batchedLayout = () => async (dispatch) => {
   try {
     await dispatch(userActions.refreshUserInfo());
     await dispatch(userActions.getInfo());
+  } catch (err) {
+    new FlashMessage(
+      'Please log in again, as your previously saved credentials appear to be invalid.',
+      messageType.WARNING,
+      messageTTL.MEDIUM
+    );
+    dispatch(push(AppRoutes.Login));
+    ErrorReporter.getInstance().notify(err);
+  }
+
+  try {
     await dispatch(organizationActions.organizationsLoad());
     dispatch(listCatalogs());
     dispatch(loadReleases());

--- a/src/actions/batchedActions.js
+++ b/src/actions/batchedActions.js
@@ -25,6 +25,8 @@ export const batchedLayout = () => async (dispatch) => {
     );
     dispatch(push(AppRoutes.Login));
     ErrorReporter.getInstance().notify(err);
+
+    return;
   }
 
   try {


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/12490

Previously, if refreshing the user info, or fetching the installation info failed, the app would be stuck in a loading state. (can be tested easily by trying to use happa locally with VPN turned off)

Now, we redirect the user to the login page and we display this flash message:

![image](https://user-images.githubusercontent.com/13508038/89921817-79364f80-dbfe-11ea-8b57-e4ca568e9235.png)
