### PR TITLE
Increase dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
     rebase-strategy: "disabled"
     reviewers:
       - giantswarm/chapter-front-end


### PR DESCRIPTION
With the current limit, we are not moving when one PR is in process.