### PR TITLE
Remove Google Analytics tracking code used in test installations

### DIFF
--- a/scripts/rum.inc.html
+++ b/scripts/rum.inc.html
@@ -1,14 +1,3 @@
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-D0QNZ9NDTH"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('set', 'allow_google_signals', false);
-      gtag('set', 'allow_ad_personalization_signals', false);
-      gtag('config', 'G-D0QNZ9NDTH');
-    </script>
-    <!-- / end Global site tag (gtag.js) - Google Analytics -->
     <!-- Datadog RUM -->
     <script
       src="https://www.datadoghq-browser-agent.com/datadog-rum.js"


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/12047

This PR removes Google Analytics tracking code, which has been included temporarily for test purposes.