### PR TITLE
Allow having apps defined without labels

### DIFF
--- a/src/@types/appcatalogs.d.ts
+++ b/src/@types/appcatalogs.d.ts
@@ -1,6 +1,6 @@
 interface IAppCatalogMetaData {
   name: string;
-  labels: Record<string, string>;
+  labels: Record<string, string> | null;
 }
 
 interface IAppCatalogSpec {

--- a/src/@types/v4clusters.d.ts
+++ b/src/@types/v4clusters.d.ts
@@ -25,7 +25,7 @@ declare namespace V4 {
   }
 
   export interface IClusterWorker {
-    labels: IClusterLabelMap;
+    labels: IClusterLabelMap | null;
     cpu: IClusterCPU;
     memory: IClusterMemory;
     storage: IClusterStorage;

--- a/src/components/Cluster/ClusterDetail/ClusterApps.js
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.js
@@ -328,8 +328,12 @@ class ClusterApps extends React.Component {
 
     const { hasOptionalIngress } = this.props;
     const filteredApps = apps.filter((app) => {
-      const isManagedByClusterOperator =
-        app.metadata.labels['giantswarm.io/managed-by'] === 'cluster-operator';
+      let isManagedByClusterOperator = false;
+      if (app.metadata.labels) {
+        isManagedByClusterOperator =
+          app.metadata.labels['giantswarm.io/managed-by'] ===
+          'cluster-operator';
+      }
 
       switch (true) {
         case hasOptionalIngress &&


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/12568

This PR accounts for having a `null` label map in the app spec. It also defines other label maps as nullable, since that's how they behave in Go, and how they are serialized and passed around.