### PR TITLE
Do not check non-related to cloud capabilities

### DIFF
--- a/helm/happa/templates/configmap.yaml
+++ b/helm/happa/templates/configmap.yaml
@@ -13,8 +13,12 @@ data:
   cp-audience: {{ .Values.Installation.V1.GiantSwarm.OIDC.IssuerAddress }}
   ingress-base-domain: {{ .Values.Installation.V1.Guest.Kubernetes.IngressController.BaseDomain }}
   installation-name: {{ .Values.Installation.V1.Name }}
+  {{- if eq .Values.Installation.V1.Provider.Kind "aws" }}
   aws-capabilities-json: '{{ .Values.Installation.V1.Provider.AWS.EC2.Instance.Capabilities | toJson }}'
+  {{- end }}
+  {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
   azure-capabilities-json: '{{ .Values.Installation.V1.Provider.Azure.VM.VmSize.Capabilities | toJson }}'
+  {{- end }}
   default-request-timeout-seconds: '{{ .Values.Installation.V1.GiantSwarm.Happa.DefaultRequestTimeoutSeconds }}'
   provider: {{ .Values.Installation.V1.Provider.Kind }}
 

--- a/helm/happa/templates/deployment.yaml
+++ b/helm/happa/templates/deployment.yaml
@@ -40,16 +40,20 @@ spec:
       - name: happa
         image: {{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
         env:
+        {{- if eq .Values.Installation.V1.Provider.Kind "aws" }}
         - name: AWS_CAPABILITIES_JSON
           valueFrom:
             configMapKeyRef:
               name: happa-configmap
               key: aws-capabilities-json
+        {{- end }}
+        {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
         - name: AZURE_CAPABILITIES_JSON
           valueFrom:
             configMapKeyRef:
               name: happa-configmap
               key: azure-capabilities-json
+        {{- end }}
         - name: PASSAGE_ENDPOINT
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Happa fails to be installed on AWS tenant cluster due to missing Azure configuration (which should not be expected on AWS)