### PR TITLE
Fix updateApp action request payload

### DIFF
--- a/src/stores/clusterapps/__tests__/actions.ts
+++ b/src/stores/clusterapps/__tests__/actions.ts
@@ -1,0 +1,38 @@
+import nock from 'nock';
+import { IState } from 'reducers/types';
+import { StatusCodes } from 'shared/constants';
+import { IAsynchronousDispatch } from 'stores/asynchronousAction';
+import { API_ENDPOINT } from 'testUtils/mockHttpCalls';
+import { V5_CLUSTER } from 'testUtils/mockHttpCalls';
+
+import { updateClusterApp } from '../actions';
+
+describe('updateClusterApp', () => {
+  it('correctly composes the request payload', async () => {
+    const appName = 'nginx-ingress-controller-app';
+    const clusterId = V5_CLUSTER.id;
+    const version = '1.9.2';
+
+    const request = nock(API_ENDPOINT)
+      .patch(`/v5/clusters/${clusterId}/apps/${appName}/`, {
+        spec: { version: version },
+      })
+      .reply(StatusCodes.Ok);
+
+    const dispatch: IAsynchronousDispatch<{}> = ((() => {}) as unknown) as IAsynchronousDispatch<{}>;
+
+    await updateClusterApp({ appName, clusterId, version }).doPerform(
+      ({
+        entities: {
+          clusters: {
+            v5Clusters: [clusterId],
+          },
+        },
+      } as unknown) as IState,
+      dispatch
+    );
+
+    // expect the request mock has been used
+    expect(request.isDone());
+  });
+});

--- a/src/stores/clusterapps/actions.ts
+++ b/src/stores/clusterapps/actions.ts
@@ -41,7 +41,7 @@ export const updateClusterApp = createAsynchronousAction<
     );
 
     try {
-      await modifyApp(clusterId, appName, { body: { spec: version } });
+      await modifyApp(clusterId, appName, { body: { spec: { version } } });
 
       new FlashMessage(
         `App <code>${appName}</code> on <code>${clusterId}</code> has been updated. Changes might take some time to take effect.`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6587,7 +6587,7 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy@^1.17.0:
+http-proxy@^1.17.0, http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==


### PR DESCRIPTION
This PR fixes the payload for updating an app in a cluster

(& a change in yarn.lock. Possibly related to recent http-proxy vulnerabilities)