### PR TITLE
Force 'ua-parser-js' version v0.7.22 to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,8 @@
     "kind-of": "^6.0.3",
     "lodash": "^4.17.19",
     "serialize-javascript": "^4.0.0",
-    "http-proxy": "^1.18.1"
+    "http-proxy": "^1.18.1",
+    "ua-parser-js": "^0.7.22"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12642,10 +12642,10 @@ typical@^4.0.0:
   resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
   integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
 
-ua-parser-js@^0.7.18:
-  version "0.7.21"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
-  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.22:
+  version "0.7.22"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.22.tgz#960df60a5f911ea8f1c818f3747b99c6e177eae3"
+  integrity sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
 
 uncontrollable@^7.0.2:
   version "7.1.1"


### PR DESCRIPTION
Allows us to fix https://snyk.io/vuln/SNYK-JS-UAPARSERJS-610226