### PR TITLE
Rename AppRoutes to MainRoutes

### DIFF
--- a/__tests__/AdminLogin.js
+++ b/__tests__/AdminLogin.js
@@ -10,7 +10,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import React from 'react';
 import { AuthorizationTypes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import configureStore from 'stores/configureStore';
 import theme from 'styles/theme';
 import {
@@ -63,7 +63,7 @@ helpers.isJwtExpired = jest.fn();
 helpers.validateOrRaise = jest.fn();
 
 const renderRouteWithStore = (
-  initialRoute = OtherRoutes.Home,
+  initialRoute = MainRoutes.Home,
   state = {},
   storage = initialStorage
 ) => {
@@ -87,7 +87,7 @@ describe('AdminLogin', () => {
   });
 
   it('renders without crashing', async () => {
-    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {}, {});
+    const { findByText } = renderRouteWithStore(MainRoutes.AdminLogin, {}, {});
 
     await findByText(
       /verifying credentials, and redirecting to our authentication provider if necessary./i
@@ -103,7 +103,7 @@ describe('AdminLogin', () => {
 
     mockAuth0Authorize.mockImplementation(() => {
       store.dispatch(
-        push(`${OtherRoutes.OAuthCallback}#response_type=id_token`)
+        push(`${MainRoutes.OAuthCallback}#response_type=id_token`)
       );
     });
 
@@ -111,7 +111,7 @@ describe('AdminLogin', () => {
       callback(null, mockSuccessfulAuthResponse);
     });
 
-    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {}, {});
+    const { findByText } = renderRouteWithStore(MainRoutes.AdminLogin, {}, {});
 
     // Check if the user has been redirected to the homepage
     await findByText(/there are no organizations yet in your installation./i);
@@ -129,7 +129,7 @@ describe('AdminLogin', () => {
 
     helpers.isJwtExpired.mockReturnValue(false);
 
-    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {
+    const { findByText } = renderRouteWithStore(MainRoutes.AdminLogin, {
       ...preloginState,
       main: { loggedInUser: mockUserData },
     });
@@ -163,7 +163,7 @@ describe('AdminLogin', () => {
       callback(null, mockAuthResponseWithNewToken)
     );
 
-    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {
+    const { findByText } = renderRouteWithStore(MainRoutes.AdminLogin, {
       ...preloginState,
       main: { loggedInUser: mockUserData },
     });
@@ -179,16 +179,14 @@ describe('AdminLogin', () => {
 
   it('displays an error message if the OAuth provider callback URL is not valid', async () => {
     mockAuth0Authorize.mockImplementation(() => {
-      store.dispatch(
-        push(`${OtherRoutes.OAuthCallback}#response_type=invalid`)
-      );
+      store.dispatch(push(`${MainRoutes.OAuthCallback}#response_type=invalid`));
     });
 
     mockAuth0ParseHash.mockImplementation((callback) => {
       callback(null, mockSuccessfulAuthResponse);
     });
 
-    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {}, {});
+    const { findByText } = renderRouteWithStore(MainRoutes.AdminLogin, {}, {});
 
     await findByText(
       /invalid or empty response from the authentication provider./i
@@ -198,7 +196,7 @@ describe('AdminLogin', () => {
   it('displays an error message if the OAuth provider can not login', async () => {
     mockAuth0Authorize.mockImplementation(() => {
       store.dispatch(
-        push(`${OtherRoutes.OAuthCallback}#response_type=id_token`)
+        push(`${MainRoutes.OAuthCallback}#response_type=id_token`)
       );
     });
 
@@ -206,7 +204,7 @@ describe('AdminLogin', () => {
       callback(new Error('u w0t m8?'), mockSuccessfulAuthResponse);
     });
 
-    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {}, {});
+    const { findByText } = renderRouteWithStore(MainRoutes.AdminLogin, {}, {});
 
     await findByText(/^Something went wrong$/i);
   });
@@ -223,7 +221,7 @@ describe('AdminLogin', () => {
       callback(new Error('u w0t m8?'), mockAuthResponseWithNewToken)
     );
 
-    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {
+    const { findByText } = renderRouteWithStore(MainRoutes.AdminLogin, {
       ...preloginState,
       main: { loggedInUser: mockUserData },
     });

--- a/__tests__/AdminLogin.js
+++ b/__tests__/AdminLogin.js
@@ -10,7 +10,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import React from 'react';
 import { AuthorizationTypes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import configureStore from 'stores/configureStore';
 import theme from 'styles/theme';
 import {
@@ -63,7 +63,7 @@ helpers.isJwtExpired = jest.fn();
 helpers.validateOrRaise = jest.fn();
 
 const renderRouteWithStore = (
-  initialRoute = AppRoutes.Home,
+  initialRoute = OtherRoutes.Home,
   state = {},
   storage = initialStorage
 ) => {
@@ -87,7 +87,7 @@ describe('AdminLogin', () => {
   });
 
   it('renders without crashing', async () => {
-    const { findByText } = renderRouteWithStore(AppRoutes.AdminLogin, {}, {});
+    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {}, {});
 
     await findByText(
       /verifying credentials, and redirecting to our authentication provider if necessary./i
@@ -102,14 +102,16 @@ describe('AdminLogin', () => {
     getMockCall('/v4/appcatalogs/');
 
     mockAuth0Authorize.mockImplementation(() => {
-      store.dispatch(push(`${AppRoutes.OAuthCallback}#response_type=id_token`));
+      store.dispatch(
+        push(`${OtherRoutes.OAuthCallback}#response_type=id_token`)
+      );
     });
 
     mockAuth0ParseHash.mockImplementation((callback) => {
       callback(null, mockSuccessfulAuthResponse);
     });
 
-    const { findByText } = renderRouteWithStore(AppRoutes.AdminLogin, {}, {});
+    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {}, {});
 
     // Check if the user has been redirected to the homepage
     await findByText(/there are no organizations yet in your installation./i);
@@ -127,7 +129,7 @@ describe('AdminLogin', () => {
 
     helpers.isJwtExpired.mockReturnValue(false);
 
-    const { findByText } = renderRouteWithStore(AppRoutes.AdminLogin, {
+    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {
       ...preloginState,
       main: { loggedInUser: mockUserData },
     });
@@ -161,7 +163,7 @@ describe('AdminLogin', () => {
       callback(null, mockAuthResponseWithNewToken)
     );
 
-    const { findByText } = renderRouteWithStore(AppRoutes.AdminLogin, {
+    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {
       ...preloginState,
       main: { loggedInUser: mockUserData },
     });
@@ -177,14 +179,16 @@ describe('AdminLogin', () => {
 
   it('displays an error message if the OAuth provider callback URL is not valid', async () => {
     mockAuth0Authorize.mockImplementation(() => {
-      store.dispatch(push(`${AppRoutes.OAuthCallback}#response_type=invalid`));
+      store.dispatch(
+        push(`${OtherRoutes.OAuthCallback}#response_type=invalid`)
+      );
     });
 
     mockAuth0ParseHash.mockImplementation((callback) => {
       callback(null, mockSuccessfulAuthResponse);
     });
 
-    const { findByText } = renderRouteWithStore(AppRoutes.AdminLogin, {}, {});
+    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {}, {});
 
     await findByText(
       /invalid or empty response from the authentication provider./i
@@ -193,14 +197,16 @@ describe('AdminLogin', () => {
 
   it('displays an error message if the OAuth provider can not login', async () => {
     mockAuth0Authorize.mockImplementation(() => {
-      store.dispatch(push(`${AppRoutes.OAuthCallback}#response_type=id_token`));
+      store.dispatch(
+        push(`${OtherRoutes.OAuthCallback}#response_type=id_token`)
+      );
     });
 
     mockAuth0ParseHash.mockImplementation((callback) => {
       callback(new Error('u w0t m8?'), mockSuccessfulAuthResponse);
     });
 
-    const { findByText } = renderRouteWithStore(AppRoutes.AdminLogin, {}, {});
+    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {}, {});
 
     await findByText(/^Something went wrong$/i);
   });
@@ -217,7 +223,7 @@ describe('AdminLogin', () => {
       callback(new Error('u w0t m8?'), mockAuthResponseWithNewToken)
     );
 
-    const { findByText } = renderRouteWithStore(AppRoutes.AdminLogin, {
+    const { findByText } = renderRouteWithStore(OtherRoutes.AdminLogin, {
       ...preloginState,
       main: { loggedInUser: mockUserData },
     });

--- a/__tests__/ClusterManagement.js
+++ b/__tests__/ClusterManagement.js
@@ -6,7 +6,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import {
   API_ENDPOINT,
   appCatalogsResponse,
@@ -204,7 +204,7 @@ it('Cluster list shows all clusters, each one with its details, for the selected
     v4AWSClusterStatusResponse
   );
 
-  const clusterDetailPath = RoutePath.createUsablePath(OtherRoutes.Home);
+  const clusterDetailPath = RoutePath.createUsablePath(MainRoutes.Home);
   const { getAllByTestId, getByText } = renderRouteWithStore(clusterDetailPath);
 
   // Wait for the last elements to load.

--- a/__tests__/ClusterManagement.js
+++ b/__tests__/ClusterManagement.js
@@ -6,7 +6,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
 import {
   API_ENDPOINT,
   appCatalogsResponse,
@@ -204,7 +204,7 @@ it('Cluster list shows all clusters, each one with its details, for the selected
     v4AWSClusterStatusResponse
   );
 
-  const clusterDetailPath = RoutePath.createUsablePath(AppRoutes.Home);
+  const clusterDetailPath = RoutePath.createUsablePath(OtherRoutes.Home);
   const { getAllByTestId, getByText } = renderRouteWithStore(clusterDetailPath);
 
   // Wait for the last elements to load.

--- a/__tests__/ForgotPassword.js
+++ b/__tests__/ForgotPassword.js
@@ -7,7 +7,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import {
   authTokenResponse,
   AWSInfoResponse,
@@ -35,7 +35,7 @@ describe('PasswordReset', () => {
     it('takes us to the forgot password form when clicking on "Forgot your password?" from the login form', async () => {
       // Given I am not logged in and visit the app.
       const { findByText, getByText } = renderRouteWithStore(
-        AppRoutes.Home,
+        OtherRoutes.Home,
         {},
         {}
       );
@@ -67,7 +67,7 @@ describe('PasswordReset', () => {
 
       // And I am not logged in and visit the app.
       const { getByText, findByText, getByLabelText } = renderRouteWithStore(
-        AppRoutes.ForgotPassword,
+        OtherRoutes.ForgotPassword,
         {},
         {}
       );
@@ -98,7 +98,7 @@ describe('PasswordReset', () => {
   describe('SetPassword', () => {
     // eslint-disable-next-line no-magic-numbers
     const token = generateRandomString(22);
-    const routeWithToken = RoutePath.createUsablePath(AppRoutes.SetPassword, {
+    const routeWithToken = RoutePath.createUsablePath(OtherRoutes.SetPassword, {
       token,
     });
 

--- a/__tests__/ForgotPassword.js
+++ b/__tests__/ForgotPassword.js
@@ -7,7 +7,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import {
   authTokenResponse,
   AWSInfoResponse,
@@ -35,7 +35,7 @@ describe('PasswordReset', () => {
     it('takes us to the forgot password form when clicking on "Forgot your password?" from the login form', async () => {
       // Given I am not logged in and visit the app.
       const { findByText, getByText } = renderRouteWithStore(
-        OtherRoutes.Home,
+        MainRoutes.Home,
         {},
         {}
       );
@@ -67,7 +67,7 @@ describe('PasswordReset', () => {
 
       // And I am not logged in and visit the app.
       const { getByText, findByText, getByLabelText } = renderRouteWithStore(
-        OtherRoutes.ForgotPassword,
+        MainRoutes.ForgotPassword,
         {},
         {}
       );
@@ -98,7 +98,7 @@ describe('PasswordReset', () => {
   describe('SetPassword', () => {
     // eslint-disable-next-line no-magic-numbers
     const token = generateRandomString(22);
-    const routeWithToken = RoutePath.createUsablePath(OtherRoutes.SetPassword, {
+    const routeWithToken = RoutePath.createUsablePath(MainRoutes.SetPassword, {
       token,
     });
 

--- a/__tests__/GettingStarted.js
+++ b/__tests__/GettingStarted.js
@@ -4,7 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import {
   appCatalogsResponse,
   AWSInfoResponse,
@@ -43,7 +43,7 @@ it('lets me get there from the dashboard and go through the pages', async () => 
   getMockCall('/v4/clusters/', v4ClustersResponse);
   getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
 
-  const { findByText } = renderRouteWithStore(OtherRoutes.Home);
+  const { findByText } = renderRouteWithStore(MainRoutes.Home);
 
   const getStartedButton = await findByText('Get Started');
   expect(getStartedButton).toBeInTheDocument();
@@ -86,7 +86,7 @@ it('the get started button does not show up if the cluster is older than 30 days
   getMockCall('/v4/clusters/', modifiedClustersResponse);
   getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, modifiedClusterResponse);
 
-  const { findByText, queryByText } = renderRouteWithStore(OtherRoutes.Home);
+  const { findByText, queryByText } = renderRouteWithStore(MainRoutes.Home);
 
   await findByText(V4_CLUSTER.id);
   expect(queryByText('Get Started')).not.toBeInTheDocument();

--- a/__tests__/GettingStarted.js
+++ b/__tests__/GettingStarted.js
@@ -4,7 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import {
   appCatalogsResponse,
   AWSInfoResponse,
@@ -43,7 +43,7 @@ it('lets me get there from the dashboard and go through the pages', async () => 
   getMockCall('/v4/clusters/', v4ClustersResponse);
   getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, v4AWSClusterResponse);
 
-  const { findByText } = renderRouteWithStore(AppRoutes.Home);
+  const { findByText } = renderRouteWithStore(OtherRoutes.Home);
 
   const getStartedButton = await findByText('Get Started');
   expect(getStartedButton).toBeInTheDocument();
@@ -86,7 +86,7 @@ it('the get started button does not show up if the cluster is older than 30 days
   getMockCall('/v4/clusters/', modifiedClustersResponse);
   getMockCall(`/v4/clusters/${V4_CLUSTER.id}/`, modifiedClusterResponse);
 
-  const { findByText, queryByText } = renderRouteWithStore(AppRoutes.Home);
+  const { findByText, queryByText } = renderRouteWithStore(OtherRoutes.Home);
 
   await findByText(V4_CLUSTER.id);
   expect(queryByText('Get Started')).not.toBeInTheDocument();

--- a/__tests__/Login.js
+++ b/__tests__/Login.js
@@ -5,7 +5,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import {
   API_ENDPOINT,
   authTokenResponse,
@@ -22,7 +22,7 @@ beforeEach(() => {
 });
 
 it('renders the login page at /login', async () => {
-  const { getByText } = renderRouteWithStore(AppRoutes.Login, {}, {});
+  const { getByText } = renderRouteWithStore(OtherRoutes.Login, {}, {});
 
   await waitFor(() => {
     expect(getByText('Log in to Giant Swarm')).toBeInTheDocument();
@@ -51,7 +51,7 @@ it('redirects to / and shows the layout after a succesful login', async () => {
 
   // AND I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore(
-    AppRoutes.Login,
+    OtherRoutes.Login,
     {},
     {}
   );
@@ -83,7 +83,7 @@ it('redirects to / and shows the layout after a succesful login', async () => {
 it('tells the user to give a password if they leave it blank', async () => {
   // Given I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore(
-    AppRoutes.Login,
+    OtherRoutes.Login,
     {},
     {}
   );
@@ -107,7 +107,7 @@ it('tells the user to give a password if they leave it blank', async () => {
 it('tells the user to give a email if they leave it blank', async () => {
   // Given I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore(
-    AppRoutes.Login,
+    OtherRoutes.Login,
     {},
     {}
   );
@@ -134,7 +134,7 @@ it('shows an error if the user logs in with invalid credentials', async () => {
 
   // And I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore(
-    AppRoutes.Login,
+    OtherRoutes.Login,
     {},
     {}
   );

--- a/__tests__/Login.js
+++ b/__tests__/Login.js
@@ -5,7 +5,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import {
   API_ENDPOINT,
   authTokenResponse,
@@ -22,7 +22,7 @@ beforeEach(() => {
 });
 
 it('renders the login page at /login', async () => {
-  const { getByText } = renderRouteWithStore(OtherRoutes.Login, {}, {});
+  const { getByText } = renderRouteWithStore(MainRoutes.Login, {}, {});
 
   await waitFor(() => {
     expect(getByText('Log in to Giant Swarm')).toBeInTheDocument();
@@ -51,7 +51,7 @@ it('redirects to / and shows the layout after a succesful login', async () => {
 
   // AND I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore(
-    OtherRoutes.Login,
+    MainRoutes.Login,
     {},
     {}
   );
@@ -83,7 +83,7 @@ it('redirects to / and shows the layout after a succesful login', async () => {
 it('tells the user to give a password if they leave it blank', async () => {
   // Given I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore(
-    OtherRoutes.Login,
+    MainRoutes.Login,
     {},
     {}
   );
@@ -107,7 +107,7 @@ it('tells the user to give a password if they leave it blank', async () => {
 it('tells the user to give a email if they leave it blank', async () => {
   // Given I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore(
-    OtherRoutes.Login,
+    MainRoutes.Login,
     {},
     {}
   );
@@ -134,7 +134,7 @@ it('shows an error if the user logs in with invalid credentials', async () => {
 
   // And I arrive at the login page with nothing in the state.
   const { getByText, getByLabelText } = renderRouteWithStore(
-    OtherRoutes.Login,
+    MainRoutes.Login,
     {},
     {}
   );

--- a/__tests__/Logout.js
+++ b/__tests__/Logout.js
@@ -5,7 +5,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import {
   API_ENDPOINT,
   AWSInfoResponse,
@@ -37,7 +37,7 @@ it('logging out redirects to the login page', async () => {
   nock(API_ENDPOINT).delete('/v4/auth-tokens/').reply(StatusCodes.Ok);
 
   // Given I am logged in and on the home page.
-  const { getByText } = renderRouteWithStore(AppRoutes.Home);
+  const { getByText } = renderRouteWithStore(OtherRoutes.Home);
 
   // Wait till the app is ready and we're on the home page.
   await waitFor(() => {

--- a/__tests__/Logout.js
+++ b/__tests__/Logout.js
@@ -5,7 +5,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import {
   API_ENDPOINT,
   AWSInfoResponse,
@@ -37,7 +37,7 @@ it('logging out redirects to the login page', async () => {
   nock(API_ENDPOINT).delete('/v4/auth-tokens/').reply(StatusCodes.Ok);
 
   // Given I am logged in and on the home page.
-  const { getByText } = renderRouteWithStore(OtherRoutes.Home);
+  const { getByText } = renderRouteWithStore(MainRoutes.Home);
 
   // Wait till the app is ready and we're on the home page.
   await waitFor(() => {

--- a/__tests__/SignUp.js
+++ b/__tests__/SignUp.js
@@ -7,7 +7,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import {
   AWSInfoResponse,
   getMockCall,
@@ -20,7 +20,7 @@ import { renderRouteWithStore } from 'testUtils/renderUtils';
 const testToken = 'm0ckt0ken';
 const tokenTestPath = `/invite/${testToken}`;
 
-const verifyingRoute = RoutePath.createUsablePath(OtherRoutes.SignUp, {
+const verifyingRoute = RoutePath.createUsablePath(MainRoutes.SignUp, {
   token: testToken,
 });
 

--- a/__tests__/SignUp.js
+++ b/__tests__/SignUp.js
@@ -7,7 +7,7 @@ import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import {
   AWSInfoResponse,
   getMockCall,
@@ -20,7 +20,7 @@ import { renderRouteWithStore } from 'testUtils/renderUtils';
 const testToken = 'm0ckt0ken';
 const tokenTestPath = `/invite/${testToken}`;
 
-const verifyingRoute = RoutePath.createUsablePath(AppRoutes.SignUp, {
+const verifyingRoute = RoutePath.createUsablePath(OtherRoutes.SignUp, {
   token: testToken,
 });
 

--- a/src/components/Auth/AdminLogin.tsx
+++ b/src/components/Auth/AdminLogin.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { AuthorizationTypes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import { MainActions } from 'stores/main/types';
 import { IState } from 'stores/state';
@@ -39,7 +39,7 @@ const AdminLogin: React.FC<IAdminLoginProps> = ({ user, dispatch }) => {
               await dispatch(mainActions.auth0Login(result));
 
               // Redirect to dashboard.
-              dispatch(push(OtherRoutes.Home));
+              dispatch(push(MainRoutes.Home));
             } catch {
               // Unable to refresh token silently, so send the down the auth0
               // flow.
@@ -47,7 +47,7 @@ const AdminLogin: React.FC<IAdminLoginProps> = ({ user, dispatch }) => {
             }
           } else {
             // Token isn't expired yet, so just redirect the user to the dashboard.
-            dispatch(push(OtherRoutes.Home));
+            dispatch(push(MainRoutes.Home));
           }
         } else {
           // User doesn't have any previous token at all, send them to auth0 so

--- a/src/components/Auth/AdminLogin.tsx
+++ b/src/components/Auth/AdminLogin.tsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { AuthorizationTypes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import { MainActions } from 'stores/main/types';
 import { IState } from 'stores/state';
@@ -39,7 +39,7 @@ const AdminLogin: React.FC<IAdminLoginProps> = ({ user, dispatch }) => {
               await dispatch(mainActions.auth0Login(result));
 
               // Redirect to dashboard.
-              dispatch(push(AppRoutes.Home));
+              dispatch(push(OtherRoutes.Home));
             } catch {
               // Unable to refresh token silently, so send the down the auth0
               // flow.
@@ -47,7 +47,7 @@ const AdminLogin: React.FC<IAdminLoginProps> = ({ user, dispatch }) => {
             }
           } else {
             // Token isn't expired yet, so just redirect the user to the dashboard.
-            dispatch(push(AppRoutes.Home));
+            dispatch(push(OtherRoutes.Home));
           }
         } else {
           // User doesn't have any previous token at all, send them to auth0 so

--- a/src/components/Auth/CP/CPLoginPage.tsx
+++ b/src/components/Auth/CP/CPLoginPage.tsx
@@ -6,7 +6,7 @@ import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import React, { useCallback, useEffect } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import DocumentTitle from 'shared/DocumentTitle';
 import { getCPAuthUser } from 'stores/cpauth/selectors';
 
@@ -34,7 +34,7 @@ const CPLoginPage: React.FC<ICPLoginPageProps> = () => {
         if (isLoggedIn) {
           await auth.logout();
           // Force a reload, so we could re-run the batched actions.
-          window.location.href = AppRoutes.Home;
+          window.location.href = OtherRoutes.Home;
         } else {
           await auth.attemptLogin();
         }
@@ -48,14 +48,14 @@ const CPLoginPage: React.FC<ICPLoginPageProps> = () => {
   useEffect(() => {
     const currentURL = window.location.href;
 
-    if (currentURL.includes(AppRoutes.CPAccessCallback)) {
+    if (currentURL.includes(OtherRoutes.CPAccessCallback)) {
       const handleAuthParams = async () => {
         try {
           const auth = CPAuth.getInstance();
           await auth.handleLoginResponse(currentURL);
 
           // Force a reload, so we could re-run the batched actions.
-          window.location.href = AppRoutes.Home;
+          window.location.href = OtherRoutes.Home;
         } catch (err) {
           new FlashMessage(err.message, messageType.ERROR, messageTTL.MEDIUM);
         }
@@ -69,7 +69,7 @@ const CPLoginPage: React.FC<ICPLoginPageProps> = () => {
     <Breadcrumb
       data={{
         title: 'Control Plane Access'.toUpperCase(),
-        pathname: AppRoutes.CPAccess,
+        pathname: OtherRoutes.CPAccess,
       }}
     >
       <DocumentTitle title='Control Plane Access'>

--- a/src/components/Auth/CP/CPLoginPage.tsx
+++ b/src/components/Auth/CP/CPLoginPage.tsx
@@ -6,7 +6,7 @@ import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import React, { useCallback, useEffect } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import DocumentTitle from 'shared/DocumentTitle';
 import { getCPAuthUser } from 'stores/cpauth/selectors';
 
@@ -34,7 +34,7 @@ const CPLoginPage: React.FC<ICPLoginPageProps> = () => {
         if (isLoggedIn) {
           await auth.logout();
           // Force a reload, so we could re-run the batched actions.
-          window.location.href = OtherRoutes.Home;
+          window.location.href = MainRoutes.Home;
         } else {
           await auth.attemptLogin();
         }
@@ -48,14 +48,14 @@ const CPLoginPage: React.FC<ICPLoginPageProps> = () => {
   useEffect(() => {
     const currentURL = window.location.href;
 
-    if (currentURL.includes(OtherRoutes.CPAccessCallback)) {
+    if (currentURL.includes(MainRoutes.CPAccessCallback)) {
       const handleAuthParams = async () => {
         try {
           const auth = CPAuth.getInstance();
           await auth.handleLoginResponse(currentURL);
 
           // Force a reload, so we could re-run the batched actions.
-          window.location.href = OtherRoutes.Home;
+          window.location.href = MainRoutes.Home;
         } catch (err) {
           new FlashMessage(err.message, messageType.ERROR, messageTTL.MEDIUM);
         }
@@ -69,7 +69,7 @@ const CPLoginPage: React.FC<ICPLoginPageProps> = () => {
     <Breadcrumb
       data={{
         title: 'Control Plane Access'.toUpperCase(),
-        pathname: OtherRoutes.CPAccess,
+        pathname: MainRoutes.CPAccess,
       }}
     >
       <DocumentTitle title='Control Plane Access'>

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -10,7 +10,7 @@ import React, { ReactNode } from 'react';
 import { connect, DispatchProp } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators, Dispatch } from 'redux';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import SlideTransition from 'styles/transitions/SlideTransition';
 import Button from 'UI/Button';
@@ -107,7 +107,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
       this.props.actions
         .giantswarmLogin(this.state.email, this.state.password)
         .then(() => {
-          this.props.dispatch(push(AppRoutes.Home));
+          this.props.dispatch(push(OtherRoutes.Home));
 
           return null;
         })
@@ -174,7 +174,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
               >
                 Log in
               </Button>
-              <Link to={AppRoutes.ForgotPassword}>Forgot your password?</Link>
+              <Link to={OtherRoutes.ForgotPassword}>Forgot your password?</Link>
             </form>
 
             <div className='login_form--legal'>

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -10,7 +10,7 @@ import React, { ReactNode } from 'react';
 import { connect, DispatchProp } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators, Dispatch } from 'redux';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import SlideTransition from 'styles/transitions/SlideTransition';
 import Button from 'UI/Button';
@@ -107,7 +107,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
       this.props.actions
         .giantswarmLogin(this.state.email, this.state.password)
         .then(() => {
-          this.props.dispatch(push(OtherRoutes.Home));
+          this.props.dispatch(push(MainRoutes.Home));
 
           return null;
         })
@@ -174,7 +174,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
               >
                 Log in
               </Button>
-              <Link to={OtherRoutes.ForgotPassword}>Forgot your password?</Link>
+              <Link to={MainRoutes.ForgotPassword}>Forgot your password?</Link>
             </form>
 
             <div className='login_form--legal'>

--- a/src/components/Auth/Logout.js
+++ b/src/components/Auth/Logout.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { AuthorizationTypes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import BaseTransition from 'styles/transitions/BaseTransition';
 
@@ -29,13 +29,13 @@ class Logout extends React.Component {
       this.props.user.auth.scheme
     ) {
       if (this.props.user.auth.scheme === AuthorizationTypes.BEARER) {
-        this.props.dispatch(push(OtherRoutes.Login));
+        this.props.dispatch(push(MainRoutes.Login));
         this.props.actions.logoutSuccess();
       } else {
         this.props.actions.giantswarmLogout();
       }
     } else {
-      this.props.dispatch(push(OtherRoutes.Login));
+      this.props.dispatch(push(MainRoutes.Login));
       this.props.actions.logoutSuccess();
     }
   }

--- a/src/components/Auth/Logout.js
+++ b/src/components/Auth/Logout.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { AuthorizationTypes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import BaseTransition from 'styles/transitions/BaseTransition';
 
@@ -29,13 +29,13 @@ class Logout extends React.Component {
       this.props.user.auth.scheme
     ) {
       if (this.props.user.auth.scheme === AuthorizationTypes.BEARER) {
-        this.props.dispatch(push(AppRoutes.Login));
+        this.props.dispatch(push(OtherRoutes.Login));
         this.props.actions.logoutSuccess();
       } else {
         this.props.actions.giantswarmLogout();
       }
     } else {
-      this.props.dispatch(push(AppRoutes.Login));
+      this.props.dispatch(push(OtherRoutes.Login));
       this.props.actions.logoutSuccess();
     }
   }

--- a/src/components/Auth/OAuthCallback.js
+++ b/src/components/Auth/OAuthCallback.js
@@ -6,7 +6,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import SlideTransition from 'styles/transitions/SlideTransition';
 
@@ -26,7 +26,7 @@ const OAuthCallback = ({ location, dispatch, actions }) => {
         // Login user officially
         try {
           await actions.auth0Login(authResult);
-          dispatch(push(OtherRoutes.Home));
+          dispatch(push(MainRoutes.Home));
         } catch (authError) {
           setError(authError);
         }
@@ -50,7 +50,7 @@ const OAuthCallback = ({ location, dispatch, actions }) => {
             <>
               <h1>Something went wrong</h1>
               <p>{error.errorDescription}</p>
-              <Link to={OtherRoutes.AdminLogin}>Try again</Link>
+              <Link to={MainRoutes.AdminLogin}>Try again</Link>
             </>
           ) : (
             <img className='loader' src={spinner} />

--- a/src/components/Auth/OAuthCallback.js
+++ b/src/components/Auth/OAuthCallback.js
@@ -6,7 +6,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import SlideTransition from 'styles/transitions/SlideTransition';
 
@@ -26,7 +26,7 @@ const OAuthCallback = ({ location, dispatch, actions }) => {
         // Login user officially
         try {
           await actions.auth0Login(authResult);
-          dispatch(push(AppRoutes.Home));
+          dispatch(push(OtherRoutes.Home));
         } catch (authError) {
           setError(authError);
         }
@@ -50,7 +50,7 @@ const OAuthCallback = ({ location, dispatch, actions }) => {
             <>
               <h1>Something went wrong</h1>
               <p>{error.errorDescription}</p>
-              <Link to={AppRoutes.AdminLogin}>Try again</Link>
+              <Link to={OtherRoutes.AdminLogin}>Try again</Link>
             </>
           ) : (
             <img className='loader' src={spinner} />

--- a/src/components/Cluster/ClusterDetail/ClusterDetail.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetail.js
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import { selectClusterById } from 'stores/cluster/selectors';
 
 import GettingStarted from '../../GettingStarted/GettingStarted';
@@ -27,7 +27,7 @@ const ClusterDetail = () => {
         messageTTL.MEDIUM
       );
 
-      dispatch(push(AppRoutes.Home));
+      dispatch(push(OtherRoutes.Home));
     }
   }, [clusterExists, clusterID, dispatch]);
 

--- a/src/components/Cluster/ClusterDetail/ClusterDetail.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetail.js
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
 import { Route, Switch, useRouteMatch } from 'react-router-dom';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import { selectClusterById } from 'stores/cluster/selectors';
 
 import GettingStarted from '../../GettingStarted/GettingStarted';
@@ -27,7 +27,7 @@ const ClusterDetail = () => {
         messageTTL.MEDIUM
       );
 
-      dispatch(push(OtherRoutes.Home));
+      dispatch(push(MainRoutes.Home));
     }
   }, [clusterExists, clusterID, dispatch]);
 

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import ReactTimeout from 'react-timeout';
 import { bindActionCreators } from 'redux';
 import { Constants, Providers } from 'shared/constants';
-import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import Tabs from 'shared/Tabs';
 import {
   batchedClusterDetailView,
@@ -122,7 +122,7 @@ class ClusterDetailView extends React.Component {
 
     this.props.clearInterval(this.loadDataInterval);
 
-    dispatch(push(OtherRoutes.Home));
+    dispatch(push(MainRoutes.Home));
   };
 
   loadDetails = () => {

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
 import ReactTimeout from 'react-timeout';
 import { bindActionCreators } from 'redux';
 import { Constants, Providers } from 'shared/constants';
-import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
 import Tabs from 'shared/Tabs';
 import {
   batchedClusterDetailView,
@@ -122,7 +122,7 @@ class ClusterDetailView extends React.Component {
 
     this.props.clearInterval(this.loadDataInterval);
 
-    dispatch(push(AppRoutes.Home));
+    dispatch(push(OtherRoutes.Home));
   };
 
   loadDetails = () => {

--- a/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
+++ b/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
@@ -10,7 +10,7 @@ import { Breadcrumb } from 'react-breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { Constants, Providers } from 'shared/constants';
-import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
 import { computeCapabilities } from 'stores/cluster/utils';
 import { getFirstNodePoolsRelease, getProvider } from 'stores/main/selectors';
 import Headline from 'UI/ClusterCreation/Headline';
@@ -90,7 +90,7 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = ({
   const dispatch = useDispatch();
 
   const closeForm = () => {
-    dispatch(push(AppRoutes.Home));
+    dispatch(push(OtherRoutes.Home));
   };
 
   return (

--- a/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
+++ b/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
@@ -10,7 +10,7 @@ import { Breadcrumb } from 'react-breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { Constants, Providers } from 'shared/constants';
-import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import { computeCapabilities } from 'stores/cluster/utils';
 import { getFirstNodePoolsRelease, getProvider } from 'stores/main/selectors';
 import Headline from 'UI/ClusterCreation/Headline';
@@ -90,7 +90,7 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = ({
   const dispatch = useDispatch();
 
   const closeForm = () => {
-    dispatch(push(OtherRoutes.Home));
+    dispatch(push(MainRoutes.Home));
   };
 
   return (

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import SlideTransition from 'styles/transitions/SlideTransition';
 import Button from 'UI/Button';
@@ -108,7 +108,7 @@ class ForgotPassword extends React.Component {
         </small>
 
         <small>
-          <Link to={OtherRoutes.Login}>Back to login form</Link>
+          <Link to={MainRoutes.Login}>Back to login form</Link>
         </small>
       </div>
     );
@@ -144,7 +144,7 @@ class ForgotPassword extends React.Component {
           >
             {this.state.submitting ? 'Submitting ...' : 'Submit'}
           </Button>
-          <Link to={OtherRoutes.Login}>Back to login form</Link>
+          <Link to={MainRoutes.Login}>Back to login form</Link>
         </form>
       </>
     );

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import SlideTransition from 'styles/transitions/SlideTransition';
 import Button from 'UI/Button';
@@ -108,7 +108,7 @@ class ForgotPassword extends React.Component {
         </small>
 
         <small>
-          <Link to={AppRoutes.Login}>Back to login form</Link>
+          <Link to={OtherRoutes.Login}>Back to login form</Link>
         </small>
       </div>
     );
@@ -144,7 +144,7 @@ class ForgotPassword extends React.Component {
           >
             {this.state.submitting ? 'Submitting ...' : 'Submit'}
           </Button>
-          <Link to={AppRoutes.Login}>Back to login form</Link>
+          <Link to={OtherRoutes.Login}>Back to login form</Link>
         </form>
       </>
     );

--- a/src/components/ForgotPassword/SetPassword.js
+++ b/src/components/ForgotPassword/SetPassword.js
@@ -12,7 +12,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import SlideTransition from 'styles/transitions/SlideTransition';
 
@@ -106,7 +106,7 @@ class SetPassword extends React.Component {
           messageTTL.MEDIUM
         );
 
-        this.props.dispatch(push(OtherRoutes.Home));
+        this.props.dispatch(push(MainRoutes.Home));
 
         return null;
       })
@@ -282,7 +282,7 @@ class SetPassword extends React.Component {
               <img className='loader' src={spinner} />
             </SlideTransition>
           </div>
-          <Link to={OtherRoutes.Login}>Back to login form</Link>
+          <Link to={MainRoutes.Login}>Back to login form</Link>
         </form>
       );
     }
@@ -302,7 +302,7 @@ class SetPassword extends React.Component {
           Something went wrong.
         </div>
         <br />
-        <Link to={OtherRoutes.ForgotPassword}>Request a new token</Link>
+        <Link to={MainRoutes.ForgotPassword}>Request a new token</Link>
       </>
     );
   };
@@ -341,10 +341,10 @@ class SetPassword extends React.Component {
             <img className='loader' src={spinner} />
           </SlideTransition>
         </div>
-        <Link to={OtherRoutes.Login}>Back to login form</Link>
+        <Link to={MainRoutes.Login}>Back to login form</Link>
         <br />
         <br />
-        <Link to={OtherRoutes.ForgotPassword}>Request a new token</Link>
+        <Link to={MainRoutes.ForgotPassword}>Request a new token</Link>
       </form>
     );
   };

--- a/src/components/ForgotPassword/SetPassword.js
+++ b/src/components/ForgotPassword/SetPassword.js
@@ -12,7 +12,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import SlideTransition from 'styles/transitions/SlideTransition';
 
@@ -106,7 +106,7 @@ class SetPassword extends React.Component {
           messageTTL.MEDIUM
         );
 
-        this.props.dispatch(push(AppRoutes.Home));
+        this.props.dispatch(push(OtherRoutes.Home));
 
         return null;
       })
@@ -282,7 +282,7 @@ class SetPassword extends React.Component {
               <img className='loader' src={spinner} />
             </SlideTransition>
           </div>
-          <Link to={AppRoutes.Login}>Back to login form</Link>
+          <Link to={OtherRoutes.Login}>Back to login form</Link>
         </form>
       );
     }
@@ -302,7 +302,7 @@ class SetPassword extends React.Component {
           Something went wrong.
         </div>
         <br />
-        <Link to={AppRoutes.ForgotPassword}>Request a new token</Link>
+        <Link to={OtherRoutes.ForgotPassword}>Request a new token</Link>
       </>
     );
   };
@@ -341,10 +341,10 @@ class SetPassword extends React.Component {
             <img className='loader' src={spinner} />
           </SlideTransition>
         </div>
-        <Link to={AppRoutes.Login}>Back to login form</Link>
+        <Link to={OtherRoutes.Login}>Back to login form</Link>
         <br />
         <br />
-        <Link to={AppRoutes.ForgotPassword}>Request a new token</Link>
+        <Link to={OtherRoutes.ForgotPassword}>Request a new token</Link>
       </form>
     );
   };

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -10,9 +10,9 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import {
   AccountSettingsRoutes,
   AppCatalogRoutes,
-  AppRoutes,
   ExceptionNotificationTestRoutes,
   OrganizationsRoutes,
+  OtherRoutes,
   UsersRoutes,
 } from 'shared/constants/routes';
 import FeatureFlags from 'shared/FeatureFlags';
@@ -46,7 +46,7 @@ class Layout extends React.Component {
       // firsts calls happa makes to the API.
       this.props.dispatch(batchedLayout());
     } else {
-      this.props.dispatch(push(AppRoutes.Login));
+      this.props.dispatch(push(OtherRoutes.Login));
     }
   }
 
@@ -67,11 +67,11 @@ class Layout extends React.Component {
             showAppCatalog={Object.keys(this.props.catalogs.items).length > 0}
             user={this.props.user}
           />
-          <Breadcrumb data={{ title: 'HOME', pathname: AppRoutes.Home }}>
+          <Breadcrumb data={{ title: 'HOME', pathname: OtherRoutes.Home }}>
             <div className='main'>
               <Switch>
                 {/*prettier-ignore*/}
-                <Route component={Home} exact path={AppRoutes.Home} />
+                <Route component={Home} exact path={OtherRoutes.Home} />
                 <Route component={AppCatalog} path={AppCatalogRoutes.Home} />
                 <Route component={Users} exact path={UsersRoutes.Home} />
                 <Route
@@ -90,10 +90,10 @@ class Layout extends React.Component {
                 />
 
                 {FeatureFlags.FEATURE_CP_ACCESS && (
-                  <Route component={CPLoginPage} path={AppRoutes.CPAccess} />
+                  <Route component={CPLoginPage} path={OtherRoutes.CPAccess} />
                 )}
 
-                <Redirect path='*' to={AppRoutes.Home} />
+                <Redirect path='*' to={OtherRoutes.Home} />
               </Switch>
             </div>
           </Breadcrumb>

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -11,8 +11,8 @@ import {
   AccountSettingsRoutes,
   AppCatalogRoutes,
   ExceptionNotificationTestRoutes,
+  MainRoutes,
   OrganizationsRoutes,
-  OtherRoutes,
   UsersRoutes,
 } from 'shared/constants/routes';
 import FeatureFlags from 'shared/FeatureFlags';
@@ -46,7 +46,7 @@ class Layout extends React.Component {
       // firsts calls happa makes to the API.
       this.props.dispatch(batchedLayout());
     } else {
-      this.props.dispatch(push(OtherRoutes.Login));
+      this.props.dispatch(push(MainRoutes.Login));
     }
   }
 
@@ -67,11 +67,11 @@ class Layout extends React.Component {
             showAppCatalog={Object.keys(this.props.catalogs.items).length > 0}
             user={this.props.user}
           />
-          <Breadcrumb data={{ title: 'HOME', pathname: OtherRoutes.Home }}>
+          <Breadcrumb data={{ title: 'HOME', pathname: MainRoutes.Home }}>
             <div className='main'>
               <Switch>
                 {/*prettier-ignore*/}
-                <Route component={Home} exact path={OtherRoutes.Home} />
+                <Route component={Home} exact path={MainRoutes.Home} />
                 <Route component={AppCatalog} path={AppCatalogRoutes.Home} />
                 <Route component={Users} exact path={UsersRoutes.Home} />
                 <Route
@@ -90,10 +90,10 @@ class Layout extends React.Component {
                 />
 
                 {FeatureFlags.FEATURE_CP_ACCESS && (
-                  <Route component={CPLoginPage} path={OtherRoutes.CPAccess} />
+                  <Route component={CPLoginPage} path={MainRoutes.CPAccess} />
                 )}
 
-                <Redirect path='*' to={OtherRoutes.Home} />
+                <Redirect path='*' to={MainRoutes.Home} />
               </Switch>
             </div>
           </Breadcrumb>

--- a/src/components/NotFound/NotFound.js
+++ b/src/components/NotFound/NotFound.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 
 const NotFound = () => (
   <>
@@ -11,7 +11,7 @@ const NotFound = () => (
       In any case, what you were looking for isn&apos;t here! Sorry!
     </p>
     <p>
-      Go back to <Link to={AppRoutes.Home}>Home</Link>
+      Go back to <Link to={OtherRoutes.Home}>Home</Link>
     </p>
     <p>If you want to contact us about this issue, you can reach us here:</p>
     <p>

--- a/src/components/NotFound/NotFound.js
+++ b/src/components/NotFound/NotFound.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 
 const NotFound = () => (
   <>
@@ -11,7 +11,7 @@ const NotFound = () => (
       In any case, what you were looking for isn&apos;t here! Sorry!
     </p>
     <p>
-      Go back to <Link to={OtherRoutes.Home}>Home</Link>
+      Go back to <Link to={MainRoutes.Home}>Home</Link>
     </p>
     <p>If you want to contact us about this issue, you can reach us here:</p>
     <p>

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 
 import AdminLogin from './Auth/AdminLogin';
 import Login from './Auth/Login';
@@ -15,15 +15,15 @@ import StyleGuide from './UI/StyleGuide';
 const Routes = () => {
   return (
     <Switch>
-      <Route component={AdminLogin} path={OtherRoutes.AdminLogin} />
-      <Route component={Login} path={OtherRoutes.Login} />
-      <Route component={Logout} path={OtherRoutes.Logout} />
-      <Route component={SetPassword} path={OtherRoutes.SetPassword} />
-      <Route component={ForgotPassword} path={OtherRoutes.ForgotPassword} />
-      <Route component={SignUp} path={OtherRoutes.SignUp} />
-      <Route component={OAuthCallback} path={OtherRoutes.OAuthCallback} />
-      <Route component={StyleGuide} path={OtherRoutes.StyleGuide} />
-      <Route component={Layout} path={OtherRoutes.Home} />
+      <Route component={AdminLogin} path={MainRoutes.AdminLogin} />
+      <Route component={Login} path={MainRoutes.Login} />
+      <Route component={Logout} path={MainRoutes.Logout} />
+      <Route component={SetPassword} path={MainRoutes.SetPassword} />
+      <Route component={ForgotPassword} path={MainRoutes.ForgotPassword} />
+      <Route component={SignUp} path={MainRoutes.SignUp} />
+      <Route component={OAuthCallback} path={MainRoutes.OAuthCallback} />
+      <Route component={StyleGuide} path={MainRoutes.StyleGuide} />
+      <Route component={Layout} path={MainRoutes.Home} />
     </Switch>
   );
 };

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 
 import AdminLogin from './Auth/AdminLogin';
 import Login from './Auth/Login';
@@ -15,15 +15,15 @@ import StyleGuide from './UI/StyleGuide';
 const Routes = () => {
   return (
     <Switch>
-      <Route component={AdminLogin} path={AppRoutes.AdminLogin} />
-      <Route component={Login} path={AppRoutes.Login} />
-      <Route component={Logout} path={AppRoutes.Logout} />
-      <Route component={SetPassword} path={AppRoutes.SetPassword} />
-      <Route component={ForgotPassword} path={AppRoutes.ForgotPassword} />
-      <Route component={SignUp} path={AppRoutes.SignUp} />
-      <Route component={OAuthCallback} path={AppRoutes.OAuthCallback} />
-      <Route component={StyleGuide} path={AppRoutes.StyleGuide} />
-      <Route component={Layout} path={AppRoutes.Home} />
+      <Route component={AdminLogin} path={OtherRoutes.AdminLogin} />
+      <Route component={Login} path={OtherRoutes.Login} />
+      <Route component={Logout} path={OtherRoutes.Logout} />
+      <Route component={SetPassword} path={OtherRoutes.SetPassword} />
+      <Route component={ForgotPassword} path={OtherRoutes.ForgotPassword} />
+      <Route component={SignUp} path={OtherRoutes.SignUp} />
+      <Route component={OAuthCallback} path={OtherRoutes.OAuthCallback} />
+      <Route component={StyleGuide} path={OtherRoutes.StyleGuide} />
+      <Route component={Layout} path={OtherRoutes.Home} />
     </Switch>
   );
 };

--- a/src/components/SignUp/SignUp.js
+++ b/src/components/SignUp/SignUp.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { AuthorizationTypes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import Button from 'UI/Button';
 
@@ -150,7 +150,7 @@ export class SignUp extends React.Component {
     );
 
     setTimeout(() => {
-      this.props.dispatch(push(AppRoutes.Home));
+      this.props.dispatch(push(OtherRoutes.Home));
     }, transitionDelay);
   }
 

--- a/src/components/SignUp/SignUp.js
+++ b/src/components/SignUp/SignUp.js
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { AuthorizationTypes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import * as mainActions from 'stores/main/actions';
 import Button from 'UI/Button';
 
@@ -150,7 +150,7 @@ export class SignUp extends React.Component {
     );
 
     setTimeout(() => {
-      this.props.dispatch(push(OtherRoutes.Home));
+      this.props.dispatch(push(MainRoutes.Home));
     }, transitionDelay);
   }
 

--- a/src/components/UI/Navigation/MainMenu.js
+++ b/src/components/UI/Navigation/MainMenu.js
@@ -5,8 +5,8 @@ import { NavLink } from 'react-router-dom';
 import { CSSBreakpoints } from 'shared/constants';
 import {
   AppCatalogRoutes,
+  MainRoutes,
   OrganizationsRoutes,
-  OtherRoutes,
   UsersRoutes,
 } from 'shared/constants/routes';
 import { mq } from 'styles';
@@ -76,7 +76,7 @@ function MainMenu({ showAppCatalog, isUserAdmin }) {
   return (
     <>
       <NavDiv>
-        <StyledNavLink activeClassName='active' exact to={OtherRoutes.Home}>
+        <StyledNavLink activeClassName='active' exact to={MainRoutes.Home}>
           Clusters
         </StyledNavLink>
         <StyledNavLink activeClassName='active' to={OrganizationsRoutes.Home}>
@@ -121,7 +121,7 @@ function MainMenu({ showAppCatalog, isUserAdmin }) {
                   <DropdownNavLink
                     activeClassName='active'
                     exact
-                    to={OtherRoutes.Home}
+                    to={MainRoutes.Home}
                     onClick={onClickHandler}
                   >
                     Clusters

--- a/src/components/UI/Navigation/MainMenu.js
+++ b/src/components/UI/Navigation/MainMenu.js
@@ -5,8 +5,8 @@ import { NavLink } from 'react-router-dom';
 import { CSSBreakpoints } from 'shared/constants';
 import {
   AppCatalogRoutes,
-  AppRoutes,
   OrganizationsRoutes,
+  OtherRoutes,
   UsersRoutes,
 } from 'shared/constants/routes';
 import { mq } from 'styles';
@@ -76,7 +76,7 @@ function MainMenu({ showAppCatalog, isUserAdmin }) {
   return (
     <>
       <NavDiv>
-        <StyledNavLink activeClassName='active' exact to={AppRoutes.Home}>
+        <StyledNavLink activeClassName='active' exact to={OtherRoutes.Home}>
           Clusters
         </StyledNavLink>
         <StyledNavLink activeClassName='active' to={OrganizationsRoutes.Home}>
@@ -121,7 +121,7 @@ function MainMenu({ showAppCatalog, isUserAdmin }) {
                   <DropdownNavLink
                     activeClassName='active'
                     exact
-                    to={AppRoutes.Home}
+                    to={OtherRoutes.Home}
                     onClick={onClickHandler}
                   >
                     Clusters

--- a/src/components/UI/Navigation/Navigation.js
+++ b/src/components/UI/Navigation/Navigation.js
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import RUMActionTarget from 'RUM/RUMActionTarget';
 import { CSSBreakpoints } from 'shared/constants';
 import { RUMActions } from 'shared/constants/realUserMonitoring';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import { mq } from 'styles';
 
 import MainMenu from './MainMenu';
@@ -114,7 +114,7 @@ class Navigation extends React.Component {
       <OuterNav>
         <div className='main-nav'>
           <RUMActionTarget name={RUMActions.ClickMainNavLogo}>
-            <Link to={AppRoutes.Home}>
+            <Link to={OtherRoutes.Home}>
               <img className='logo' src={logo} />
             </Link>
           </RUMActionTarget>

--- a/src/components/UI/Navigation/Navigation.js
+++ b/src/components/UI/Navigation/Navigation.js
@@ -7,7 +7,7 @@ import { Link } from 'react-router-dom';
 import RUMActionTarget from 'RUM/RUMActionTarget';
 import { CSSBreakpoints } from 'shared/constants';
 import { RUMActions } from 'shared/constants/realUserMonitoring';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import { mq } from 'styles';
 
 import MainMenu from './MainMenu';
@@ -114,7 +114,7 @@ class Navigation extends React.Component {
       <OuterNav>
         <div className='main-nav'>
           <RUMActionTarget name={RUMActions.ClickMainNavLogo}>
-            <Link to={OtherRoutes.Home}>
+            <Link to={MainRoutes.Home}>
               <img className='logo' src={logo} />
             </Link>
           </RUMActionTarget>

--- a/src/components/UI/Navigation/OrganizationDropdown.js
+++ b/src/components/UI/Navigation/OrganizationDropdown.js
@@ -3,7 +3,7 @@ import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
-import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
 import DropdownMenu, { DropdownTrigger, List } from 'UI/DropdownMenu';
 import Truncated from 'UI/Truncated';
 
@@ -208,8 +208,8 @@ const OrganizationDropdown = ({
                       {sortedOrganizations.map((org) => (
                         <li role='presentation' key={org}>
                           <MenuItem
-                            href={AppRoutes.Home}
-                            to={AppRoutes.Home}
+                            href={OtherRoutes.Home}
+                            to={OtherRoutes.Home}
                             activeClassName=''
                             onClick={() => {
                               onSelectOrganization(org);

--- a/src/components/UI/Navigation/OrganizationDropdown.js
+++ b/src/components/UI/Navigation/OrganizationDropdown.js
@@ -3,7 +3,7 @@ import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
-import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import DropdownMenu, { DropdownTrigger, List } from 'UI/DropdownMenu';
 import Truncated from 'UI/Truncated';
 
@@ -208,8 +208,8 @@ const OrganizationDropdown = ({
                       {sortedOrganizations.map((org) => (
                         <li role='presentation' key={org}>
                           <MenuItem
-                            href={OtherRoutes.Home}
-                            to={OtherRoutes.Home}
+                            href={MainRoutes.Home}
+                            to={MainRoutes.Home}
                             activeClassName=''
                             onClick={() => {
                               onSelectOrganization(org);

--- a/src/components/UI/Navigation/UserDropdown.tsx
+++ b/src/components/UI/Navigation/UserDropdown.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Gravatar from 'react-gravatar';
 import { NavLink } from 'react-router-dom';
 import { AuthorizationTypes } from 'shared/constants';
-import { AccountSettingsRoutes, OtherRoutes } from 'shared/constants/routes';
+import { AccountSettingsRoutes, MainRoutes } from 'shared/constants/routes';
 import FeatureFlags from 'shared/FeatureFlags';
 import DropdownMenu, { DropdownTrigger, List } from 'UI/DropdownMenu';
 
@@ -113,15 +113,15 @@ const UserDropdown: React.FC<IUserDropdownProps> = ({ user }) => {
                 {FeatureFlags.FEATURE_CP_ACCESS && (
                   <li role='presentation'>
                     <MenuItem
-                      href={OtherRoutes.CPAccess}
-                      to={OtherRoutes.CPAccess}
+                      href={MainRoutes.CPAccess}
+                      to={MainRoutes.CPAccess}
                     >
                       Control Plane Access
                     </MenuItem>
                   </li>
                 )}
                 <li role='presentation'>
-                  <MenuItem href={OtherRoutes.Logout} to={OtherRoutes.Logout}>
+                  <MenuItem href={MainRoutes.Logout} to={MainRoutes.Logout}>
                     Logout
                   </MenuItem>
                 </li>

--- a/src/components/UI/Navigation/UserDropdown.tsx
+++ b/src/components/UI/Navigation/UserDropdown.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Gravatar from 'react-gravatar';
 import { NavLink } from 'react-router-dom';
 import { AuthorizationTypes } from 'shared/constants';
-import { AccountSettingsRoutes, AppRoutes } from 'shared/constants/routes';
+import { AccountSettingsRoutes, OtherRoutes } from 'shared/constants/routes';
 import FeatureFlags from 'shared/FeatureFlags';
 import DropdownMenu, { DropdownTrigger, List } from 'UI/DropdownMenu';
 
@@ -112,13 +112,16 @@ const UserDropdown: React.FC<IUserDropdownProps> = ({ user }) => {
                 )}
                 {FeatureFlags.FEATURE_CP_ACCESS && (
                   <li role='presentation'>
-                    <MenuItem href={AppRoutes.CPAccess} to={AppRoutes.CPAccess}>
+                    <MenuItem
+                      href={OtherRoutes.CPAccess}
+                      to={OtherRoutes.CPAccess}
+                    >
                       Control Plane Access
                     </MenuItem>
                   </li>
                 )}
                 <li role='presentation'>
-                  <MenuItem href={AppRoutes.Logout} to={AppRoutes.Logout}>
+                  <MenuItem href={OtherRoutes.Logout} to={OtherRoutes.Logout}>
                     Logout
                   </MenuItem>
                 </li>

--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
-import { AppRoutes, UsersRoutes } from 'shared/constants/routes';
+import { OtherRoutes, UsersRoutes } from 'shared/constants/routes';
 import {
   invitationCreate,
   invitationsLoad,
@@ -44,7 +44,7 @@ class Users extends React.Component {
         .dispatch(usersLoad())
         .then(this.props.dispatch(invitationsLoad()));
     } else {
-      this.props.dispatch(push(AppRoutes.Home));
+      this.props.dispatch(push(OtherRoutes.Home));
     }
   }
 

--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { connect } from 'react-redux';
-import { OtherRoutes, UsersRoutes } from 'shared/constants/routes';
+import { MainRoutes, UsersRoutes } from 'shared/constants/routes';
 import {
   invitationCreate,
   invitationsLoad,
@@ -44,7 +44,7 @@ class Users extends React.Component {
         .dispatch(usersLoad())
         .then(this.props.dispatch(invitationsLoad()));
     } else {
-      this.props.dispatch(push(OtherRoutes.Home));
+      this.props.dispatch(push(MainRoutes.Home));
     }
   }
 

--- a/src/lib/CPAuth/config.ts
+++ b/src/lib/CPAuth/config.ts
@@ -1,5 +1,5 @@
 import { IOAuth2Config } from 'lib/OAuth2/OAuth2';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 
 let authority = window.config.cpAudience;
 if (!/http(s)?:\/\//.test(authority)) {
@@ -20,7 +20,7 @@ export const defaultConfig: IOAuth2Config = {
   clientId: 'fFlz7lckhWA0kIaW3fLIl8chFSs2wvW6',
   clientSecret:
     'PoioOqWKUndxVnbcRzlv59EgvwPVJQIdIlved143Uko0SjGJ7OprnecZQbab3WhH',
-  redirectUri: `${window.location.origin}${AppRoutes.CPAccessCallback}`,
+  redirectUri: `${window.location.origin}${OtherRoutes.CPAccessCallback}`,
   scope:
     'openid offline_access profile email groups audience:server:client_id:dex-k8s-authenticator',
   responseType: 'code',

--- a/src/lib/CPAuth/config.ts
+++ b/src/lib/CPAuth/config.ts
@@ -1,5 +1,5 @@
 import { IOAuth2Config } from 'lib/OAuth2/OAuth2';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 
 let authority = window.config.cpAudience;
 if (!/http(s)?:\/\//.test(authority)) {
@@ -20,7 +20,7 @@ export const defaultConfig: IOAuth2Config = {
   clientId: 'fFlz7lckhWA0kIaW3fLIl8chFSs2wvW6',
   clientSecret:
     'PoioOqWKUndxVnbcRzlv59EgvwPVJQIdIlved143Uko0SjGJ7OprnecZQbab3WhH',
-  redirectUri: `${window.location.origin}${OtherRoutes.CPAccessCallback}`,
+  redirectUri: `${window.location.origin}${MainRoutes.CPAccessCallback}`,
   scope:
     'openid offline_access profile email groups audience:server:client_id:dex-k8s-authenticator',
   responseType: 'code',

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -1,4 +1,4 @@
-const AppRoutes = {
+const OtherRoutes = {
   Home: '/',
   AdminLogin: '/admin-login',
   Login: '/login',
@@ -59,9 +59,9 @@ const OrganizationsRoutes = {
 
 export {
   AccountSettingsRoutes,
-  AppRoutes,
   AppCatalogRoutes,
   OrganizationsRoutes,
+  OtherRoutes,
   UsersRoutes,
   ExceptionNotificationTestRoutes,
 };

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -1,4 +1,4 @@
-const OtherRoutes = {
+const MainRoutes = {
   Home: '/',
   AdminLogin: '/admin-login',
   Login: '/login',
@@ -61,7 +61,7 @@ export {
   AccountSettingsRoutes,
   AppCatalogRoutes,
   OrganizationsRoutes,
-  OtherRoutes,
+  MainRoutes,
   UsersRoutes,
   ExceptionNotificationTestRoutes,
 };

--- a/src/stores/batchActions.ts
+++ b/src/stores/batchActions.ts
@@ -5,7 +5,7 @@ import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import RoutePath from 'lib/routePath';
 import { AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { AppRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
 import FeatureFlags from 'shared/FeatureFlags';
 import { INodePool } from 'shared/types';
 import { listCatalogs } from 'stores/appcatalog/actions';
@@ -69,7 +69,7 @@ export function batchedLayout(): ThunkAction<
         messageType.WARNING,
         messageTTL.MEDIUM
       );
-      dispatch(push(AppRoutes.Login));
+      dispatch(push(OtherRoutes.Login));
       ErrorReporter.getInstance().notify(err);
 
       return;
@@ -302,7 +302,7 @@ export function batchedClusterDeleteConfirmed(
   return async (dispatch) => {
     try {
       await dispatch(clusterDeleteConfirmed(cluster));
-      dispatch(push(AppRoutes.Home));
+      dispatch(push(OtherRoutes.Home));
       dispatch(modalHide());
     } catch (err) {
       ErrorReporter.getInstance().notify(err);

--- a/src/stores/batchActions.ts
+++ b/src/stores/batchActions.ts
@@ -5,7 +5,7 @@ import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import RoutePath from 'lib/routePath';
 import { AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { OrganizationsRoutes, OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import FeatureFlags from 'shared/FeatureFlags';
 import { INodePool } from 'shared/types';
 import { listCatalogs } from 'stores/appcatalog/actions';
@@ -69,7 +69,7 @@ export function batchedLayout(): ThunkAction<
         messageType.WARNING,
         messageTTL.MEDIUM
       );
-      dispatch(push(OtherRoutes.Login));
+      dispatch(push(MainRoutes.Login));
       ErrorReporter.getInstance().notify(err);
 
       return;
@@ -302,7 +302,7 @@ export function batchedClusterDeleteConfirmed(
   return async (dispatch) => {
     try {
       await dispatch(clusterDeleteConfirmed(cluster));
-      dispatch(push(OtherRoutes.Home));
+      dispatch(push(MainRoutes.Home));
       dispatch(modalHide());
     } catch (err) {
       ErrorReporter.getInstance().notify(err);

--- a/src/stores/main/actions.ts
+++ b/src/stores/main/actions.ts
@@ -13,7 +13,7 @@ import { GiantSwarmClient } from 'model/clients/GiantSwarmClient';
 import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { ThunkAction } from 'redux-thunk';
 import { AuthorizationTypes, StatusCodes } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import {
   CLUSTER_SELECT,
   GLOBAL_LOAD_ERROR,
@@ -152,8 +152,8 @@ export function refreshUserInfo(): ThunkAction<
           messageTTL.MEDIUM
         );
         const redirectPath = loggedInUser.isAdmin
-          ? OtherRoutes.AdminLogin
-          : OtherRoutes.Login;
+          ? MainRoutes.AdminLogin
+          : MainRoutes.Login;
 
         dispatch(push(redirectPath));
       } else {
@@ -242,7 +242,7 @@ export function giantswarmLogin(
     } catch (err) {
       const message = (err as Error).message ?? (err as string);
       dispatch(loginError(message));
-      dispatch(push(OtherRoutes.Login));
+      dispatch(push(MainRoutes.Login));
 
       return Promise.reject(err);
     }
@@ -262,12 +262,12 @@ export function giantswarmLogout(): ThunkAction<
       const authTokensApi = new GiantSwarm.AuthTokensApi();
       await authTokensApi.deleteAuthToken();
 
-      dispatch(push(OtherRoutes.Login));
+      dispatch(push(MainRoutes.Login));
       dispatch(logoutSuccess());
 
       return Promise.resolve();
     } catch (err) {
-      dispatch(push(OtherRoutes.Login));
+      dispatch(push(MainRoutes.Login));
       dispatch(logoutError(err));
 
       return Promise.reject(err);

--- a/src/stores/main/actions.ts
+++ b/src/stores/main/actions.ts
@@ -13,7 +13,7 @@ import { GiantSwarmClient } from 'model/clients/GiantSwarmClient';
 import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { ThunkAction } from 'redux-thunk';
 import { AuthorizationTypes, StatusCodes } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import {
   CLUSTER_SELECT,
   GLOBAL_LOAD_ERROR,
@@ -152,8 +152,8 @@ export function refreshUserInfo(): ThunkAction<
           messageTTL.MEDIUM
         );
         const redirectPath = loggedInUser.isAdmin
-          ? AppRoutes.AdminLogin
-          : AppRoutes.Login;
+          ? OtherRoutes.AdminLogin
+          : OtherRoutes.Login;
 
         dispatch(push(redirectPath));
       } else {
@@ -242,7 +242,7 @@ export function giantswarmLogin(
     } catch (err) {
       const message = (err as Error).message ?? (err as string);
       dispatch(loginError(message));
-      dispatch(push(AppRoutes.Login));
+      dispatch(push(OtherRoutes.Login));
 
       return Promise.reject(err);
     }
@@ -262,12 +262,12 @@ export function giantswarmLogout(): ThunkAction<
       const authTokensApi = new GiantSwarm.AuthTokensApi();
       await authTokensApi.deleteAuthToken();
 
-      dispatch(push(AppRoutes.Login));
+      dispatch(push(OtherRoutes.Login));
       dispatch(logoutSuccess());
 
       return Promise.resolve();
     } catch (err) {
-      dispatch(push(AppRoutes.Login));
+      dispatch(push(OtherRoutes.Login));
       dispatch(logoutError(err));
 
       return Promise.reject(err);

--- a/testUtils/preloginState.js
+++ b/testUtils/preloginState.js
@@ -1,5 +1,5 @@
 import { Providers } from 'shared/constants';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 
 // This is what the state looks like when someone brand new arrives at the site
 // and they are not logged in at all.
@@ -7,7 +7,7 @@ import { OtherRoutes } from 'shared/constants/routes';
 export default {
   router: {
     location: {
-      pathname: OtherRoutes.Login,
+      pathname: MainRoutes.Login,
       search: '',
       hash: '',
       key: '0fgz24',

--- a/testUtils/preloginState.js
+++ b/testUtils/preloginState.js
@@ -1,5 +1,5 @@
 import { Providers } from 'shared/constants';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 
 // This is what the state looks like when someone brand new arrives at the site
 // and they are not logged in at all.
@@ -7,7 +7,7 @@ import { AppRoutes } from 'shared/constants/routes';
 export default {
   router: {
     location: {
-      pathname: AppRoutes.Login,
+      pathname: OtherRoutes.Login,
       search: '',
       hash: '',
       key: '0fgz24',

--- a/testUtils/renderUtils.js
+++ b/testUtils/renderUtils.js
@@ -1,12 +1,12 @@
+import { ThemeProvider } from '@emotion/react';
 import { render } from '@testing-library/react';
 import App from 'App';
 import { ConnectedRouter } from 'connected-react-router';
-import { ThemeProvider } from '@emotion/react';
 import { createMemoryHistory } from 'history';
 import CPAuth from 'lib/CPAuth/CPAuth';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { AppRoutes } from 'shared/constants/routes';
+import { OtherRoutes } from 'shared/constants/routes';
 import configureStore from 'stores/configureStore';
 import theme from 'styles/theme';
 
@@ -24,7 +24,7 @@ export const initialStorage = {
  * @param {CPAuth} cpAuth Control Plane API handler.
  */
 export function renderRouteWithStore(
-  initialRoute = AppRoutes.Home,
+  initialRoute = OtherRoutes.Home,
   state = {},
   storage = initialStorage,
   cpAuth = CPAuth.getInstance()

--- a/testUtils/renderUtils.js
+++ b/testUtils/renderUtils.js
@@ -6,7 +6,7 @@ import { createMemoryHistory } from 'history';
 import CPAuth from 'lib/CPAuth/CPAuth';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { OtherRoutes } from 'shared/constants/routes';
+import { MainRoutes } from 'shared/constants/routes';
 import configureStore from 'stores/configureStore';
 import theme from 'styles/theme';
 
@@ -24,7 +24,7 @@ export const initialStorage = {
  * @param {CPAuth} cpAuth Control Plane API handler.
  */
 export function renderRouteWithStore(
-  initialRoute = OtherRoutes.Home,
+  initialRoute = MainRoutes.Home,
   state = {},
   storage = initialStorage,
   cpAuth = CPAuth.getInstance()


### PR DESCRIPTION
Because I will be introducing `AppsRoutes` in another PR towards https://github.com/giantswarm/giantswarm/issues/13652

Having `AppRoutes` and `AppsRoutes` is a bit confusing to me. I'd like to reserve the App name for things specifically in the domain of the App Catalog / Managed Apps world.