### PR TITLE
[CP Auth 2/5]: Add OIDC login helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "moment": "2.27.0",
     "normalize.css": "8.0.1",
     "noty": "^3.1.4",
+    "oidc-client": "^1.10.1",
     "platform": "1.3.6",
     "prop-types": "15.7.2",
     "query-string": "6.13.1",

--- a/src/lib/OAuth2/OAuth2.ts
+++ b/src/lib/OAuth2/OAuth2.ts
@@ -1,0 +1,209 @@
+import {
+  convertToOIDCMetadata,
+  IOAuth2CustomMetadata,
+} from 'lib/OAuth2/OAuth2CustomMetadata';
+import OAuth2UserImpl from 'lib/OAuth2/OAuth2User';
+import {
+  User,
+  UserManager,
+  UserManagerSettings,
+  WebStorageStateStore,
+} from 'oidc-client';
+
+export enum OAuth2Events {
+  UserLoaded = 'userLoaded',
+  TokenExpired = 'tokenExpired',
+  TokenExpiring = 'tokenExpiring',
+  UserUnloaded = 'userUnloaded',
+  UserSignedOut = 'userSignedOut',
+  SilentRenewError = 'silentRenewError',
+}
+
+interface IOAuth2EventCallbacks {
+  [OAuth2Events.UserLoaded]: (event: CustomEvent<OAuth2UserImpl>) => void;
+  [OAuth2Events.TokenExpired]: () => void;
+  [OAuth2Events.TokenExpiring]: () => void;
+  [OAuth2Events.UserUnloaded]: () => void;
+  [OAuth2Events.UserSignedOut]: () => void;
+  [OAuth2Events.SilentRenewError]: (error: CustomEvent<Error>) => void;
+}
+
+export interface IOAuth2SigningKey {
+  use: string;
+  kty: string;
+  kid: string;
+  alg: string;
+  n: string;
+  e: string;
+}
+
+export interface IOAuth2Config {
+  authority: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  responseType?: string;
+  responseMode?: 'query' | 'fragment';
+  scope?: string;
+  prompt?: string;
+  automaticSilentRenew?: boolean;
+  includeIDTokenInSilentRenew?: boolean;
+  loadUserInfo?: boolean;
+  revokeAccessTokenOnLogout?: boolean;
+  filterProtocolClaims?: boolean;
+  validateSubOnSilentRenew?: boolean;
+  persistenceMethod?: Storage;
+  customMetadata?: Partial<IOAuth2CustomMetadata>;
+  signingKeys?: IOAuth2SigningKey[];
+}
+
+class OAuth2 {
+  protected userManager: UserManager;
+  protected eventEmitter: EventTarget;
+
+  constructor(config: IOAuth2Config) {
+    const persistenceMethod = new WebStorageStateStore({
+      store: config.persistenceMethod,
+    });
+
+    const customMetadata = convertToOIDCMetadata(config.customMetadata);
+
+    const managerConfig: UserManagerSettings = {
+      authority: config.authority,
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      redirect_uri: config.redirectUri,
+      response_type: config.responseType,
+      response_mode: config.responseMode,
+      scope: config.scope,
+      prompt: config.prompt,
+      automaticSilentRenew: config.automaticSilentRenew,
+      includeIdTokenInSilentRenew: config.includeIDTokenInSilentRenew,
+      loadUserInfo: config.loadUserInfo,
+      revokeAccessTokenOnSignout: config.revokeAccessTokenOnLogout,
+      filterProtocolClaims: config.filterProtocolClaims,
+      validateSubOnSilentRenew: config.validateSubOnSilentRenew,
+      userStore: persistenceMethod,
+      signingKeys: config.signingKeys,
+      metadata: customMetadata,
+    };
+
+    this.eventEmitter = new EventTarget();
+    this.userManager = new UserManager(managerConfig);
+
+    this.registerInternalEvents();
+  }
+
+  public attemptLogin(): Promise<void> {
+    return this.userManager.signinRedirect({ useReplaceToNavigate: true });
+  }
+
+  public async handleLoginResponse(
+    currentURL: string
+  ): Promise<OAuth2UserImpl> {
+    const origUser = await this.userManager.signinRedirectCallback(currentURL);
+    const newUser = OAuth2UserImpl.fromOIDCUser(origUser);
+
+    return newUser;
+  }
+
+  public async getLoggedInUser(): Promise<OAuth2UserImpl | null> {
+    let origUser = await this.userManager.getUser();
+    if (!origUser) return null;
+
+    // If user is already expired, renew his authentication.
+    if (origUser.expired) {
+      origUser = await this.userManager.signinSilent();
+    }
+
+    this.userManager.events.load(origUser);
+    const newUser = OAuth2UserImpl.fromOIDCUser(origUser);
+
+    return newUser;
+  }
+
+  public async renewUser(): Promise<OAuth2UserImpl> {
+    const origUser = await this.userManager.signinSilent();
+
+    this.userManager.events.load(origUser);
+    const newUser = OAuth2UserImpl.fromOIDCUser(origUser);
+
+    return newUser;
+  }
+
+  public async logout(): Promise<void> {
+    await this.userManager.removeUser();
+    await this.userManager.clearStaleState();
+  }
+
+  public addEventListener<
+    T extends OAuth2Events,
+    U extends IOAuth2EventCallbacks[T]
+  >(event: T, cb: U) {
+    this.eventEmitter.addEventListener(event, cb as EventListener, false);
+  }
+
+  public removeEventListener<
+    T extends OAuth2Events,
+    U extends IOAuth2EventCallbacks[T]
+  >(event: T, fn: U) {
+    this.eventEmitter.removeEventListener(event, fn as EventListener, false);
+  }
+
+  public unregisterInternalEvents() {
+    this.userManager.events.removeUserLoaded(this.onUserLoaded);
+    this.userManager.events.removeAccessTokenExpired(this.onAccessTokenExpired);
+    this.userManager.events.removeAccessTokenExpiring(
+      this.onAccessTokenExpiring
+    );
+    this.userManager.events.removeUserUnloaded(this.onUserUnloaded);
+    this.userManager.events.removeUserSignedOut(this.onUserSignedOut);
+    this.userManager.events.removeSilentRenewError(this.onSilentRenewError);
+  }
+
+  protected registerInternalEvents() {
+    this.userManager.events.addUserLoaded(this.onUserLoaded);
+    this.userManager.events.addAccessTokenExpired(this.onAccessTokenExpired);
+    this.userManager.events.addAccessTokenExpiring(this.onAccessTokenExpiring);
+    this.userManager.events.addUserUnloaded(this.onUserUnloaded);
+    this.userManager.events.addUserSignedOut(this.onUserSignedOut);
+    this.userManager.events.addSilentRenewError(this.onSilentRenewError);
+  }
+
+  protected onUserLoaded = (user: User) => {
+    const newUser = OAuth2UserImpl.fromOIDCUser(user);
+    const event = new CustomEvent(OAuth2Events.UserLoaded, {
+      detail: newUser,
+    });
+    this.eventEmitter.dispatchEvent(event);
+  };
+
+  protected onAccessTokenExpired = () => {
+    const event = new CustomEvent(OAuth2Events.TokenExpired);
+    this.eventEmitter.dispatchEvent(event);
+  };
+
+  protected onAccessTokenExpiring = () => {
+    const event = new CustomEvent(OAuth2Events.TokenExpiring);
+    this.eventEmitter.dispatchEvent(event);
+  };
+
+  protected onUserUnloaded = () => {
+    const event = new CustomEvent(OAuth2Events.UserUnloaded);
+    this.eventEmitter.dispatchEvent(event);
+  };
+
+  protected onUserSignedOut = () => {
+    const event = new CustomEvent(OAuth2Events.UserSignedOut);
+    this.eventEmitter.dispatchEvent(event);
+  };
+
+  protected onSilentRenewError = (error: Error) => {
+    const event = new CustomEvent(OAuth2Events.UserLoaded, {
+      detail: error,
+    });
+    this.eventEmitter.dispatchEvent(event);
+  };
+}
+
+export default OAuth2;

