### PR TITLE
Change icon for cluster creation in progress

### DIFF
--- a/src/components/Home/ClusterStatus.tsx
+++ b/src/components/Home/ClusterStatus.tsx
@@ -82,7 +82,7 @@ const ClusterStatus: React.FC<IClusterStatusProps> = ({
 
     case isClusterCreating(cluster):
       color = theme.colors.gray;
-      iconClassName = 'fa fa-crane';
+      iconClassName = 'fa fa-change-in-progress';
       message = 'Cluster creating…';
       tooltip =
         'The cluster is currently creating. This step usually takes about 30 minutes.';


### PR DESCRIPTION
This PR changes the icon shown for a cluster in creation.

The new cogs icon fits our other icons in use better and can also be used to indicate all sorts of infrastructure changes in progress (scaling, upgrades, deletion).

## Old

![image](https://user-images.githubusercontent.com/273727/93770835-08328080-fc1d-11ea-9fb9-4f40f4819dc3.png)

![image](https://user-images.githubusercontent.com/273727/93771017-4334b400-fc1d-11ea-8306-eea3a6355b7e.png)

![image](https://user-images.githubusercontent.com/273727/93771054-4a5bc200-fc1d-11ea-924f-4366f5d8a605.png)


## New

![image](https://user-images.githubusercontent.com/273727/93770874-1385ac00-fc1d-11ea-92f4-9d83d2148895.png)

![image](https://user-images.githubusercontent.com/273727/93770979-3617c500-fc1d-11ea-8bed-531d2977238f.png)

![image](https://user-images.githubusercontent.com/273727/93770968-30ba7a80-fc1d-11ea-81b0-3efde1291229.png)

