### PR TITLE
Add a search query input, sorting dropdown, and an area for facets

### DIFF
--- a/src/components/Apps/AppsList/AppsList.tsx
+++ b/src/components/Apps/AppsList/AppsList.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 import styled from 'styled-components';
 import App from 'UI/AppList/App';
 
+import Facets from './Facets';
+import Toolbar from './Toolbar';
+
 const ListAndFacets = styled.div`
   display: flex;
-`;
-
-const Facets = styled.div`
-  width: 230px;
-  flex-shrink: 0;
 `;
 
 const List = styled.div`
@@ -18,6 +16,21 @@ const List = styled.div`
   border-left: 1px solid ${({ theme }) => theme.colors.darkBlueLighter1};
   width: 100%;
   padding-left: 20px;
+`;
+
+const Icon = styled.img`
+  width: 20px;
+  margin-right: 6px;
+`;
+
+const CatalogType = styled.span`
+  background-color: #8dc163;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 0px 6px;
+  border-radius: 3px;
+  margin-left: 8px;
+  color: #222;
 `;
 
 const AppsList: React.FC = () => {
@@ -36,9 +49,42 @@ const AppsList: React.FC = () => {
         </a>
       </p>
       <hr />
-
+      <Toolbar matchCount={10} />
       <ListAndFacets>
-        <Facets />
+        <Facets
+          options={[
+            {
+              value: 'giantswarm',
+              label: (
+                <>
+                  <Icon src='/images/repo_icons/managed.png' />
+                  Giant Swarm <CatalogType>MANAGED</CatalogType>
+                </>
+              ),
+              checked: false,
+            },
+            {
+              value: 'giantswarm-playground',
+              label: (
+                <>
+                  <Icon src='/images/repo_icons/incubator.png' />
+                  Giant Swarm Playground
+                </>
+              ),
+              checked: false,
+            },
+            {
+              value: 'helm-stable',
+              label: (
+                <>
+                  <Icon src='/images/repo_icons/community.png' />
+                  Helm Stable
+                </>
+              ),
+              checked: false,
+            },
+          ]}
+        />
         <List>
           {[
             'g8s-prometheus',
@@ -50,7 +96,6 @@ const AppsList: React.FC = () => {
             'prometheus-mongodb-exporter',
             'prometheus-pushgateway',
             'prometheus-postgres-exporter',
-            ...Array(100).fill('other app'),
           ].map((name) => (
             <App
               key={name}

--- a/src/components/Apps/AppsList/AppsList.tsx
+++ b/src/components/Apps/AppsList/AppsList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import App from 'UI/AppList/App';
+import Facets from 'UI/Inputs/Facets';
 
-import Facets from './Facets';
 import Toolbar from './Toolbar';
 
 const ListAndFacets = styled.div`
