### PR TITLE
Set background color early

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,11 @@
       sizes="128x128"
       href="/images/app_icon_128.png"
     />
+    <style>
+    html {
+      background-color: #234a61;
+    }
+    </style>
     <placeholder_rum/>
     <link
       rel="stylesheet"
@@ -51,13 +56,12 @@
     </script>
 
     <style>
-      body {
-        background: #234a61;
-      }
-
-      .loading footer {
-        display: none;
-      }
+    html, body {
+      background-color: #234a61;
+    }
+    .loading footer {
+      display: none;
+    }
     </style>
   </head>
   <body class="loading">

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
     />
     <style>
     html {
-      background-color: #234a61;
+      background-color: #152531;
     }
     </style>
     <placeholder_rum/>
@@ -57,7 +57,7 @@
 
     <style>
     html, body {
-      background-color: #234a61;
+      background-color: #152531;
     }
     .loading footer {
       display: none;

--- a/src/index.html
+++ b/src/index.html
@@ -56,9 +56,6 @@
     </script>
 
     <style>
-    html, body {
-      background-color: #152531;
-    }
     .loading footer {
       display: none;
     }


### PR DESCRIPTION
This PR attempts to change the loading behaviour so that the final background color of the viewport is set as early as possible, preventing a white flash during loading.

Note that this uses the background color of the login page, which is darker than the app's normal background

## Before

![image](https://user-images.githubusercontent.com/273727/96226710-56743e80-0f93-11eb-9fc9-0ea770471a0f.png)

Timing here based on webpagetest.org with "cable" as network bandwith (5 MBit/Sec).

Results: https://www.webpagetest.org/result/201016_DiYT_ae9f28b21731b39e2c4c287dfa1455ba/

## After

![image](https://user-images.githubusercontent.com/273727/96415242-8c612f00-11ee-11eb-9153-0a6c6bea3f7e.png)

Results: https://www.webpagetest.org/result/201019_DiDF_5a79b726d23f0ad1c5c95755a8cebb8c/
