### PR TITLE
add ErrorBoundary around Clusterlist to catch Errors there

### DIFF
--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -22,6 +22,7 @@ import { Dot, mq } from 'styles';
 import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 import ErrorFallback from 'UI/ErrorFallback';
+import ErrorText from 'UI/ErrorText';
 import RefreshableLabel from 'UI/RefreshableLabel';
 import { isClusterCreating } from 'utils/clusterUtils';
 
@@ -216,14 +217,10 @@ function ClusterDashboardItem({
               </RefreshableLabel>
             </TitleWrapper>
             <ClusterDetailsDiv>
-              <ErrorFallback
-                error={
-                  <>
-                    <i className='fa fa-warning' /> Error while loading cluster
-                    details. We have been notified.
-                  </>
-                }
-              />
+              <ErrorText>
+                <i className='fa fa-warning' /> Error while loading cluster
+                details. We have been notified.
+              </ErrorText>
             </ClusterDetailsDiv>
           </ContentWrapper>
         </Wrapper>

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -17,6 +17,7 @@ import {
 } from 'selectors/clusterSelectors';
 import { CSSBreakpoints } from 'shared/constants';
 import { OrganizationsRoutes } from 'shared/constants/routes';
+import ErrorBoundary from 'shared/ErrorBoundary';
 import { Dot, mq } from 'styles';
 import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
@@ -202,66 +203,96 @@ function ClusterDashboardItem({
   }
 
   return (
-    <Wrapper>
-      <LabelWrapper>
-        <Link to={linkToCluster}>
-          <ClusterIDLabel clusterID={clusterId} copyEnabled />
-        </Link>
-      </LabelWrapper>
-
-      <ContentWrapper>
-        <TitleWrapper>
+    <ErrorBoundary
+      fallback={
+        <Wrapper>
+          <LabelWrapper>
+            <ClusterIDLabel clusterID={clusterId} copyEnabled />
+          </LabelWrapper>
+          <ContentWrapper>
+            <TitleWrapper>
+              <RefreshableLabel value={cluster.name}>
+                <NameWrapper>{cluster.name}</NameWrapper>
+              </RefreshableLabel>
+            </TitleWrapper>
+            <ClusterDetailsDiv>
+              <ErrorFallback
+                error={
+                  <>
+                    <i className='fa fa-warning' /> Error while loading cluster
+                    details. We have been notified.
+                  </>
+                }
+              />
+            </ClusterDetailsDiv>
+          </ContentWrapper>
+        </Wrapper>
+      }
+    >
+      <Wrapper>
+        <LabelWrapper>
           <Link to={linkToCluster}>
-            <RefreshableLabel value={cluster.name}>
-              <NameWrapper>{cluster.name}</NameWrapper>
-            </RefreshableLabel>
-            <UpgradeNotice clusterId={clusterId} />
+            <ClusterIDLabel clusterID={clusterId} copyEnabled />
           </Link>
-        </TitleWrapper>
+        </LabelWrapper>
 
-        <>
-          <RefreshableLabel value={cluster.release_version}>
-            <span>
-              <i className='fa fa-version-tag' title='Release version' />{' '}
-              {cluster.release_version}
-            </span>
-          </RefreshableLabel>
-          <Dot style={{ paddingLeft: 0 }} />
-          Created {relativeDate(cluster.create_date)}
-        </>
+        <ContentWrapper>
+          <TitleWrapper>
+            <Link to={linkToCluster}>
+              <RefreshableLabel value={cluster.name}>
+                <NameWrapper>{cluster.name}</NameWrapper>
+              </RefreshableLabel>
+              <UpgradeNotice clusterId={clusterId} />
+            </Link>
+          </TitleWrapper>
 
-        {/* Cluster resources */}
-        <ErrorFallback error={nodePoolsLoadError}>
-          <ClusterDetailsDiv>
-            {isV5Cluster ? (
-              <ClusterDashboardResourcesV5
-                cluster={cluster}
-                nodePools={nodePools}
-                isClusterCreating={isCreating}
-              />
-            ) : (
-              <ClusterDashboardResourcesV4
-                cluster={cluster}
-                isClusterCreating={isCreating}
-              />
-            )}
-          </ClusterDetailsDiv>
-        </ErrorFallback>
-      </ContentWrapper>
+          <>
+            <RefreshableLabel value={cluster.release_version}>
+              <span>
+                <i className='fa fa-version-tag' title='Release version' />{' '}
+                {cluster.release_version}
+              </span>
+            </RefreshableLabel>
+            <Dot style={{ paddingLeft: 0 }} />
+            Created {relativeDate(cluster.create_date)}
+          </>
 
-      <ButtonsWrapper>
-        {clusterYoungerThan30Days() ? (
-          <ButtonGroup>
-            <GetStartedButton onClick={accessCluster}>
-              <i className='fa fa-start' />
-              Get Started
-            </GetStartedButton>
-          </ButtonGroup>
-        ) : (
-          ''
-        )}
-      </ButtonsWrapper>
-    </Wrapper>
+          {/* Cluster resources */}
+
+          <ErrorFallback error={nodePoolsLoadError}>
+            <ClusterDetailsDiv>
+              {/*<ErrorBoundary>*/}
+              {isV5Cluster ? (
+                <ClusterDashboardResourcesV5
+                  cluster={cluster}
+                  nodePools={nodePools}
+                  isClusterCreating={isCreating}
+                />
+              ) : (
+                <ClusterDashboardResourcesV4
+                  cluster={cluster}
+                  isClusterCreating={isCreating}
+                />
+              )}
+              {/*</ErrorBoundary>*/}
+            </ClusterDetailsDiv>
+          </ErrorFallback>
+        </ContentWrapper>
+
+        <ButtonsWrapper>
+          {clusterYoungerThan30Days() ? (
+            <ButtonGroup>
+              <GetStartedButton onClick={accessCluster}>
+                <i className='fa fa-start' />
+                Get Started
+              </GetStartedButton>
+            </ButtonGroup>
+          ) : (
+            ''
+          )}
+        </ButtonsWrapper>
+      </Wrapper>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -258,10 +258,8 @@ function ClusterDashboardItem({
           </>
 
           {/* Cluster resources */}
-
           <ErrorFallback error={nodePoolsLoadError}>
             <ClusterDetailsDiv>
-              {/*<ErrorBoundary>*/}
               {isV5Cluster ? (
                 <ClusterDashboardResourcesV5
                   cluster={cluster}
@@ -274,7 +272,6 @@ function ClusterDashboardItem({
                   isClusterCreating={isCreating}
                 />
               )}
-              {/*</ErrorBoundary>*/}
             </ClusterDetailsDiv>
           </ErrorFallback>
         </ContentWrapper>

--- a/src/components/UI/ErrorFallback.tsx
+++ b/src/components/UI/ErrorFallback.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 
 const ErrorWrapperSpan = styled.span`
   color: ${(props) => props.theme.colors.error};
@@ -9,7 +9,7 @@ const ErrorWrapperSpan = styled.span`
 
 interface IErrorFallbackProps {
   children?: ReactElement;
-  error?: string;
+  error?: string | ReactNode;
   className?: string;
 }
 

--- a/src/components/UI/ErrorFallback.tsx
+++ b/src/components/UI/ErrorFallback.tsx
@@ -1,11 +1,6 @@
-import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import React, { ReactElement, ReactNode } from 'react';
-
-const ErrorWrapperSpan = styled.span`
-  color: ${(props) => props.theme.colors.error};
-  font-weight: 300;
-`;
+import ErrorText from 'UI/ErrorText';
 
 interface IErrorFallbackProps {
   children?: ReactElement;
@@ -23,7 +18,7 @@ const ErrorFallback: React.FC<IErrorFallbackProps> = ({
   className,
 }) => {
   if (error) {
-    return <ErrorWrapperSpan className={className}>{error}</ErrorWrapperSpan>;
+    return <ErrorText className={className}>{error}</ErrorText>;
   } else if (children) {
     return children;
   }

--- a/src/components/UI/ErrorText.tsx
+++ b/src/components/UI/ErrorText.tsx
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+const ErrorText = styled.span`
+  color: ${({ theme }) => theme.colors.error};
+  font-weight: 400;
+`;
+
+export default ErrorText;

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -30,10 +30,9 @@ export default class ErrorBoundary extends Component<
     return { hasError: true };
   }
 
-  constructor(props: IErrorBoundaryProps) {
-    super(props);
-    this.state = { hasError: false };
-  }
+  public readonly state: IErrorBoundaryState = {
+    hasError: false,
+  };
 
   componentDidCatch(error: Error) {
     if (this.props.reportError) {

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { ErrorReporter } from 'lib/errors';
+import PropTypes from 'prop-types';
+import React, { Component, ReactNode } from 'react';
+
+interface IErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+  reportError?: boolean;
+}
+
+interface IErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<
+  IErrorBoundaryProps,
+  IErrorBoundaryState
+> {
+  static propTypes = {
+    children: PropTypes.element.isRequired,
+    fallback: PropTypes.element,
+    reportError: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    reportError: true,
+  };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  constructor(props: IErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidCatch(error: Error) {
+    if (this.props.reportError) {
+      ErrorReporter.getInstance().notify(error);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <div>Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
This PR adds an ErrorBoundary component which can be used to wrap Components and display a fallback.

Its first use is wrapping ClusterDashboardItems and displaying a fallback component like this:

![image](https://user-images.githubusercontent.com/1494211/90139479-b9b9d880-dd78-11ea-9007-7ca5c1b010da.png)
