### PR TITLE
Let the 'Release notes' link in the footer point to the docs.giantswarm.io release page

### DIFF
--- a/src/components/Footer/FooterUtils.ts
+++ b/src/components/Footer/FooterUtils.ts
@@ -22,7 +22,7 @@ export function getReleaseURL(version: string): string {
   if (isHash) {
     URL = `https://github.com/giantswarm/happa/commit/${version}`;
   } else {
-    URL = `https://github.com/giantswarm/happa/releases/tag/${version}`;
+    URL = `https://docs.giantswarm.io/changes/web-ui/happa/${version}`;
   }
 
   return URL;


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3870

For v1.0.4 this would be https://docs.giantswarm.io/changes/web-ui/happa/v1.0.4/