### PR TITLE
Improve upgrade UI interaction during Azure v4 to v5 cluster upgrade

### DIFF
--- a/src/@types/clusters.d.ts
+++ b/src/@types/clusters.d.ts
@@ -11,6 +11,7 @@ interface IBaseCluster {
   name: string;
   release_version: string;
 
+  path?: string;
   credential_id?: string;
   delete_date?: string | null;
 

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -144,14 +144,14 @@ class ClusterDetailView extends React.Component {
   };
 
   refreshClusterData = () => {
-    const { cluster, dispatch, isV5Cluster } = this.props;
+    const { cluster, dispatch } = this.props;
 
     if (typeof cluster === 'undefined' || cluster.delete_date) {
       this.doesNotExist(Boolean(cluster?.delete_date));
     }
 
     if (cluster) {
-      dispatch(batchedRefreshClusterDetailView(cluster.id, isV5Cluster));
+      dispatch(batchedRefreshClusterDetailView(cluster.id));
     }
   };
 

--- a/src/stores/batchActions.ts
+++ b/src/stores/batchActions.ts
@@ -123,6 +123,7 @@ export function batchedRefreshClusters(): ThunkAction<
           filterBySelectedOrganization: true,
           withLoadingFlags: false,
           initializeNodePools: false,
+          refreshPaths: true,
         })
       );
       dispatch(
@@ -237,16 +238,20 @@ export function batchedClusterDetailView(
 }
 
 export function batchedRefreshClusterDetailView(
-  clusterId: string,
-  isV5Cluster: boolean
+  clusterId: string
 ): ThunkAction<Promise<void>, IState, void, AnyAction> {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     try {
       const cluster = await dispatch(
         clusterLoadDetails(clusterId, {
           withLoadingFlags: false,
           initializeNodePools: false,
+          refreshPath: true,
         })
+      );
+
+      const isV5Cluster = getState().entities.clusters.v5Clusters.includes(
+        clusterId
       );
       if (isV5Cluster) {
         await dispatch(

--- a/src/stores/cluster/reducer.ts
+++ b/src/stores/cluster/reducer.ts
@@ -74,10 +74,20 @@ const clusterReducer = produce(
         break;
 
       case CLUSTER_LOAD_DETAILS_SUCCESS: {
-        draft.items[action.cluster.id] = {
-          ...draft.items[action.cluster.id],
+        const clusterID = action.cluster.id;
+
+        draft.items[clusterID] = {
+          ...draft.items[clusterID],
           ...action.cluster,
         };
+
+        if (action.isV5Cluster) {
+          if (!draft.v5Clusters.includes(clusterID)) {
+            draft.v5Clusters.push(clusterID);
+          }
+        } else {
+          draft.v5Clusters = draft.v5Clusters.filter((id) => id !== clusterID);
+        }
 
         draft.idsAwaitingUpgrade = reconcileClustersAwaitingUpgrade(
           draft.items,

--- a/src/stores/cluster/types.ts
+++ b/src/stores/cluster/types.ts
@@ -98,6 +98,7 @@ export interface IClusterLoadClusterDetailsSuccessAction {
   type: typeof CLUSTER_LOAD_DETAILS_SUCCESS;
   cluster: Cluster;
   id: string;
+  isV5Cluster: boolean;
 }
 
 export interface IClusterLoadClusterDetailsErrorAction {

--- a/src/stores/cluster/utils.ts
+++ b/src/stores/cluster/utils.ts
@@ -327,7 +327,6 @@ export function getClusterLatestCondition(
  */
 export function isClusterCreating(cluster: Cluster): boolean {
   const latestCondition = getClusterLatestCondition(cluster);
-  if (!latestCondition) return true;
 
   return latestCondition === 'Creating';
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14122

This PR improves the UI experience on the Azure upgrade from V4 to V5:
* The cluster details UI is automatically changed to the one that includes node pools during the upgrade
* The cluster information in the cluster overview is no longer lost during the upgrade (e.g. the cluster name is no longer set to the cluster ID)

Bonus: Clusters that don't have any conditions are no longer considered in creation.