### PR TITLE
Improve number picker UX to allow the user enter the value they want

### DIFF
--- a/__tests__/V4AzureClusterManagement.js
+++ b/__tests__/V4AzureClusterManagement.js
@@ -166,14 +166,14 @@ describe('V4AzureClusterManagement', () => {
 
     fireEvent.change(azInput, {
       target: {
-        value: defaultAZCount - 1,
+        value: defaultAZCount,
       },
     });
     expect(azInput.value).toBe(String(defaultAZCount));
 
     fireEvent.change(azInput, {
       target: {
-        value: maxAZCount + 1,
+        value: maxAZCount,
       },
     });
     expect(azInput.value).toBe(String(maxAZCount));

--- a/src/components/UI/NumberPicker.js
+++ b/src/components/UI/NumberPicker.js
@@ -251,6 +251,8 @@ class NumberPicker extends React.Component {
                   this.state.inputValue === this.props.min && 'disabled'
                 }
                 onClick={this.decrement}
+                aria-label='Decrement'
+                role='button'
               >
                 &ndash;
               </DecrementButton>
@@ -278,6 +280,8 @@ class NumberPicker extends React.Component {
               <IncrementButton
                 className={this.props.value === this.props.max && 'disabled'}
                 onClick={this.increment}
+                aria-label='Increment'
+                role='button'
               >
                 +
               </IncrementButton>

--- a/src/components/UI/NumberPicker.js
+++ b/src/components/UI/NumberPicker.js
@@ -145,37 +145,43 @@ class NumberPicker extends React.Component {
     const currentValue = this.props.value;
     const desiredValue = currentValue + this.props.stepSize;
 
-    this.updateInput({
-      target: { value: desiredValue },
-    });
+    this.updateInput(desiredValue);
   };
 
   decrement = () => {
     const currentValue = this.props.value;
     const desiredValue = currentValue - this.props.stepSize;
 
-    this.updateInput({
-      target: { value: desiredValue },
-    });
+    this.updateInput(desiredValue);
   };
 
-  updateInput = (e) => {
-    const desiredValue = e.target.value;
-
+  updateInput = (desiredValue, allowInvalidValues = false) => {
     // Validate.
     // eslint-disable-next-line prefer-const
     let { value, validationError } = this.validateInput(desiredValue);
 
     // Ensure values are never above max or below min. They can be null.
     const { max, min } = this.props;
-    value = value === null ? '' : value < min ? min : value > max ? max : value;
+    switch (true) {
+      case value === null:
+        value = '';
+        break;
+      case !allowInvalidValues && value < min:
+        value = min;
+        break;
+      case !allowInvalidValues && value > max:
+        value = max;
+        break;
+    }
+
+    const isValid = validationError.length < 1 || (min <= 0 && value === 0);
 
     // Update state.
     this.setState(
       {
         inputValue: value,
         value,
-        valid: Boolean(value) || (min <= 0 && value === 0),
+        valid: isValid,
         validationError,
       },
       () => {
@@ -253,9 +259,7 @@ class NumberPicker extends React.Component {
           <ValueSpan>
             <input
               disabled={this.props.readOnly}
-              // max={this.props.max}
-              // min={this.props.min}
-              onChange={this.updateInput}
+              onChange={(e) => this.updateInput(e.target.value, true)}
               onFocus={this.handleFocus}
               step={this.props.stepSize}
               type='number'

--- a/src/components/shared/__tests__/NodeCountSelector.js
+++ b/src/components/shared/__tests__/NodeCountSelector.js
@@ -50,29 +50,30 @@ describe('NodeCountSelector', () => {
 
   it('respects value constraints, with autoscale off', () => {
     const minValue = 5;
-    const maxValue = 8;
+    const maxValue = 5;
 
-    const { getByTestId } = renderWithProps({
+    const { getByTestId, getByRole } = renderWithProps({
       autoscalingEnabled: false,
       minValue,
       maxValue,
     });
     const input = getByTestId(labelTestID).querySelector('input');
 
-    fireEvent.change(input, {
-      target: {
-        value: '3',
-      },
+    const decrementButton = getByRole('button', {
+      name: 'Decrement',
+    });
+    const incrementButton = getByRole('button', {
+      name: 'Increment',
     });
 
+    for (let i = 0; i < 9; i++) {
+      fireEvent.click(decrementButton);
+    }
     expect(input.value).toBe(`${minValue}`);
 
-    fireEvent.change(input, {
-      target: {
-        value: '10',
-      },
-    });
-
+    for (let i = 0; i < 9; i++) {
+      fireEvent.click(incrementButton);
+    }
     expect(input.value).toBe(`${maxValue}`);
   });
 
@@ -80,7 +81,7 @@ describe('NodeCountSelector', () => {
     const minValue = 5;
     const maxValue = 8;
 
-    const { getAllByTestId } = renderWithProps({
+    const { getAllByTestId, getAllByRole } = renderWithProps({
       autoscalingEnabled: true,
       minValue,
       maxValue,
@@ -88,17 +89,17 @@ describe('NodeCountSelector', () => {
     const inputs = getAllByTestId(labelTestID).map((label) =>
       label.querySelector('input')
     );
+    const decrementButtons = getAllByRole('button', {
+      name: 'Decrement',
+    });
+    const incrementButtons = getAllByRole('button', {
+      name: 'Increment',
+    });
 
-    fireEvent.change(inputs[0], {
-      target: {
-        value: '3',
-      },
-    });
-    fireEvent.change(inputs[1], {
-      target: {
-        value: '10',
-      },
-    });
+    for (let i = 0; i < 9; i++) {
+      fireEvent.click(decrementButtons[0]);
+      fireEvent.click(incrementButtons[1]);
+    }
 
     expect(inputs[0].value).toBe(`${minValue}`);
     expect(inputs[1].value).toBe(`${maxValue}`);


### PR DESCRIPTION
Reproduce the problem:
- Enter the cluster creation page
- Select a release version that supports node pool autoscaling
- Try to create a new node pool, set the minimum scaling to `3`, and select the text in the maximum input, and try to enter `20`
- Notice that the value is `30` instead of `20`

With this PR, we let the user enter the value they want via keyboard. But don't worry, if the user tries to enter an invalid value, the input will be marked as invalid, and a validation error will be shown. This improves UX by letting the user enter the value they want.

cc @whites11 for extra details about the issue

Affected components:
- Node pool scaling (both autoscaling on or off)
- Node pool availability zone count
- V4 cluster creation availability zone counter