### PR TITLE
Remove NP appear transitions and make enter and exit transitions quicker

### DIFF
--- a/src/components/Cluster/ClusterDetail/NodePool.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePool.tsx
@@ -270,16 +270,6 @@ class NodePool extends Component<INodePoolsProps, INodePoolsState> {
   }
 }
 
-function mapStateToProps(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  state: Record<string, any>,
-  ownProps: INodePoolsProps
-) {
-  return {
-    nodePool: state.entities.nodePools.items[ownProps.nodePool.id],
-  };
-}
-
 function mapDispatchToProps(dispatch: Dispatch): IDispatchProps {
   return {
     // @ts-ignore
@@ -289,4 +279,4 @@ function mapDispatchToProps(dispatch: Dispatch): IDispatchProps {
 }
 
 // @ts-ignore
-export default connect(mapStateToProps, mapDispatchToProps)(NodePool);
+export default connect(null, mapDispatchToProps)(NodePool);

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -45,26 +45,25 @@ const NodePoolsWrapper = styled.div`
     margin: 0;
   }
   /* Manual */
-  .np-enter,
-  .np-appear {
+  .np-enter {
     opacity: 0.01;
     transform: translateX(20px);
   }
-  .np-enter.np-enter-active,
-  .np-appear.np-appear-active {
+  .np-enter.np-enter-active {
     opacity: 1;
     transform: translateX(0px);
-    transition: opacity 200ms, transform 300ms;
-    transition-delay: 300ms, 300ms;
+    transition: opacity 0.2s, transform 0.3s;
+    transition-timing-function: ease-out, ease-out;
+    transition-delay: 0.1s, 0.1s;
   }
   .np-exit {
     opacity: 1;
   }
   .np-exit.np-exit-active {
     opacity: 0.01;
-    transform: translateX(0px);
-    transition: all 100ms ease-in;
-    transition-delay: 0ms;
+    transform: translateX(20px);
+    transition: all 0.2s ease-out;
+    transition-delay: 0.1s;
   }
 `;
 
@@ -459,11 +458,9 @@ class V5ClusterDetailTable extends React.Component {
                   })
                   .map((nodePool) => (
                     <BaseTransition
-                      key={nodePool.id || Date.now()}
-                      appear={true}
-                      exit={false}
+                      key={nodePool.id}
                       classNames='np'
-                      timeout={{ enter: 500, appear: 500 }}
+                      timeout={{ enter: 400, exit: 400 }}
                     >
                       <GridRowNodePoolsItem data-testid={nodePool.id}>
                         <NodePool


### PR DESCRIPTION
As seen on https://github.com/orgs/giantswarm/projects/85#card-40662167

This PR:
* disables the NP `appear` transition (which is executed when the component is rendered).
* makes the `enter` transition quicker (when a node pool is created)
* adds an `exit` transition (when a node pool is deleted)
* fixes a bug that would make the `exit` transition display a loading spinner fading out, instead of the actual node pool

GIFs don't do this justice. Please take a look 👍 