### PR TITLE
Support readme urls in annotations as well as sources of an app's Chart.yml.

### DIFF
--- a/src/@types/appcatalogs.d.ts
+++ b/src/@types/appcatalogs.d.ts
@@ -25,8 +25,8 @@ interface IAppCatalogApp {
   home: string;
   icon: string;
   name: string;
-  sources: string[];
-  annotations: IAppCatalogAppAnnotations;
+  sources?: string[];
+  annotations?: IAppCatalogAppAnnotations;
   urls: string[];
 
   // Injected by client-side.

--- a/src/@types/appcatalogs.d.ts
+++ b/src/@types/appcatalogs.d.ts
@@ -26,10 +26,15 @@ interface IAppCatalogApp {
   icon: string;
   name: string;
   sources: string[];
+  annotations: IAppCatalogAppAnnotations;
   urls: string[];
 
   // Injected by client-side.
   readme?: string;
+}
+
+interface IAppCatalogAppAnnotations {
+  'application.giantswarm.io/readme': string;
 }
 
 interface IAppCatalogAppMap {

--- a/src/components/AppCatalog/AppDetail/AppDetail.js
+++ b/src/components/AppCatalog/AppDetail/AppDetail.js
@@ -24,14 +24,6 @@ import LoadingOverlay from 'UI/LoadingOverlay';
 
 import InstallAppModal from './InstallAppModal';
 
-function hasReadmeSource(appVersion) {
-  if (!appVersion.sources) {
-    return false;
-  }
-
-  return appVersion.sources.some((url) => url.endsWith(Constants.README_FILE));
-}
-
 class AppDetail extends React.Component {
   imgError = () => {
     this.setState({
@@ -77,11 +69,11 @@ class AppDetail extends React.Component {
       errorLoadingReadme,
     } = this.props;
 
+    // Skip if we don't know what app we're looking at yet
+    if (!selectedAppVersion) return;
+
     // Skip if there was an error loading the readme.
     if (errorLoadingReadme) return;
-
-    // Skip if there is no readme source to load.
-    if (!hasReadmeSource(selectedAppVersion)) return;
 
     // Skip if the readme is already loaded.
     if (selectedAppVersion.readme) return;
@@ -195,7 +187,7 @@ function mapStateToProps(state, ownProps) {
   const appName = decodeURIComponent(ownProps.match.params.app);
   const version = decodeURIComponent(ownProps.match.params.version);
 
-  let appVersions = [{}];
+  let appVersions = [];
   if (
     state.entities.catalogs.items[catalogName] &&
     !state.entities.catalogs.items[catalogName].isFetchingIndex &&

--- a/src/stores/appcatalog/actions.ts
+++ b/src/stores/appcatalog/actions.ts
@@ -257,17 +257,6 @@ export function loadAppReadme(
       appVersion,
     });
 
-    if (!appVersion.sources) {
-      dispatch({
-        type: CLUSTER_LOAD_APP_README_ERROR,
-        catalogName,
-        appVersion,
-        error: 'No list of sources to check for a README.',
-      });
-
-      return Promise.resolve();
-    }
-
     let readmeURL = selectReadmeURL(appVersion);
     if (!readmeURL) {
       dispatch({

--- a/src/stores/appcatalog/selectors.ts
+++ b/src/stores/appcatalog/selectors.ts
@@ -28,5 +28,8 @@ export function selectIngressAppFromCluster(cluster: Cluster) {
 export function selectReadmeURL(
   appVersion: IAppCatalogApp
 ): string | undefined {
-  return appVersion.sources?.find((url) => url.endsWith(Constants.README_FILE));
+  return (
+    appVersion.annotations?.['application.giantswarm.io/readme'] ||
+    appVersion.sources?.find((url) => url.endsWith(Constants.README_FILE))
+  );
 }


### PR DESCRIPTION
We've changed the location of the app README url to the 'annotations' block in Chart.yaml instead of the 'sources' array.

Happa should be backwards compatible for a while though. This PR lets Happa also check for README's in the "application.giantswarm.io/readme" annotation, with a fallback to the original 'sources' location.

https://github.com/giantswarm/giantswarm/pull/13982

fyi @cokiengchiara 