### PR TITLE
Fix breaking app catalog layout after clearing the search bar

### DIFF
--- a/src/components/AppCatalog/AppList/AppListInner.js
+++ b/src/components/AppCatalog/AppList/AppListInner.js
@@ -3,12 +3,13 @@ import { replace } from 'connected-react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import CatalogTypeLabel from 'UI/CatalogTypeLabel';
-import { memoize } from 'underscore';
+import { memoize, throttle } from 'underscore';
 
 import AppListItems from './AppListItems';
 import AppListSearch from './AppListSearch';
 
 const SEARCH_URL_PARAM = 'q';
+const SEARCH_THROTTLE_RATE_MS = 100;
 
 const StyledCatalogTypeLabel = styled(CatalogTypeLabel)`
   position: relative;
@@ -34,7 +35,7 @@ const TitleAndIcons = styled('div')`
 `;
 
 class AppListInner extends React.Component {
-  static filterApps(searchQuery, allApps) {
+  static filterApps = throttle((searchQuery, allApps) => {
     const fieldsToCheck = ['name', 'description', 'keywords'];
     const trimmedSearchQuery = searchQuery.trim().toLowerCase();
 
@@ -58,7 +59,7 @@ class AppListInner extends React.Component {
     });
 
     return filteredApps;
-  }
+  }, SEARCH_THROTTLE_RATE_MS);
 
   static getSearchQueryFromLocation(location) {
     const searchParams = new URLSearchParams(location.search);

--- a/src/components/AppCatalog/AppList/AppListItems.js
+++ b/src/components/AppCatalog/AppList/AppListItems.js
@@ -43,40 +43,40 @@ class AppListItems extends React.Component {
       this.props.scrollToApp
     );
 
-    if (apps.length < 1) {
-      return <AppListPlaceholder searchQuery={searchQuery} />;
-    }
-
     return (
       <StyledAppsWrapper ref={this.appsListRef}>
-        <StyledVirtualizedGrid
-          columnCount={{
-            small: 1,
-            med: 3,
-            large: 4,
-          }}
-          rowHeight={APP_CONTAINER_HEIGHT}
-          data={apps}
-          adaptWidthToElement={this.appsListRef.current}
-          scrollToItemIndex={scrollToAppIndex}
-        >
-          {(style, content) => {
-            const newContent = [].concat(content);
+        {apps.length < 1 ? (
+          <AppListPlaceholder searchQuery={searchQuery} />
+        ) : (
+          <StyledVirtualizedGrid
+            columnCount={{
+              small: 1,
+              med: 3,
+              large: 4,
+            }}
+            rowHeight={APP_CONTAINER_HEIGHT}
+            data={apps}
+            adaptWidthToElement={this.appsListRef.current}
+            scrollToItemIndex={scrollToAppIndex}
+          >
+            {(style, content) => {
+              const newContent = [].concat(content);
 
-            return (
-              <AppContainer
-                style={style}
-                appVersions={newContent}
-                catalog={this.props.catalog}
-                hasIconError={this.props.iconErrors.hasOwnProperty(
-                  newContent[0].icon
-                )}
-                onImgError={this.props.onImgError}
-                searchQuery={searchQuery}
-              />
-            );
-          }}
-        </StyledVirtualizedGrid>
+              return (
+                <AppContainer
+                  style={style}
+                  appVersions={newContent}
+                  catalog={this.props.catalog}
+                  hasIconError={this.props.iconErrors.hasOwnProperty(
+                    newContent[0].icon
+                  )}
+                  onImgError={this.props.onImgError}
+                  searchQuery={searchQuery}
+                />
+              );
+            }}
+          </StyledVirtualizedGrid>
+        )}
       </StyledAppsWrapper>
     );
   }

--- a/src/components/shared/VirtualizedScrollableGrid.js
+++ b/src/components/shared/VirtualizedScrollableGrid.js
@@ -6,7 +6,7 @@ import { FixedSizeGrid as List } from 'react-window';
 import { debounce } from 'underscore';
 
 const MIN_COLUMN_COUNT = 1;
-const RESPONSIVE_FEATURES_UPDATE_TIME = 300;
+const RESPONSIVE_FEATURES_UPDATE_TIME = 200;
 
 class VirtualizedScrollableGrid extends React.PureComponent {
   static defaultProps = {

--- a/src/components/shared/VirtualizedScrollableGrid.js
+++ b/src/components/shared/VirtualizedScrollableGrid.js
@@ -6,7 +6,7 @@ import { FixedSizeGrid as List } from 'react-window';
 import { debounce } from 'underscore';
 
 const MIN_COLUMN_COUNT = 1;
-const RESPONSIVE_FEATURES_UPDATE_TIME = 200;
+const RESPONSIVE_FEATURES_UPDATE_TIME = 300;
 
 class VirtualizedScrollableGrid extends React.PureComponent {
   static defaultProps = {


### PR DESCRIPTION
If you use a screen that is not very wide, this is what currently happens when clearing the search bar contents quickly after typing:

![image](https://user-images.githubusercontent.com/13508038/93505014-94416100-f91a-11ea-93fe-cb7f7c24a40b.png)


