### PR TITLE
Select the organization ID from storage before comparing it to the cluster owner reference

### DIFF
--- a/src/components/AppCatalog/AppDetail/InstallAppModal.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppModal.js
@@ -10,6 +10,7 @@ import { OrganizationsRoutes } from 'shared/constants/routes';
 import { installApp } from 'stores/appcatalog/actions';
 import { selectIsClusterAwaitingUpgrade } from 'stores/cluster/selectors';
 import { isClusterCreating, isClusterUpdating } from 'stores/cluster/utils';
+import { selectOrganizationByID } from 'stores/organization/selectors';
 import Button from 'UI/Button';
 import ClusterIDLabel from 'UI/ClusterIDLabel';
 
@@ -320,10 +321,13 @@ function mapStateToProps(state) {
         selectIsClusterAwaitingUpgrade(clusterID)(state);
       const isCreatingOrUpdating = isClusterCreating(cluster) || isUpdating;
 
+      const organizationID =
+        selectOrganizationByID(cluster.owner)(state)?.id ?? cluster.owner;
+
       return {
         id: clusterID,
         name: cluster.name,
-        owner: cluster.owner,
+        owner: organizationID,
         isAvailable: !cluster.status || !isCreatingOrUpdating,
         isDeleted: Boolean(cluster.delete_date),
       };

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -17,6 +17,7 @@ import { isClusterCreating } from 'stores/cluster/utils';
 import { selectErrorByIdAndAction } from 'stores/entityerror/selectors';
 import { CLUSTER_NODEPOOLS_LOAD_REQUEST } from 'stores/nodepool/constants';
 import { selectClusterNodePools } from 'stores/nodepool/selectors';
+import { selectOrganizationByID } from 'stores/organization/selectors';
 import { getAllReleases } from 'stores/releases/selectors';
 import { Dot, mq } from 'styles';
 import Button from 'UI/Button';
@@ -141,6 +142,7 @@ const StyledErrorFallback = styled(ErrorFallback)`
 
 function ClusterDashboardItem({
   cluster,
+  organizationID,
   isV5Cluster,
   selectedOrganization,
   nodePools,
@@ -174,7 +176,7 @@ function ClusterDashboardItem({
     const clusterGuidePath = RoutePath.createUsablePath(
       OrganizationsRoutes.Clusters.GettingStarted.Overview,
       {
-        orgId: cluster.owner,
+        orgId: organizationID,
         clusterId,
       }
     );
@@ -305,6 +307,7 @@ function ClusterDashboardItem({
 
 ClusterDashboardItem.propTypes = {
   cluster: PropTypes.object,
+  organizationID: PropTypes.string,
   selectedOrganization: PropTypes.string,
   dispatch: PropTypes.func,
   isV5Cluster: PropTypes.bool,
@@ -315,8 +318,16 @@ ClusterDashboardItem.propTypes = {
 };
 
 function mapStateToProps(state, props) {
+  const cluster = selectClusterById(state, props.clusterId);
+  let organizationID = '';
+  if (cluster) {
+    organizationID =
+      selectOrganizationByID(cluster.owner)(state)?.id ?? cluster.owner;
+  }
+
   return {
-    cluster: selectClusterById(state, props.clusterId),
+    cluster,
+    organizationID,
     nodePools: selectClusterNodePools(state, props.clusterId),
     nodePoolsLoadError: selectErrorByIdAndAction(
       state,

--- a/src/components/Organizations/Detail/Detail.js
+++ b/src/components/Organizations/Detail/Detail.js
@@ -7,6 +7,7 @@ import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { OrganizationsRoutes } from 'shared/constants/routes';
+import { selectOrganizationByID } from 'stores/organization/selectors';
 
 import DetailView from './View';
 
@@ -65,13 +66,15 @@ DetailIndex.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   const allClusters = state.entities.clusters.items;
+  const organizationParam = ownProps.match.params.orgId;
+  const organizationID =
+    selectOrganizationByID(organizationParam)(state)?.id ?? organizationParam;
 
   const clusters = Object.values(allClusters).filter(
-    (cluster) => cluster.owner === ownProps.match.params.orgId
+    (cluster) => cluster.owner === organizationID
   );
 
-  const organization =
-    state.entities.organizations.items[ownProps.match.params.orgId];
+  const organization = state.entities.organizations.items[organizationParam];
   const membersForTable = organization?.members.map((member) => {
     return Object.assign({}, member, {
       emailDomain: member.email.split('@')[1],

--- a/src/components/UI/OrganizationList/OrganizationList.js
+++ b/src/components/UI/OrganizationList/OrganizationList.js
@@ -33,7 +33,11 @@ const OrganizationList = ({ provider, ...props }) => {
           return (
             <Row
               key={organization.id}
-              clusters={clustersForOrg(organization.id, props.clusters)}
+              clusters={clustersForOrg(
+                organization.id,
+                props.organizations,
+                props.clusters
+              )}
               getViewURL={props.getViewURL}
               onDelete={props.deleteOrganization}
               organization={organization}

--- a/src/lib/__tests__/helpers.ts
+++ b/src/lib/__tests__/helpers.ts
@@ -406,6 +406,12 @@ token: can't be blank`)
   });
 
   describe('clustersForOrg', () => {
+    const organizations: IOrganization[] = [
+      { id: 'giantswarm' },
+      { id: 'smallswarm' },
+      { id: 'mediumswarm' },
+    ];
+
     it('filters all clusters for a given organization', () => {
       const clusters: IClusterMap = {
         '1sa1s': {
@@ -469,14 +475,20 @@ token: can't be blank`)
           credential_id: 'some-credential',
         },
       };
-      expect(clustersForOrg('giantswarm', clusters)).toHaveLength(3);
-      expect(clustersForOrg('mediumswarm', clusters)).toHaveLength(1);
-      expect(clustersForOrg('smallswarm', clusters)).toHaveLength(1);
-      expect(clustersForOrg('random', clusters)).toHaveLength(0);
+      expect(
+        clustersForOrg('giantswarm', organizations, clusters)
+      ).toHaveLength(3);
+      expect(
+        clustersForOrg('mediumswarm', organizations, clusters)
+      ).toHaveLength(1);
+      expect(
+        clustersForOrg('smallswarm', organizations, clusters)
+      ).toHaveLength(1);
+      expect(clustersForOrg('random', organizations, clusters)).toHaveLength(0);
     });
 
     it('returns an empty list of clusters, if there are no clusters provided', () => {
-      expect(clustersForOrg('giantswarm')).toHaveLength(0);
+      expect(clustersForOrg('giantswarm', organizations)).toHaveLength(0);
     });
   });
 

