### PR TITLE
Hide availability zone options when location does not support AZs

### DIFF
--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePool.js
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePool.js
@@ -134,6 +134,7 @@ class AddNodePool extends Component {
   componentDidMount() {
     this.setState({
       ...this.computeInstanceCapabilities(),
+      ...this.computeAvailabilityZonesPresence(),
     });
   }
 
@@ -145,6 +146,18 @@ class AddNodePool extends Component {
       this.setState(this.computeInstanceCapabilities());
     }
   }
+
+  computeAvailabilityZonesPresence = () => {
+    const { availabilityZones } = this.props;
+
+    return {
+      // Region does not support availability zones.
+      azSelection:
+        availabilityZones.length === 0
+          ? AvailabilityZoneSelection.NotSpecified
+          : AvailabilityZoneSelection.Automatic,
+    };
+  };
 
   computeInstanceCapabilities = () => {
     const { selectedRelease, provider } = this.props;

--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolAZSelection.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolAZSelection.tsx
@@ -135,70 +135,74 @@ const AddNodePoolAZSelection: React.FC<IAddNodePoolAZSelectionProps> = ({
   return (
     <div {...rest}>
       <AZSelectionLabel>Availability Zones selection</AZSelectionLabel>
-      <StyledPanel
-        expanded={value === AvailabilityZoneSelection.Automatic}
-        onToggle={onToggleFakeCallback}
-      >
-        <AddNodePoolAZSelectionCheckbox
-          onChange={onChange}
-          value={value}
-          npID={npID}
-          label='Automatic'
-          type={AvailabilityZoneSelection.Automatic}
-        />
-        <StyledPanelCollapse>
-          <AZSelectorWrapper>
-            <p>Number of availability zones to use:</p>
-            <AvailabilityZonesParser
-              min={minNumOfZones}
-              max={maxNumOfZones}
-              defaultValue={defaultNumOfZones}
-              zones={allZones}
-              updateAZValuesInParent={onUpdateZones(
-                AvailabilityZoneSelection.Automatic
-              )}
-              isLabels={false}
-            />
-          </AZSelectorWrapper>
-          <p>{automaticAZSelectionMessage}</p>
-        </StyledPanelCollapse>
-      </StyledPanel>
-      <StyledPanel
-        expanded={value === AvailabilityZoneSelection.Manual}
-        onToggle={onToggleFakeCallback}
-      >
-        <AddNodePoolAZSelectionCheckbox
-          onChange={onChange}
-          value={value}
-          npID={npID}
-          label='Manual'
-          type={AvailabilityZoneSelection.Manual}
-        />
-        <StyledPanelCollapse>
-          <p>
-            You can select up to {maxNumOfZones} availability zones to make use
-            of.
-          </p>
-          <AZSelectorWrapper>
-            <ManualAZSelector>
+      {maxNumOfZones !== undefined && maxNumOfZones > 0 && (
+        <StyledPanel
+          expanded={value === AvailabilityZoneSelection.Automatic}
+          onToggle={onToggleFakeCallback}
+        >
+          <AddNodePoolAZSelectionCheckbox
+            onChange={onChange}
+            value={value}
+            npID={npID}
+            label='Automatic'
+            type={AvailabilityZoneSelection.Automatic}
+          />
+          <StyledPanelCollapse>
+            <AZSelectorWrapper>
+              <p>Number of availability zones to use:</p>
               <AvailabilityZonesParser
                 min={minNumOfZones}
                 max={maxNumOfZones}
-                defaultValue={2}
+                defaultValue={defaultNumOfZones}
                 zones={allZones}
                 updateAZValuesInParent={onUpdateZones(
-                  AvailabilityZoneSelection.Manual
+                  AvailabilityZoneSelection.Automatic
                 )}
-                isLabels={true}
+                isLabels={false}
               />
-            </ManualAZSelector>
+            </AZSelectorWrapper>
+            <p>{automaticAZSelectionMessage}</p>
+          </StyledPanelCollapse>
+        </StyledPanel>
+      )}
+      {maxNumOfZones !== undefined && maxNumOfZones > 0 && (
+        <StyledPanel
+          expanded={value === AvailabilityZoneSelection.Manual}
+          onToggle={onToggleFakeCallback}
+        >
+          <AddNodePoolAZSelectionCheckbox
+            onChange={onChange}
+            value={value}
+            npID={npID}
+            label='Manual'
+            type={AvailabilityZoneSelection.Manual}
+          />
+          <StyledPanelCollapse>
+            <p>
+              You can select up to {maxNumOfZones} availability zones to make
+              use of.
+            </p>
+            <AZSelectorWrapper>
+              <ManualAZSelector>
+                <AvailabilityZonesParser
+                  min={minNumOfZones}
+                  max={maxNumOfZones}
+                  defaultValue={2}
+                  zones={allZones}
+                  updateAZValuesInParent={onUpdateZones(
+                    AvailabilityZoneSelection.Manual
+                  )}
+                  isLabels={true}
+                />
+              </ManualAZSelector>
 
-            {manualAZSelectionErrorMessage && (
-              <ErrorMessage>{manualAZSelectionErrorMessage}</ErrorMessage>
-            )}
-          </AZSelectorWrapper>
-        </StyledPanelCollapse>
-      </StyledPanel>
+              {manualAZSelectionErrorMessage && (
+                <ErrorMessage>{manualAZSelectionErrorMessage}</ErrorMessage>
+              )}
+            </AZSelectorWrapper>
+          </StyledPanelCollapse>
+        </StyledPanel>
+      )}
 
       {provider === Providers.AZURE && (
         <StyledPanel

--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolAZSelection.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolAZSelection.tsx
@@ -135,7 +135,7 @@ const AddNodePoolAZSelection: React.FC<IAddNodePoolAZSelectionProps> = ({
   return (
     <div {...rest}>
       <AZSelectionLabel>Availability Zones selection</AZSelectionLabel>
-      {maxNumOfZones !== undefined && maxNumOfZones > 0 && (
+      {(maxNumOfZones as number) > 0 && (
         <StyledPanel
           expanded={value === AvailabilityZoneSelection.Automatic}
           onToggle={onToggleFakeCallback}

--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolAZSelection.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolAZSelection.tsx
@@ -165,7 +165,7 @@ const AddNodePoolAZSelection: React.FC<IAddNodePoolAZSelectionProps> = ({
           </StyledPanelCollapse>
         </StyledPanel>
       )}
-      {maxNumOfZones !== undefined && maxNumOfZones > 0 && (
+      {(maxNumOfZones as number) > 0 && (
         <StyledPanel
           expanded={value === AvailabilityZoneSelection.Manual}
           onToggle={onToggleFakeCallback}


### PR DESCRIPTION
When creating node pools in regions that do not support AZs (on azure) there is only one option for the availability zone choice: "Not Specified".
This PR hides the other options in this scenario.