@@ -52,6 +52,9 @@ const AppsList: React.FC = () => {
       <Toolbar matchCount={10} />
       <ListAndFacets>
         <Facets
+          onChange={(value, checked) => {
+            console.log(value, checked);
+          }}
           options={[
             {
               value: 'giantswarm',
@@ -61,7 +64,7 @@ const AppsList: React.FC = () => {
                   Giant Swarm <CatalogType>MANAGED</CatalogType>
                 </>
               ),
-              checked: false,
+              checked: true,
             },
             {
               value: 'giantswarm-playground',

--- a/src/components/Apps/AppsList/Facets.tsx
+++ b/src/components/Apps/AppsList/Facets.tsx
@@ -1,0 +1,59 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import Checkbox from 'UI/Inputs/Checkbox';
+
+const Wrapper = styled.div`
+  width: 270px;
+  flex-shrink: 0;
+`;
+
+const CatalogList = styled.ul`
+  padding: 0px;
+  list-style-type: none;
+`;
+
+const ListItem = styled.li`
+  display: flex;
+  align-items: center;
+`;
+
+interface IFacetsProps {
+  errorMessage?: string;
+  options: IFacetOption[];
+}
+
+interface IFacetOption {
+  value: string;
+  checked: boolean;
+  label: JSX.Element;
+}
+
+const Facets: React.FC<IFacetsProps> = (props) => {
+  return (
+    <Wrapper>
+      <label>Filter by Catalog</label>
+      <CatalogList>
+        {props.options.map((o) => (
+          <ListItem key={o.value}>
+            <Checkbox
+              checked={o.checked}
+              onChange={() => {
+                console.log(o.value);
+              }}
+              label={o.label}
+            />
+          </ListItem>
+        ))}
+      </CatalogList>
+      {props.errorMessage && <span>{props.errorMessage}</span>}
+    </Wrapper>
+  );
+};
+
+Facets.propTypes = {
+  errorMessage: PropTypes.string,
+  options: PropTypes.array.isRequired,
+};
+
+export default Facets;

--- a/src/components/Apps/AppsList/SortingDropdown.tsx
+++ b/src/components/Apps/AppsList/SortingDropdown.tsx
@@ -1,0 +1,114 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import DropdownMenu, {
+  DropdownTrigger,
+  Link,
+  List,
+} from 'UI/Controls/DropdownMenu';
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledDropdownTrigger = styled(DropdownTrigger)`
+  width: unset;
+  display: flex;
+  align-items: center;
+  padding: 0px 15px;
+  background-color: ${({ theme }) => theme.colors.darkBlueDarker1};
+
+  .caret {
+    margin-left: 10px;
+  }
+`;
+
+const StyledList = styled(List)``;
+
+interface ISortingDropdownProps {
+  setSortingOrder: (order: string) => void;
+}
+
+const SortingDropdown: React.FC<ISortingDropdownProps> = (props) => {
+  return (
+    <Wrapper {...props}>
+      <DropdownMenu
+        render={({
+          isOpen,
+          onClickHandler,
+          onFocusHandler,
+          onBlurHandler,
+          onKeyDownHandler,
+        }) => (
+          <div onBlur={onBlurHandler} onFocus={onFocusHandler}>
+            <StyledDropdownTrigger
+              aria-expanded={isOpen}
+              aria-haspopup='true'
+              onClick={onClickHandler}
+              onKeyDown={onKeyDownHandler}
+              type='button'
+            >
+              Name
+              <span className='caret' />
+            </StyledDropdownTrigger>
+            {isOpen && (
+              <StyledList>
+                <li role='presentation'>
+                  <Link
+                    href='#'
+                    onClick={(e) => {
+                      e.preventDefault();
+                      props.setSortingOrder('Name');
+                    }}
+                  >
+                    Name
+                  </Link>
+                </li>
+                <li role='presentation'>
+                  <Link
+                    href='#'
+                    onClick={(e) => {
+                      e.preventDefault();
+                      props.setSortingOrder('Catalog');
+                    }}
+                  >
+                    Catalog
+                  </Link>
+                </li>
+                <li role='presentation'>
+                  <Link
+                    href='#'
+                    onClick={(e) => {
+                      e.preventDefault();
+                      props.setSortingOrder('Latest');
+                    }}
+                  >
+                    Latest release (newest first)
+                  </Link>
+                </li>
+                <li role='presentation'>
+                  <Link
+                    href='#'
+                    onClick={(e) => {
+                      e.preventDefault();
+                      props.setSortingOrder('Relevance');
+                    }}
+                  >
+                    Relevance for search term
+                  </Link>
+                </li>
+              </StyledList>
+            )}
+          </div>
+        )}
+      />
+    </Wrapper>
+  );
+};
+
+SortingDropdown.propTypes = {
+  setSortingOrder: PropTypes.func.isRequired,
+};
+
+export default SortingDropdown;

--- a/src/components/Apps/AppsList/Toolbar.tsx
+++ b/src/components/Apps/AppsList/Toolbar.tsx
@@ -1,0 +1,75 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import Input from 'UI/Inputs/Input';
+
+import SortingDropdown from './SortingDropdown';
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+`;
+const Search = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const SearchInput = styled(Input)`
+  margin-right: 10px;
+  margin-bottom: 0px;
+  width: 280px;
+`;
+
+const StyledSortingDropdown = styled(SortingDropdown)`
+  margin-left: 8px;
+`;
+
+const Sort = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+function matchCountMessage(count: number) {
+  if (count === 1) {
+    return `Showing 1 app matching your query`;
+  }
+
+  if (count > 1) {
+    return `Showing ${count} apps matching your query`;
+  }
+
+  // Anything less than 1, or non numbers
+  return 'No apps match your query';
+}
+
+interface IToolbarProps {
+  matchCount: number;
+}
+
+const Toolbar: React.FC<IToolbarProps> = (props) => {
+  return (
+    <Wrapper>
+      <Search>
+        <SearchInput hideHint />
+        {matchCountMessage(props.matchCount)}
+      </Search>
+
+      <Sort>
+        Sort by{' '}
+        <StyledSortingDropdown
+          setSortingOrder={(x: string) => {
+            console.log(x);
+          }}
+        />
+      </Sort>
+    </Wrapper>
+  );
+};
+
+Toolbar.propTypes = {
+  matchCount: PropTypes.number.isRequired,
+};
+
+export default Toolbar;

--- a/src/components/UI/AppList/Icon.tsx
+++ b/src/components/UI/AppList/Icon.tsx
@@ -26,22 +26,16 @@ function acronymize(text: string) {
   return acronym;
 }
 
-interface IStyledImageWithFallbackProps {
-  outlineColor: string;
-}
-
-const StyledImageWithFallback = styled(
-  ImgWithFallback
-)<IStyledImageWithFallbackProps>`
-  font-size: 40px;
-  align-items: center;
-  font-weight: 800;
-  justify-content: center;
-  text-shadow: -1px -1px 0 ${({ outlineColor }) => outlineColor},
-    1px -1px 0 ${({ outlineColor }) => outlineColor},
-    -1px 1px 0 ${({ outlineColor }) => outlineColor},
-    1px 1px 0 ${({ outlineColor }) => outlineColor};
-`;
+const StyledImageWithFallback = (outlinecolor: string) => {
+  return styled(ImgWithFallback)`
+    font-size: 40px;
+    align-items: center;
+    font-weight: 800;
+    justify-content: center;
+    text-shadow: -1px -1px 0 ${outlinecolor}, 1px -1px 0 ${outlinecolor},
+      -1px 1px 0 ${outlinecolor}, 1px 1px 0 ${outlinecolor};
+  `;
+};
 
 interface IIconProps {
   name: string;
@@ -49,11 +43,12 @@ interface IIconProps {
 }
 
 const Icon: React.FC<IIconProps> = ({ name, src }) => {
+  const Image = StyledImageWithFallback(colorHash.calculateColor(name));
+
   return (
-    <StyledImageWithFallback
+    <Image
       src={src}
       alt={name}
-      outlineColor={colorHash.calculateColor(name)}
       fallback={{
         label: acronymize(name),
         backgroundColor: 'transparent',

--- a/src/components/UI/AppList/Icon.tsx
+++ b/src/components/UI/AppList/Icon.tsx
@@ -26,16 +26,22 @@ function acronymize(text: string) {
   return acronym;
 }
 
-const StyledImageWithFallback = (outlinecolor: string) => {
-  return styled(ImgWithFallback)`
-    font-size: 40px;
-    align-items: center;
-    font-weight: 800;
-    justify-content: center;
-    text-shadow: -1px -1px 0 ${outlinecolor}, 1px -1px 0 ${outlinecolor},
-      -1px 1px 0 ${outlinecolor}, 1px 1px 0 ${outlinecolor};
-  `;
-};
+interface IStyledImageWithFallbackProps {
+  outlinecolor: string;
+}
+
+const StyledImageWithFallback = styled(
+  ImgWithFallback
+)<IStyledImageWithFallbackProps>`
+  font-size: 40px;
+  align-items: center;
+  font-weight: 800;
+  justify-content: center;
+  text-shadow: -1px -1px 0 ${({ outlinecolor }) => outlinecolor},
+    1px -1px 0 ${({ outlinecolor }) => outlinecolor},
+    -1px 1px 0 ${({ outlinecolor }) => outlinecolor},
+    1px 1px 0 ${({ outlinecolor }) => outlinecolor};
+`;
 
 interface IIconProps {
   name: string;
@@ -43,10 +49,9 @@ interface IIconProps {
 }
 
 const Icon: React.FC<IIconProps> = ({ name, src }) => {
-  const Image = StyledImageWithFallback(colorHash.calculateColor(name));
-
   return (
-    <Image
+    <StyledImageWithFallback
+      outlinecolor={colorHash.calculateColor(name)}
       src={src}
       alt={name}
       fallback={{

--- a/src/components/UI/Inputs/Checkbox.js
+++ b/src/components/UI/Inputs/Checkbox.js
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 
 const CheckboxWrapper = styled.span`
   cursor: pointer;
+  display: flex;
+  align-items: center;
 `;
 
 const FaCheckBoxIcon = styled.i`
@@ -12,6 +14,8 @@ const FaCheckBoxIcon = styled.i`
 
 const CheckboxLabel = styled.span`
   margin-left: 5px;
+  display: flex;
+  align-items: center;
 `;
 
 const Checkbox = ({ checked, label, onChange }) => {

--- a/src/components/UI/Inputs/Facets.tsx
+++ b/src/components/UI/Inputs/Facets.tsx
@@ -21,6 +21,7 @@ const ListItem = styled.li`
 interface IFacetsProps {
   errorMessage?: string;
   options: IFacetOption[];
+  onChange: (value: string, checked: boolean) => void;
 }
 
 interface IFacetOption {
@@ -38,9 +39,7 @@ const Facets: React.FC<IFacetsProps> = (props) => {
           <ListItem key={o.value}>
             <Checkbox
               checked={o.checked}
-              onChange={() => {
-                console.log(o.value);
-              }}
+              onChange={props.onChange.bind(this, o.value)}
               label={o.label}
             />
           </ListItem>
@@ -54,6 +53,7 @@ const Facets: React.FC<IFacetsProps> = (props) => {
 Facets.propTypes = {
   errorMessage: PropTypes.string,
   options: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default Facets;

--- a/src/components/UI/Inputs/Input.tsx
+++ b/src/components/UI/Inputs/Input.tsx
@@ -64,6 +64,7 @@ export interface IInput<T> {
   className?: string;
   description?: ReactNode;
   hint?: ReactNode;
+  hideHint?: boolean;
   icon?: string;
   inputId?: string;
   label?: string;
@@ -110,7 +111,7 @@ const Input: FC<IInput<string | FileList>> = (props) => {
           <i className='fa fa-warning' /> {props.validationError}
         </ValidationError>
       ) : (
-        <Hint>{props.hint ?? <>&nbsp;</>}</Hint>
+        !props.hideHint && <Hint>{props.hint ?? <>&nbsp;</>}</Hint>
       )}
     </Wrapper>
   );
@@ -121,6 +122,7 @@ Input.propTypes = {
   className: PropTypes.string,
   description: PropTypes.string,
   hint: PropTypes.node,
+  hideHint: PropTypes.bool,
   icon: PropTypes.string,
   inputId: PropTypes.string,
   label: PropTypes.string,


### PR DESCRIPTION
This adds the remaining UI elements and controls to the new App listing page.

Not hooked up to any actual data yet. Just the UI elements, and a bit of the presentational logic.

Icons will have to have transparent backgrounds, but used what we have for now.

<img width="1299" alt="Screenshot 2021-01-24 at 10 03 59 PM" src="https://user-images.githubusercontent.com/455309/105632796-18d75980-5e90-11eb-8104-5e0ab3fb976d.png">
