### PR TITLE
Fix error on app values/secrets upload cancellation

### DIFF
--- a/src/components/AppCatalog/AppDetail/InstallAppModal.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppModal.js
@@ -140,6 +140,13 @@ const InstallAppModal = (props) => {
   };
 
   const updateValuesYAML = (files) => {
+    if (files.length < 1) {
+      setValuesYAML({});
+      setValuesYAMLError('');
+
+      return;
+    }
+
     const reader = new FileReader();
 
     reader.onload = (e) => {
@@ -156,6 +163,13 @@ const InstallAppModal = (props) => {
   };
 
   const updateSecretsYAML = (files) => {
+    if (files.length < 1) {
+      setSecretsYAML({});
+      setSecretsYAMLError('');
+
+      return;
+    }
+
     const reader = new FileReader();
 
     reader.onload = (e) => {


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C3MCF5EJK/p1597247224000200

#### How to reproduce the issue?
1. Open the app installation modal

<details>
<summary>2. Press on 'Choose file' and select a file</summary>

![image](https://user-images.githubusercontent.com/13508038/90120284-de06bc80-dd5a-11ea-87fb-faba48c2713f.png)

</details>

<details>
<summary>3. Press on 'Choose file' again</summary>

![image](https://user-images.githubusercontent.com/13508038/90120376-f676d700-dd5a-11ea-83b3-9b79f8bfb0e8.png)

</details>

<details>
<summary>4. Press 'Cancel'</summary>

![image](https://user-images.githubusercontent.com/13508038/90120444-0989a700-dd5b-11ea-86d4-a7ed2837deb5.png)

</details>

<details>
<summary>5. The input should now be empty again</summary>

![image](https://user-images.githubusercontent.com/13508038/90120495-160dff80-dd5b-11ea-87b9-dbee909df1ce.png)

</details>

<details>
<summary>6. Now if you check your console, you'll see the error. Also, if you now install the app, and check its details afterwards, you'll see that the app has config values set up, even though the file showed up as empty before</summary>

![image](https://user-images.githubusercontent.com/13508038/90120860-887edf80-dd5b-11ea-95e8-5121627e988f.png)

</details>