### PR TITLE
Change variables to uppercase

### DIFF
--- a/scripts/webpack/getServiceURL.js
+++ b/scripts/webpack/getServiceURL.js
@@ -36,9 +36,9 @@ const getInstallationInfo = function (installation) {
 const getServiceURL = (installation, service) => {
   const installationInfo = getInstallationInfo(installation);
 
-  const { scheme, host } = installationInfo.services[service];
-  const hostWithoutPort = host.split(':')[0];
-  return scheme + '://' + hostWithoutPort;
+  const { Scheme, Host } = installationInfo.Services[service];
+  const hostWithoutPort = Host.split(':')[0];
+  return Scheme + '://' + hostWithoutPort;
 };
 
 module.exports = getServiceURL;


### PR DESCRIPTION
This updates happa to the latest behaviour of `opsctl show installation`, which prints some variables we need with mixed case names.