### PR TITLE
Display unknown if appVersion not given

### DIFF
--- a/src/components/UI/AppDetails/ChartVersionsTable.js
+++ b/src/components/UI/AppDetails/ChartVersionsTable.js
@@ -37,13 +37,18 @@ const ChartVersionsTable = (props) => {
   const { appVersions } = props;
 
   const groupedAppVersions = appVersions.reduce((groups, obj) => {
+    let av = 'unknown';
+    if (obj.appVersion) {
+      av = obj.appVersion;
+    }
+
     // Create a group if there isn't one yet.
-    if (!groups.hasOwnProperty(obj.appVersion)) {
-      groups[obj.appVersion] = [];
+    if (!groups.hasOwnProperty(av)) {
+      groups[av] = [];
     }
 
     // Push the appVersion to the group.
-    groups[obj.appVersion].push(obj);
+    groups[av].push(obj);
 
     // Pass the object on to the next loop
     return groups;


### PR DESCRIPTION
Related to https://github.com/giantswarm/happa/pull/1957

In the `Other versions` tab, currently we show `undefined` if the charts provide no appVersion.

This PR changes this to display `unknown`.

![image](https://user-images.githubusercontent.com/273727/97895339-f40d9300-1d33-11eb-827b-5fc95608bcde.png)
