### PR TITLE
Extract k8s version into component, remove patch level

### DIFF
--- a/src/components/Cluster/ClusterDetail/RegionAndVersions.tsx
+++ b/src/components/Cluster/ClusterDetail/RegionAndVersions.tsx
@@ -72,7 +72,10 @@ const RegionAndVersions: FC<IRegionAndVersionsProps> = ({
             </span>
             <Dot />
             <RefreshableLabel value={release?.kubernetesVersion}>
-              <KubernetesVersionLabel version={release?.kubernetesVersion} hidePatchVersion={false} />
+              <KubernetesVersionLabel
+                version={release?.kubernetesVersion}
+                hidePatchVersion={false}
+              />
             </RefreshableLabel>
           </>
         )}

--- a/src/components/Cluster/ClusterDetail/RegionAndVersions.tsx
+++ b/src/components/Cluster/ClusterDetail/RegionAndVersions.tsx
@@ -7,6 +7,7 @@ import React, { FC, RefObject, useRef } from 'react';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import { Code, Dot } from 'styles';
+import KubernetesVersionLabel from 'UI/KubernetesVersionLabel';
 import RefreshableLabel from 'UI/RefreshableLabel';
 
 interface IRegionAndVersionsProps {
@@ -69,11 +70,10 @@ const RegionAndVersions: FC<IRegionAndVersionsProps> = ({
                 </ReleaseDetail>
               </RefreshableLabel>
             </span>
-            <ReleaseDetail onClick={onReleaseDetailClick}>
-              <Dot />
-              <i className='fa fa-kubernetes' />
-              {release.kubernetesVersion}
-            </ReleaseDetail>
+            <Dot />
+            <RefreshableLabel value={release?.kubernetesVersion}>
+              <KubernetesVersionLabel version={release?.kubernetesVersion} hidePatchVersion={false} />
+            </RefreshableLabel>
           </>
         )}
       </div>

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -23,6 +23,7 @@ import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 import ErrorFallback from 'UI/ErrorFallback';
 import ErrorText from 'UI/ErrorText';
+import KubernetesVersionLabel from 'UI/KubernetesVersionLabel';
 import RefreshableLabel from 'UI/RefreshableLabel';
 
 import ClusterDashboardResourcesV4 from './ClusterDashboardResourcesV4';
@@ -257,10 +258,7 @@ function ClusterDashboardItem({
             </RefreshableLabel>
             <Dot style={{ paddingLeft: 0 }} />
             <RefreshableLabel value={release?.kubernetesVersion}>
-              <span>
-                <i className='fa fa-kubernetes' title='Kubernetes version' />{' '}
-                {release?.kubernetesVersion ?? 'n/a'}
-              </span>
+              <KubernetesVersionLabel version={release?.kubernetesVersion} />
             </RefreshableLabel>
             <Dot style={{ paddingLeft: 0 }} />
             Created {relativeDate(cluster.create_date)}

--- a/src/components/UI/KubernetesVersionLabel.tsx
+++ b/src/components/UI/KubernetesVersionLabel.tsx
@@ -1,14 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-
 interface IKubernetesVersionLabelProps {
   version: string;
 }
 
-const KubernetesVersionLabel = ({
-  version,
-}: IKubernetesVersionLabelProps) => {
+const KubernetesVersionLabel = ({ version }: IKubernetesVersionLabelProps) => {
   let versionLabel = 'n/a';
   if (version) {
     // only show major and minor k8s version

--- a/src/components/UI/KubernetesVersionLabel.tsx
+++ b/src/components/UI/KubernetesVersionLabel.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 interface IKubernetesVersionLabelProps {
-  version: string;
+  version?: string;
 }
 
 const KubernetesVersionLabel: React.FC<IKubernetesVersionLabelProps> = ({

--- a/src/components/UI/KubernetesVersionLabel.tsx
+++ b/src/components/UI/KubernetesVersionLabel.tsx
@@ -3,16 +3,21 @@ import React from 'react';
 
 interface IKubernetesVersionLabelProps {
   version?: string;
+  hidePatchVersion?: boolean;
 }
 
 const KubernetesVersionLabel: React.FC<IKubernetesVersionLabelProps> = ({
   version,
+  hidePatchVersion,
 }) => {
   let versionLabel = 'n/a';
+
   if (version) {
-    // only show major and minor k8s version
-    const v = version.split('.');
-    versionLabel = [v[0], v[1]].join('.');
+    versionLabel = version;
+    if (hidePatchVersion) {
+      const v = version.split('.');
+      versionLabel = [v[0], v[1]].join('.');
+    }
   }
 
   return (
@@ -25,10 +30,12 @@ const KubernetesVersionLabel: React.FC<IKubernetesVersionLabelProps> = ({
 
 KubernetesVersionLabel.propTypes = {
   version: PropTypes.string,
+  hidePatchVersion: PropTypes.bool,
 };
 
 KubernetesVersionLabel.defaultProps = {
   version: '',
+  hidePatchVersion: true,
 };
 
 export default KubernetesVersionLabel;

--- a/src/components/UI/KubernetesVersionLabel.tsx
+++ b/src/components/UI/KubernetesVersionLabel.tsx
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+
+interface IKubernetesVersionLabelProps {
+  version: string;
+}
+
+const KubernetesVersionLabel = ({
+  version,
+}: IKubernetesVersionLabelProps) => {
+  let versionLabel = 'n/a';
+  if (version) {
+    // only show major and minor k8s version
+    const v = version.split('.');
+    versionLabel = [v[0], v[1]].join('.');
+  }
+
+  return (
+    <span>
+      <i className='fa fa-kubernetes' title='Kubernetes version' />{' '}
+      {versionLabel}
+    </span>
+  );
+};
+
+KubernetesVersionLabel.propTypes = {
+  version: PropTypes.string,
+};
+
+KubernetesVersionLabel.defaultProps = {
+  version: '',
+};
+
+export default KubernetesVersionLabel;

--- a/src/components/UI/KubernetesVersionLabel.tsx
+++ b/src/components/UI/KubernetesVersionLabel.tsx
@@ -5,7 +5,7 @@ interface IKubernetesVersionLabelProps {
   version: string;
 }
 
-const KubernetesVersionLabel = ({ version }: IKubernetesVersionLabelProps) => {
+const KubernetesVersionLabel: React.FC<IKubernetesVersionLabelProps> = ({ version }) => {
   let versionLabel = 'n/a';
   if (version) {
     // only show major and minor k8s version

--- a/src/components/UI/KubernetesVersionLabel.tsx
+++ b/src/components/UI/KubernetesVersionLabel.tsx
@@ -5,7 +5,9 @@ interface IKubernetesVersionLabelProps {
   version: string;
 }
 
-const KubernetesVersionLabel: React.FC<IKubernetesVersionLabelProps> = ({ version }) => {
+const KubernetesVersionLabel: React.FC<IKubernetesVersionLabelProps> = ({
+  version,
+}) => {
   let versionLabel = 'n/a';
   if (version) {
     // only show major and minor k8s version


### PR DESCRIPTION
Extracts the Kubernetes version label into a component. Also reduces the amount of information given to the minor version, cuts off the patch version (in the cluster overview only).

Preparation for https://github.com/giantswarm/giantswarm/issues/13439

### Preview

![image](https://user-images.githubusercontent.com/273727/95103910-83278b00-0735-11eb-8186-82b59e865a0b.png)

![image](https://user-images.githubusercontent.com/273727/95176703-85cdc300-07bd-11eb-9629-2d84f0ea875a.png)

