### PR TITLE
Discourage the usage of pre-release versions

### DIFF
--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
@@ -10,7 +10,7 @@ import {
   getReleasesIsFetching,
   getSortedReleaseVersions,
 } from 'stores/releases/selectors';
-import { getReleaseEOLStatus } from 'stores/releases/utils';
+import { getReleaseEOLStatus, isPreRelease } from 'stores/releases/utils';
 import {
   ListToggler,
   SelectedDescription,
@@ -93,7 +93,7 @@ const ReleaseSelector: FC<IReleaseSelector> = ({
         selectRelease(firstActiveRelease);
       }
     }
-  }, [selectRelease, sortedReleaseVersions, autoSelectLatest]);
+  }, [allReleases, selectRelease, sortedReleaseVersions, autoSelectLatest]);
 
   const [collapsed, setCollapsed] = useState(collapsible as boolean);
 
@@ -235,7 +235,7 @@ function getLatestReleaseVersion(
   if (releaseVersions.length < 1) return null;
 
   for (const version of releaseVersions) {
-    if (releaseMap[version].active) {
+    if (releaseMap[version]?.active && !isPreRelease(version)) {
       return version;
     }
   }

--- a/src/components/Cluster/NewCluster/ReleaseSelector/__tests__/ReleaseSelector.ts
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/__tests__/ReleaseSelector.ts
@@ -273,8 +273,8 @@ describe('ReleaseSelector', () => {
 
     expect(filterFn).toBeCalled();
 
-    // Skip the first version.
-    for (let i = 1; i < mockSortedReleaseVersions.length; i++) {
+    // Skip the first 2 versions.
+    for (let i = 2; i < mockSortedReleaseVersions.length; i++) {
       expect(
         screen.queryByText(mockSortedReleaseVersions[i])
       ).not.toBeInTheDocument();

--- a/src/components/Cluster/NewCluster/ReleaseSelector/__tests__/ReleaseSelector.ts
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/__tests__/ReleaseSelector.ts
@@ -5,6 +5,15 @@ import { getComponentWithStore, renderWithStore } from 'testUtils/renderUtils';
 jest.unmock('stores/main/selectors');
 
 const mockReleases: IReleases = {
+  '1001.0.0-alpha': {
+    version: '1001.0.0-alpha',
+    timestamp: '2020-07-11T12:34:56Z',
+    components: [{ name: 'kubernetes', version: '1.16.3' }],
+    changelog: [{ component: 'dummy', description: 'dummy' }],
+    active: true,
+    kubernetesVersion: '1.16.3',
+    releaseNotesURL: 'dummy',
+  },
   '1000.0.0': {
     version: '1000.0.0',
     timestamp: '2020-06-11T12:34:56Z',
@@ -38,7 +47,7 @@ const mockSortedReleaseVersions = Object.keys(mockReleases);
 
 const defaultProps = {
   selectRelease: () => {},
-  selectedRelease: mockSortedReleaseVersions[0],
+  selectedRelease: mockSortedReleaseVersions[1],
 };
 
 const defaultStoreState = {
@@ -90,12 +99,12 @@ describe('ReleaseSelector', () => {
       { ...defaultStoreState }
     );
 
-    expect(screen.getByText(mockSortedReleaseVersions[0])).toBeInTheDocument();
+    expect(screen.getByText(mockSortedReleaseVersions[1])).toBeInTheDocument();
     expect(screen.getByText(/This release contains:/i)).toBeInTheDocument();
     expect(screen.getByText(/kubernetes/i)).toBeInTheDocument();
     expect(
       screen.getByText(
-        mockReleases[mockReleases[mockSortedReleaseVersions[0]].version]
+        mockReleases[mockReleases[mockSortedReleaseVersions[1]].version]
           .kubernetesVersion as string
       )
     ).toBeInTheDocument();
@@ -253,7 +262,7 @@ describe('ReleaseSelector', () => {
 
   it('can filter releases based on a provided filter function', () => {
     const filterFn = jest.fn((currentRelease) => {
-      return currentRelease === mockSortedReleaseVersions[0];
+      return currentRelease === mockSortedReleaseVersions[1];
     });
 
     renderWithStore(
@@ -273,14 +282,22 @@ describe('ReleaseSelector', () => {
   });
 
   it('automatically selects the newest active version when automatic selection is enabled', () => {
+    const mockSelectReleaseFn = jest.fn();
+
     renderWithStore(
       ReleaseSelector,
-      { ...defaultProps, collapsible: false, autoSelectLatest: true },
+      {
+        ...defaultProps,
+        collapsible: false,
+        autoSelectLatest: true,
+        selectedRelease: '',
+        selectRelease: mockSelectReleaseFn,
+      },
       { ...defaultStoreState }
     );
 
-    expect(
-      screen.getByLabelText(/the currently selected version is 1000\.0\.0/i)
-    ).toBeInTheDocument();
+    expect(mockSelectReleaseFn).toHaveBeenCalledWith(
+      mockSortedReleaseVersions[1]
+    );
   });
 });

--- a/src/stores/cluster/__tests__/selectors.ts
+++ b/src/stores/cluster/__tests__/selectors.ts
@@ -77,13 +77,14 @@ describe('cluster::selectors', () => {
       expect(releaseVersion).toBeNull();
     });
 
-    it(`returns null if there's a newer active version available, but it's inactive`, () => {
+    it(`returns null if there's a newer version available, but it's inactive, or if there's a newer version, but it's a pre-release one`, () => {
       const initialState = createInitialState({
         '1.0.0': createRelease('1.0.0', true),
         '2.0.0': createRelease('2.0.0', false),
         '2.0.1': createRelease('2.0.1', true),
         '3.0.0': createRelease('3.0.0', true),
         '3.0.1': createRelease('3.0.1', false),
+        '3.0.1-beta': createRelease('3.0.1-beta', true),
       });
       const cluster = (Object.assign({}, v5ClusterResponse, {
         release_version: '3.0.0',
@@ -111,6 +112,7 @@ describe('cluster::selectors', () => {
           '1.0.0': createRelease('1.0.0', true),
           '2.0.0': createRelease('2.0.0', false),
           '2.0.1': createRelease('2.0.1', false),
+          '2.0.2-alpha': createRelease('2.0.2-alpha', true),
           '2.0.2': createRelease('2.0.2', true),
           '3.0.0': createRelease('3.0.0', true),
         },
@@ -140,6 +142,25 @@ describe('cluster::selectors', () => {
       }) as unknown) as V5.ICluster;
       const releaseVersion = selectTargetRelease(initialState, cluster);
       expect(releaseVersion).toBe('3.0.1');
+    });
+
+    it('returns the next pre-release version, if the user is an admin and there is no newer active version', () => {
+      const initialState = createInitialState(
+        {
+          '1.0.0': createRelease('1.0.0', true),
+          '2.0.0': createRelease('2.0.0', false),
+          '2.0.1': createRelease('2.0.1', false),
+          '2.0.2': createRelease('2.0.2', true),
+          '3.0.0': createRelease('3.0.0', true),
+          '3.0.1-alpha': createRelease('3.0.1-alpha', true),
+        },
+        true
+      );
+      const cluster = (Object.assign({}, v5ClusterResponse, {
+        release_version: '3.0.0',
+      }) as unknown) as V5.ICluster;
+      const releaseVersion = selectTargetRelease(initialState, cluster);
+      expect(releaseVersion).toBe('3.0.1-alpha');
     });
   });
 });

--- a/src/stores/cluster/__tests__/utils.ts
+++ b/src/stores/cluster/__tests__/utils.ts
@@ -28,9 +28,23 @@ import preloginState from 'testUtils/preloginState';
 
 describe('cluster::utils', () => {
   describe('canClusterUpgrade', () => {
-    it('returns false if the provided versions are empty', () => {
-      expect(canClusterUpgrade(undefined, '1', 'aws')).toBeFalsy();
-      expect(canClusterUpgrade('1', undefined, 'aws')).toBeFalsy();
+    describe('all providers', () => {
+      it('returns false if the provided versions are empty', () => {
+        expect(canClusterUpgrade(undefined, '1', 'aws')).toBeFalsy();
+        expect(canClusterUpgrade('1', undefined, 'aws')).toBeFalsy();
+      });
+
+      it('returns false if the target version is a pre-release one', () => {
+        expect(
+          canClusterUpgrade('1.0.0', '1.0.1-alpha', Providers.AWS)
+        ).toBeFalsy();
+        expect(
+          canClusterUpgrade('1.0.0', '1.0.1-beta+somebuild', Providers.AZURE)
+        ).toBeFalsy();
+        expect(
+          canClusterUpgrade('1.0.0', '1.0.1+somebuild', Providers.KVM)
+        ).toBeFalsy();
+      });
     });
 
     describe('on azure', () => {

--- a/src/stores/cluster/__tests__/utils.ts
+++ b/src/stores/cluster/__tests__/utils.ts
@@ -26,7 +26,7 @@ import {
 } from 'testUtils/mockHttpCalls';
 import preloginState from 'testUtils/preloginState';
 
-describe('clusterUtils', () => {
+describe('cluster::utils', () => {
   describe('canClusterUpgrade', () => {
     it('returns false if the provided versions are empty', () => {
       expect(canClusterUpgrade(undefined, '1', 'aws')).toBeFalsy();
@@ -65,6 +65,1085 @@ describe('clusterUtils', () => {
     });
   });
 
+  describe('getNumberOfNodes', () => {
+    it('returns 0 worker nodes if the cluster status is not loaded yet', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+      };
+
+      expect(getNumberOfNodes(cluster)).toBe(0);
+    });
+
+    it('returns 0 if there are no nodes', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+        status: {
+          cluster: ({
+            nodes: [],
+          } as unknown) as V4.IClusterStatusCluster,
+        } as V4.IClusterStatus,
+      };
+      expect(getNumberOfNodes(cluster)).toBe(0);
+
+      (cluster.status as V4.IClusterStatus).cluster.nodes = null;
+      expect(getNumberOfNodes(cluster)).toBe(0);
+    });
+
+    it('returns the number of total worker nodes, discarding master nodes', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+        status: {
+          cluster: ({
+            nodes: [
+              {
+                labels: {
+                  role: 'master',
+                },
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                labels: {
+                  'kubernetes.io/role': 'master',
+                },
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                labels: {},
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+            ],
+          } as unknown) as V4.IClusterStatusCluster,
+        } as V4.IClusterStatus,
+      };
+
+      expect(getNumberOfNodes(cluster)).toBe(2);
+    });
+  });
+
+  describe('getMemoryTotal', () => {
+    it('returns the right memory for a given number of worker nodes', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+        status: {
+          cluster: ({
+            nodes: [
+              {
+                labels: {
+                  'kubernetes.io/role': 'master',
+                },
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+            ],
+          } as unknown) as V4.IClusterStatusCluster,
+        } as V4.IClusterStatus,
+        workers: [
+          ({
+            memory: {
+              size_gb: 1.337,
+            },
+          } as unknown) as V4.IClusterWorker,
+        ],
+      };
+      // eslint-disable-next-line no-magic-numbers
+      expect(getMemoryTotal(cluster)).toBe(2.68);
+    });
+
+    it('returns 0 for no workers', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+        status: {
+          cluster: ({
+            nodes: [
+              {
+                labels: {
+                  'kubernetes.io/role': 'master',
+                },
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+            ],
+          } as unknown) as V4.IClusterStatusCluster,
+        } as V4.IClusterStatus,
+        workers: [],
+      };
+      // eslint-disable-next-line no-magic-numbers
+      expect(getMemoryTotal(cluster)).toBe(0);
+    });
+  });
+
+  describe('getStorageTotal', () => {
+    it('returns the right storage amount for a given number of worker nodes', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+        status: {
+          cluster: ({
+            nodes: [
+              {
+                labels: {
+                  'kubernetes.io/role': 'master',
+                },
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+            ],
+          } as unknown) as V4.IClusterStatusCluster,
+        } as V4.IClusterStatus,
+        workers: [
+          ({
+            storage: {
+              size_gb: 1.337,
+            },
+          } as unknown) as V4.IClusterWorker,
+        ],
+      };
+
+      // eslint-disable-next-line no-magic-numbers
+      expect(getStorageTotal(cluster)).toBe(2.68);
+    });
+
+    it('returns 0 for no workers', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+        status: {
+          cluster: ({
+            nodes: [
+              {
+                labels: {
+                  'kubernetes.io/role': 'master',
+                },
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+            ],
+          } as unknown) as V4.IClusterStatusCluster,
+        } as V4.IClusterStatus,
+        workers: [],
+      };
+      expect(getStorageTotal(cluster)).toBe(0);
+
+      cluster.workers = undefined;
+      expect(getStorageTotal(cluster)).toBe(0);
+
+      (cluster.status as V4.IClusterStatus).cluster.nodes = null;
+      expect(getStorageTotal(cluster)).toBe(0);
+    });
+  });
+
+  describe('getCpusTotal', () => {
+    it('returns the right number of CPUs for a given list of workers', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+        status: {
+          cluster: ({
+            nodes: [
+              {
+                labels: {
+                  'kubernetes.io/role': 'master',
+                },
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+            ],
+          } as unknown) as V4.IClusterStatusCluster,
+        } as V4.IClusterStatus,
+        workers: [
+          ({
+            cpu: {
+              cores: 2,
+            },
+          } as unknown) as V4.IClusterWorker,
+        ],
+      };
+
+      expect(getCpusTotal(cluster)).toBe(4);
+    });
+
+    it('returns 0 for no workers', () => {
+      const cluster: V4.ICluster = {
+        api_endpoint: '',
+        create_date: null,
+        credential_id: '',
+        id: '',
+        owner: '',
+        status: {
+          cluster: ({
+            nodes: [
+              {
+                labels: {
+                  'kubernetes.io/role': 'master',
+                },
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+              {
+                name: '',
+                version: '',
+                lastTransitionTime: null,
+              },
+            ],
+          } as unknown) as V4.IClusterStatusCluster,
+        } as V4.IClusterStatus,
+        workers: [],
+      };
+      expect(getCpusTotal(cluster)).toBe(0);
+    });
+  });
+
+  describe('getNumberOfNodePoolsNodes', () => {
+    it('returns the right total number of nodes in a given list of node pools', () => {
+      const nodePools: INodePool[] = [
+        {
+          status: {
+            nodes: 3,
+          } as INodePoolStatus,
+        } as INodePool,
+        {
+          status: {
+            nodes: 5,
+          } as INodePoolStatus,
+        } as INodePool,
+      ];
+
+      expect(getNumberOfNodePoolsNodes(nodePools)).toBe(8);
+    });
+
+    it('returns 0 for no node pools', () => {
+      expect(getNumberOfNodePoolsNodes([])).toBe(0);
+    });
+  });
+
+  describe('getMemoryTotalNodePools', () => {
+    it('returns the right amount of total memory in a given list of node pools, on AWS', () => {
+      const initialInstanceTypes = window.config.awsCapabilitiesJSON;
+      window.config.awsCapabilitiesJSON = JSON.stringify({
+        gigantic: {
+          memory_size_gb: 3.138,
+        },
+      });
+
+      const nodePools: INodePool[] = [
+        {
+          node_spec: {
+            aws: {
+              instance_type: 'gigantic',
+            },
+          },
+          status: {
+            nodes_ready: 3,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {
+            aws: {
+              instance_type: 'nonexistent',
+            },
+          },
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+      ];
+
+      // eslint-disable-next-line no-magic-numbers
+      expect(getMemoryTotalNodePools(nodePools)).toBe(9.42);
+
+      window.config.awsCapabilitiesJSON = initialInstanceTypes;
+    });
+
+    it('returns the right amount of total memory in a given list of node pools, on Azure', () => {
+      const initialInstanceTypes = window.config.azureCapabilitiesJSON;
+      window.config.azureCapabilitiesJSON = JSON.stringify({
+        gigantic: {
+          memoryInMb: 3773,
+        },
+      });
+
+      const nodePools: INodePool[] = [
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'gigantic',
+            },
+          },
+          status: {
+            nodes_ready: 3,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'nonexistent',
+            },
+          },
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+      ];
+
+      // eslint-disable-next-line no-magic-numbers
+      expect(getMemoryTotalNodePools(nodePools)).toBe(11.4);
+
+      window.config.azureCapabilitiesJSON = initialInstanceTypes;
+    });
+
+    it('returns 0 if the provider cannot be determined', () => {
+      const nodePools: INodePool[] = [
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 3,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+      ];
+
+      expect(getMemoryTotalNodePools(nodePools)).toBe(0);
+    });
+
+    it('returns 0 if there are no instance types', () => {
+      const initialInstanceTypes = window.config.azureCapabilitiesJSON;
+      // @ts-expect-error
+      delete window.config.azureCapabilitiesJSON;
+
+      const nodePools: INodePool[] = [
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'gigantic',
+            },
+          },
+          status: {
+            nodes_ready: 3,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'nonexistent',
+            },
+          },
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+      ];
+
+      expect(getMemoryTotalNodePools(nodePools)).toBe(0);
+
+      window.config.azureCapabilitiesJSON = initialInstanceTypes;
+    });
+
+    it('returns 0 if there are no node pools', () => {
+      expect(getMemoryTotalNodePools([])).toBe(0);
+    });
+  });
+
+  describe('getCpusTotalNodePools', () => {
+    it('returns the right total number of CPUs in a given list of node pools, on AWS', () => {
+      const initialInstanceTypes = window.config.awsCapabilitiesJSON;
+      window.config.awsCapabilitiesJSON = JSON.stringify({
+        gigantic: {
+          cpu_cores: 3,
+        },
+        cool: {
+          cpu_cores: 5,
+        },
+      });
+
+      const nodePools: INodePool[] = [
+        {
+          node_spec: {
+            aws: {
+              instance_type: 'gigantic',
+            },
+          },
+          status: {
+            nodes_ready: 3,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {
+            aws: {
+              instance_type: 'nonexistent',
+            },
+          },
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {
+            aws: {
+              instance_type: 'cool',
+            },
+          },
+          status: {
+            nodes_ready: 4,
+          },
+        } as INodePool,
+      ];
+
+      // eslint-disable-next-line no-magic-numbers
+      expect(getCpusTotalNodePools(nodePools)).toBe(29);
+
+      window.config.awsCapabilitiesJSON = initialInstanceTypes;
+    });
+
+    it('returns the right total number of CPUs in a given list of node pools, on Azure', () => {
+      const initialInstanceTypes = window.config.azureCapabilitiesJSON;
+      window.config.azureCapabilitiesJSON = JSON.stringify({
+        gigantic: {
+          numberOfCores: 3,
+        },
+        cool: {
+          numberOfCores: 5,
+        },
+      });
+
+      const nodePools: INodePool[] = [
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'gigantic',
+            },
+          },
+          status: {
+            nodes_ready: 3,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'nonexistent',
+            },
+          },
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'cool',
+            },
+          },
+          status: {
+            nodes_ready: 4,
+          },
+        } as INodePool,
+      ];
+
+      // eslint-disable-next-line no-magic-numbers
+      expect(getCpusTotalNodePools(nodePools)).toBe(29);
+
+      window.config.azureCapabilitiesJSON = initialInstanceTypes;
+    });
+
+    it('returns 0 if the provider cannot be determined', () => {
+      const nodePools: INodePool[] = [
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 3,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+      ];
+
+      expect(getCpusTotalNodePools(nodePools)).toBe(0);
+    });
+
+    it('returns 0 if there are no instance types', () => {
+      const initialInstanceTypes = window.config.azureCapabilitiesJSON;
+      // @ts-expect-error
+      delete window.config.azureCapabilitiesJSON;
+
+      const nodePools: INodePool[] = [
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'gigantic',
+            },
+          },
+          status: {
+            nodes_ready: 3,
+          },
+        } as INodePool,
+        {
+          node_spec: {},
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+        {
+          node_spec: {
+            azure: {
+              vm_size: 'nonexistent',
+            },
+          },
+          status: {
+            nodes_ready: 5,
+          },
+        } as INodePool,
+      ];
+
+      expect(getCpusTotalNodePools(nodePools)).toBe(0);
+
+      window.config.azureCapabilitiesJSON = initialInstanceTypes;
+    });
+
+    it('returns 0 if there are no node pools', () => {
+      expect(getCpusTotalNodePools([])).toBe(0);
+    });
+  });
+
+  describe('computeCapabilities', () => {
+    describe('hasOptionalIngress', () => {
+      describe('on azure', () => {
+        it('is false for Azure below 12.0.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('azure')
+          )('11.0.0', 'azure');
+          expect(capabilities.hasOptionalIngress).toBe(false);
+        });
+
+        it('is true for Azure at 12.0.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('azure')
+          )('12.0.0', 'azure');
+          expect(capabilities.hasOptionalIngress).toBe(true);
+        });
+
+        it('is true for Azure above 12.0.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('azure')
+          )('13.0.0', 'azure');
+          expect(capabilities.hasOptionalIngress).toBe(true);
+        });
+      });
+
+      describe('on aws', () => {
+        it('is false for AWS below 10.1.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('aws')
+          )('9.0.0', 'aws');
+          expect(capabilities.hasOptionalIngress).toBe(false);
+        });
+
+        it('is true for AWS at 10.1.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('aws')
+          )('10.1.0', 'aws');
+          expect(capabilities.hasOptionalIngress).toBe(true);
+        });
+
+        it('is true for AWS above 10.1.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('aws')
+          )('11.1.0', 'aws');
+          expect(capabilities.hasOptionalIngress).toBe(true);
+        });
+      });
+
+      describe('on kvm', () => {
+        it('is false for KVM below 12.2.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('kvm')
+          )('11.0.0', 'kvm');
+          expect(capabilities.hasOptionalIngress).toBe(false);
+        });
+
+        it('is true for KVM at 12.2.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('kvm')
+          )('12.2.0', 'kvm');
+          expect(capabilities.hasOptionalIngress).toBe(true);
+        });
+
+        it('is true for KVM above 12.2.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('kvm')
+          )('13.0.0', 'kvm');
+          expect(capabilities.hasOptionalIngress).toBe(true);
+        });
+      });
+    });
+
+    describe('supportsHAMasters', () => {
+      describe('on azure', () => {
+        it('is false for Azure at any version', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('azure')
+          )('8.1.0', 'azure');
+          expect(capabilities.supportsHAMasters).toBe(false);
+        });
+      });
+
+      describe('on aws', () => {
+        it('is false for AWS below 9.0.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('aws')
+          )('9.0.0', 'aws');
+          expect(capabilities.supportsHAMasters).toBe(false);
+        });
+
+        it('is true for AWS at 11.4.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('aws')
+          )('11.4.0', 'aws');
+          expect(capabilities.supportsHAMasters).toBe(true);
+        });
+
+        it('is true for AWS above 13.0.0', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('aws')
+          )('13.0.0', 'aws');
+          expect(capabilities.supportsHAMasters).toBe(true);
+        });
+      });
+
+      describe('on kvm', () => {
+        it('is false for KVM at any version', () => {
+          const capabilities = computeCapabilities(
+            getEmptyStateWithProvider('kvm')
+          )('8.0.0', 'kvm');
+          expect(capabilities.supportsHAMasters).toBe(false);
+        });
+      });
+    });
+  });
+
+  describe('getClusterLatestCondition', () => {
+    it('gets the latest cluster condition, on a v5 cluster', () => {
+      const cluster = (Object.assign(
+        {},
+        v5ClusterResponse
+      ) as unknown) as V5.ICluster;
+
+      expect(getClusterLatestCondition(cluster)).toBe('Created');
+    });
+
+    it('gets the latest cluster condition, on a v4 cluster', () => {
+      const cluster = (Object.assign({}, v4AWSClusterResponse, {
+        status: v4AWSClusterStatusResponse,
+      }) as unknown) as V4.ICluster;
+
+      expect(getClusterLatestCondition(cluster)).toBe('Created');
+    });
+
+    it(`doesn't break if there are no conditions in a v5 cluster`, () => {
+      const cluster = Object.assign({}, v5ClusterResponse, {
+        conditions: undefined,
+      }) as V5.ICluster;
+
+      expect(getClusterLatestCondition(cluster)).not.toBe('Created');
+    });
+
+    it(`doesn't break if there are no conditions in a v4 cluster`, () => {
+      const cluster = (Object.assign({}, v4AWSClusterResponse, {
+        status: undefined,
+      }) as unknown) as V4.ICluster;
+
+      expect(getClusterLatestCondition(cluster)).not.toBe('Created');
+    });
+  });
+
+  describe('isClusterCreating', () => {
+    it('checks if the latest condition is the creating one, on a v5 cluster', () => {
+      let cluster = (Object.assign(
+        {},
+        v5ClusterResponse
+      ) as unknown) as V5.ICluster;
+      expect(isClusterCreating(cluster)).toBeFalsy();
+
+      cluster = (Object.assign({}, v5ClusterResponse, {
+        conditions: [
+          {
+            last_transition_time: new Date().toISOString(),
+            condition: 'Creating',
+          },
+        ],
+      }) as unknown) as V5.ICluster;
+      expect(isClusterCreating(cluster)).toBeTruthy();
+    });
+
+    it('checks if the latest condition is the creating one, on a v4 cluster', () => {
+      const cluster = (Object.assign({}, v4AWSClusterResponse, {
+        status: v4AWSClusterStatusResponse,
+      }) as unknown) as V4.ICluster;
+      expect(isClusterCreating(cluster)).toBeFalsy();
+
+      cluster.status = {
+        ...cluster.status,
+        cluster: {
+          ...cluster.status?.cluster,
+          conditions: [
+            {
+              lastTransitionTime: new Date().toISOString(),
+              type: 'Creating',
+              status: '',
+            },
+          ],
+        },
+      } as V4.IClusterStatus;
+
+      expect(isClusterCreating(cluster)).toBeTruthy();
+    });
+  });
+
+  describe('isClusterUpdating', () => {
+    it('checks if the latest condition is the updating one, on a v5 cluster', () => {
+      let cluster = (Object.assign(
+        {},
+        v5ClusterResponse
+      ) as unknown) as V5.ICluster;
+      expect(isClusterUpdating(cluster)).toBeFalsy();
+
+      cluster = (Object.assign({}, v5ClusterResponse, {
+        conditions: [
+          {
+            last_transition_time: new Date().toISOString(),
+            condition: 'Updating',
+          },
+        ],
+      }) as unknown) as V5.ICluster;
+      expect(isClusterUpdating(cluster)).toBeTruthy();
+    });
+
+    it('checks if the latest condition is the updating one, on a v4 cluster', () => {
+      const cluster = (Object.assign({}, v4AWSClusterResponse, {
+        status: v4AWSClusterStatusResponse,
+      }) as unknown) as V4.ICluster;
+      expect(isClusterUpdating(cluster)).toBeFalsy();
+
+      cluster.status = {
+        ...cluster.status,
+        cluster: {
+          ...cluster.status?.cluster,
+          conditions: [
+            {
+              lastTransitionTime: new Date().toISOString(),
+              type: 'Updating',
+              status: '',
+            },
+          ],
+        },
+      } as V4.IClusterStatus;
+
+      expect(isClusterUpdating(cluster)).toBeTruthy();
+    });
+  });
+
+  describe('isClusterDeleting', () => {
+    it('checks if the latest condition is the deleting one, on a v5 cluster', () => {
+      let cluster = (Object.assign(
+        {},
+        v5ClusterResponse
+      ) as unknown) as V5.ICluster;
+      expect(isClusterDeleting(cluster)).toBeFalsy();
+
+      cluster = (Object.assign({}, v5ClusterResponse, {
+        conditions: [
+          {
+            last_transition_time: new Date().toISOString(),
+            condition: 'Deleting',
+          },
+        ],
+      }) as unknown) as V5.ICluster;
+      expect(isClusterDeleting(cluster)).toBeTruthy();
+    });
+
+    it('checks if the latest condition is the deleting one, on a v4 cluster', () => {
+      const cluster = (Object.assign({}, v4AWSClusterResponse, {
+        status: v4AWSClusterStatusResponse,
+      }) as unknown) as V4.ICluster;
+      expect(isClusterDeleting(cluster)).toBeFalsy();
+
+      cluster.status = {
+        ...cluster.status,
+        cluster: {
+          ...cluster.status?.cluster,
+          conditions: [
+            {
+              lastTransitionTime: new Date().toISOString(),
+              type: 'Deleting',
+              status: '',
+            },
+          ],
+        },
+      } as V4.IClusterStatus;
+
+      expect(isClusterDeleting(cluster)).toBeTruthy();
+    });
+  });
+
+  describe('guessProviderFromNodePools', () => {
+    it(`returns 'null' for an empty NP list`, () => {
+      const result = guessProviderFromNodePools([]);
+
+      expect(result).toBeNull();
+    });
+
+    it(`returns 'aws' for an AWS node pool list`, () => {
+      const nodePools = [
+        {
+          id: '3jx5q',
+          node_spec: {
+            aws: { instance_type: 'm3.xlarge' },
+          },
+        },
+      ] as INodePool[];
+      const result = guessProviderFromNodePools(nodePools);
+
+      expect(result).toBe('aws');
+    });
+
+    it(`returns 'azure' for an Azure node pool list`, () => {
+      const nodePools = [
+        {
+          id: '3jx5q',
+          node_spec: {
+            azure: { vm_size: 'm3.xlarge' },
+          },
+        },
+      ] as INodePool[];
+      const result = guessProviderFromNodePools(nodePools);
+
+      expect(result).toBe('azure');
+    });
+
+    it(`returns 'null' for an unknown provider node pool list`, () => {
+      const nodePools = [
+        {
+          id: '3jx5q',
+          node_spec: {},
+        },
+      ] as INodePool[];
+      const result = guessProviderFromNodePools(nodePools);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getInstanceTypesForProvider', () => {
+    const initialAWSCapabilitiesJSON = window.config.awsCapabilitiesJSON;
+    const initialAzureCapabilitiesJSON = window.config.azureCapabilitiesJSON;
+
+    afterEach(() => {
+      window.config.awsCapabilitiesJSON = initialAWSCapabilitiesJSON;
+      window.config.azureCapabilitiesJSON = initialAzureCapabilitiesJSON;
+    });
+
+    it('gets the correct list for the AWS provider', () => {
+      const instanceTypes = getInstanceTypesForProvider('aws');
+      expect(instanceTypes).toStrictEqual(
+        JSON.parse(initialAWSCapabilitiesJSON)
+      );
+    });
+
+    it('gets the correct list for the Azure provider', () => {
+      const instanceTypes = getInstanceTypesForProvider('azure');
+      expect(instanceTypes).toStrictEqual(
+        JSON.parse(initialAzureCapabilitiesJSON)
+      );
+    });
+
+    it(`returns 'null' for an unknown provider`, () => {
+      const instanceTypes = getInstanceTypesForProvider(
+        '' as PropertiesOf<typeof Providers>
+      );
+      expect(instanceTypes).toBeNull();
+    });
+
+    it(`returns 'null' if the capabilities are mis-configured for the current provider`, () => {
+      // @ts-expect-error
+      delete window.config.awsCapabilitiesJSON;
+      // @ts-expect-error
+      delete window.config.azureCapabilitiesJSON;
+
+      expect(getInstanceTypesForProvider('aws')).toBeNull();
+      expect(getInstanceTypesForProvider('azure')).toBeNull();
+    });
+  });
+
+  describe('v4orV5', () => {
+    const state: IState = ({
+      entities: {
+        clusters: {
+          v5Clusters: ['123sd', 'fas10', '349aa'],
+        },
+      },
+    } as unknown) as IState;
+
+    const v4Fn = jest.fn();
+    const v5Fn = jest.fn();
+
+    it(`runs the 'v4' func if the cluster is not a v5 cluster`, () => {
+      expect(v4orV5(v4Fn, v5Fn, '240aa', state)).toBe(v4Fn);
+    });
+
+    it(`runs the 'v5' func if the cluster is a v5 cluster`, () => {
+      expect(v4orV5(v4Fn, v5Fn, 'fas10', state)).toBe(v5Fn);
+    });
+  });
   describe('getNumberOfNodes', () => {
     it('returns 0 worker nodes if the cluster status is not loaded yet', () => {
       const cluster: V4.ICluster = {

--- a/src/stores/cluster/selectors.ts
+++ b/src/stores/cluster/selectors.ts
@@ -9,6 +9,7 @@ import {
   isClusterUpdating,
 } from 'stores/cluster/utils';
 import { getUserIsAdmin } from 'stores/main/selectors';
+import { isPreRelease } from 'stores/releases/utils';
 import { IState } from 'stores/state';
 import { createDeepEqualSelector } from 'stores/utils';
 
@@ -86,7 +87,10 @@ export function selectTargetRelease(state: IState, cluster?: Cluster | null) {
     }
     if (!currVersionFound) continue;
 
-    if (releases[availableVersions[i]].active) {
+    if (
+      releases[availableVersions[i]].active &&
+      !isPreRelease(availableVersions[i])
+    ) {
       nextVersion = availableVersions[i];
 
       break;

--- a/src/stores/cluster/utils.ts
+++ b/src/stores/cluster/utils.ts
@@ -2,6 +2,7 @@ import { compare } from 'lib/semver';
 import { Constants, Providers } from 'shared/constants';
 import { INodePool, PropertiesOf } from 'shared/types';
 import { getMinHAMastersVersion } from 'stores/main/selectors';
+import { isPreRelease } from 'stores/releases/utils';
 import { IState } from 'stores/state';
 import { validateLabelKey } from 'utils/labelUtils';
 
@@ -28,6 +29,8 @@ export function canClusterUpgrade(
   const onAWS = provider === Providers.AWS;
 
   if (onAWS && targetingV5 && currentlyV4) return false;
+
+  if (isPreRelease(targetVersion)) return false;
 
   return true;
 }

--- a/src/stores/releases/__tests__/utils.ts
+++ b/src/stores/releases/__tests__/utils.ts
@@ -1,4 +1,4 @@
-import { getReleaseEOLStatus } from 'stores/releases/utils';
+import { getReleaseEOLStatus, isPreRelease } from 'stores/releases/utils';
 
 describe('releases::utils', () => {
   describe('getReleaseEOLStatus', () => {
@@ -40,6 +40,16 @@ describe('releases::utils', () => {
 
       expect(result.isEol).toBeFalsy();
       expect(result.message).toBe('');
+    });
+  });
+
+  describe('isPreRelease', () => {
+    it('distinguishes pre-release versions from regular versions', () => {
+      expect(isPreRelease('1.0.0-alpha')).toBeTruthy();
+      expect(isPreRelease('1.0.0+metadata')).toBeTruthy();
+      expect(isPreRelease('1.0.0-beta+somemeta')).toBeTruthy();
+      expect(isPreRelease('1.0.0')).toBeFalsy();
+      expect(isPreRelease('24.12.9')).toBeFalsy();
     });
   });
 });

--- a/src/stores/releases/utils.ts
+++ b/src/stores/releases/utils.ts
@@ -28,3 +28,13 @@ export function getReleaseEOLStatus(
 
   return result;
 }
+
+const preReleaseRegexp = /([0-9]*)\.([0-9]*)\.([0-9]*)([-+].*)/;
+
+/**
+ * Check if a version number is a pre-release Semver version.
+ * @param version
+ */
+export function isPreRelease(version: string): boolean {
+  return preReleaseRegexp.test(version);
+}


### PR DESCRIPTION
Semver pre-releases can have the following formats:
* 1.0.0-alpha (or beta, rc1 etc.)
* 1.0.0+buildmetadata
* 1.0.0-alpha+buildmetadata

This PR:
* Blocks pre-release versions from being selected by default when you're creating a new cluster.
* Prevents upgrades from regular versions to pre-release versions.
* Moves cluster utils tests to the correct folder.