### PR TITLE
Worker node counter is broken when there are no node pools

### DIFF
--- a/src/components/Cluster/ClusterDetail/NodesRunning.tsx
+++ b/src/components/Cluster/ClusterDetail/NodesRunning.tsx
@@ -18,7 +18,7 @@ const NodesRunning: FC<INodesRunningProps> = ({
   numNodePools,
   workerNodesRunning,
 }) => {
-  if (workerNodesRunning === 0 && isClusterCreating) {
+  if (isClusterCreating) {
     return (
       <div data-testid='nodes-running'>
         <FallbackSpan>{FallbackMessages.NODES_NOT_READY}</FallbackSpan>
@@ -33,7 +33,7 @@ const NodesRunning: FC<INodesRunningProps> = ({
     <div data-testid='nodes-running'>
       <span>
         {`${workerNodesRunning} ${nodesSingularPlural}`}
-        {numNodePools && ` in ${numNodePools} ${npSingularPlural}`}
+        {` in ${numNodePools} ${npSingularPlural}`}
       </span>
       <span>
         <Dot />
@@ -53,6 +53,10 @@ NodesRunning.propTypes = {
   isClusterCreating: PropTypes.bool.isRequired,
   workerNodesRunning: PropTypes.number.isRequired,
   numNodePools: PropTypes.number,
+};
+
+NodesRunning.defaultProps = {
+  numNodePools: 0,
 };
 
 export default NodesRunning;

--- a/src/components/Cluster/ClusterDetail/NodesRunning.tsx
+++ b/src/components/Cluster/ClusterDetail/NodesRunning.tsx
@@ -29,12 +29,14 @@ const NodesRunning: FC<INodesRunningProps> = ({
   const nodesSingularPlural = workerNodesRunning === 1 ? ' node' : ' nodes';
   const npSingularPlural = numNodePools === 1 ? ' node pool' : ' node pools';
 
+  let workerNodesStatus = `${workerNodesRunning} ${nodesSingularPlural}`;
+  if (numNodePools) {
+    workerNodesStatus += ` in ${numNodePools} ${npSingularPlural}`;
+  }
+
   return (
     <div data-testid='nodes-running'>
-      <span>
-        {`${workerNodesRunning} ${nodesSingularPlural}`}
-        {` in ${numNodePools} ${npSingularPlural}`}
-      </span>
+      <span>{workerNodesStatus}</span>
       <span>
         <Dot />
         {RAM} GB RAM
@@ -53,10 +55,6 @@ NodesRunning.propTypes = {
   isClusterCreating: PropTypes.bool.isRequired,
   workerNodesRunning: PropTypes.number.isRequired,
   numNodePools: PropTypes.number,
-};
-
-NodesRunning.defaultProps = {
-  numNodePools: 0,
 };
 
 export default NodesRunning;


### PR DESCRIPTION
When you have a cluster ready, with no node pools (and therefore no nodes), the node count display is broken.

### Before

![image](https://user-images.githubusercontent.com/13508038/95892099-46d3da80-0d86-11eb-9d9f-bce154b01cdd.png)

### After

![image](https://user-images.githubusercontent.com/13508038/95892720-3839f300-0d87-11eb-8947-0214a94d81e9.png)
