### PR TITLE
Use the NavLink to go Home.

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -55,9 +55,7 @@ class Layout extends React.Component {
 
   selectOrganization = (orgId) => {
     const { dispatch } = this.props;
-
     dispatch(batchedOrganizationSelect(orgId));
-    dispatch(push(AppRoutes.Home));
   };
 
   render() {

--- a/src/components/UI/Navigation/OrganizationDropdown.js
+++ b/src/components/UI/Navigation/OrganizationDropdown.js
@@ -3,7 +3,7 @@ import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
-import { OrganizationsRoutes } from 'shared/constants/routes';
+import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import DropdownMenu, { DropdownTrigger, List } from 'UI/DropdownMenu';
 
 const OrganizationDropdownTrigger = styled(DropdownTrigger)`
@@ -203,8 +203,8 @@ const OrganizationDropdown = ({
                       {sortedOrganizations.map((org) => (
                         <li role='presentation' key={org}>
                           <MenuItem
-                            href='#'
-                            to='#'
+                            href={AppRoutes.Home}
+                            to={AppRoutes.Home}
                             activeClassName=''
                             onClick={() => {
                               onSelectOrganization(org);


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/12705 

I noticed what was happening is actually that two route change events were occurring right after one another.

The dropdown menu item is a NavLink that wants to go to "#" after being clicked on.

Let's use the NavLink to bring us home instead.