--- a/src/lib/helpers.tsx
+++ b/src/lib/helpers.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import { IKeyPair } from 'shared/types';
+import { getOrganizationByID } from 'stores/organization/utils';
 import validate from 'validate.js';
 
 /**
@@ -302,16 +303,20 @@ export function makeKubeConfigTextFile(
 /**
  * Get all the clusters owned by a given organization.
  * @param orgId
+ * @param organizations
  * @param allClusters
  */
 export function clustersForOrg(
   orgId: string,
+  organizations: IOrganization[],
   allClusters?: IClusterMap
 ): Cluster[] {
   if (!allClusters) return [];
 
+  const organizationID = getOrganizationByID(orgId, organizations)?.id;
+
   return Object.values(allClusters).filter(
-    (cluster) => cluster.owner === orgId
+    (cluster) => cluster.owner === organizationID
   );
 }
 

--- a/src/stores/cluster/selectors.ts
+++ b/src/stores/cluster/selectors.ts
@@ -9,6 +9,7 @@ import {
   isClusterUpdating,
 } from 'stores/cluster/utils';
 import { getUserIsAdmin } from 'stores/main/selectors';
+import { selectOrganizationByID } from 'stores/organization/selectors';
 import { isPreRelease } from 'stores/releases/utils';
 import { IState } from 'stores/state';
 import { createDeepEqualSelector } from 'stores/utils';
