### PR TITLE
Use EnableUserMonitoring setting to enable user monitoring

### DIFF
--- a/helm/happa/ci/default-values.yaml
+++ b/helm/happa/ci/default-values.yaml
@@ -10,6 +10,7 @@ Installation:
         Letsencrypt: ""
         API:
           Letsencrypt: ""
+        EnableUserMonitoring: false
       Passage:
         Address: ""
       OIDC:

--- a/helm/happa/templates/configmap.yaml
+++ b/helm/happa/templates/configmap.yaml
@@ -18,7 +18,9 @@ data:
   default-request-timeout-seconds: '{{ .Values.Installation.V1.GiantSwarm.Happa.DefaultRequestTimeoutSeconds }}'
   provider: {{ .Values.Installation.V1.Provider.Kind }}
 
-  {{ if .Values.Installation.V1.GiantSwarm.Happa.EnableUserMonitoring }}
   # Enables real user monitoring (RUM)
+  {{ if eq .Values.Installation.V1.GiantSwarm.Happa.EnableUserMonitoring true }}
   enable-rum: 'TRUE'
+  {{ else }}
+  enable-rum: 'FALSE'
   {{ end }}

--- a/helm/happa/templates/configmap.yaml
+++ b/helm/happa/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
   default-request-timeout-seconds: '{{ .Values.Installation.V1.GiantSwarm.Happa.DefaultRequestTimeoutSeconds }}'
   provider: {{ .Values.Installation.V1.Provider.Kind }}
 
-  {{ if .Values.Installation.V1.Infra.TestingEnvironment }}
+  {{ if .Values.Installation.V1.GiantSwarm.Happa.EnableUserMonitoring }}
   # Enables real user monitoring (RUM)
   enable-rum: 'TRUE'
   {{ end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12047

This PR makes use of the `.Values.Installation.V1.GiantSwarm.Happa.EnableUserMonitoring` introduced in https://github.com/giantswarm/installations/pull/1493 to enable RUM.

So far, the fact that an installation is a test installation also enabled user monitoring. As we want to roll it out to more non-testing installations, we need a dedicated switch.