### PR TITLE
Fix a crash when labels is undefined.

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
@@ -70,7 +70,7 @@ const ClusterLabels: FC<IClusterLabelsProps> = ({
 }) => {
   const [allowEditing, setAllowEditing] = useState(true);
 
-  const noLabels = Object.keys(labels).length === 0;
+  const noLabels = !labels || Object.keys(labels).length === 0;
 
   const dispatch = useDispatch();
 

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
@@ -15,7 +15,7 @@ import EditLabelTooltip from './EditLabelTooltip';
 
 interface IClusterLabelsProps extends ComponentPropsWithoutRef<'div'> {
   clusterId: string;
-  labels: V5ClusterLabelsProperty;
+  labels?: V5ClusterLabelsProperty;
 }
 
 const ClusterLabelsWrapper = styled.div`
@@ -98,28 +98,29 @@ const ClusterLabels: FC<IClusterLabelsProps> = ({
       ) : (
         <>
           <LabelsWrapper>
-            {Object.entries(labels).map(([label, value]) => (
-              <LabelWrapper key={label}>
-                <EditLabelTooltip
-                  allowInteraction={!loading && allowEditing}
-                  label={label}
-                  onOpen={(isOpen) => setAllowEditing(isOpen)}
-                  onSave={save}
-                  value={value}
-                />
-                <DeleteLabelButton
-                  allowInteraction={!loading && allowEditing}
-                  onOpen={(isOpen) => setAllowEditing(isOpen)}
-                  onDelete={() => {
-                    save({ key: label, value: null });
-                  }}
-                  role='button'
-                  aria-label={`Delete '${label}' label`}
-                >
-                  &times;
-                </DeleteLabelButton>
-              </LabelWrapper>
-            ))}
+            {labels &&
+              Object.entries(labels).map(([label, value]) => (
+                <LabelWrapper key={label}>
+                  <EditLabelTooltip
+                    allowInteraction={!loading && allowEditing}
+                    label={label}
+                    onOpen={(isOpen) => setAllowEditing(isOpen)}
+                    onSave={save}
+                    value={value}
+                  />
+                  <DeleteLabelButton
+                    allowInteraction={!loading && allowEditing}
+                    onOpen={(isOpen) => setAllowEditing(isOpen)}
+                    onDelete={() => {
+                      save({ key: label, value: null });
+                    }}
+                    role='button'
+                    aria-label={`Delete '${label}' label`}
+                  >
+                    &times;
+                  </DeleteLabelButton>
+                </LabelWrapper>
+              ))}
             <EditLabelTooltip
               allowInteraction={!loading && allowEditing}
               label=''
@@ -144,8 +145,7 @@ const ClusterLabels: FC<IClusterLabelsProps> = ({
 ClusterLabels.propTypes = {
   className: PropTypes.string,
   clusterId: PropTypes.string.isRequired,
-  // @ts-ignore
-  labels: PropTypes.object.isRequired,
+  labels: PropTypes.object,
 };
 
 export default ClusterLabels;

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
@@ -145,6 +145,7 @@ const ClusterLabels: FC<IClusterLabelsProps> = ({
 ClusterLabels.propTypes = {
   className: PropTypes.string,
   clusterId: PropTypes.string.isRequired,
+  // @ts-ignore
   labels: PropTypes.object,
 };
 


### PR DESCRIPTION
Stops happa from crashing when cluster details cannot be fetched for whatever reason.


Fixes exception report:
```
TypeError: Cannot convert undefined or null to object
 at keys (webpack:///./src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx:73:26)
```