### PR TITLE
Added support for selecting no availability zones for azure masters

### DIFF
--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -145,14 +145,29 @@ class CreateNodePoolsCluster extends Component {
       release_version: this.props.selectedRelease,
     };
 
-    if (this.state.masterAZMode === MASTER_AZ_MODE_MANUAL) {
-      createPayload.master = {
-        availability_zone: this.state.availabilityZonesLabels.zonesArray[0],
-      };
-    } else {
-      createPayload.master = {
-        availability_zone: this.state.masterAZMode,
-      };
+    switch (this.state.masterAZMode) {
+      case MASTER_AZ_MODE_MANUAL:
+        createPayload.master_nodes = {
+          availability_zones: this.state.availabilityZonesLabels.zonesArray,
+          azure: {
+            availability_zones_unspecified: false
+          }
+        };
+        break;
+      case MASTER_AZ_MODE_AUTO:
+        createPayload.master_nodes = {
+          azure: {
+            availability_zones_unspecified: false
+          }
+        };
+        break;
+      case MASTER_AZ_MODE_NOT_SPECIFIED:
+        createPayload.master_nodes = {
+          azure: {
+            availability_zones_unspecified: true
+          }
+        };
+        break;
     }
 
     if (this.props.capabilities.supportsHAMasters) {

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -325,7 +325,9 @@ class CreateNodePoolsCluster extends Component {
                       <InputGroup>
                         <RadioInput
                           id='notspecified'
-                          checked={masterAZMode === MASTER_AZ_MODE_NOT_SPECIFIED}
+                          checked={
+                            masterAZMode === MASTER_AZ_MODE_NOT_SPECIFIED
+                          }
                           label='Not specified'
                           onChange={() =>
                             this.setMasterAZMode(MASTER_AZ_MODE_NOT_SPECIFIED)

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { TransitionGroup } from 'react-transition-group';
 import RUMActionTarget from 'RUM/RUMActionTarget';
-import { Constants,Providers } from 'shared/constants';
+import { Constants, Providers } from 'shared/constants';
 import { RUMActions } from 'shared/constants/realUserMonitoring';
 import { batchedClusterCreate } from 'stores/batchActions';
 import { CLUSTER_CREATE_REQUEST } from 'stores/cluster/constants';

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -272,7 +272,7 @@ class CreateNodePoolsCluster extends Component {
                   </RUMActionTarget>
                   {masterAZMode === MASTER_AZ_MODE_AUTO && (
                     <p>
-                      An Availabilty Zone will be automatcially chosen from the
+                      An Availabilty Zone will be automatically chosen from the
                       existing ones.
                     </p>
                   )}

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { TransitionGroup } from 'react-transition-group';
 import RUMActionTarget from 'RUM/RUMActionTarget';
-import { Providers, Constants } from 'shared/constants';
+import { Constants,Providers } from 'shared/constants';
 import { RUMActions } from 'shared/constants/realUserMonitoring';
 import { batchedClusterCreate } from 'stores/batchActions';
 import { CLUSTER_CREATE_REQUEST } from 'stores/cluster/constants';

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -150,22 +150,22 @@ class CreateNodePoolsCluster extends Component {
         createPayload.master_nodes = {
           availability_zones: this.state.availabilityZonesLabels.zonesArray,
           azure: {
-            availability_zones_unspecified: false
-          }
+            availability_zones_unspecified: false,
+          },
         };
         break;
       case MASTER_AZ_MODE_AUTO:
         createPayload.master_nodes = {
           azure: {
-            availability_zones_unspecified: false
-          }
+            availability_zones_unspecified: false,
+          },
         };
         break;
       case MASTER_AZ_MODE_NOT_SPECIFIED:
         createPayload.master_nodes = {
           azure: {
-            availability_zones_unspecified: true
-          }
+            availability_zones_unspecified: true,
+          },
         };
         break;
     }

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -113,7 +113,11 @@ class CreateNodePoolsCluster extends Component {
   isValid = () => {
     // Not checking release version as we would be checking it before accessing this form
     // and sending user too the v4 form if NPs aren't supported
-    const { masterAZMode, availabilityZonesLabels, nodePoolsForms } = this.state;
+    const {
+      masterAZMode,
+      availabilityZonesLabels,
+      nodePoolsForms,
+    } = this.state;
 
     const areNodePoolsValid = Object.keys(nodePoolsForms.nodePools)
       .map((np) => nodePoolsForms.nodePools[np].isValid)
@@ -122,7 +126,10 @@ class CreateNodePoolsCluster extends Component {
     const isValid =
       this.props.allowSubmit &&
       areNodePoolsValid &&
-      (masterAZMode === MASTER_AZ_MODE_AUTO || masterAZMode === MASTER_AZ_MODE_NOT_SPECIFIED || (masterAZMode === MASTER_AZ_MODE_MANUAL && availabilityZonesLabels.valid));
+      (masterAZMode === MASTER_AZ_MODE_AUTO ||
+        masterAZMode === MASTER_AZ_MODE_NOT_SPECIFIED ||
+        (masterAZMode === MASTER_AZ_MODE_MANUAL &&
+          availabilityZonesLabels.valid));
 
     return isValid;
   };
@@ -240,14 +247,19 @@ class CreateNodePoolsCluster extends Component {
                     <InputGroup>
                       <RadioInput
                         id='automatic'
-                        checked={masterAZMode===MASTER_AZ_MODE_AUTO}
+                        checked={masterAZMode === MASTER_AZ_MODE_AUTO}
                         label='Automatic'
-                        onChange={() => this.setMasterAZMode(MASTER_AZ_MODE_AUTO)}
+                        onChange={() =>
+                          this.setMasterAZMode(MASTER_AZ_MODE_AUTO)
+                        }
                       />
                     </InputGroup>
                   </RUMActionTarget>
-                  {masterAZMode===MASTER_AZ_MODE_AUTO && (
-                    <p>An Availabilty Zone will be automatcially chosen from the existing ones.</p>
+                  {masterAZMode === MASTER_AZ_MODE_AUTO && (
+                    <p>
+                      An Availabilty Zone will be automatcially chosen from the
+                      existing ones.
+                    </p>
                   )}
                   <RUMActionTarget
                     name={RUMActions.SelectMasterAZSelectionManual}
@@ -255,13 +267,15 @@ class CreateNodePoolsCluster extends Component {
                     <InputGroup>
                       <RadioInput
                         id='manual'
-                        checked={masterAZMode===MASTER_AZ_MODE_MANUAL}
+                        checked={masterAZMode === MASTER_AZ_MODE_MANUAL}
                         label='Manual'
-                        onChange={() => this.setMasterAZMode(MASTER_AZ_MODE_MANUAL)}
+                        onChange={() =>
+                          this.setMasterAZMode(MASTER_AZ_MODE_MANUAL)
+                        }
                       />
                     </InputGroup>
                   </RUMActionTarget>
-                  {masterAZMode===MASTER_AZ_MODE_MANUAL && (
+                  {masterAZMode === MASTER_AZ_MODE_MANUAL && (
                     <AZWrapperDiv>
                       <AvailabilityZonesParser
                         min={minAZ}
@@ -273,7 +287,9 @@ class CreateNodePoolsCluster extends Component {
                         isRadioButtons
                       />
                       {zonesArray.length < 1 && (
-                        <p className='danger'>Please select one availability zone.</p>
+                        <p className='danger'>
+                          Please select one availability zone.
+                        </p>
                       )}
                       {zonesArray.length > maxAZ && (
                         <p className='danger'>
@@ -284,19 +300,25 @@ class CreateNodePoolsCluster extends Component {
                     </AZWrapperDiv>
                   )}
                   <RUMActionTarget
-                        name={RUMActions.SelectMasterAZSelectionNotSpecified}
+                    name={RUMActions.SelectMasterAZSelectionNotSpecified}
                   >
                     <InputGroup>
                       <RadioInput
                         id='notspecified'
-                        checked={masterAZMode===MASTER_AZ_MODE_NOT_SPECIFIED}
+                        checked={masterAZMode === MASTER_AZ_MODE_NOT_SPECIFIED}
                         label='Not specified'
-                        onChange={() => this.setMasterAZMode(MASTER_AZ_MODE_NOT_SPECIFIED)}
+                        onChange={() =>
+                          this.setMasterAZMode(MASTER_AZ_MODE_NOT_SPECIFIED)
+                        }
                       />
                     </InputGroup>
                   </RUMActionTarget>
-                  {masterAZMode===MASTER_AZ_MODE_NOT_SPECIFIED && (
-                    <p>By not specifying an availability zone, Azure will select a zone by itself, where the requested virtual machine size has the best availability.</p>
+                  {masterAZMode === MASTER_AZ_MODE_NOT_SPECIFIED && (
+                    <p>
+                      By not specifying an availability zone, Azure will select
+                      a zone by itself, where the requested virtual machine size
+                      has the best availability.
+                    </p>
                   )}
                 </div>
               </MasterAZSelectionInput>

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -80,9 +80,9 @@ const NodePoolHeading = styled.div`
   word-break: break-all;
 `;
 
-const MASTER_AZ_MODE_AUTO = "auto";
-const MASTER_AZ_MODE_MANUAL = "manual";
-const MASTER_AZ_MODE_NOT_SPECIFIED = "";
+const MASTER_AZ_MODE_AUTO = 'auto';
+const MASTER_AZ_MODE_MANUAL = 'manual';
+const MASTER_AZ_MODE_NOT_SPECIFIED = '';
 
 const defaultNodePool = () => ({
   data: { name: Constants.DEFAULT_NODEPOOL_NAME },
@@ -164,7 +164,7 @@ class CreateNodePoolsCluster extends Component {
   };
 
   setMasterAZMode = (mode) => {
-    this.setState((state) => ({
+    this.setState(() => ({
       masterAZMode: mode,
     }));
   };

--- a/src/shared/constants/realUserMonitoring.ts
+++ b/src/shared/constants/realUserMonitoring.ts
@@ -13,6 +13,7 @@ export enum RUMActions {
 
   SelectMasterAZSelectionAutomatic = 'SELECT_MASTER_AZ_SELECTION_AUTOMATIC',
   SelectMasterAZSelectionManual = 'SELECT_MASTER_AZ_SELECTION_MANUAL',
+  SelectMasterAZSelectionNotSpecified = 'SELECT_MASTER_AZ_NOT_SPECIFIED',
 
   CreateClusterSubmit = 'CREATE_CLUSTER_SUBMIT',
   CreateClusterCancel = 'CREATE_CLUSTER_CANCEL',


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/12101 and https://github.com/giantswarm/giantswarm/issues/13842

This PR has 2 goals:

1. Remove the usage of the deprecated `masters` field in the v5/cluster/create API call and replace it with the new `master_nodes` field.
2. Allow more fine grained control over the availability zone that master nodes should be put in for an azure cluster (the same we already do for node pools).

The AZ selection before my change was:

![Before](https://user-images.githubusercontent.com/868430/100376001-09ae6980-300f-11eb-886c-0f10b60c4031.png)

My proposed change makes it look like this:

![after](https://user-images.githubusercontent.com/868430/100376068-26e33800-300f-11eb-91f7-f9a2aeae2792.png)
![after2](https://user-images.githubusercontent.com/868430/100376074-29459200-300f-11eb-855d-ec589bedc61f.png)
![after3](https://user-images.githubusercontent.com/868430/100376076-2ba7ec00-300f-11eb-878b-cfa5f67d9b21.png)

I tested this as best as I could but I please bear in mind I am not fluent with TypeScript
