### PR TITLE
azure v5: disable node pool autoscaling

### DIFF
--- a/src/components/Cluster/ClusterDetail/AddNodePool.js
+++ b/src/components/Cluster/ClusterDetail/AddNodePool.js
@@ -11,6 +11,7 @@ import Tooltip from 'react-bootstrap/lib/Tooltip';
 import { connect } from 'react-redux';
 import { Constants, Providers } from 'shared/constants';
 import NodeCountSelector from 'shared/NodeCountSelector';
+import { supportsNodePoolAutoscaling } from 'stores/nodepool/utils';
 import BaseTransition from 'styles/transitions/BaseTransition';
 import Checkbox from 'UI/Checkbox';
 import ClusterCreationLabelSpan from 'UI/ClusterCreation/ClusterCreationLabelSpan';
@@ -285,17 +286,6 @@ class AddNodePool extends Component {
     allowSpotInstances: false,
     allowAlikeInstances: false,
   };
-
-  static isScalingAutomatic(provider) {
-    switch (provider) {
-      case Providers.AWS:
-      case Providers.AZURE:
-        return true;
-
-      default:
-        return false;
-    }
-  }
 
   static getDerivedStateFromProps(newProps, prevState) {
     // Set scaling defaults.
@@ -593,7 +583,7 @@ class AddNodePool extends Component {
 
     const machineType = this.getMachineType();
 
-    const isScalingAuto = AddNodePool.isScalingAutomatic(provider);
+    const isScalingAuto = supportsNodePoolAutoscaling(provider);
     const scalingLabel = isScalingAuto ? 'Scaling range' : 'Node count';
 
     let azLabelClassName = '';

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -20,6 +20,10 @@ import {
   makeV5ResourcesSelector,
   selectClusterNodePools,
 } from 'stores/nodepool/selectors';
+import {
+  supportsNodePoolAutoscaling,
+  supportsNodePoolSpotInstances,
+} from 'stores/nodepool/utils';
 import { FlexRowWithTwoBlocksOnEdges, mq, Row } from 'styles';
 import BaseTransition from 'styles/transitions/BaseTransition';
 import SlideTransition from 'styles/transitions/SlideTransition';
@@ -67,13 +71,13 @@ const NodePoolsWrapper = styled.div`
   }
 `;
 
-const GridRowNodePoolsBase = (hasSpotInstances) => css`
+const GridRowNodePoolsBase = (additionalColumnCount) => css`
   ${Row};
   display: grid;
   grid-gap: 0 10px;
   grid-template-columns:
     minmax(47px, 1fr) minmax(50px, 4fr) 4fr 3fr repeat(
-      ${hasSpotInstances ? 5 : 4},
+      ${additionalColumnCount},
       2fr
     )
     1fr;
@@ -84,7 +88,7 @@ const GridRowNodePoolsBase = (hasSpotInstances) => css`
 `;
 
 const GridRowNodePoolsNodes = styled.div`
-  ${({ hasSpotInstances }) => GridRowNodePoolsBase(hasSpotInstances)};
+  ${({ additionalColumnCount }) => GridRowNodePoolsBase(additionalColumnCount)};
   margin-bottom: 0;
   margin-top: -12px;
   min-height: 25px;
@@ -93,8 +97,8 @@ const GridRowNodePoolsNodes = styled.div`
   padding-bottom: 0;
   transform: translateY(12px);
   div {
-    grid-column: ${({ hasSpotInstances }) =>
-      hasSpotInstances ? '5 / span 5' : '5 / span 4'};
+    grid-column: ${({ additionalColumnCount }) =>
+      `5 / span ${additionalColumnCount}`};
     font-size: 12px;
     position: relative;
     width: 100%;
@@ -120,7 +124,7 @@ const GridRowNodePoolsNodes = styled.div`
 `;
 
 const GridRowNodePoolsHeaders = styled.div`
-  ${({ hasSpotInstances }) => GridRowNodePoolsBase(hasSpotInstances)};
+  ${({ additionalColumnCount }) => GridRowNodePoolsBase(additionalColumnCount)};
   margin-bottom: 0;
 `;
 
@@ -138,7 +142,7 @@ const NodePoolsNameColumn = styled.span`
 `;
 
 const GridRowNodePoolsItem = styled.div`
-  ${({ hasSpotInstances }) => GridRowNodePoolsBase(hasSpotInstances)};
+  ${({ additionalColumnCount }) => GridRowNodePoolsBase(additionalColumnCount)};
   background-color: ${({ theme }) => theme.colors.foreground};
 `;
 
@@ -341,6 +345,20 @@ class V5ClusterDetailTable extends React.Component {
     });
   };
 
+  getNumberOfAdditionalColumns() {
+    const { provider } = this.props;
+
+    let additionalColumnCount = 2;
+    if (supportsNodePoolAutoscaling(provider)) {
+      additionalColumnCount += 2;
+    }
+    if (supportsNodePoolSpotInstances(provider)) {
+      additionalColumnCount++;
+    }
+
+    return additionalColumnCount;
+  }
+
   render() {
     const { nodePoolForm } = this.state;
     const {
@@ -376,7 +394,7 @@ class V5ClusterDetailTable extends React.Component {
     const machineTypeLabel =
       provider === Providers.AWS ? 'Instance type' : 'VM Size';
 
-    const hasSpotInstances = provider === Providers.AWS;
+    const additionalColumnCount = this.getNumberOfAdditionalColumns();
 
     return (
       <>
@@ -435,12 +453,16 @@ class V5ClusterDetailTable extends React.Component {
           <h2>Node Pools</h2>
           {!zeroNodePools && !loadingNodePools && (
             <>
-              <GridRowNodePoolsNodes hasSpotInstances={hasSpotInstances}>
+              <GridRowNodePoolsNodes
+                additionalColumnCount={additionalColumnCount}
+              >
                 <div>
                   <span>NODES</span>
                 </div>
               </GridRowNodePoolsNodes>
-              <GridRowNodePoolsHeaders hasSpotInstances={hasSpotInstances}>
+              <GridRowNodePoolsHeaders
+                additionalColumnCount={additionalColumnCount}
+              >
                 <NodePoolsColumnHeader>Id</NodePoolsColumnHeader>
                 <NodePoolsNameColumn>Name</NodePoolsNameColumn>
                 <NodePoolsColumnHeader>
@@ -472,7 +494,7 @@ class V5ClusterDetailTable extends React.Component {
                       timeout={{ enter: 400, exit: 400 }}
                     >
                       <GridRowNodePoolsItem
-                        hasSpotInstances={hasSpotInstances}
+                        additionalColumnCount={additionalColumnCount}
                         data-testid={nodePool.id}
                       >
                         <NodePool

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTableNodePoolScaling.tsx
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTableNodePoolScaling.tsx
@@ -5,6 +5,10 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import { Constants, Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
+import {
+  supportsNodePoolAutoscaling,
+  supportsNodePoolSpotInstances,
+} from 'stores/nodepool/utils';
 
 interface IV5ClusterDetailTableNodePoolScalingProps {
   provider: PropertiesOf<typeof Providers>;
@@ -13,29 +17,42 @@ interface IV5ClusterDetailTableNodePoolScalingProps {
 const V5ClusterDetailTableNodePoolScaling: React.FC<IV5ClusterDetailTableNodePoolScalingProps> = ({
   provider,
 }) => {
+  const supportsAutoScaling = supportsNodePoolAutoscaling(provider);
+  const supportsSpotInstances = supportsNodePoolSpotInstances(provider);
+  const desiredCountTooltipMessage = supportsAutoScaling
+    ? Constants.DESIRED_NODES_EXPLANATION_AUTOSCALER
+    : Constants.DESIRED_NODES_EXPLANATION;
+
   return (
     <>
+      {supportsAutoScaling && (
+        <>
+          <OverlayTrigger
+            overlay={
+              <Tooltip id='min-tooltip'>
+                {Constants.MIN_NODES_EXPLANATION}
+              </Tooltip>
+            }
+            placement='top'
+          >
+            <NodePoolsColumnHeader>Min</NodePoolsColumnHeader>
+          </OverlayTrigger>
+          <OverlayTrigger
+            overlay={
+              <Tooltip id='max-tooltip'>
+                {Constants.MAX_NODES_EXPLANATION}
+              </Tooltip>
+            }
+            placement='top'
+          >
+            <NodePoolsColumnHeader>Max</NodePoolsColumnHeader>
+          </OverlayTrigger>
+        </>
+      )}
+
       <OverlayTrigger
         overlay={
-          <Tooltip id='min-tooltip'>{Constants.MIN_NODES_EXPLANATION}</Tooltip>
-        }
-        placement='top'
-      >
-        <NodePoolsColumnHeader>Min</NodePoolsColumnHeader>
-      </OverlayTrigger>
-      <OverlayTrigger
-        overlay={
-          <Tooltip id='max-tooltip'>{Constants.MAX_NODES_EXPLANATION}</Tooltip>
-        }
-        placement='top'
-      >
-        <NodePoolsColumnHeader>Max</NodePoolsColumnHeader>
-      </OverlayTrigger>
-      <OverlayTrigger
-        overlay={
-          <Tooltip id='desired-tooltip'>
-            {Constants.DESIRED_NODES_EXPLANATION}
-          </Tooltip>
+          <Tooltip id='desired-tooltip'>{desiredCountTooltipMessage}</Tooltip>
         }
         placement='top'
       >
@@ -52,7 +69,7 @@ const V5ClusterDetailTableNodePoolScaling: React.FC<IV5ClusterDetailTableNodePoo
         <NodePoolsColumnHeader>Current</NodePoolsColumnHeader>
       </OverlayTrigger>
 
-      {provider === Providers.AWS && (
+      {supportsSpotInstances && (
         <OverlayTrigger
           overlay={
             <Tooltip id='spot-tooltip'>

--- a/src/components/Cluster/ClusterDetail/WorkerNodesAWS.js
+++ b/src/components/Cluster/ClusterDetail/WorkerNodesAWS.js
@@ -59,7 +59,7 @@ function WorkerNodesAWS({
           <OverlayTrigger
             overlay={
               <Tooltip id='desired-tooltip'>
-                {Constants.DESIRED_NODES_EXPLANATION}
+                {Constants.DESIRED_NODES_EXPLANATION_AUTOSCALER}
               </Tooltip>
             }
             placement='top'

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -34,6 +34,8 @@ export const Constants = {
   CURRENT_NODES_INPOOL_EXPLANATION:
     'Current number of worker nodes in the node pool',
   DESIRED_NODES_EXPLANATION:
+    'The requested number of worker nodes in the node pool',
+  DESIRED_NODES_EXPLANATION_AUTOSCALER:
     'Autoscaler’s idea of how many nodes would be required for the workloads',
   MIN_NODES_EXPLANATION:
     'Lower end of the scaling range for the cluster autoscaler',
@@ -61,7 +63,7 @@ export const Constants = {
   NP_DEFAULT_MIN_SCALING_AWS: 3,
   NP_DEFAULT_MAX_SCALING_AWS: 10,
   NP_DEFAULT_MIN_SCALING_AZURE: 3,
-  NP_DEFAULT_MAX_SCALING_AZURE: 10,
+  NP_DEFAULT_MAX_SCALING_AZURE: 3,
 
   // App name of the 'nginx-ingress-controller-app'
   INSTALL_INGRESS_TAB_APP_NAME: 'nginx-ingress-controller-app',

--- a/src/stores/nodepool/utils.ts
+++ b/src/stores/nodepool/utils.ts
@@ -1,0 +1,26 @@
+import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
+
+export function supportsNodePoolAutoscaling(
+  provider: PropertiesOf<typeof Providers>
+): boolean {
+  switch (provider) {
+    case Providers.AWS:
+      return true;
+
+    default:
+      return false;
+  }
+}
+
+export function supportsNodePoolSpotInstances(
+  provider: PropertiesOf<typeof Providers>
+): boolean {
+  switch (provider) {
+    case Providers.AWS:
+      return true;
+
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13649

This disables node pool autoscaling for Azure V5 clusters. We decided to postpone this feature.
Also, with the changes in this PR, turning autoscaling back on should be just a matter of adding 2 lines of code.

### Preview

<details>
<summary>Node pools list</summary>

![image](https://user-images.githubusercontent.com/13508038/95245554-93ae3300-0813-11eb-8481-f7fa6c7dbcb8.png)

</details>

<details>
<summary>Node pool creation form</summary>

![image](https://user-images.githubusercontent.com/13508038/95245614-a3c61280-0813-11eb-8e25-861bf16a85fc.png)

</details>