### PR TITLE
Show kubernetes version in cluster overview

### DIFF
--- a/src/components/Cluster/ClusterDetail/RegionAndVersions.js
+++ b/src/components/Cluster/ClusterDetail/RegionAndVersions.js
@@ -66,14 +66,7 @@ function RegionAndVersions({
             <>
               <Dot />
               <i className='fa fa-kubernetes' />
-              {(() => {
-                const kubernetes = release.components.find(
-                  (component) => component.name === 'kubernetes'
-                );
-                if (kubernetes) return kubernetes.version;
-
-                return null;
-              })()}
+              {release.kubernetesVersion}
             </>
           )}
           {!release &&

--- a/src/components/Cluster/ClusterDetail/RegionAndVersions.js
+++ b/src/components/Cluster/ClusterDetail/RegionAndVersions.js
@@ -66,7 +66,14 @@ function RegionAndVersions({
             <>
               <Dot />
               <i className='fa fa-kubernetes' />
-              {release.kubernetesVersion}
+              {(() => {
+                const kubernetes = release.components.find(
+                  (component) => component.name === 'kubernetes'
+                );
+                if (kubernetes) return kubernetes.version;
+
+                return null;
+              })()}
             </>
           )}
           {!release &&

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -254,10 +254,10 @@ function ClusterDashboardItem({
               </span>
             </RefreshableLabel>
             <Dot style={{ paddingLeft: 0 }} />
-            <RefreshableLabel value={release.kubernetesVersion}>
+            <RefreshableLabel value={release?.kubernetesVersion}>
               <span>
                 <i className='fa fa-kubernetes' title='Kubernetes version' />{' '}
-                {release.kubernetesVersion}
+                {release?.kubernetesVersion ?? 'n/a'}
               </span>
             </RefreshableLabel>
             <Dot style={{ paddingLeft: 0 }} />

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -254,19 +254,10 @@ function ClusterDashboardItem({
               </span>
             </RefreshableLabel>
             <Dot style={{ paddingLeft: 0 }} />
-            <RefreshableLabel value={cluster.kubernetes_version}>
+            <RefreshableLabel value={release.kubernetesVersion}>
               <span>
                 <i className='fa fa-kubernetes' title='Kubernetes version' />{' '}
-                <span>
-                  {(() => {
-                    const kubernetes = release.components.find(
-                      (component) => component.name === 'kubernetes'
-                    );
-                    if (kubernetes) return kubernetes.version;
-
-                    return null;
-                  })()}
-                </span>
+                {release.kubernetesVersion}
               </span>
             </RefreshableLabel>
             <Dot style={{ paddingLeft: 0 }} />

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -13,6 +13,7 @@ import {
   selectClusterById,
   selectErrorByIdAndAction,
 } from 'selectors/clusterSelectors';
+import { getAllReleases } from 'selectors/releaseSelectors';
 import { CSSBreakpoints } from 'shared/constants';
 import { OrganizationsRoutes } from 'shared/constants/routes';
 import ErrorBoundary from 'shared/ErrorBoundary';
@@ -143,10 +144,12 @@ function ClusterDashboardItem({
   dispatch,
   nodePoolsLoadError,
   clusterId,
+  releases,
 }) {
   // If the cluster has been deleted using gsctl, Happa doesn't know yet.
   if (!cluster) return null;
 
+  const release = releases[cluster.release_version] ?? null;
   const isCreating = isClusterCreating(cluster);
 
   /**
@@ -251,6 +254,22 @@ function ClusterDashboardItem({
               </span>
             </RefreshableLabel>
             <Dot style={{ paddingLeft: 0 }} />
+            <RefreshableLabel value={cluster.kubernetes_version}>
+              <span>
+                <i className='fa fa-kubernetes' title='Kubernetes version' />{' '}
+                <span>
+                  {(() => {
+                    const kubernetes = release.components.find(
+                      (component) => component.name === 'kubernetes'
+                    );
+                    if (kubernetes) return kubernetes.version;
+
+                    return null;
+                  })()}
+                </span>
+              </span>
+            </RefreshableLabel>
+            <Dot style={{ paddingLeft: 0 }} />
             Created {relativeDate(cluster.create_date)}
           </>
 
@@ -298,6 +317,7 @@ ClusterDashboardItem.propTypes = {
   nodePools: PropTypes.array,
   nodePoolsLoadError: PropTypes.string,
   clusterId: PropTypes.string,
+  releases: PropTypes.object,
 };
 
 function mapStateToProps(state, props) {
@@ -309,6 +329,7 @@ function mapStateToProps(state, props) {
       props.clusterId,
       CLUSTER_NODEPOOLS_LOAD_REQUEST
     ),
+    releases: getAllReleases(state),
   };
 }
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/13478

This PR adds the k8s version number to the cluster overview.

## Before

![image](https://user-images.githubusercontent.com/273727/94439978-62918b00-01a1-11eb-856c-4bfcd07cb0e5.png)

## After

![image](https://user-images.githubusercontent.com/273727/94440016-6c1af300-01a1-11eb-9eb6-ace1ce551c78.png)