--- a/src/lib/OAuth2/OAuth2CustomMetadata.ts
+++ b/src/lib/OAuth2/OAuth2CustomMetadata.ts
@@ -1,0 +1,41 @@
+import { OidcMetadata } from 'oidc-client';
+
+export interface IOAuth2CustomMetadata {
+  issuer: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  jwksUri: string;
+  userInfoEndpoint: string;
+  endSessionEndpoint: string;
+
+  idTokenSigningAlgValuesSupported: string[];
+  tokenEndpointAuthMethodsSupported: string[];
+  scopesSupported: string[];
+  responseTypesSupported: string[];
+  subjectTypesSupported: string[];
+  claimsSupported: string[];
+}
+
+export function convertToOIDCMetadata(
+  metadata?: Partial<IOAuth2CustomMetadata>
+): Partial<OidcMetadata> | undefined {
+  if (!metadata) return undefined;
+
+  return {
+    issuer: metadata.issuer,
+    authorization_endpoint: metadata.authorizationEndpoint,
+    token_endpoint: metadata.tokenEndpoint,
+    jwks_uri: metadata.jwksUri,
+    userinfo_endpoint: metadata.userInfoEndpoint,
+    end_session_endpoint: metadata.endSessionEndpoint,
+
+    id_token_signing_alg_values_supported:
+      metadata.idTokenSigningAlgValuesSupported,
+    token_endpoint_auth_methods_supported:
+      metadata.tokenEndpointAuthMethodsSupported,
+    scopes_supported: metadata.scopesSupported,
+    response_types_supported: metadata.responseTypesSupported,
+    subject_types_supported: metadata.subjectTypesSupported,
+    claims_supported: metadata.claimsSupported,
+  };
+}

