### PR TITLE
azure v5: Enable node pool autoscaling

### DIFF
--- a/src/actions/nodePoolActions.js
+++ b/src/actions/nodePoolActions.js
@@ -142,13 +142,6 @@ export function nodePoolPatch(clusterId, nodePool, payload) {
           nodePool,
         });
 
-        new FlashMessage(
-          'Something went wrong while trying to update the node pool name',
-          messageType.ERROR,
-          messageTTL.MEDIUM,
-          'Please try again later or contact support: support@giantswarm.io'
-        );
-
         throw error;
       });
   };

--- a/src/components/Cluster/ClusterDetail/AddNodePool.js
+++ b/src/components/Cluster/ClusterDetail/AddNodePool.js
@@ -289,6 +289,7 @@ class AddNodePool extends Component {
   static isScalingAutomatic(provider) {
     switch (provider) {
       case Providers.AWS:
+      case Providers.AZURE:
         return true;
 
       default:

--- a/src/components/Cluster/ClusterDetail/NodePool.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePool.tsx
@@ -3,6 +3,7 @@ import * as nodePoolActions from 'actions/nodePoolActions';
 import NodePoolScaling from 'Cluster/ClusterDetail/NodePoolScaling';
 import { spinner } from 'images';
 import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
@@ -148,6 +149,19 @@ class NodePool extends Component<INodePoolsProps, INodePoolsState> {
         nodePoolActions.nodePoolPatch(cluster.id, nodePool, { name })
       );
     } catch (err) {
+      let errorMessage = `Something went wrong while trying to update the node pool's name.`;
+      if (err.response?.message || err.message) {
+        errorMessage = `There was a problem updating the node pool's name: ${
+          err.response?.message ?? err.message
+        }`;
+      }
+      new FlashMessage(
+        errorMessage,
+        messageType.ERROR,
+        messageTTL.MEDIUM,
+        'Please try again later or contact support: support@giantswarm.io'
+      );
+
       ErrorReporter.getInstance().notify(err);
     }
   };

--- a/src/components/Cluster/ClusterDetail/NodePool.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePool.tsx
@@ -63,10 +63,6 @@ const MixedInstanceType = styled(Code)`
   background-color: ${({ theme }) => theme.colors.shade9};
 `;
 
-const StyledNodePoolDropdownMenu = styled(NodePoolDropdownMenu)`
-  grid-column: 10/10;
-`;
-
 interface INPViewAndEditName extends HTMLSpanElement {
   activateEditMode: () => boolean;
 }
@@ -258,7 +254,7 @@ class NodePool extends Component<INodePoolsProps, INodePoolsState> {
               <AvailabilityZonesWrapper zones={availability_zones} />
             </div>
             <NodePoolScaling nodePool={nodePool} provider={provider} />
-            <StyledNodePoolDropdownMenu
+            <NodePoolDropdownMenu
               provider={provider}
               clusterId={cluster.id}
               nodePool={nodePool}

--- a/src/components/Cluster/ClusterDetail/NodePoolScaling.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePoolScaling.tsx
@@ -59,7 +59,7 @@ const NodePoolScaling: React.FC<INodePoolScalingProps> = ({
       <NodesWrapper>{desired}</NodesWrapper>
       <NodesWrapper highlight={current < desired}>{current}</NodesWrapper>
 
-      {provider === Providers.AWS ? (
+      {provider === Providers.AWS && (
         <OverlayTrigger
           overlay={
             <Tooltip id={`${id}-spot-distribution-tooltip`}>
@@ -70,8 +70,6 @@ const NodePoolScaling: React.FC<INodePoolScalingProps> = ({
         >
           <NodesWrapper>{spot_instances}</NodesWrapper>
         </OverlayTrigger>
-      ) : (
-        <NodesWrapper />
       )}
     </>
   );

--- a/src/components/Cluster/ClusterDetail/NodePoolScaling.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePoolScaling.tsx
@@ -54,14 +54,9 @@ const NodePoolScaling: React.FC<INodePoolScalingProps> = ({
 
   return (
     <>
-      {provider === Providers.AWS && (
-        <NodesWrapper data-testid='scaling-min'>{scaling.min}</NodesWrapper>
-      )}
-
+      <NodesWrapper data-testid='scaling-min'>{scaling.min}</NodesWrapper>
       <NodesWrapper data-testid='scaling-max'>{scaling.max}</NodesWrapper>
-
-      {provider === Providers.AWS && <NodesWrapper>{desired}</NodesWrapper>}
-
+      <NodesWrapper>{desired}</NodesWrapper>
       <NodesWrapper highlight={current < desired}>{current}</NodesWrapper>
 
       {provider === Providers.AWS ? (

--- a/src/components/Cluster/ClusterDetail/ScaleNodePoolModal.js
+++ b/src/components/Cluster/ClusterDetail/ScaleNodePoolModal.js
@@ -13,9 +13,14 @@ import ClusterIDLabel from 'UI/ClusterIDLabel';
 
 class ScaleNodePoolModal extends React.Component {
   static supportsAutoscaling(provider) {
-    if (provider !== Providers.AWS) return false;
+    switch (provider) {
+      case Providers.AWS:
+      case Providers.AZURE:
+        return true;
 
-    return true;
+      default:
+        return false;
+    }
   }
 
   // eslint-disable-next-line no-magic-numbers

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -67,12 +67,15 @@ const NodePoolsWrapper = styled.div`
   }
 `;
 
-const GridRowNodePoolsBase = css`
+const GridRowNodePoolsBase = (hasSpotInstances) => css`
   ${Row};
   display: grid;
   grid-gap: 0 10px;
   grid-template-columns:
-    minmax(47px, 1fr) minmax(50px, 4fr) 4fr 3fr repeat(5, 2fr)
+    minmax(47px, 1fr) minmax(50px, 4fr) 4fr 3fr repeat(
+      ${hasSpotInstances ? 5 : 4},
+      2fr
+    )
     1fr;
   grid-template-rows: 30px;
   justify-content: space-between;
@@ -81,7 +84,7 @@ const GridRowNodePoolsBase = css`
 `;
 
 const GridRowNodePoolsNodes = styled.div`
-  ${GridRowNodePoolsBase};
+  ${({ hasSpotInstances }) => GridRowNodePoolsBase(hasSpotInstances)};
   margin-bottom: 0;
   margin-top: -12px;
   min-height: 25px;
@@ -90,7 +93,8 @@ const GridRowNodePoolsNodes = styled.div`
   padding-bottom: 0;
   transform: translateY(12px);
   div {
-    grid-column: ${({ compact }) => (compact ? '5 / span 4' : '5 / span 5')};
+    grid-column: ${({ hasSpotInstances }) =>
+      hasSpotInstances ? '5 / span 5' : '5 / span 4'};
     font-size: 12px;
     position: relative;
     width: 100%;
@@ -116,7 +120,7 @@ const GridRowNodePoolsNodes = styled.div`
 `;
 
 const GridRowNodePoolsHeaders = styled.div`
-  ${GridRowNodePoolsBase};
+  ${({ hasSpotInstances }) => GridRowNodePoolsBase(hasSpotInstances)};
   margin-bottom: 0;
 `;
 
@@ -134,7 +138,7 @@ const NodePoolsNameColumn = styled.span`
 `;
 
 const GridRowNodePoolsItem = styled.div`
-  ${GridRowNodePoolsBase};
+  ${({ hasSpotInstances }) => GridRowNodePoolsBase(hasSpotInstances)};
   background-color: ${({ theme }) => theme.colors.foreground};
 `;
 
@@ -372,6 +376,8 @@ class V5ClusterDetailTable extends React.Component {
     const machineTypeLabel =
       provider === Providers.AWS ? 'Instance type' : 'VM Size';
 
+    const hasSpotInstances = provider === Providers.AWS;
+
     return (
       <>
         <FlexRowWithTwoBlocksOnEdges>
@@ -431,12 +437,12 @@ class V5ClusterDetailTable extends React.Component {
           <h2>Node Pools</h2>
           {!zeroNodePools && !loadingNodePools && (
             <>
-              <GridRowNodePoolsNodes compact={provider === Providers.AZURE}>
+              <GridRowNodePoolsNodes hasSpotInstances={hasSpotInstances}>
                 <div>
                   <span>NODES</span>
                 </div>
               </GridRowNodePoolsNodes>
-              <GridRowNodePoolsHeaders>
+              <GridRowNodePoolsHeaders hasSpotInstances={hasSpotInstances}>
                 <NodePoolsColumnHeader>Id</NodePoolsColumnHeader>
                 <NodePoolsNameColumn>Name</NodePoolsNameColumn>
                 <NodePoolsColumnHeader>
@@ -467,7 +473,10 @@ class V5ClusterDetailTable extends React.Component {
                       classNames='np'
                       timeout={{ enter: 400, exit: 400 }}
                     >
-                      <GridRowNodePoolsItem data-testid={nodePool.id}>
+                      <GridRowNodePoolsItem
+                        hasSpotInstances={hasSpotInstances}
+                        data-testid={nodePool.id}
+                      >
                         <NodePool
                           cluster={cluster}
                           nodePool={nodePool}

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -369,6 +369,9 @@ class V5ClusterDetailTable extends React.Component {
       !isClusterCreating(cluster) &&
       !isClusterUpdating(cluster);
 
+    const machineTypeLabel =
+      provider === Providers.AWS ? 'Instance type' : 'VM Size';
+
     return (
       <>
         <FlexRowWithTwoBlocksOnEdges>
@@ -436,7 +439,9 @@ class V5ClusterDetailTable extends React.Component {
               <GridRowNodePoolsHeaders>
                 <NodePoolsColumnHeader>Id</NodePoolsColumnHeader>
                 <NodePoolsNameColumn>Name</NodePoolsNameColumn>
-                <NodePoolsColumnHeader>Instance Type</NodePoolsColumnHeader>
+                <NodePoolsColumnHeader>
+                  {machineTypeLabel}
+                </NodePoolsColumnHeader>
                 <NodePoolsColumnHeader>
                   Availability Zones
                 </NodePoolsColumnHeader>

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -90,12 +90,12 @@ const GridRowNodePoolsNodes = styled.div`
   padding-bottom: 0;
   transform: translateY(12px);
   div {
-    grid-column: ${({ compact }) => (compact ? '5 / span 2' : '5 / span 5')};
+    grid-column: ${({ compact }) => (compact ? '5 / span 4' : '5 / span 5')};
     font-size: 12px;
     position: relative;
     width: 100%;
     text-align: center;
-    transform: ${({ compact }) => !compact && 'translateX(0.8vw)'};
+    transform: translateX(0.8vw);
     span {
       display: inline-block;
       padding: 0 10px;

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTableNodePoolScaling.tsx
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTableNodePoolScaling.tsx
@@ -15,54 +15,32 @@ const V5ClusterDetailTableNodePoolScaling: React.FC<IV5ClusterDetailTableNodePoo
 }) => {
   return (
     <>
-      {provider === Providers.AWS && (
-        <>
-          <OverlayTrigger
-            overlay={
-              <Tooltip id='min-tooltip'>
-                {Constants.MIN_NODES_EXPLANATION}
-              </Tooltip>
-            }
-            placement='top'
-          >
-            <NodePoolsColumnHeader>Min</NodePoolsColumnHeader>
-          </OverlayTrigger>
-          <OverlayTrigger
-            overlay={
-              <Tooltip id='max-tooltip'>
-                {Constants.MAX_NODES_EXPLANATION}
-              </Tooltip>
-            }
-            placement='top'
-          >
-            <NodePoolsColumnHeader>Max</NodePoolsColumnHeader>
-          </OverlayTrigger>
-          <OverlayTrigger
-            overlay={
-              <Tooltip id='desired-tooltip'>
-                {Constants.DESIRED_NODES_EXPLANATION}
-              </Tooltip>
-            }
-            placement='top'
-          >
-            <NodePoolsColumnHeader>Desired</NodePoolsColumnHeader>
-          </OverlayTrigger>
-        </>
-      )}
-
-      {provider === Providers.AZURE && (
-        <OverlayTrigger
-          overlay={
-            <Tooltip id='min-tooltip'>
-              {Constants.NODES_COUNT_EXPLANATION}
-            </Tooltip>
-          }
-          placement='top'
-        >
-          <NodePoolsColumnHeader>Count</NodePoolsColumnHeader>
-        </OverlayTrigger>
-      )}
-
+      <OverlayTrigger
+        overlay={
+          <Tooltip id='min-tooltip'>{Constants.MIN_NODES_EXPLANATION}</Tooltip>
+        }
+        placement='top'
+      >
+        <NodePoolsColumnHeader>Min</NodePoolsColumnHeader>
+      </OverlayTrigger>
+      <OverlayTrigger
+        overlay={
+          <Tooltip id='max-tooltip'>{Constants.MAX_NODES_EXPLANATION}</Tooltip>
+        }
+        placement='top'
+      >
+        <NodePoolsColumnHeader>Max</NodePoolsColumnHeader>
+      </OverlayTrigger>
+      <OverlayTrigger
+        overlay={
+          <Tooltip id='desired-tooltip'>
+            {Constants.DESIRED_NODES_EXPLANATION}
+          </Tooltip>
+        }
+        placement='top'
+      >
+        <NodePoolsColumnHeader>Desired</NodePoolsColumnHeader>
+      </OverlayTrigger>
       <OverlayTrigger
         overlay={
           <Tooltip id='current-tooltip'>

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -33,7 +33,6 @@ export const Constants = {
   // UI labels
   CURRENT_NODES_INPOOL_EXPLANATION:
     'Current number of worker nodes in the node pool',
-  NODES_COUNT_EXPLANATION: 'Desired number of worker nodes in the node pool',
   DESIRED_NODES_EXPLANATION:
     'Autoscaler’s idea of how many nodes would be required for the workloads',
   MIN_NODES_EXPLANATION:
@@ -62,7 +61,7 @@ export const Constants = {
   NP_DEFAULT_MIN_SCALING_AWS: 3,
   NP_DEFAULT_MAX_SCALING_AWS: 10,
   NP_DEFAULT_MIN_SCALING_AZURE: 3,
-  NP_DEFAULT_MAX_SCALING_AZURE: 3,
+  NP_DEFAULT_MAX_SCALING_AZURE: 10,
 
   // App name of the 'nginx-ingress-controller-app'
   INSTALL_INGRESS_TAB_APP_NAME: 'nginx-ingress-controller-app',


### PR DESCRIPTION
This PR:
* adds support for node pool autoscaling on Azure V5
* displays the actual error message when a node pool name change fails

The behaviour is the same as on AWS, so no logic changes.