### PR TITLE
Clarify that the EOL tag is associated with the Kubernetes release

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterApps.js
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.js
@@ -15,7 +15,7 @@ import {
 import { isClusterCreating, isClusterUpdating } from 'stores/cluster/utils';
 import { selectErrorByIdAndAction } from 'stores/entityerror/selectors';
 import { selectCluster } from 'stores/main/actions';
-import { getReleaseEOLStatus } from 'stores/releases/utils';
+import { getKubernetesReleaseEOLStatus } from 'stores/releases/utils';
 import Button from 'UI/Button';
 import ClusterDetailPreinstalledApp from 'UI/ClusterDetailPreinstalledApp';
 import FlashMessageComponent from 'UI/FlashMessage';
@@ -199,7 +199,9 @@ class ClusterApps extends React.Component {
       release.k8sVersionEOLDate &&
       !version.endsWith(Constants.APP_VERSION_EOL_SUFFIX)
     ) {
-      const { isEol } = getReleaseEOLStatus(release.k8sVersionEOLDate);
+      const { isEol } = getKubernetesReleaseEOLStatus(
+        release.k8sVersionEOLDate
+      );
       if (isEol) {
         return `${version} ${Constants.APP_VERSION_EOL_SUFFIX}`;
       }

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
@@ -12,7 +12,10 @@ import {
   getReleasesIsFetching,
   getSortedReleaseVersions,
 } from 'stores/releases/selectors';
-import { getReleaseEOLStatus, isPreRelease } from 'stores/releases/utils';
+import {
+  getKubernetesReleaseEOLStatus,
+  isPreRelease,
+} from 'stores/releases/utils';
 import {
   ListToggler,
   SelectedDescription,
@@ -76,7 +79,7 @@ const ReleaseSelector: FC<IReleaseSelector> = ({
       k8sVersionEOLDate &&
       !kubernetesVersion?.endsWith(Constants.APP_VERSION_EOL_SUFFIX)
     ) {
-      const { isEol } = getReleaseEOLStatus(k8sVersionEOLDate);
+      const { isEol } = getKubernetesReleaseEOLStatus(k8sVersionEOLDate);
       if (isEol) {
         return `${kubernetesVersion} ${Constants.APP_VERSION_EOL_SUFFIX}`;
       }

--- a/src/components/Modals/ReleaseDetailsModal/ReleaseDetailsModal.js
+++ b/src/components/Modals/ReleaseDetailsModal/ReleaseDetailsModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
 import { Constants, Providers } from 'shared/constants';
-import { getReleaseEOLStatus } from 'stores/releases/utils';
+import { getKubernetesReleaseEOLStatus } from 'stores/releases/utils';
 import Button from 'UI/Button';
 import ComponentChangelog from 'UI/ComponentChangelog';
 import ReleaseComponentLabel from 'UI/ReleaseComponentLabel';
@@ -21,7 +21,9 @@ class ReleaseDetailsModal extends React.Component {
       release.k8sVersionEOLDate &&
       !version.endsWith(Constants.APP_VERSION_EOL_SUFFIX)
     ) {
-      const { isEol } = getReleaseEOLStatus(release.k8sVersionEOLDate);
+      const { isEol } = getKubernetesReleaseEOLStatus(
+        release.k8sVersionEOLDate
+      );
       if (isEol) {
         return `${version} ${Constants.APP_VERSION_EOL_SUFFIX}`;
       }

--- a/src/components/UI/KubernetesVersionLabel.tsx
+++ b/src/components/UI/KubernetesVersionLabel.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useState } from 'react';
 import { Overlay } from 'react-bootstrap';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import { Constants } from 'shared/constants';
-import { getReleaseEOLStatus } from 'stores/releases/utils';
+import { getKubernetesReleaseEOLStatus } from 'stores/releases/utils';
 
 const EolLabel = styled.span`
   background: ${({ theme }) => theme.colors.darkBlueDarker3};
@@ -37,7 +37,7 @@ const KubernetesVersionLabel: React.FC<IKubernetesVersionLabelProps> = ({
   const labelRef = useRef<HTMLSpanElement>(null);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
-  const eolStatus = getReleaseEOLStatus(eolDate as string);
+  const eolStatus = getKubernetesReleaseEOLStatus(eolDate as string);
   const isEol = eolStatus.isEol && Boolean(version);
 
   const tryToToggleTooltip = (open: boolean) => () => {

--- a/src/components/UI/__tests__/KubernetesVersionLabel.tsx
+++ b/src/components/UI/__tests__/KubernetesVersionLabel.tsx
@@ -57,7 +57,7 @@ describe('KubernetesVersionLabel', () => {
     );
     expect(versionLabel).toBeInTheDocument();
 
-    let tooltipMessageRegexp = /This version reached its end of life/i;
+    let tooltipMessageRegexp = /This Kubernetes version reached its end of life/i;
     fireEvent.mouseEnter(versionLabel);
     expect(screen.getByText(tooltipMessageRegexp)).toBeInTheDocument();
     fireEvent.mouseLeave(versionLabel);
@@ -74,7 +74,7 @@ describe('KubernetesVersionLabel', () => {
     versionLabel = screen.getByLabelText(/end of life/i);
     expect(versionLabel).toBeInTheDocument();
 
-    tooltipMessageRegexp = /This version reached its end of life/i;
+    tooltipMessageRegexp = /This Kubernetes version reached its end of life/i;
     fireEvent.mouseEnter(versionLabel);
     expect(screen.getByText(tooltipMessageRegexp)).toBeInTheDocument();
     fireEvent.mouseLeave(versionLabel);

--- a/src/components/UI/__tests__/KubernetesVersionLabel.tsx
+++ b/src/components/UI/__tests__/KubernetesVersionLabel.tsx
@@ -92,7 +92,7 @@ describe('KubernetesVersionLabel', () => {
     expect(versionLabel).not.toBeInTheDocument();
 
     versionLabel = screen.getByText(/1.0/i);
-    tooltipMessageRegexp = /This version will reach its end of life/i;
+    tooltipMessageRegexp = /This Kubernetes version will reach its end of life/i;
     fireEvent.mouseEnter(versionLabel);
     expect(screen.getByText(tooltipMessageRegexp)).toBeInTheDocument();
     fireEvent.mouseLeave(versionLabel);

--- a/src/stores/releases/__tests__/utils.ts
+++ b/src/stores/releases/__tests__/utils.ts
@@ -1,13 +1,16 @@
-import { getReleaseEOLStatus, isPreRelease } from 'stores/releases/utils';
+import {
+  getKubernetesReleaseEOLStatus,
+  isPreRelease,
+} from 'stores/releases/utils';
 
 describe('releases::utils', () => {
-  describe('getReleaseEOLStatus', () => {
+  describe('getKubernetesReleaseEOLStatus', () => {
     // eslint-disable-next-line no-magic-numbers
     const oneDay = 24 * 60 * 60 * 1000;
 
     it('returns the correct status for a version that reached its EOL', () => {
       const date = new Date(Date.now() - oneDay).toISOString();
-      const result = getReleaseEOLStatus(date);
+      const result = getKubernetesReleaseEOLStatus(date);
 
       expect(result.isEol).toBeTruthy();
       expect(result.message).toBe(
@@ -17,7 +20,7 @@ describe('releases::utils', () => {
 
     it('returns the correct status for a version that just reached its EOL now', () => {
       const date = new Date(Date.now()).toISOString();
-      const result = getReleaseEOLStatus(date);
+      const result = getKubernetesReleaseEOLStatus(date);
 
       expect(result.isEol).toBeTruthy();
       expect(result.message).toMatch(
@@ -27,7 +30,7 @@ describe('releases::utils', () => {
 
     it('returns the correct status for a version that will reach its EOL at some point', () => {
       const date = new Date(Date.now() + oneDay).toISOString();
-      const result = getReleaseEOLStatus(date);
+      const result = getKubernetesReleaseEOLStatus(date);
 
       expect(result.isEol).toBeFalsy();
       expect(result.message).toBe(
@@ -36,7 +39,7 @@ describe('releases::utils', () => {
     });
 
     it('returns the correct status for a version with an unknown EOL date', () => {
-      const result = getReleaseEOLStatus('');
+      const result = getKubernetesReleaseEOLStatus('');
 
       expect(result.isEol).toBeFalsy();
       expect(result.message).toBe('');

--- a/src/stores/releases/__tests__/utils.ts
+++ b/src/stores/releases/__tests__/utils.ts
@@ -14,7 +14,7 @@ describe('releases::utils', () => {
 
       expect(result.isEol).toBeTruthy();
       expect(result.message).toBe(
-        'This version reached its end of life a day ago.'
+        'This Kubernetes version reached its end of life a day ago.'
       );
     });
 
@@ -24,7 +24,7 @@ describe('releases::utils', () => {
 
       expect(result.isEol).toBeTruthy();
       expect(result.message).toMatch(
-        /This version reached its end of life (today|a few seconds ago)\./
+        /This Kubernetes version reached its end of life (today|a few seconds ago)\./
       );
     });
 
@@ -34,7 +34,7 @@ describe('releases::utils', () => {
 
       expect(result.isEol).toBeFalsy();
       expect(result.message).toBe(
-        'This version will reach its end of life in a day.'
+        'This Kubernetes version will reach its end of life in a day.'
       );
     });
 

--- a/src/stores/releases/utils.ts
+++ b/src/stores/releases/utils.ts
@@ -1,6 +1,6 @@
 import { compareDates, getRelativeDateFromNow } from 'lib/helpers';
 
-export function getReleaseEOLStatus(
+export function getKubernetesReleaseEOLStatus(
   eolDate: string
 ): { message: string; isEol: boolean } {
   const result = {

--- a/src/stores/releases/utils.ts
+++ b/src/stores/releases/utils.ts
@@ -14,14 +14,14 @@ export function getReleaseEOLStatus(
   const relativeDate = getRelativeDateFromNow(eolDate);
   switch (compareDates(now, eolDate)) {
     case -1:
-      result.message = `This version will reach its end of life ${relativeDate}.`;
+      result.message = `This Kuberntes version will reach its end of life ${relativeDate}.`;
       break;
     case 0:
-      result.message = 'This version reached its end of life today.';
+      result.message = 'This Kuberntes version reached its end of life today.';
       result.isEol = true;
       break;
     case 1:
-      result.message = `This version reached its end of life ${relativeDate}.`;
+      result.message = `This Kuberntes version reached its end of life ${relativeDate}.`;
       result.isEol = true;
       break;
   }

--- a/src/stores/releases/utils.ts
+++ b/src/stores/releases/utils.ts
@@ -14,14 +14,14 @@ export function getKubernetesReleaseEOLStatus(
   const relativeDate = getRelativeDateFromNow(eolDate);
   switch (compareDates(now, eolDate)) {
     case -1:
-      result.message = `This Kuberntes version will reach its end of life ${relativeDate}.`;
+      result.message = `This Kubernetes version will reach its end of life ${relativeDate}.`;
       break;
     case 0:
-      result.message = 'This Kuberntes version reached its end of life today.';
+      result.message = 'This Kubernetes version reached its end of life today.';
       result.isEol = true;
       break;
     case 1:
-      result.message = `This Kuberntes version reached its end of life ${relativeDate}.`;
+      result.message = `This Kubernetes version reached its end of life ${relativeDate}.`;
       result.isEol = true;
       break;
   }


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/14987

This PR adds clarification regarding the `EOL`( end of life) marker displayed next to a Kubernetes version. This should help avoid the impression that the Giant Swarm tenant cluster release is EOL.

The wording change makes the function specific to Kubernetes, so I renamed it from `getReleaseEOLStatus` to `getKubernetesReleaseEOLStatus`.

## Preview

### Before

![image](https://user-images.githubusercontent.com/273727/103640375-2b750780-4f50-11eb-8f60-f51b2f3318f4.png)

### After

![image](https://user-images.githubusercontent.com/273727/103641436-097c8480-4f52-11eb-8d3c-e76b7ecf8ca9.png)

