### PR TITLE
Automatically enable the latest active version, even for admins

### DIFF
--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
@@ -23,6 +23,7 @@ import ReleaseRow from './ReleaseRow';
 
 interface IReleaseSelector {
   selectRelease(releaseVersion: string): void;
+
   selectedRelease: string;
   collapsible?: boolean;
   autoSelectLatest?: boolean;
@@ -68,7 +69,13 @@ const ReleaseSelector: FC<IReleaseSelector> = ({
 
   useEffect(() => {
     if (autoSelectLatest && sortedReleaseVersions.length !== 0) {
-      selectRelease(sortedReleaseVersions[0]);
+      const firstActiveRelease = getLatestReleaseVersion(
+        sortedReleaseVersions,
+        allReleases
+      );
+      if (firstActiveRelease !== null) {
+        selectRelease(firstActiveRelease);
+      }
     }
   }, [selectRelease, sortedReleaseVersions, autoSelectLatest]);
 
@@ -111,7 +118,9 @@ const ReleaseSelector: FC<IReleaseSelector> = ({
   return (
     <LoadingOverlay loading={releasesIsFetching}>
       <SelectedWrapper>
-        <SelectedItem>
+        <SelectedItem
+          aria-label={`The currently selected version is ${selectedRelease}`}
+        >
           <i className='fa fa-version-tag' /> {selectedRelease}
         </SelectedItem>
         <SelectedDescription>
@@ -197,3 +206,18 @@ ReleaseSelector.defaultProps = {
 };
 
 export default ReleaseSelector;
+
+function getLatestReleaseVersion(
+  releaseVersions: string[],
+  releaseMap: IReleases
+): string | null {
+  if (releaseVersions.length < 1) return null;
+
+  for (const version of releaseVersions) {
+    if (releaseMap[version].active) {
+      return version;
+    }
+  }
+
+  return releaseVersions[0];
+}

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
@@ -23,7 +23,6 @@ import ReleaseRow from './ReleaseRow';
 
 interface IReleaseSelector {
   selectRelease(releaseVersion: string): void;
-
   selectedRelease: string;
   collapsible?: boolean;
   autoSelectLatest?: boolean;

--- a/src/components/Cluster/NewCluster/ReleaseSelector/__tests__/ReleaseSelector.ts
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/__tests__/ReleaseSelector.ts
@@ -271,4 +271,16 @@ describe('ReleaseSelector', () => {
       ).not.toBeInTheDocument();
     }
   });
+
+  it('automatically selects the newest active version when automatic selection is enabled', () => {
+    renderWithStore(
+      ReleaseSelector,
+      { ...defaultProps, collapsible: false, autoSelectLatest: true },
+      { ...defaultStoreState }
+    );
+
+    expect(
+      screen.getByLabelText(/the currently selected version is 1000\.0\.0/i)
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/13589

Listed this as a `dev-change`, because it is only relevant for GS Staff, as this behaviour was already present for non-GS staff.

This PR makes the latest active version be selected by default in the cluster creation form, regardless if you are an admin or not.