### PR TITLE
Allow setting node counter values in any order

### DIFF
--- a/src/components/UI/Inputs/NumberPicker.js
+++ b/src/components/UI/Inputs/NumberPicker.js
@@ -141,6 +141,14 @@ class NumberPicker extends React.Component {
     validationError: '',
   };
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.max !== this.props.max || prevProps.min !== this.props.min) {
+      const { validationError } = this.validateInput(this.state.value);
+      const isValid = validationError.length < 1;
+      this.updateValue(this.state.value, isValid, validationError);
+    }
+  }
+
   increment = () => {
     const currentValue = this.props.value;
     const desiredValue = currentValue + this.props.stepSize;
@@ -176,11 +184,14 @@ class NumberPicker extends React.Component {
 
     const isValid = validationError.length < 1 || (min <= 0 && value === 0);
 
-    // Update state.
+    this.updateValue(value, isValid, validationError);
+  };
+
+  updateValue(newValue, isValid = false, validationError = '') {
     this.setState(
       {
-        inputValue: value,
-        value,
+        inputValue: newValue,
+        value: newValue,
         valid: isValid,
         validationError,
       },
@@ -194,7 +205,7 @@ class NumberPicker extends React.Component {
         }
       }
     );
-  };
+  }
 
   validateInput = (desiredValue) => {
     if (desiredValue === '') {
@@ -268,6 +279,7 @@ class NumberPicker extends React.Component {
               value={
                 this.props.readOnly ? this.props.value : this.state.inputValue
               }
+              title={this.props.title}
             />
           </ValueSpan>
           {this.props.readOnly ? undefined : (
@@ -304,6 +316,7 @@ NumberPicker.propTypes = {
   readOnly: PropTypes.bool,
   theme: PropTypes.string,
   className: PropTypes.string,
+  title: PropTypes.string,
   /** This string is appended to the user action event names recorded in Real User Monitoring. Should be UPPERCASE. */
   eventNameSuffix: PropTypes.string,
 };

--- a/src/components/UI/Inputs/NumberPicker.js
+++ b/src/components/UI/Inputs/NumberPicker.js
@@ -143,9 +143,9 @@ class NumberPicker extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.max !== this.props.max || prevProps.min !== this.props.min) {
-      const { validationError } = this.validateInput(this.state.value);
+      const { value, validationError } = this.validateInput(this.state.value);
       const isValid = validationError.length < 1;
-      this.updateValue(this.state.value, isValid, validationError);
+      this.updateValue(value, isValid, validationError);
     }
   }
 

--- a/src/components/shared/NodeCountSelector.js
+++ b/src/components/shared/NodeCountSelector.js
@@ -78,6 +78,7 @@ class NodeCountSelector extends React.Component {
                   stepSize={DEFAULT_VALUE_CONSTRAINTS.stepSize}
                   value={scaling.min}
                   eventNameSuffix='SCALING_MIN'
+                  title='Minimum'
                 />
               </label>
             </InnerTwoInputArea>
@@ -95,6 +96,7 @@ class NodeCountSelector extends React.Component {
                   stepSize={DEFAULT_VALUE_CONSTRAINTS.stepSize}
                   value={scaling.max}
                   eventNameSuffix='SCALING_MAX'
+                  title='Maximum'
                 />
               </label>
             </InnerTwoInputArea>
@@ -120,6 +122,7 @@ class NodeCountSelector extends React.Component {
             stepSize={DEFAULT_VALUE_CONSTRAINTS.stepSize}
             value={scaling.min}
             eventNameSuffix='WORKER_NODES'
+            title='Count'
           />
         </label>
       </form>

--- a/src/components/shared/__tests__/NodeCountSelector.js
+++ b/src/components/shared/__tests__/NodeCountSelector.js
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import NodeCountSelector from 'shared/NodeCountSelector';
 import { getComponentWithTheme } from 'testUtils/renderUtils';
 
@@ -290,5 +290,78 @@ describe('NodeCountSelector', () => {
     expect(getByTestId(autoScalingLabelTestID).textContent).toBe(
       'To disable autoscaling, set both numbers to the same value.'
     );
+  });
+
+  it('allows setting the autoscaling values in any order', () => {
+    const onChangeMockFn = jest.fn();
+    const baseProps = {
+      autoscalingEnabled: true,
+      minValue: 1,
+      maxValue: 99,
+      onChange: onChangeMockFn,
+    };
+
+    const scaling = {
+      min: 3,
+      minValid: true,
+      max: 10,
+      maxValid: true,
+    };
+
+    const { rerender } = renderWithProps({
+      ...baseProps,
+      scaling,
+    });
+
+    const minInputElement = screen.getByTitle('Minimum');
+    const maxInputElement = screen.getByTitle('Maximum');
+
+    fireEvent.change(maxInputElement, { target: { value: 2 } });
+    scaling.max = 2;
+    scaling.maxValid = false;
+    scaling.minValid = false;
+    rerender(
+      getComponent({
+        ...baseProps,
+        scaling,
+      })
+    );
+    expect(onChangeMockFn).toHaveBeenLastCalledWith({ scaling });
+
+    fireEvent.change(minInputElement, { target: { value: 2 } });
+    scaling.min = 2;
+    scaling.maxValid = true;
+    scaling.minValid = true;
+    rerender(
+      getComponent({
+        ...baseProps,
+        scaling,
+      })
+    );
+    expect(onChangeMockFn).toHaveBeenLastCalledWith({ scaling });
+
+    fireEvent.change(minInputElement, { target: { value: 5 } });
+    scaling.min = 5;
+    scaling.maxValid = false;
+    scaling.minValid = false;
+    rerender(
+      getComponent({
+        ...baseProps,
+        scaling,
+      })
+    );
+    expect(onChangeMockFn).toHaveBeenLastCalledWith({ scaling });
+
+    fireEvent.change(maxInputElement, { target: { value: 8 } });
+    scaling.max = 8;
+    scaling.maxValid = true;
+    scaling.minValid = true;
+    rerender(
+      getComponent({
+        ...baseProps,
+        scaling,
+      })
+    );
+    expect(onChangeMockFn).toHaveBeenLastCalledWith({ scaling });
   });
 });


### PR DESCRIPTION
This was a problem found by the app destroyer (@whites11).

Let's say you wanted to create a node pool, and you wanted to set up the autoscaling configuration. Let's say you don't want any autoscaling, and you want `2` nodes set to both minimum and maximum.
If you set the `MIN` value first, and the `MAX` value second, everything's perfect. However, if you set the `MAX` value first, and then the `MIN` value, you'll still see the validation error near the `MAX` input, and you wouldn't be able to create your node pool, even though the values are valid (theoretically).

This PR addresses the issue by re-validating the number pickers if their minimum or maximum limits change.