### PR TITLE
[CP Auth 3/5]: add CP client and catalog service

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "dotenv": "8.2.0",
     "emotion-theming": "10.0.27",
     "giantswarm": "git+https://github.com/giantswarm/giantswarm-js-client.git",
+    "giantswarm-cp-client": "git+https://github.com/giantswarm/giantswarm-cp-client.git",
     "history": "4.10.1",
     "immer": "7.0.7",
     "immutable": "3.8.2",

--- a/src/components/Auth/AdminLogin.tsx
+++ b/src/components/Auth/AdminLogin.tsx
@@ -87,7 +87,7 @@ AdminLogin.propTypes = {
   user: PropTypes.object,
 };
 
-function mapStateToProps(state: IState) {
+function mapStateToProps(state: IState): IStateProps {
   return {
     user: state.main.loggedInUser,
   };
@@ -99,7 +99,4 @@ function mapDispatchToProps(dispatch: Dispatch): IDispatchProps {
   };
 }
 
-export default connect<IStateProps, IDispatchProps>(
-  mapStateToProps,
-  mapDispatchToProps
-)(AdminLogin);
+export default connect(mapStateToProps, mapDispatchToProps)(AdminLogin);

--- a/src/components/Cluster/ClusterDetail/__tests__/UpgradeClusterModal.tsx
+++ b/src/components/Cluster/ClusterDetail/__tests__/UpgradeClusterModal.tsx
@@ -8,7 +8,7 @@ import { renderWithStore } from 'testUtils/renderUtils';
 
 function renderAndOpen(
   props: React.ComponentPropsWithoutRef<typeof UpgradeClusterModal> = {},
-  state: IState = {}
+  state: Partial<IState> = {}
 ) {
   interface IComponent {
     show: () => void;
@@ -39,13 +39,13 @@ function createRelease(version: string, active: boolean): IRelease {
 function createInitialState(
   releases: Record<string, IRelease>,
   isAdmin: boolean = false
-) {
+): Partial<IState> {
   return {
-    entities: {
+    entities: ({
       releases: {
         items: releases,
       },
-    },
+    } as unknown) as IState['entities'],
     main: {
       loggedInUser: {
         isAdmin,
@@ -310,7 +310,9 @@ describe('UpgradeClusterModal', () => {
     fireEvent.click(screen.getByText(/inspect changes/i));
     fireEvent.click(screen.getByText(/change version/i));
 
-    const releaseVersions = Object.keys(initialState.entities.releases.items);
+    const releaseVersions = Object.keys(
+      (initialState as IState).entities.releases.items
+    );
     const currentVersionIdx = releaseVersions.indexOf(cluster.release_version);
     for (let i = 0; i < releaseVersions.length; i++) {
       if (i > currentVersionIdx) {

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -30,7 +30,9 @@ enum GlobalEnvironment {
 
 interface IGlobalConfig {
   apiEndpoint: string;
+  cpApiEndpoint: string;
   audience: string;
+  cpAudience: string;
   passageEndpoint: string;
   environment: GlobalEnvironment;
   ingressBaseDomain: string;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -14,6 +14,7 @@ import monkeyPatchGiantSwarmClient from 'lib/giantswarmClientPatcher';
 import { Requester } from 'lib/patchedAirbrakeRequester';
 import React from 'react';
 import { render } from 'react-dom';
+import { IState } from 'reducers/types';
 import { Store } from 'redux';
 import configureStore from 'stores/configureStore';
 import history from 'stores/history';
@@ -47,7 +48,7 @@ declare global {
 }
 
 // Configure the redux store.
-const store: Store = configureStore({}, history);
+const store: Store = configureStore({} as IState, history);
 
 // Patch the Giant Swarm client so it has access to the store and can dispatch
 // redux actions. This is needed because admin tokens expire after 5 minutes.

--- a/src/model/clients/CPClient.ts
+++ b/src/model/clients/CPClient.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from './HttpClient';
+
+/**
+ * The client used to access the Control Plane API.
+ */
+export class CPClient extends HttpClient {
+  /**
+   * Create a new Control Plane API client.
+   */
+  constructor(authToken: string, authType: string) {
+    super({
+      baseURL: window.config.cpApiEndpoint,
+    });
+
+    this.setHeader('Accept', 'application/json');
+    this.setAuthorizationToken(authType, authToken);
+  }
+}
+
+export default CPClient;

--- a/src/model/clients/FetchAdapter.ts
+++ b/src/model/clients/FetchAdapter.ts
@@ -1,0 +1,79 @@
+import { GenericResponse } from 'model/clients/GenericResponse';
+import { HttpClient } from 'model/clients/HttpClient';
+
+/**
+ * This is an adapter for using an HttpClient with the same
+ * interface as the global `fetch` function.
+ */
+class FetchAdapter<T extends HttpClient = HttpClient> {
+  public readonly baseClient: T;
+
+  constructor(baseClient: T) {
+    this.baseClient = baseClient;
+  }
+
+  private configureFromRequestInfo(reqInfo: RequestInfo) {
+    if (typeof reqInfo === 'string') {
+      this.baseClient.setURL(reqInfo);
+
+      return;
+    }
+
+    // Copy headers.
+    for (const [key, value] of reqInfo.headers.entries()) {
+      this.baseClient.setHeader(key, value);
+    }
+
+    // Copy request method.
+    this.baseClient.setRequestMethod(reqInfo.method);
+
+    // Copy the request body.
+    this.baseClient.setBody(JSON.stringify(reqInfo.body) as never);
+  }
+
+  private configureFromRequestInit(reqInit?: RequestInit) {
+    if (!reqInit) return;
+
+    const { headers, method, body } = reqInit;
+
+    if (headers) {
+      // Copy headers.
+      const newHeaders = new Headers(headers);
+      for (const [key, value] of newHeaders.entries()) {
+        this.baseClient.setHeader(key, value);
+      }
+    }
+
+    if (method) {
+      // Copy request method.
+      this.baseClient.setRequestMethod(method);
+    }
+
+    if (body) {
+      // Copy the request body.
+      this.baseClient.setBody(JSON.stringify(body) as never);
+    }
+  }
+
+  public async fetch(
+    input: RequestInfo,
+    init?: RequestInit,
+  ): Promise<Response> {
+    this.configureFromRequestInfo(input);
+    this.configureFromRequestInit(init);
+
+    try {
+      const result = await this.baseClient.execute();
+
+      return Promise.resolve(result.convertToFetchResponse());
+    } catch (err) {
+      if (err instanceof GenericResponse) {
+        return Promise.reject(err.convertToFetchResponse());
+      }
+
+      return Promise.reject(err);
+    }
+  }
+}
+
+export default FetchAdapter;

--- a/src/model/clients/FetchAdapter.ts
+++ b/src/model/clients/FetchAdapter.ts
@@ -57,7 +57,7 @@ class FetchAdapter<T extends HttpClient = HttpClient> {
 
   public async fetch(
     input: RequestInfo,
-    init?: RequestInit,
+    init?: RequestInit
   ): Promise<Response> {
     this.configureFromRequestInfo(input);
     this.configureFromRequestInit(init);

--- a/src/model/clients/GenericResponse.js
+++ b/src/model/clients/GenericResponse.js
@@ -85,8 +85,8 @@ export class GenericResponse {
 
   /**
    * Set a response header
-   * @param {number} key - Header name
-   * @param {number} [value=""] - Header Value
+   * @param {string} key - Header name
+   * @param {string} [value=""] - Header Value
    */
   setHeader(key, value = '') {
     this.config.headers[key] = value;
@@ -102,5 +102,27 @@ export class GenericResponse {
 
   get headers() {
     return Object.assign({}, this.config.headers);
+  }
+
+  /**
+   * Convert the object to a `Response` object returned by the fetch command.
+   * @returns {Response}
+   */
+  convertToFetchResponse() {
+    // Set headers.
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(this.headers)) {
+      headers.append(key, value);
+    }
+
+    const data = JSON.stringify(this.data);
+
+    const resultingResponse = new Response(data, {
+      headers: headers,
+      status: this.status,
+      statusText: this.message,
+    });
+
+    return resultingResponse;
   }
 }

--- a/src/model/services/controlplane/appcatalogs/appcatalogs.ts
+++ b/src/model/services/controlplane/appcatalogs/appcatalogs.ts
@@ -1,0 +1,57 @@
+import { HttpClient } from 'model/clients';
+import {
+  IAppCatalog,
+  IMetaData,
+  ISpec,
+  IStorage,
+} from 'model/services/controlplane/appcatalogs/types';
+import { getBaseConfiguration } from 'model/services/controlplane/base';
+
+/**
+ * Get the all the app catalogs in the installation.
+ * @param client - The HTTP client.
+ */
+export async function getAppCatalogs(
+  client: HttpClient
+): Promise<IAppCatalog[]> {
+  const { ApplicationGiantswarmIoV1alpha1Api } = await import(
+    'giantswarm-cp-client'
+  );
+  const baseConfig = await getBaseConfiguration(client);
+  const appsAPI = new ApplicationGiantswarmIoV1alpha1Api(baseConfig);
+
+  const catalogs = await appsAPI.listApplicationGiantswarmIoV1alpha1AppCatalog(
+    {}
+  );
+  const result = catalogs.items.map(convertAppCatalogCRToCatalog);
+
+  return result;
+}
+
+function convertAppCatalogCRToCatalog(
+  catalog: import('giantswarm-cp-client').ComGithubGiantswarmApiextensionsPkgApisApplicationV1alpha1AppCatalog
+): IAppCatalog {
+  const metadata: IMetaData = {
+    name: catalog.metadata.name ?? '',
+    labels: catalog.metadata.labels ?? {},
+  };
+
+  const storage: IStorage = {
+    type: catalog.spec.storage.type,
+    URL: catalog.spec.storage.uRL,
+  };
+
+  const spec: ISpec = {
+    title: catalog.spec.title,
+    description: catalog.spec.description,
+    logoURL: catalog.spec.logoURL,
+    storage: storage,
+  };
+
+  const newCatalog: IAppCatalog = {
+    metadata: metadata,
+    spec: spec,
+  };
+
+  return newCatalog;
+}

--- a/src/model/services/controlplane/appcatalogs/types.ts
+++ b/src/model/services/controlplane/appcatalogs/types.ts
@@ -1,0 +1,21 @@
+export interface IAppCatalog {
+  metadata: IMetaData;
+  spec: ISpec;
+}
+
+export interface IMetaData {
+  name: string;
+  labels: Record<string, string>;
+}
+
+export interface ISpec {
+  title: string;
+  description: string;
+  logoURL: string;
+  storage: IStorage;
+}
+
+export interface IStorage {
+  type: string;
+  URL: string;
+}

--- a/src/model/services/controlplane/base.ts
+++ b/src/model/services/controlplane/base.ts
@@ -1,0 +1,22 @@
+import { HttpClient } from 'model/clients';
+import FetchAdapter from 'model/clients/FetchAdapter';
+
+type Configuration = import('giantswarm-cp-client').Configuration;
+
+/**
+ * Get the base configuration for the Control Plane API requests.
+ * @param client - The HTTP client to use.
+ */
+export async function getBaseConfiguration(
+  client: HttpClient
+): Promise<Configuration> {
+  const { Configuration } = await import('giantswarm-cp-client');
+  const fetchAdapter = new FetchAdapter(client);
+
+  const configBuilder = new Configuration({
+    basePath: client.requestConfig.baseURL,
+    fetchApi: fetchAdapter.fetch.bind(fetchAdapter),
+  });
+
+  return configBuilder;
+}

--- a/src/reducers/types.ts
+++ b/src/reducers/types.ts
@@ -1,3 +1,14 @@
-// Giving state a generic type for now, until whole state is typed
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface IState extends Record<string, any> {}
+import { IAppCatalogsState } from 'stores/appcatalog/types';
+
+// Giving state a generic type for now, until whole state is typed.
+export interface IState {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+
+  entities: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+
+    catalogs: IAppCatalogsState;
+  };
+}

--- a/src/selectors/ingressTabSelectors.ts
+++ b/src/selectors/ingressTabSelectors.ts
@@ -1,7 +1,8 @@
 import { IState } from 'reducers/types';
 import { Constants } from 'shared';
+import { IStoredAppCatalog } from 'stores/appcatalog/types';
 
-export const selectIngressCatalog: (state: IState) => Record<string, never> = (
+export const selectIngressCatalog: (state: IState) => IStoredAppCatalog = (
   state
 ) =>
   state.entities?.catalogs?.items?.[

--- a/src/stores/appcatalog/__tests__/actions.ts
+++ b/src/stores/appcatalog/__tests__/actions.ts
@@ -1,5 +1,5 @@
-import '@testing-library/jest-dom/extend-expect';
-
+import { IState } from 'reducers/types';
+import { IAppCatalogsMap } from 'stores/appcatalog/types';
 import { IAsynchronousDispatch } from 'stores/asynchronousAction';
 import { appCatalogsResponse, getMockCall } from 'testUtils/mockHttpCalls';
 
@@ -10,7 +10,10 @@ describe('listCatalogs', () => {
     getMockCall('/v4/appcatalogs/', appCatalogsResponse);
 
     const dispatch: IAsynchronousDispatch<{}> = ((() => {}) as unknown) as IAsynchronousDispatch<{}>;
-    const response = await listCatalogs().doPerform({}, dispatch);
+    const response = (await listCatalogs().doPerform(
+      {} as IState,
+      dispatch
+    )) as IAppCatalogsMap;
 
     expect(response['giantswarm-incubator'].metadata.name).toEqual(
       'giantswarm-incubator'

--- a/src/stores/appcatalog/reducer.ts
+++ b/src/stores/appcatalog/reducer.ts
@@ -7,7 +7,7 @@ import { IApplicationVersion } from './types';
 const initialState = {
   lastUpdated: 0,
   isFetching: false,
-  items: [],
+  items: {},
 };
 
 const catalogReducer = produce((draft, action) => {

--- a/src/stores/appcatalog/types.ts
+++ b/src/stores/appcatalog/types.ts
@@ -1,5 +1,24 @@
+import { IAppCatalog } from 'model/services/controlplane/appcatalogs/types';
+
 export interface IApplicationVersion {
   version: string;
+}
+
+export interface IStoredAppCatalog extends IAppCatalog {
+  isFetchingIndex: boolean;
+  // FIXME(axbarsan): Write proper type.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  apps?: any;
+}
+
+export interface IAppCatalogsMap {
+  [key: string]: IStoredAppCatalog;
+}
+
+export interface IAppCatalogsState {
+  lastUpdated: number;
+  isFetching: boolean;
+  items: IAppCatalogsMap;
 }
 
 export interface IInstallIngress {

--- a/src/stores/configureStore.ts
+++ b/src/stores/configureStore.ts
@@ -1,6 +1,7 @@
 import { routerMiddleware } from 'connected-react-router';
 import { History } from 'history';
 import rootReducer from 'reducers';
+import { IState } from 'reducers/types';
 import { applyMiddleware, compose, createStore, Store } from 'redux';
 import thunk from 'redux-thunk';
 
@@ -12,8 +13,7 @@ let store: Store = {} as Store;
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 export default function configureStore(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  initialState: Record<string, any>,
+  initialState: IState,
   history: History<History.LocationState>
 ) {
   store = createStore(

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -103,6 +103,7 @@ module.exports = {
     publicPath: '/',
     path: path.resolve(__dirname, 'dist'),
     filename: 'assets/[name].[chunkhash:12].js',
+    chunkFilename: '[name].bundle.js',
   },
   module: {
     rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6130,6 +6130,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+"giantswarm-cp-client@git+https://github.com/giantswarm/giantswarm-cp-client.git":
+  version "1.0.0"
+  resolved "git+https://github.com/giantswarm/giantswarm-cp-client.git#dc0b411907d321d2d46c81f7f86ff69fd92d8725"
+
 "giantswarm@git+https://github.com/giantswarm/giantswarm-js-client.git":
   version "4.0.1"
   resolved "git+https://github.com/giantswarm/giantswarm-js-client.git#bf2810afa140487c44a9ef392c65eb211bd416e6"


### PR DESCRIPTION
Part of the larger #1547

This PR adds the CP client library, client and handlers.
It also links the newly created types throughout the app.