### PR TITLE
Hack the catalog urls for helm stable special case.

### DIFF
--- a/src/stores/appcatalog/actions.ts
+++ b/src/stores/appcatalog/actions.ts
@@ -203,11 +203,21 @@ export function catalogLoadIndex(
 async function loadIndexForCatalog(catalog: IAppCatalog): Promise<IAppCatalog> {
   let indexURL = `${catalog.spec.storage.URL}index.yaml`;
 
+  // If we are trying to reach the Helm Stable catalog at it's old location,
+  // this URL hack helps us get it properly.
   if (
     catalog.spec.storage.URL ===
     'https://kubernetes-charts.storage.googleapis.com/'
   ) {
     indexURL = `/catalogs?url=${indexURL}`;
+  }
+
+  // If we are trying to reach the Helm Stable catalog at it's new location,
+  // it's url structure is a bit different.
+  // We need to remove /packages/ from the URL before adding /index.yaml.
+  if (catalog.spec.storage.URL === 'https://charts.helm.sh/stable/packages/') {
+    console.log('bingo bongo');
+    indexURL = 'https://charts.helm.sh/stable/index.yaml';
   }
 
   const response = await fetch(indexURL, { mode: 'cors' });

--- a/src/stores/appcatalog/actions.ts
+++ b/src/stores/appcatalog/actions.ts
@@ -204,7 +204,8 @@ async function loadIndexForCatalog(catalog: IAppCatalog): Promise<IAppCatalog> {
   let indexURL = `${catalog.spec.storage.URL}index.yaml`;
 
   // If we are trying to reach the Helm Stable catalog at it's old location,
-  // this URL hack helps us get it properly.
+  // route the request through a proxy in Happa's container which adds necessary
+  // CORS headers.
   if (
     catalog.spec.storage.URL ===
     'https://kubernetes-charts.storage.googleapis.com/'
@@ -216,7 +217,6 @@ async function loadIndexForCatalog(catalog: IAppCatalog): Promise<IAppCatalog> {
   // it's url structure is a bit different.
   // We need to remove /packages/ from the URL before adding /index.yaml.
   if (catalog.spec.storage.URL === 'https://charts.helm.sh/stable/packages/') {
-    console.log('bingo bongo');
     indexURL = 'https://charts.helm.sh/stable/index.yaml';
   }
 


### PR DESCRIPTION
The Helm Stable catalog is going EOL, but a mirror will be kept up at a new url.

Unfortunately that new URL doesn't really play nice with our assumptions, so have to add a special case here in Happa. 

Towards: https://github.com/giantswarm/giantswarm/issues/9985
See also: https://gigantic.slack.com/archives/C76JX6YLQ/p1604058274081800

Fyi @rossf7 