@@ -23,9 +24,14 @@ export function selectClusterById(
 function selectOrganizationClusterNames(state: IState): string[] {
   const clusters = state.entities.clusters.items;
   const clusterIds = Object.keys(clusters);
+  const selectedOrganization =
+    state.main.selectedOrganization?.toLowerCase() ?? '';
+  const organizationID =
+    selectOrganizationByID(selectedOrganization)(state)?.id ??
+    selectedOrganization;
 
   return clusterIds
-    .filter((id) => clusters[id].owner === state.main.selectedOrganization)
+    .filter((id) => clusters[id].owner === organizationID)
     .sort((a, b) =>
       (clusters[a].name as string) > (clusters[b].name as string) ? 1 : -1
     );

--- a/src/stores/nodepool/actions.ts
+++ b/src/stores/nodepool/actions.ts
@@ -27,6 +27,7 @@ import {
   INodePoolPatchActionPayload,
   NodePoolActions,
 } from 'stores/nodepool/types';
+import { selectOrganizationByID } from 'stores/organization/selectors';
 import { IState } from 'stores/state';
 import { extractMessageFromError } from 'utils/errorUtils';
 
@@ -101,7 +102,12 @@ export function nodePoolsLoad(opts?: {
     if (opts?.withLoadingFlags)
       dispatch({ type: NODEPOOL_MULTIPLE_LOAD_REQUEST });
 
-    const selectedOrganization = getState().main.selectedOrganization;
+    const selectedOrganization =
+      getState().main.selectedOrganization?.toLowerCase() ?? '';
+    const organizationID =
+      selectOrganizationByID(selectedOrganization)(getState())?.id ??
+      selectedOrganization;
+
     const allClusters = getState().entities.clusters.items;
     const v5ClusterIDs: string[] =
       getState().entities.clusters.v5Clusters || [];
@@ -115,7 +121,7 @@ export function nodePoolsLoad(opts?: {
 
       if (
         opts?.filterBySelectedOrganization &&
-        cluster.owner !== selectedOrganization
+        cluster.owner !== organizationID
       ) {
         return false;
       }

--- a/src/stores/organization/__tests__/utils.ts
+++ b/src/stores/organization/__tests__/utils.ts
@@ -1,0 +1,38 @@
+import { getOrganizationByID } from 'stores/organization/utils';
+
+describe('organization::utils', () => {
+  describe('getOrganizationByID', () => {
+    it('returns the organization with a given ID', () => {
+      const organizations: IOrganization[] = [
+        { id: 'giantswarm' },
+        { id: 'medium-sw-arm' },
+      ];
+
+      expect(getOrganizationByID('medium-sw-arm', organizations)).toStrictEqual(
+        organizations[1]
+      );
+    });
+
+    it('returns the organization with a given lowercase ID, even if the organization ID has a mixed case', () => {
+      const organizations: IOrganization[] = [
+        { id: 'giantswarm' },
+        { id: 'medium-SW-arm' },
+      ];
+
+      expect(getOrganizationByID('medium-sw-arm', organizations)).toStrictEqual(
+        organizations[1]
+      );
+    });
+
+    it('returns undefined if an organization could not be found', () => {
+      const organizations: IOrganization[] = [
+        { id: 'giantswarm' },
+        { id: 'medium-SW-arm' },
+      ];
+
+      expect(getOrganizationByID('medium-sw-arm', organizations)).toStrictEqual(
+        organizations[1]
+      );
+    });
+  });
+});

--- a/src/stores/organization/selectors.ts
+++ b/src/stores/organization/selectors.ts
@@ -1,0 +1,11 @@
+import { getOrganizationByID } from 'stores/organization/utils';
+import { IState } from 'stores/state';
+
+export const selectOrganizationByID = (id: string) => (
+  state: IState
+): IOrganization | undefined => {
+  return getOrganizationByID(
+    id,
+    Object.values(state.entities.organizations.items)
+  );
+};

--- a/src/stores/organization/utils.ts
+++ b/src/stores/organization/utils.ts
@@ -1,0 +1,14 @@
+export function getOrganizationByID(
+  id: string,
+  organizations: IOrganization[]
+): IOrganization | undefined {
+  const idLowerCased = id.toLowerCase();
+
+  for (const org of organizations) {
+    if (org.id.toLowerCase() === idLowerCased) {
+      return org;
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Related to https://github.com/giantswarm/api/pull/1159

Because organization IDs are now normalized in the API cluster lister, some calls and checks no longer work like before (e.g. we filter clusters using the `owner` reference field, to see if any of them belong to a specific organization).

To achieve this, we now get the original organization ID from the global state, based on the cluster `owner` reference, in order to get the ID with the proper casing.