### PR TITLE
Add creation in progress label

### DIFF
--- a/src/components/Cluster/ClusterDetail/RegionAndVersions.js
+++ b/src/components/Cluster/ClusterDetail/RegionAndVersions.js
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import UpgradeNotice from 'Home/UpgradeNotice';
+import ClusterStatus from 'Home/ClusterStatus';
 import { relativeDate } from 'lib/helpers';
 import ReleaseDetailsModal from 'Modals/ReleaseDetailsModal';
 import PropTypes from 'prop-types';
@@ -82,7 +82,7 @@ function RegionAndVersions({
             <i className='fa fa-kubernetes' /> + k8sVersion}
         </ReleaseDetail>
       </div>
-      <UpgradeNotice clusterId={clusterId} onClick={showUpgradeModal} />
+      <ClusterStatus clusterId={clusterId} onClick={showUpgradeModal} />
       {release && (
         <ReleaseDetailsModal ref={releaseDetailsModal} releases={[release]} />
       )}

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -28,7 +28,7 @@ import { isClusterCreating } from 'utils/clusterUtils';
 
 import ClusterDashboardResourcesV4 from './ClusterDashboardResourcesV4';
 import ClusterDashboardResourcesV5 from './ClusterDashboardResourcesV5';
-import UpgradeNotice from './UpgradeNotice';
+import ClusterStatus from './ClusterStatus';
 
 const LabelWrapper = styled.div`
   width: 90px;
@@ -239,7 +239,7 @@ function ClusterDashboardItem({
               <RefreshableLabel value={cluster.name}>
                 <NameWrapper>{cluster.name}</NameWrapper>
               </RefreshableLabel>
-              <UpgradeNotice clusterId={clusterId} />
+              <ClusterStatus clusterId={clusterId} />
             </Link>
           </TitleWrapper>
 

--- a/src/components/Home/ClusterStatus.tsx
+++ b/src/components/Home/ClusterStatus.tsx
@@ -40,7 +40,7 @@ const Wrapper = styled.div<{
   }
 `;
 
-interface IUpgradeNoticeProps extends React.ComponentPropsWithoutRef<'div'> {
+interface IClusterStatusProps extends React.ComponentPropsWithoutRef<'div'> {
   clusterId: string;
   hideText?: boolean;
   onClick?: () => void;
@@ -48,7 +48,7 @@ interface IUpgradeNoticeProps extends React.ComponentPropsWithoutRef<'div'> {
 
 // This component receive a cluster id, finds if this cluster is 'upgradable' and
 // in case it is, outputs an upgrade notice,
-const ClusterStatus: React.FC<IUpgradeNoticeProps> = ({
+const ClusterStatus: React.FC<IClusterStatusProps> = ({
   clusterId,
   hideText,
   onClick,

--- a/src/components/Home/ClusterStatus.tsx
+++ b/src/components/Home/ClusterStatus.tsx
@@ -7,7 +7,7 @@ import {
   selectIsClusterUpgrading,
 } from 'selectors/clusterSelectors';
 
-const UpgradeWrapperDiv = styled.div<{
+const Wrapper = styled.div<{
   disabled: boolean;
   isHyperlink: boolean;
 }>`
@@ -33,18 +33,17 @@ const UpgradeWrapperDiv = styled.div<{
   }
 `;
 
-interface IUpgradeNoticeProps {
+interface IUpgradeNoticeProps extends React.ComponentPropsWithoutRef<'div'> {
   clusterId: string;
-  className?: string;
   onClick?: () => void;
 }
 
 // This component receive a cluster id, finds if this cluster is 'upgradable' and
 // in case it is, outputs an upgrade notice,
-const UpgradeNotice: React.FC<IUpgradeNoticeProps> = ({
+const ClusterStatus: React.FC<IUpgradeNoticeProps> = ({
   clusterId,
-  className,
   onClick,
+  ...rest
 }) => {
   const canClusterUpgrade = useSelector(selectCanClusterUpgrade(clusterId));
   const isClusterUpgrading = useSelector(selectIsClusterUpgrading(clusterId));
@@ -65,23 +64,21 @@ const UpgradeNotice: React.FC<IUpgradeNoticeProps> = ({
     : 'Upgrade Available';
 
   return (
-    <UpgradeWrapperDiv
-      id={`upgrade-notice-${clusterId}`}
-      className={className}
+    <Wrapper
+      {...rest}
       onClick={handleUpgrade}
       disabled={isClusterUpgrading}
       isHyperlink={Boolean(onClick) && !isClusterUpgrading}
     >
       <i className={iconClassName} />
       <span>{message}</span>
-    </UpgradeWrapperDiv>
+    </Wrapper>
   );
 };
 
-UpgradeNotice.propTypes = {
+ClusterStatus.propTypes = {
   clusterId: PropTypes.string.isRequired,
   onClick: PropTypes.func,
-  className: PropTypes.string,
 };
 
-export default UpgradeNotice;
+export default ClusterStatus;

--- a/src/components/Home/ClusterStatus.tsx
+++ b/src/components/Home/ClusterStatus.tsx
@@ -73,13 +73,19 @@ const ClusterStatus: React.FC<IUpgradeNoticeProps> = ({
     case isClusterDeleting(cluster as Record<string, unknown>):
       return null;
 
+    case canClusterUpgrade:
+      iconClassName = 'fa fa-warning';
+      message = 'Upgrade Available';
+      isButtonDisabled = false;
+      tooltip = `There's a new release version available. Upgrade now to get the latest features.`;
+      break;
+
     case isClusterCreating(cluster as Record<string, unknown>):
       color = theme.colors.gray;
       iconClassName = 'fa fa-crane';
       message = 'Cluster creating…';
       tooltip =
         'The cluster is currently creating. This step usually takes about 30 minutes.';
-
       break;
 
     case isClusterUpdating(cluster as Record<string, unknown>):
@@ -87,13 +93,6 @@ const ClusterStatus: React.FC<IUpgradeNoticeProps> = ({
       message = 'Upgrade in progress…';
       tooltip =
         'The cluster is currently upgrading. This step usually takes about 30 minutes.';
-      break;
-
-    case canClusterUpgrade:
-      iconClassName = 'fa fa-warning';
-      message = 'Upgrade Available';
-      isButtonDisabled = false;
-      tooltip = `There's a new release version available. Upgrade now to get the latest features.`;
       break;
 
     default:
@@ -118,8 +117,9 @@ const ClusterStatus: React.FC<IUpgradeNoticeProps> = ({
         isHyperlink={Boolean(onClick) && !isButtonDisabled}
         color={color}
         aria-label={message}
+        role='document'
       >
-        <i className={iconClassName} />
+        <i className={iconClassName} role='presentation' aria-hidden='true' />
 
         {!hideText && <span>{message}</span>}
       </Wrapper>

--- a/src/components/Home/UpgradeNotice.tsx
+++ b/src/components/Home/UpgradeNotice.tsx
@@ -34,8 +34,6 @@ const UpgradeWrapperDiv = styled.div<{
 `;
 
 interface IUpgradeNoticeProps {
-  canClusterUpgrade: boolean;
-  isClusterUpgrading: boolean;
   clusterId: string;
   className?: string;
   onClick?: () => void;

--- a/src/components/Home/__tests__/ClusterStatus.tsx
+++ b/src/components/Home/__tests__/ClusterStatus.tsx
@@ -1,0 +1,240 @@
+import {
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import ClusterStatus from 'Home/ClusterStatus';
+import { IState } from 'reducers/types';
+import { Providers } from 'shared/constants';
+import {
+  nodePoolRelease,
+  nodePoolWithFlatcarRelease,
+} from 'testUtils/mockHttpCalls';
+import { renderWithStore } from 'testUtils/renderUtils';
+
+describe('ClusterStatus', () => {
+  it('renders without crashing', () => {
+    renderWithStore(ClusterStatus, { clusterId: '' });
+  });
+
+  it('shows that a cluster is ready to be upgraded', async () => {
+    const state = makeState(
+      {
+        id: 'as129',
+        release_version: nodePoolRelease.version,
+        conditions: [
+          {
+            last_transition_time: 123,
+            condition: 'Created',
+          },
+        ],
+      },
+      {
+        [nodePoolRelease.version]: nodePoolRelease as IRelease,
+        [nodePoolWithFlatcarRelease.version]: nodePoolWithFlatcarRelease as IRelease,
+      }
+    );
+    const onClickMockFn = jest.fn();
+    renderWithStore(
+      ClusterStatus,
+      { clusterId: 'as129', onClick: onClickMockFn },
+      state
+    );
+
+    const statusLabel = screen.getByRole('document', {
+      name: 'Upgrade Available',
+    });
+    expect(statusLabel).toBeInTheDocument();
+
+    fireEvent.click(statusLabel);
+    expect(onClickMockFn).toHaveBeenCalled();
+
+    const hoverMessageRegex = /There's a new release version available\. Upgrade now to get the latest features\./i;
+    fireEvent.mouseEnter(statusLabel);
+    expect(screen.getByText(hoverMessageRegex)).toBeInTheDocument();
+    fireEvent.mouseLeave(statusLabel);
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(hoverMessageRegex)
+    );
+  });
+
+  it('shows that a cluster is in creation state', async () => {
+    const state = makeState(
+      {
+        id: 'as129',
+        release_version: nodePoolRelease.version,
+        conditions: [
+          {
+            last_transition_time: 123,
+            condition: 'Creating',
+          },
+        ],
+      },
+      {
+        [nodePoolRelease.version]: nodePoolRelease as IRelease,
+      }
+    );
+    const onClickMockFn = jest.fn();
+    renderWithStore(
+      ClusterStatus,
+      { clusterId: 'as129', onClick: onClickMockFn },
+      state
+    );
+
+    const statusLabel = screen.getByRole('document', {
+      name: 'Cluster creating…',
+    });
+    expect(statusLabel).toBeInTheDocument();
+
+    fireEvent.click(statusLabel);
+    expect(onClickMockFn).not.toHaveBeenCalled();
+
+    const hoverMessageRegex = /The cluster is currently creating\. This step usually takes about 30 minutes\./i;
+    fireEvent.mouseEnter(statusLabel);
+    expect(screen.getByText(hoverMessageRegex)).toBeInTheDocument();
+    fireEvent.mouseLeave(statusLabel);
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(hoverMessageRegex)
+    );
+  });
+
+  it('shows that a cluster is in upgrading state', async () => {
+    const state = makeState(
+      {
+        id: 'as129',
+        release_version: nodePoolRelease.version,
+        conditions: [
+          {
+            last_transition_time: 123,
+            condition: 'Updating',
+          },
+        ],
+      },
+      {
+        [nodePoolRelease.version]: nodePoolRelease as IRelease,
+      }
+    );
+    const onClickMockFn = jest.fn();
+    renderWithStore(
+      ClusterStatus,
+      { clusterId: 'as129', onClick: onClickMockFn },
+      state
+    );
+
+    const statusLabel = screen.getByRole('document', {
+      name: 'Upgrade in progress…',
+    });
+    expect(statusLabel).toBeInTheDocument();
+
+    fireEvent.click(statusLabel);
+    expect(onClickMockFn).not.toHaveBeenCalled();
+
+    const hoverMessageRegex = /The cluster is currently upgrading\. This step usually takes about 30 minutes\./i;
+    fireEvent.mouseEnter(statusLabel);
+    expect(screen.getByText(hoverMessageRegex)).toBeInTheDocument();
+    fireEvent.mouseLeave(statusLabel);
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(hoverMessageRegex)
+    );
+  });
+
+  it('renders an empty output if the cluster has a deleting condition', () => {
+    const state = makeState(
+      {
+        id: 'as129',
+        release_version: nodePoolRelease.version,
+        conditions: [
+          {
+            last_transition_time: 123,
+            condition: 'Deleting',
+          },
+        ],
+      },
+      {
+        [nodePoolRelease.version]: nodePoolRelease as IRelease,
+      }
+    );
+    renderWithStore(ClusterStatus, { clusterId: 'as129' }, state);
+    expect(screen.queryByRole('document')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty output if the cluster has been deleted in the app', () => {
+    const state = makeState(
+      {
+        id: 'as129',
+        release_version: nodePoolRelease.version,
+        delete_date: 123123,
+      },
+      {
+        [nodePoolRelease.version]: nodePoolRelease as IRelease,
+      }
+    );
+    renderWithStore(ClusterStatus, { clusterId: 'as129' }, state);
+    expect(screen.queryByRole('document')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty output if the cluster is not found', () => {
+    const state = makeState(
+      {
+        id: 'as129',
+        release_version: nodePoolRelease.version,
+      },
+      {
+        [nodePoolRelease.version]: nodePoolRelease as IRelease,
+      }
+    );
+    renderWithStore(ClusterStatus, { clusterId: 'd01sa' }, state);
+    expect(screen.queryByRole('document')).not.toBeInTheDocument();
+  });
+
+  it('can be rendered with no text', () => {
+    const state = makeState(
+      {
+        id: 'as129',
+        release_version: nodePoolRelease.version,
+        conditions: [
+          {
+            last_transition_time: 123,
+            condition: 'Updating',
+          },
+        ],
+      },
+      {
+        [nodePoolRelease.version]: nodePoolRelease as IRelease,
+      }
+    );
+    renderWithStore(
+      ClusterStatus,
+      { clusterId: 'as129', hideText: true },
+      state
+    );
+
+    expect(screen.queryByText('Upgrade in progress…')).not.toBeInTheDocument();
+  });
+});
+
+function makeState(
+  cluster: Record<string, unknown>,
+  releases: IReleases
+): IState {
+  return {
+    main: {
+      loggedInUser: {
+        isAdmin: false,
+      },
+      info: {
+        general: {
+          provider: Providers.AWS,
+        },
+      },
+    },
+    entities: ({
+      releases: {
+        items: releases,
+      },
+      clusters: {
+        items: { [cluster.id as string]: cluster },
+      },
+    } as unknown) as IState['entities'],
+  };
+}

--- a/src/components/Organizations/Detail/View.js
+++ b/src/components/Organizations/Detail/View.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import * as OrganizationActions from 'actions/organizationActions';
 import DocumentTitle from 'components/shared/DocumentTitle';
-import UpgradeNotice from 'Home/UpgradeNotice';
+import ClusterStatus from 'Home/ClusterStatus';
 import { relativeDate } from 'lib/helpers';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
@@ -29,7 +29,7 @@ const MembersTable = styled.div`
   }
 `;
 
-const UpgradeNoticeWrapperDiv = styled.div`
+const ClusterStatusWrapper = styled.div`
   cursor: pointer;
   width: 22px;
   span {
@@ -112,7 +112,7 @@ class OrganizationDetail extends React.Component {
         dataField: 'path',
         text: '',
         formatter: (cell, row) =>
-          upgradeNoticeIcon(cell, row, this.props.organization.id),
+          clusterStatusIcon(cell, row, this.props.organization.id),
         headerStyle: () => ({ width: '40px', paddingLeft: 0 }),
         style: { paddingLeft: 0 },
       },
@@ -256,7 +256,7 @@ function clusterIDCellFormatter(cell) {
 }
 
 // eslint-disable-next-line react/no-multi-comp
-function upgradeNoticeIcon(_, cluster, orgId) {
+function clusterStatusIcon(_, cluster, orgId) {
   const clusterDetailPath = RoutePath.createUsablePath(
     OrganizationsRoutes.Clusters.Detail.Home,
     {
@@ -275,9 +275,9 @@ function upgradeNoticeIcon(_, cluster, orgId) {
         overlay={<Tooltip id='tooltip'>{message}</Tooltip>}
         placement='top'
       >
-        <UpgradeNoticeWrapperDiv>
-          <UpgradeNotice clusterId={cluster.id} />
-        </UpgradeNoticeWrapperDiv>
+        <ClusterStatusWrapper>
+          <ClusterStatus clusterId={cluster.id} />
+        </ClusterStatusWrapper>
       </OverlayTrigger>
     </Link>
   );

--- a/src/components/Organizations/Detail/View.js
+++ b/src/components/Organizations/Detail/View.js
@@ -8,8 +8,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import BootstrapTable from 'react-bootstrap-table-next';
 import Button from 'react-bootstrap/lib/Button';
-import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
-import Tooltip from 'react-bootstrap/lib/Tooltip';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
@@ -19,21 +17,12 @@ import { OrganizationsRoutes } from 'shared/constants/routes';
 import { Ellipsis } from 'styles';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 import Section from 'UI/Section';
-import { isClusterUpdating } from 'utils/clusterUtils';
 
 import Credentials from './Credentials';
 
 const MembersTable = styled.div`
   .member-email {
     ${Ellipsis}
-  }
-`;
-
-const ClusterStatusWrapper = styled.div`
-  cursor: pointer;
-  width: 22px;
-  span {
-    display: none !important;
   }
 `;
 
@@ -86,6 +75,8 @@ class OrganizationDetail extends React.Component {
         dataField: 'name',
         text: 'Name',
         sort: true,
+        formatter: (cell, row) =>
+          formatClusterName(cell, row, this.props.organization.id),
       },
       {
         dataField: 'release_version',
@@ -98,23 +89,6 @@ class OrganizationDetail extends React.Component {
 
           return cmp(a, b);
         },
-        headerStyle: () => ({
-          textAlign: 'right',
-          paddingRight: 0,
-          transform: 'translateX(15px)',
-        }),
-        align: 'right',
-        style: { paddingRight: 0 },
-      },
-      // Using path just because if we use 'id', that is what we need, we will get
-      // duplicated keys.
-      {
-        dataField: 'path',
-        text: '',
-        formatter: (cell, row) =>
-          clusterStatusIcon(cell, row, this.props.organization.id),
-        headerStyle: () => ({ width: '40px', paddingLeft: 0 }),
-        style: { paddingLeft: 0 },
       },
       {
         dataField: 'create_date',
@@ -256,7 +230,7 @@ function clusterIDCellFormatter(cell) {
 }
 
 // eslint-disable-next-line react/no-multi-comp
-function clusterStatusIcon(_, cluster, orgId) {
+function formatClusterName(_, cluster, orgId) {
   const clusterDetailPath = RoutePath.createUsablePath(
     OrganizationsRoutes.Clusters.Detail.Home,
     {
@@ -265,21 +239,13 @@ function clusterStatusIcon(_, cluster, orgId) {
     }
   );
 
-  const message = isClusterUpdating(cluster)
-    ? 'Upgrade in progress…'
-    : 'Upgrade Available';
-
   return (
-    <Link to={clusterDetailPath}>
-      <OverlayTrigger
-        overlay={<Tooltip id='tooltip'>{message}</Tooltip>}
-        placement='top'
-      >
-        <ClusterStatusWrapper>
-          <ClusterStatus clusterId={cluster.id} />
-        </ClusterStatusWrapper>
-      </OverlayTrigger>
-    </Link>
+    <>
+      {cluster.name}{' '}
+      <Link to={clusterDetailPath}>
+        <ClusterStatus clusterId={cluster.id} hideText={true} />
+      </Link>
+    </>
   );
 }
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/12912

This PR:
* Refactors the `UpgradeNotice` component to display multiple cluster statuses.
* Displays a label near clusters that are in creation state.
* Adds a tooltip that explains what all the statuses mean.
* Moves the cluster status icon from near the `Release` column in the Organization detail view, to near the `Name` column.
* Includes tests for all the `ClusterStatus` functionality.

### Preview

<details>
<summary>Cluster overview - upgrade available (hover)</summary>

![image](https://user-images.githubusercontent.com/13508038/91178894-1953a480-e6e6-11ea-8325-60ddc92f04c7.png)

</details>

<details>
<summary>Cluster overview - cluster creating (hover)</summary>

![image](https://user-images.githubusercontent.com/13508038/91179022-41db9e80-e6e6-11ea-8d24-93e3ab764b6e.png)

</details>

<details>
<summary>Cluster overview - cluster upgrading (hover)</summary>

![image](https://user-images.githubusercontent.com/13508038/91179257-8ff0a200-e6e6-11ea-8529-2853fff2a528.png)

</details>

<details>
<summary>Cluster details - cluster creating</summary>

![image](https://user-images.githubusercontent.com/13508038/91178935-24a6d000-e6e6-11ea-8f71-624d307e2b6a.png)

</details>

<details>
<summary>Organization details</summary>

![image](https://user-images.githubusercontent.com/13508038/91178966-312b2880-e6e6-11ea-8f23-0419486b6a82.png)

</details>

<details>
<summary>Organization details 2</summary>

![image](https://user-images.githubusercontent.com/13508038/91179297-9da62780-e6e6-11ea-99e0-3bcfe89e5220.png)

</details>

<details>
<summary>Organization details - cluster creating (hover)</summary>

![image](https://user-images.githubusercontent.com/13508038/91179008-3c7e5400-e6e6-11ea-9cf8-738a205353c4.png)

</details>



