### PR TITLE
Fix release selector buttons being cut off

### DIFF
--- a/src/components/UI/Controls/ExpandableSelector/Items.tsx
+++ b/src/components/UI/Controls/ExpandableSelector/Items.tsx
@@ -2,13 +2,11 @@ import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
 
 export const TableButton = styled(Button)`
-  height: 24px;
-  line-height: 24px;
   position: relative;
-  top: -2px;
   margin-left: 5px;
   padding: 0px 15px;
   text-transform: uppercase;
+
   i {
     margin-right: 4px;
   }


### PR DESCRIPTION
This probably occured as a result of the button refactor

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/13508038/106007191-53bad680-60b6-11eb-8582-1b0e74d83795.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/13508038/106007052-2cfca000-60b6-11eb-9920-2953ce5245b5.png)

</details>
