### PR TITLE
Clean up version picker component and truncate values

### DIFF
--- a/src/components/UI/VersionPicker/VersionPickerUtils.ts
+++ b/src/components/UI/VersionPicker/VersionPickerUtils.ts
@@ -1,0 +1,26 @@
+export interface IVersion {
+  // The version
+  version: string;
+
+  // Whether or not this version is a test version.
+  test: boolean;
+}
+
+export function checkIfContainsTestVersions(versionCollection?: IVersion[]) {
+  return versionCollection?.some((v) => v.test) ?? false;
+}
+
+export function filterVersions(
+  shouldIncludeTestVersions: boolean,
+  versionCollection?: IVersion[]
+) {
+  if (!versionCollection) return [];
+
+  return versionCollection.filter((version) => {
+    if (!shouldIncludeTestVersions && version.test) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/src/components/UI/VersionPicker/__tests__/VersionPicker.js
+++ b/src/components/UI/VersionPicker/__tests__/VersionPicker.js
@@ -47,29 +47,6 @@ it('lets me click a toggle switch to show test versions', () => {
   expect(within(menu).getByText('1.0.4-test')).toBeInTheDocument();
 });
 
-it('the selectedVersion gets highlighted', () => {
-  const { getByText, getByTestId } = renderWithTheme(AppVersionPicker, {
-    selectedVersion: '1.0.5',
-    versions: [
-      { version: '1.0.5', test: false },
-      { version: '1.0.4-test', test: true },
-      { version: '1.0.3', test: false },
-    ],
-  });
-
-  fireEvent.click(getByText('1.0.5'));
-
-  const menu = getByTestId('menu');
-
-  expect(within(menu).getByText('1.0.5').classList.contains('selected')).toBe(
-    true
-  );
-
-  expect(within(menu).getByText('1.0.3').classList.contains('selected')).toBe(
-    false
-  );
-});
-
 it('clicking a version calls the onChange prop', () => {
   const mockCallback = jest.fn((x) => `Got version: ${x}`);
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/14253

Bonus: Some cleanup in the `VersionPicker` component.

**Before**

![image](https://user-images.githubusercontent.com/13508038/99526565-b77ca100-299b-11eb-921d-3507daf5a04d.png)

**After**

![image](https://user-images.githubusercontent.com/13508038/99526644-d24f1580-299b-11eb-9e01-0e8c135c0b67.png)
