### PR TITLE
Fix nginx limitation removal

### DIFF
--- a/src/components/AppCatalog/AppDetail/InstallAppModal.js
+++ b/src/components/AppCatalog/AppDetail/InstallAppModal.js
@@ -4,7 +4,7 @@ import yaml from 'js-yaml';
 import RoutePath from 'lib/routePath';
 import lunr from 'lunr';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { connect } from 'react-redux';
 import { OrganizationsRoutes } from 'shared/constants/routes';
 import { installApp } from 'stores/appcatalog/actions';
@@ -104,10 +104,13 @@ const InstallAppModal = (props) => {
       });
   }
 
-  const updateNamespace = (ns) => {
-    setNamespace(ns);
-    setNamespaceError(validateAppName(ns).message);
-  };
+  const updateNamespace = useCallback(
+    (ns) => {
+      setNamespace(ns);
+      setNamespaceError(validateAppName(ns).message);
+    },
+    [setNamespace, setNamespaceError]
+  );
 
   const updateName = (newName) => {
     if (namespace === name) {

--- a/src/components/AppCatalog/AppDetail/__tests__/InstallAppForm.js
+++ b/src/components/AppCatalog/AppDetail/__tests__/InstallAppForm.js
@@ -5,21 +5,24 @@ import { renderWithTheme } from 'testUtils/renderUtils';
 import InstallAppForm from '../InstallAppForm';
 
 it('renders without crashing', () => {
-  renderWithTheme(InstallAppForm);
+  renderWithTheme(InstallAppForm, { version: '1' });
 });
 
 it('renders a normal namespace field usually', () => {
-  const { getByLabelText } = renderWithTheme(InstallAppForm);
+  const { getByLabelText } = renderWithTheme(InstallAppForm, { version: '1' });
 
   const namespaceField = getByLabelText('Namespace:');
   expect(namespaceField).not.toHaveAttribute('read-only');
 });
 
 it('use kube-system as default namespace for nginx-ingress-controller-app', () => {
-  const { getByLabelText } = renderWithTheme(InstallAppForm, {
+  const onChangeNamespaceMock = jest.fn();
+
+  renderWithTheme(InstallAppForm, {
     appName: 'nginx-ingress-controller-app',
+    version: '1',
+    onChangeNamespace: onChangeNamespaceMock,
   });
 
-  const namespaceField = getByLabelText('Namespace:');
-  expect(namespaceField).toHaveValue('kube-system');
+  expect(onChangeNamespaceMock).toHaveBeenCalledWith('kube-system');
 });

--- a/src/components/UI/VersionPicker/__tests__/VersionPicker.js
+++ b/src/components/UI/VersionPicker/__tests__/VersionPicker.js
@@ -5,7 +5,7 @@ import { renderWithTheme } from 'testUtils/renderUtils';
 import AppVersionPicker from 'UI/VersionPicker/VersionPicker';
 
 it('renders without crashing', () => {
-  renderWithTheme(AppVersionPicker);
+  renderWithTheme(AppVersionPicker, { selectedVersion: '1' });
 });
 
 it('lists all non test versions by default', () => {


### PR DESCRIPTION
Hi @pipo02mix , here's what would need to change to make sure the useEffect block isn't being called all the time, and thus resetting the state of namespace back to `kube-system`

