### PR TITLE
Only display that a new happa version is available if a user is logged in

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -41,13 +41,18 @@ const Footer: React.FC<IFooterProps> = (props: IFooterProps) => {
     false
   );
 
-  const tooltipMessage: string = getVersionTooltipMessage(
+  const releaseURL: string = getReleaseURL(currentVersion);
+  const isLoggedIn: boolean =
+    useSelector<IState>((state) => state.main.loggedInUser) !== null;
+  const isUpdateReady: boolean = hasUpdateReady(
     currentVersion,
     newVersion,
+    isLoggedIn
+  );
+  const tooltipMessage: string = getVersionTooltipMessage(
+    isUpdateReady,
     Boolean(isUpdating)
   );
-  const releaseURL: string = getReleaseURL(currentVersion);
-  const isUpdateReady: boolean = hasUpdateReady(currentVersion, newVersion);
 
   const handleUpdate = useCallback(() => {
     dispatch(metadataActions.executeUpdate());

--- a/src/components/Footer/FooterUtils.ts
+++ b/src/components/Footer/FooterUtils.ts
@@ -29,13 +29,12 @@ export function getReleaseURL(version: string): string {
 }
 
 export function getVersionTooltipMessage(
-  currentVersion: string,
-  newVersion: string | null,
+  isUpdateReady: boolean,
   isUpdating: boolean
 ): string {
   let updateMessage: string = 'Using latest version.';
 
-  if (hasUpdateReady(currentVersion, newVersion)) {
+  if (isUpdateReady) {
     updateMessage = 'Update available!';
   }
 
@@ -65,8 +64,11 @@ export function getUpdateButtonMessage(
 
 export function hasUpdateReady(
   currentVersion: string,
-  newVersion: string | null
+  newVersion: string | null,
+  isLoggedIn: boolean
 ): boolean {
+  if (!isLoggedIn) return false;
+
   return newVersion !== null && currentVersion !== newVersion;
 }
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/13817

With this PR we no longer display that there's a new version of `happa` available if there is no user logged in.
If a new version becomes available before the user logs in, the notification would be displayed after the user logs in.