### PR TITLE
customer bug: nginx IC is not visible under installed apps, if ICs are optional

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterApps.js
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.js
@@ -317,7 +317,7 @@ class ClusterApps extends React.Component {
 
       switch (true) {
         case hasOptionalIngress &&
-          app.metadata.name === 'nginx-ingress-controller':
+          app.spec.name === Constants.INSTALL_INGRESS_TAB_APP_NAME:
           return true;
         case isManagedByClusterOperator:
           return false;

--- a/src/components/Cluster/ClusterDetail/ClusterApps.js
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.js
@@ -310,10 +310,23 @@ class ClusterApps extends React.Component {
       return [];
     }
 
-    return apps.filter(
-      (app) =>
-        app.metadata.labels['giantswarm.io/managed-by'] !== 'cluster-operator'
-    );
+    const { hasOptionalIngress } = this.props;
+    const filteredApps = apps.filter((app) => {
+      const isManagedByClusterOperator =
+        app.metadata.labels['giantswarm.io/managed-by'] === 'cluster-operator';
+
+      switch (true) {
+        case hasOptionalIngress &&
+          app.metadata.name === 'nginx-ingress-controller':
+          return true;
+        case isManagedByClusterOperator:
+          return false;
+        default:
+          return true;
+      }
+    });
+
+    return filteredApps;
   };
 
   render() {


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C13MG9F0W/p1597918009003000

This PR makes the `nginx-ingress-controller` app visible under the `Installed Apps` section, if it's installed and if ingress controllers are optional in the cluster's release version.