### PR TITLE
Fix cluster stuck on 'Awaiting upgrade' after the upgrade request failed

### DIFF
--- a/src/stores/cluster/reducer.ts
+++ b/src/stores/cluster/reducer.ts
@@ -186,10 +186,8 @@ const clusterReducer = produce(
       case CLUSTER_PATCH_ERROR: {
         if (draft.items[action.cluster.id]) {
           draft.items[action.cluster.id] = action.cluster;
-          draft.idsAwaitingUpgrade = reconcileClustersAwaitingUpgrade(
-            draft.items,
-            draft.idsAwaitingUpgrade
-          );
+
+          delete draft.idsAwaitingUpgrade[action.cluster.id];
         }
 
         break;


### PR DESCRIPTION
It seems that if you try to upgrade a cluster, even if the cluster upgrade request fails, the cluster is still stuck with the `Awaiting upgrade` status. This PR fixes that.