### PR TITLE
UX enhancements in the "About upgrading" dialog

### DIFF
--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -37,7 +37,7 @@ class UpgradeClusterModal extends React.Component {
     ) {
       return (
         <p>
-          Since this is cluster provides high-availability Kubernetes masters,
+          Since this cluster provides high-availability Kubernetes masters,
           the Kubernetes API will be available during the upgrade.
         </p>
       );

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -219,7 +219,7 @@ class UpgradeClusterModal extends React.Component {
       <div>
         <BootstrapModal.Header closeButton>
           <BootstrapModal.Title>
-            Inspect changes from version {this.props.cluster.release_version} to{' '}
+            Changes from v{this.props.cluster.release_version} to v
             {this.props.targetRelease.version}
             {this.props.isAdmin && (
               <ChangeVersionButton

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -37,8 +37,8 @@ class UpgradeClusterModal extends React.Component {
     ) {
       return (
         <p>
-          Since this cluster provides high-availability Kubernetes masters,
-          the Kubernetes API will be available during the upgrade.
+          Since this cluster provides high-availability Kubernetes masters, the
+          Kubernetes API will be available during the upgrade.
         </p>
       );
     }

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -25,6 +25,10 @@ const ChangeVersionButton = styled(Button)`
   margin-left: ${({ theme }) => 2 * theme.spacingPx}px;
 `;
 
+const DetailsHeadline = styled.p`
+  margin-top: 10px;
+`;
+
 class UpgradeClusterModal extends React.Component {
   static getMasterNodesInfo(cluster) {
     if (
@@ -42,8 +46,8 @@ class UpgradeClusterModal extends React.Component {
     return (
       <p>
         As this cluster has one master node, the{' '}
-        <strong>Kubernetes API will be unavailable for a few minutes</strong>{' '}
-        during the upgrade.
+        <b>Kubernetes API will be unavailable for a few minutes</b> during the
+        upgrade.
       </p>
     );
   }
@@ -162,9 +166,9 @@ class UpgradeClusterModal extends React.Component {
           })}
         </div>
 
-        <p>
-          <b>Changes</b>
-        </p>
+        <DetailsHeadline>
+          <b>Details</b>
+        </DetailsHeadline>
         <dl>
           {changedComponentNames.map((componentName, index) => {
             return (
@@ -192,8 +196,17 @@ class UpgradeClusterModal extends React.Component {
         </BootstrapModal.Header>
         <BootstrapModal.Body>
           <p>
-            Please read our checklist for cluster upgrades to ensure the cluster
-            and workloads are <strong>prepared for an upgrade</strong>.
+            Please read our{' '}
+            <a
+              href='https://docs.giantswarm.io/reference/cluster-upgrades/#checklist'
+              rel='noopener noreferrer'
+              target='_blank'
+            >
+              checklist for cluster upgrades&nbsp;
+              <i className='fa fa-open-in-new' />
+            </a>{' '}
+            to ensure the cluster and workloads are{' '}
+            <b>prepared for an upgrade</b>.
           </p>
           {UpgradeClusterModal.getMasterNodesInfo(this.props.cluster)}
         </BootstrapModal.Body>

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -302,7 +302,7 @@ class UpgradeClusterModal extends React.Component {
   currentPage = () => {
     switch (this.state.page) {
       case Pages.AboutUpgrading:
-        return this.aboutUpgradingPage(this.props.targetRelease.version);
+        return this.aboutUpgradingPage(this.props.targetRelease?.version);
 
       case Pages.InspectChanges:
         return this.inspectChangesPage();

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -31,10 +31,21 @@ class UpgradeClusterModal extends React.Component {
       cluster.capabilities.supportsHAMasters &&
       cluster.master_nodes?.high_availability
     ) {
-      return 'The master nodes will be terminated one by one. The Kubernetes API may be briefly unavailable during this process due to the etcd leader election process.';
+      return (
+        <p>
+          Since this is cluster provides high-availability Kubernetes masters,
+          the Kubernetes API will be available during the upgrade.
+        </p>
+      );
     }
 
-    return 'The master node will be terminated and replaced by a new one. The Kubernetes API will be unavailable during this time.';
+    return (
+      <p>
+        As this cluster has one master node, the{' '}
+        <strong>Kubernetes API will be unavailable for a few minutes</strong>{' '}
+        during the upgrade.
+      </p>
+    );
   }
 
   state = {

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -46,8 +46,8 @@ class UpgradeClusterModal extends React.Component {
     return (
       <p>
         As this cluster has one master node, the{' '}
-        <b>Kubernetes API will be unavailable for a few minutes</b> during the
-        upgrade.
+        <strong>Kubernetes API will be unavailable for a few minutes</strong>{' '}
+        during the upgrade.
       </p>
     );
   }
@@ -206,7 +206,7 @@ class UpgradeClusterModal extends React.Component {
               <i className='fa fa-open-in-new' />
             </a>{' '}
             to ensure the cluster and workloads are{' '}
-            <b>prepared for an upgrade</b>.
+            <strong>prepared for an upgrade</strong>.
           </p>
           {UpgradeClusterModal.getMasterNodesInfo(this.props.cluster)}
         </BootstrapModal.Body>

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -182,11 +182,13 @@ class UpgradeClusterModal extends React.Component {
     );
   };
 
-  aboutUpgradingPage = () => {
+  aboutUpgradingPage = (targetRelease) => {
     return (
       <div>
         <BootstrapModal.Header closeButton>
-          <BootstrapModal.Title>About Upgrading</BootstrapModal.Title>
+          <BootstrapModal.Title>
+            Upgrade to v{targetRelease}
+          </BootstrapModal.Title>
         </BootstrapModal.Header>
         <BootstrapModal.Body>
           <p>Before upgrading please acknowledge the following</p>

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -289,7 +289,7 @@ class UpgradeClusterModal extends React.Component {
   currentPage = () => {
     switch (this.state.page) {
       case Pages.AboutUpgrading:
-        return this.aboutUpgradingPage();
+        return this.aboutUpgradingPage(this.props.targetRelease.version);
 
       case Pages.InspectChanges:
         return this.inspectChangesPage();

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -191,20 +191,11 @@ class UpgradeClusterModal extends React.Component {
           </BootstrapModal.Title>
         </BootstrapModal.Header>
         <BootstrapModal.Body>
-          <p>Before upgrading please acknowledge the following</p>
-          <ul>
-            <li>
-              Worker nodes will be drained and then terminated one after another
-              to be replaced by new ones.
-            </li>
-            <li>
-              To be able to run all workloads with one worker node missing,
-              please make sure to have enough workers before upgrading.
-            </li>
-            <li>
-              {UpgradeClusterModal.getMasterNodesInfo(this.props.cluster)}
-            </li>
-          </ul>
+          <p>
+            Please read our checklist for cluster upgrades to ensure the cluster
+            and workloads are <strong>prepared for an upgrade</strong>.
+          </p>
+          {UpgradeClusterModal.getMasterNodesInfo(this.props.cluster)}
         </BootstrapModal.Body>
         <BootstrapModal.Footer>
           <Button

--- a/src/components/Cluster/ClusterDetail/__tests__/UpgradeClusterModal.tsx
+++ b/src/components/Cluster/ClusterDetail/__tests__/UpgradeClusterModal.tsx
@@ -75,7 +75,7 @@ describe('UpgradeClusterModal', () => {
     });
 
     expect(
-      screen.getByText(/Before upgrading please acknowledge the following/i)
+      screen.getByText(/Please read our/i)
     ).toBeInTheDocument();
   });
 
@@ -147,7 +147,7 @@ describe('UpgradeClusterModal', () => {
 
     fireEvent.click(screen.getByText(/inspect changes/i));
     expect(
-      screen.getByText(/inspect changes from version 2.0.2 to 3.0.0/i)
+      screen.getByText(/changes from v2.0.2 to v3.0.0/i)
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByText(/change version/i));
@@ -201,7 +201,7 @@ describe('UpgradeClusterModal', () => {
 
     fireEvent.click(screen.getByText(/inspect changes/i));
     expect(
-      screen.getByText(/inspect changes from version 2.0.2 to 3.0.0/i)
+      screen.getByText(/changes from v2.0.2 to v3.0.0/i)
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByText(/change version/i));
@@ -255,7 +255,7 @@ describe('UpgradeClusterModal', () => {
 
     fireEvent.click(screen.getByText(/inspect changes/i));
     expect(
-      screen.getByText(/inspect changes from version 2.0.2 to 3.0.0/i)
+      screen.getByText(/changes from v2.0.2 to v3.0.0/i)
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByText(/change version/i));

--- a/src/components/Cluster/ClusterDetail/__tests__/UpgradeClusterModal.tsx
+++ b/src/components/Cluster/ClusterDetail/__tests__/UpgradeClusterModal.tsx
@@ -74,9 +74,7 @@ describe('UpgradeClusterModal', () => {
       provider: Providers.AWS,
     });
 
-    expect(
-      screen.getByText(/Please read our/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Please read our/i)).toBeInTheDocument();
   });
 
   it(`can't change the upgrade release version if the user is not an admin`, () => {

--- a/src/styles/_base.sass
+++ b/src/styles/_base.sass
@@ -119,8 +119,8 @@ a
 	margin-left: 0px
 
 strong
-	font-weight: 300
-	color: #fff
+	font-weight: 700
+	color: #ddd
 
 	code
 		color: #fff


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13348

- Add target version number to dialog title
- Link from step 1 to upgrade checklist
- Make title in step 2 shorter ("Inspect Changes" -> "Changes", "version" -> "v")
- Renamed "Changes" sub-headline to "Details", added spacing above

## Preview

### Step 1

<details>
<summary>Show screenshot of current behavior</summary>

![image](https://user-images.githubusercontent.com/273727/98549706-78fc2d80-229b-11eb-9ca2-0b50932e9430.png)

</details>

![image](https://user-images.githubusercontent.com/273727/98549576-481bf880-229b-11eb-8240-732e37f51763.png)

### Step 2

<details>
<summary>Show screenshot of current behavior</summary>

![image](https://user-images.githubusercontent.com/273727/98549725-80bbd200-229b-11eb-9e52-baa3df97cd88.png)

</details>

![image](https://user-images.githubusercontent.com/273727/98549608-52d68d80-229b-11eb-8d8d-3ef924cfc5c4.png)

