### PR TITLE
Attempt to make CI faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,14 +33,6 @@ workflows:
           requires:
             - checkout
           <<: *job_filters
-      - lint:
-          requires:
-            - checkout
-          <<: *job_filters
-      - prettier:
-          requires:
-            - checkout
-          <<: *job_filters
       - typecheck:
           requires:
             - checkout
@@ -52,8 +44,6 @@ workflows:
       - build-container:
           requires:
             - test
-            - lint
-            - prettier
             - typecheck
             - build
           <<: *job_filters
@@ -162,6 +152,14 @@ jobs:
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
+      
+      - run:
+          name: Validate code style using prettier
+          command: yarn run validate-prettier --no-color
+
+      - run:
+          name: Lint code using ESlint
+          command: yarn run lint --no-color
 
       - save_cache:
           paths:
@@ -184,32 +182,6 @@ jobs:
       - run:
           name: Typecheck code using the TypeScript compiler
           command: yarn run typecheck
-
-  lint:
-    <<: *defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: ~/happa
-
-      - run:
-          name: Lint code using ESlint
-          command: yarn run lint --no-color
-
-  prettier:
-    <<: *defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: ~/happa
-
-      - run:
-          name: Validate code style using prettier
-          command: yarn run validate-prettier --no-color
 
   test:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,12 @@ workflows:
           requires:
             - checkout
           <<: *job_filters
+      - build-container:
+          requires:
+            - test
+            - typecheck
+            - build
+          <<: *job_filters
 
       - architect/push-to-docker:
           name: push-happa-to-quay
@@ -49,9 +55,8 @@ workflows:
           username_envar: "QUAY_USERNAME"
           password_envar: "QUAY_PASSWORD"
           requires:
-            - test
-            - typecheck
-            - build
+            - build-container
+          # Needed to trigger job also on git tag.
           filters:
             tags:
               only: /^v.*/
@@ -63,9 +68,7 @@ workflows:
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
           requires:
-            - test
-            - typecheck
-            - build
+            - build-container
           # Needed to trigger job only on git tag.
           filters:
             branches:
@@ -201,8 +204,6 @@ jobs:
     steps:
       - checkout
 
-      - setup_remote_docker
-
       - attach_workspace:
           at: ~/happa
 
@@ -220,6 +221,22 @@ jobs:
             else
               git tag --points-at HEAD | tr '\n' ' ' > VERSION
             fi
+
+      - persist_to_workspace:
+          root: ~/happa
+          <<: *whitelist
+
+  build-container:
+    executor: architect/architect
+
+    working_directory: ~/happa
+    steps:
+      - checkout
+
+      - setup_remote_docker
+
+      - attach_workspace:
+          at: ~/happa
 
       - run:
           environment:
@@ -257,12 +274,3 @@ jobs:
             sleep 2
             CURL_OUTPUT=$(ssh remote-docker "curl -s http://localhost:8000")
             echo "${CURL_OUTPUT}" | grep Happa
-
-      - persist_to_workspace:
-          root: ~/happa
-          <<: *whitelist      
-
-      - attach_workspace:
-          at: ~/happa
-
-      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,6 @@ workflows:
           requires:
             - checkout
           <<: *job_filters
-      - build-container:
-          requires:
-            - test
-            - typecheck
-            - build
-          <<: *job_filters
 
       - architect/push-to-docker:
           name: push-happa-to-quay
@@ -55,8 +49,9 @@ workflows:
           username_envar: "QUAY_USERNAME"
           password_envar: "QUAY_PASSWORD"
           requires:
-            - build-container
-          # Needed to trigger job also on git tag.
+            - test
+            - typecheck
+            - build
           filters:
             tags:
               only: /^v.*/
@@ -68,7 +63,9 @@ workflows:
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
           requires:
-            - build-container
+            - test
+            - typecheck
+            - build
           # Needed to trigger job only on git tag.
           filters:
             branches:
@@ -204,6 +201,8 @@ jobs:
     steps:
       - checkout
 
+      - setup_remote_docker
+
       - attach_workspace:
           at: ~/happa
 
@@ -221,22 +220,6 @@ jobs:
             else
               git tag --points-at HEAD | tr '\n' ' ' > VERSION
             fi
-
-      - persist_to_workspace:
-          root: ~/happa
-          <<: *whitelist
-
-  build-container:
-    executor: architect/architect
-
-    working_directory: ~/happa
-    steps:
-      - checkout
-
-      - setup_remote_docker
-
-      - attach_workspace:
-          at: ~/happa
 
       - run:
           environment:
@@ -274,3 +257,12 @@ jobs:
             sleep 2
             CURL_OUTPUT=$(ssh remote-docker "curl -s http://localhost:8000")
             echo "${CURL_OUTPUT}" | grep Happa
+
+      - persist_to_workspace:
+          root: ~/happa
+          <<: *whitelist      
+
+      - attach_workspace:
+          at: ~/happa
+
+      

--- a/README.md
+++ b/README.md
@@ -151,3 +151,4 @@ This runs before every commit, and it will not let commits go through if the `pr
 ### Publishing a Release
 
 See [docs/Release.md](https://github.com/giantswarm/happa/blob/master/docs/Release.md)
+


### PR DESCRIPTION
This PR tests some ways to make CI finish faster.

### Baseline

![image](https://user-images.githubusercontent.com/273727/97692863-9b729780-1aa0-11eb-8e38-5df1faf0efb5.png)

### Attempts

1. Run `prettier` and `lint` directly in `checkout` job, since they are fast compared to the duration of starting an extra job.
2. Combine `build` and `build-container`, as it can save a ton of persisting and restoring of data between the two steps.