### PR TITLE
Display full cluster update error details

### DIFF
--- a/src/components/Cluster/ClusterDetail/__tests__/ScaleClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/__tests__/ScaleClusterModal.js
@@ -583,7 +583,7 @@ describe('ScaleClusterModal', () => {
       .intercept(`/v4/clusters/${v4AWSClusterResponse.id}/`, 'PATCH')
       .reply(StatusCodes.InternalServerError, scaleResponse);
 
-    const { getByLabelText, findByText } = renderWithProps({
+    const { getByLabelText, findByText, findAllByText } = renderWithProps({
       workerNodesDesired: 4,
       workerNodesRunning: 3,
     });
@@ -603,6 +603,6 @@ describe('ScaleClusterModal', () => {
       /something went wrong while trying to scale your cluster:/i
     );
 
-    await findByText(/internal server error/i);
+    await findAllByText(/internal server error/i);
   });
 });

--- a/src/stores/cluster/actions.ts
+++ b/src/stores/cluster/actions.ts
@@ -44,6 +44,7 @@ import {
 } from 'stores/cluster/types';
 import { computeCapabilities, filterLabels } from 'stores/cluster/utils';
 import { IState } from 'stores/state';
+import { extractMessageFromError } from 'utils/errorUtils';
 
 export function clusterDelete(cluster: Cluster): ClusterActions {
   return {
@@ -463,11 +464,16 @@ export function clusterPatch(
         cluster,
       });
 
+      const errorBody = extractMessageFromError(
+        error,
+        'Please try again later or contact support: support@giantswarm.io'
+      );
+
       new FlashMessage(
-        'Something went wrong while trying to update the cluster',
+        'Something went wrong while trying to update the cluster.',
         messageType.ERROR,
         messageTTL.MEDIUM,
-        'Please try again later or contact support: support@giantswarm.io'
+        errorBody
       );
 
       return Promise.reject(error);

--- a/src/utils/__tests__/errorUtils.ts
+++ b/src/utils/__tests__/errorUtils.ts
@@ -1,0 +1,68 @@
+import { extractMessageFromError } from '../errorUtils';
+
+describe('errorUtils', () => {
+  describe('extractMessageFromError', () => {
+    it('extracts error message from superagent errors', () => {
+      expect(
+        extractMessageFromError(
+          {
+            response: {
+              body: { message: 'Something is really wrong this time' },
+            },
+          },
+          'An error'
+        )
+      ).toBe('Something is really wrong this time');
+
+      expect(
+        extractMessageFromError(
+          {
+            response: {},
+          },
+          'An error'
+        )
+      ).toBe('An error');
+
+      expect(extractMessageFromError({}, 'An error')).toBe('An error');
+    });
+
+    it('extracts error message from axios errors', () => {
+      expect(
+        extractMessageFromError(
+          {
+            response: {
+              data: { message: 'Something is really wrong this time' },
+            },
+          },
+          'An error'
+        )
+      ).toBe('Something is really wrong this time');
+
+      expect(
+        extractMessageFromError(
+          {
+            response: {},
+          },
+          'An error'
+        )
+      ).toBe('An error');
+
+      expect(extractMessageFromError({}, 'An error')).toBe('An error');
+    });
+
+    it('extracts error message from javascript errors', () => {
+      expect(
+        extractMessageFromError(
+          new Error('Something is really wrong this time'),
+          'An error'
+        )
+      ).toBe('Something is really wrong this time');
+
+      expect(extractMessageFromError(new Error(), 'An error')).toBe('An error');
+
+      expect(extractMessageFromError(new Error(''), 'An error')).toBe(
+        'An error'
+      );
+    });
+  });
+});

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,0 +1,29 @@
+import { AxiosError } from 'axios';
+import { ResponseError } from 'superagent';
+
+/**
+ * Extract error messages from any type of error object.
+ * This supports JavaScript errors, `superagent` Errors and
+ * `axios` errors.
+ * @param error
+ * @param fallbackMessage - The message to return if no message
+ * could be extracted from the error object.
+ */
+export function extractMessageFromError(
+  error: unknown,
+  fallbackMessage: string
+): string {
+  switch (true) {
+    case Boolean((error as ResponseError).response?.body?.message):
+      return (error as ResponseError).response?.body.message;
+
+    case Boolean((error as AxiosError).response?.data?.message):
+      return (error as AxiosError).response?.data.message;
+
+    case Boolean((error as Error).message):
+      return (error as Error).message;
+
+    default:
+      return fallbackMessage;
+  }
+}


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/CNUDS3AMU/p1602056757165900

This makes sure that the error received from the API is visible in the UI. Especially useful when a cluster upgrade is blocked by a webhook, and you have no idea why.

I also wrote an utility function that we can reuse for getting the error message from other requests.