### PR TITLE
Remove minimum width from the release selector component

### DIFF
--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
@@ -20,10 +20,6 @@ const FixedWidthTableButton = styled(TableButton)`
   width: 100px;
 `;
 
-const MinWidthCursorPointerCell = styled(CursorPointerCell)`
-  min-width: 120px;
-`;
-
 interface IReleaseRow extends IRelease {
   isSelected: boolean;
 
@@ -76,10 +72,8 @@ const ReleaseRow: FC<IReleaseRow> = ({
             />
           </RUMActionTarget>
         </CursorPointerCell>
-        <MinWidthCursorPointerCell>{version}</MinWidthCursorPointerCell>
-        <MinWidthCursorPointerCell>
-          {relativeDate(timestamp)}
-        </MinWidthCursorPointerCell>
+        <CursorPointerCell>{version}</CursorPointerCell>
+        <CursorPointerCell>{relativeDate(timestamp)}</CursorPointerCell>
         <CursorPointerCell>
           <KubernetesVersionLabel
             version={kubernetesVersion}


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/14201

This doesn't seem to have any bad impact on how the release version selector on the cluster creation page looks, so it's safe.

**Before**

![image](https://user-images.githubusercontent.com/13508038/99283041-c1d05b00-2834-11eb-851f-02a7bf328c92.png)


**After**

![image](https://user-images.githubusercontent.com/13508038/99282799-7453ee00-2834-11eb-8f7b-059950b54d59.png)