--- a/src/lib/OAuth2/OAuth2User.ts
+++ b/src/lib/OAuth2/OAuth2User.ts
@@ -1,0 +1,71 @@
+import { User } from 'oidc-client';
+import { AuthorizationTypes } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
+
+export interface IOAuth2User {
+  idToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  authorizationType: PropertiesOf<typeof AuthorizationTypes>;
+
+  groups: string[];
+  email: string;
+  emailVerified: boolean;
+}
+
+class OAuth2UserImpl implements IOAuth2User {
+  public readonly idToken: string = '';
+  public readonly refreshToken: string = '';
+  public readonly expiresAt: number = 0;
+  public readonly authorizationType: PropertiesOf<typeof AuthorizationTypes> =
+    AuthorizationTypes.BEARER;
+
+  public readonly groups: string[] = [];
+  public readonly email: string = '';
+  public readonly emailVerified: boolean = false;
+
+  public static fromOIDCUser(user: User): OAuth2UserImpl {
+    const newUser = new OAuth2UserImpl({
+      idToken: user.id_token,
+      refreshToken: user.refresh_token,
+      expiresAt: user.expires_at,
+      groups: user.profile.groups || [],
+      email: user.profile.email,
+      emailVerified: user.profile.email_verified,
+    });
+
+    return newUser;
+  }
+
+  constructor(fromObj?: Partial<IOAuth2User>) {
+    if (!fromObj) return;
+
+    for (const [key, value] of Object.entries(fromObj)) {
+      // @ts-ignore
+      this[key] = value;
+    }
+  }
+
+  public isExpired(): boolean {
+    const sInMs = 1000;
+    const now = Math.trunc(Date.now() / sInMs); // In seconds.
+    const expiresIn = this.expiresAt - now;
+
+    return expiresIn <= 0;
+  }
+
+  public serialize(): IOAuth2User {
+    return {
+      idToken: this.idToken,
+      refreshToken: this.refreshToken,
+      expiresAt: this.expiresAt,
+      authorizationType: this.authorizationType,
+
+      groups: this.groups,
+      email: this.email,
+      emailVerified: this.emailVerified,
+    };
+  }
+}
+
+export default OAuth2UserImpl;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4254,7 +4254,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.4, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -4399,7 +4399,7 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^3.2.1:
+crypto-js@^3.1.9-1, crypto-js@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
   integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
@@ -9181,6 +9181,16 @@ obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
+
+oidc-client@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/oidc-client/-/oidc-client-1.10.1.tgz#fe67ae54924fc1c338062f3fd733be362026192c"
+  integrity sha512-/QB5Nl7c9GmT9ir1E+OVY3+yZZnuk7Qa9ZEAJqSvDq0bAyAU9KAgeKipTEfKjGdGLTeOLy9FRWuNpULMkfZydQ==
+  dependencies:
+    base64-js "^1.3.0"
+    core-js "^2.6.4"
+    crypto-js "^3.1.9-1"
+    uuid "^3.3.2"
 
 on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Part of the larger #1547

This includes a wrapper around the `oidc-client-js` library, so we could replace the internal library at some point, and not have to cry about it.