### PR TITLE
remove 'next' button from install app modal

### DIFF
--- a/src/components/AppCatalog/AppDetail/ClusterPicker.js
+++ b/src/components/AppCatalog/AppDetail/ClusterPicker.js
@@ -11,7 +11,6 @@ const ClusterPickerWrapper = styled.div`
 `;
 
 const ClusterList = styled.div`
-  flex-grow: 1px;
   overflow: auto;
 `;
 

--- a/src/components/AppCatalog/AppDetail/InstallAppModal.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppModal.js
@@ -227,14 +227,9 @@ const InstallAppModal = (props) => {
               <GenericModal
                 {...props}
                 footer={
-                  <>
-                    <Button bsStyle='primary' onClick={next}>
-                      Next
-                    </Button>
-                    <Button bsStyle='link' onClick={onClose}>
-                      Cancel
-                    </Button>
-                  </>
+                  <Button bsStyle='link' onClick={onClose}>
+                    Cancel
+                  </Button>
                 }
                 onClose={onClose}
                 title={`Install ${props.app.name}: Pick a cluster`}


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/12545

This simply removes the `Next` button from the first page of the app installation modal since it allowed to proceed to the actual app installation page without selecting a cluster.