### PR TITLE
Catalog facets part 2

### DIFF
--- a/src/components/AppCatalog/AppCatalog.js
+++ b/src/components/AppCatalog/AppCatalog.js
@@ -13,7 +13,7 @@ import CatalogList from './CatalogList/CatalogList';
 
 class AppCatalog extends React.Component {
   catalogLoadIndex = (catalog) => {
-    return this.props.dispatch(catalogLoadIndex(catalog));
+    return this.props.dispatch(catalogLoadIndex(catalog.metadata.name));
   };
 
   render() {

--- a/src/components/Apps/AppsList/AppsList.tsx
+++ b/src/components/Apps/AppsList/AppsList.tsx
@@ -2,94 +2,12 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { disableCatalog, enableCatalog } from 'stores/appcatalog/actions';
 import { selectCatalogs } from 'stores/appcatalog/selectors';
-import { IAppCatalogsState } from 'stores/appcatalog/types';
 import { getUserIsAdmin } from 'stores/main/selectors';
 import AppsListPage from 'UI/Display/Apps/AppList/AppsListPage';
-import CatalogLabel from 'UI/Display/Apps/AppList/CatalogLabel';
-import { IFacetOption } from 'UI/Inputs/Facets';
 
-interface IAppsListProps {}
+import { catalogsToFacets } from './utils';
 
-// Determines if a catalog is an internal catalog or not.
-// We changed the location of this information at some point, so happa currently
-// supports both. TODO: Check if there are any catalogs left with the old label
-// if not, simplify this code.
-const isInternal = (catalog: IAppCatalog): boolean => {
-  const labels = catalog.metadata.labels;
-
-  if (labels) {
-    const catalogType = labels['application.giantswarm.io/catalog-type'];
-    const catalogVisibility =
-      labels['application.giantswarm.io/catalog-visibility'];
-
-    return catalogType === 'internal' || catalogVisibility === 'internal';
-  }
-
-  return false;
-};
-
-// Admins can see all catalogs.
-// Non admins can only see non internal catalogs.
-const filterFunc = (isAdmin: boolean) => {
-  return ([_, catalog]: [string, IAppCatalog]) => {
-    if (isAdmin) {
-      return true;
-    }
-
-    return !isInternal(catalog);
-  };
-};
-
-// Group internal catalogs together, but sort the groups alphabetically.
-// This makes internal catalogs appear at the bottom, and normal catalogs
-// appear at the top. And within those groups the catalogs are alphabetically
-// sorted.
-const sortFunc = (
-  [, a]: [string, IAppCatalog],
-  [, b]: [string, IAppCatalog]
-) => {
-  const aIsInternal = isInternal(a);
-  const aTitle = a.spec.title;
-
-  const bIsInternal = isInternal(b);
-  const bTitle = b.spec.title;
-
-  if (aIsInternal && !bIsInternal) {
-    return 1;
-  } else if (!aIsInternal && bIsInternal) {
-    return -1;
-  }
-  if (aTitle < bTitle) {
-    return -1;
-  } else if (aTitle > bTitle) {
-    return 1;
-  }
-
-  return 0;
-};
-
-function catalogsToFacets(
-  catalogs: IAppCatalogsState,
-  isAdmin: boolean
-): IFacetOption[] {
-  return Object.entries(catalogs.items)
-    .filter(filterFunc(isAdmin))
-    .sort(sortFunc)
-    .map(([key, catalog]) => {
-      return {
-        value: key,
-        checked: catalogs.ui.selectedCatalogs[key],
-        label: (
-          <CatalogLabel
-            catalogName={catalog.spec.title}
-            iconUrl={catalog.spec.logoURL}
-          />
-        ),
-      };
-    });
-}
-
-const AppsList: React.FC<IAppsListProps> = () => {
+const AppsList: React.FC = () => {
   const dispatch = useDispatch();
   const isAdmin = useSelector(getUserIsAdmin);
   const catalogs = useSelector(selectCatalogs);

--- a/src/components/Apps/AppsList/utils.tsx
+++ b/src/components/Apps/AppsList/utils.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { IAppCatalogsState } from 'stores/appcatalog/types';
+import CatalogLabel from 'UI/Display/Apps/AppList/CatalogLabel';
+import { IFacetOption } from 'UI/Inputs/Facets';
+
+// Determines if a catalog is an internal catalog or not.
+// We changed the location of this information at some point, so happa currently
+// supports both. TODO: Check if there are any catalogs left with the old label
+// if not, simplify this code.
+const isInternal = (catalog: IAppCatalog): boolean => {
+  const labels = catalog.metadata.labels;
+
+  if (labels) {
+    const catalogType = labels['application.giantswarm.io/catalog-type'];
+    const catalogVisibility =
+      labels['application.giantswarm.io/catalog-visibility'];
+
+    return catalogType === 'internal' || catalogVisibility === 'internal';
+  }
+
+  return false;
+};
+
+// Admins can see all catalogs.
+// Non admins can only see non internal catalogs.
+const filterFunc = (isAdmin: boolean) => {
+  return ([_, catalog]: [string, IAppCatalog]) => {
+    if (isAdmin) {
+      return true;
+    }
+
+    return !isInternal(catalog);
+  };
+};
+
+// Group internal catalogs together, but sort the groups alphabetically.
+// This makes internal catalogs appear at the bottom, and normal catalogs
+// appear at the top. And within those groups the catalogs are alphabetically
+// sorted.
+const sortFunc = (
+  [, a]: [string, IAppCatalog],
+  [, b]: [string, IAppCatalog]
+) => {
+  const aIsInternal = isInternal(a);
+  const aTitle = a.spec.title;
+
+  const bIsInternal = isInternal(b);
+  const bTitle = b.spec.title;
+
+  if (aIsInternal && !bIsInternal) {
+    return 1;
+  } else if (!aIsInternal && bIsInternal) {
+    return -1;
+  }
+  if (aTitle < bTitle) {
+    return -1;
+  } else if (aTitle > bTitle) {
+    return 1;
+  }
+
+  return 0;
+};
+
+export function catalogsToFacets(
+  catalogs: IAppCatalogsState,
+  isAdmin: boolean
+): IFacetOption[] {
+  return Object.entries(catalogs.items)
+    .filter(filterFunc(isAdmin))
+    .sort(sortFunc)
+    .map(([key, catalog]) => {
+      return {
+        value: key,
+        checked: catalogs.ui.selectedCatalogs[key],
+        label: (
+          <CatalogLabel
+            catalogName={catalog.spec.title}
+            iconUrl={catalog.spec.logoURL}
+          />
+        ),
+      };
+    });
+}

--- a/src/components/Apps/AppsList/utils.tsx
+++ b/src/components/Apps/AppsList/utils.tsx
@@ -23,7 +23,7 @@ const isInternal = (catalog: IAppCatalog): boolean => {
 
 // Admins can see all catalogs.
 // Non admins can only see non internal catalogs.
-const filterFunc = (isAdmin: boolean) => {
+export const filterFunc = (isAdmin: boolean) => {
   return ([_, catalog]: [string, IAppCatalog]) => {
     if (isAdmin) {
       return true;

--- a/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.stories.tsx
+++ b/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.stories.tsx
@@ -13,13 +13,15 @@ const Template: Story<IAppDetailPageProps> = (args) => (
   <AppDetailPage {...args} />
 );
 
+const THEYEAR = 2021;
+
 export const WithReadme = Template.bind({});
 WithReadme.args = {
   appTitle: 'efk-stack-app',
   appIconURL: 'https://dummyimage.com/125/125/fff',
   catalogName: 'Giant Swarm Managed',
   chartVersion: 'v0.3.2',
-  createDate: new Date(2021, 0, 1),
+  createDate: new Date(THEYEAR, 0, 1),
   includesVersion: 'v1.9.0',
   description: 'Open Distro for ElasticSearch',
   website: 'github.com/giantswarm/efk-stack-app',
@@ -33,7 +35,7 @@ WithoutReadme.args = {
   appIconURL: 'https://dummyimage.com/125/125/fff',
   catalogName: 'Giant Swarm Managed',
   chartVersion: 'v0.3.2',
-  createDate: new Date(2021, 0, 1),
+  createDate: new Date(THEYEAR, 0, 1),
   includesVersion: 'v1.9.0',
   description: 'Open Distro for ElasticSearch',
   website: 'github.com/giantswarm/efk-stack-app',

--- a/src/components/UI/Display/Apps/AppList/AppsListPage.stories.tsx
+++ b/src/components/UI/Display/Apps/AppList/AppsListPage.stories.tsx
@@ -16,9 +16,7 @@ const Template: Story<IAppsListPageProps> = (args) => (
 export const Standard = Template.bind({});
 Standard.args = {
   matchCount: 10,
-  onChangeFacets: (value, checked) => {
-    console.log(value, checked);
-  },
+  onChangeFacets: () => {},
   apps: [
     {
       name: 'g8s-prometheus',
@@ -114,9 +112,7 @@ Standard.args = {
 export const EmptyState = Template.bind({});
 EmptyState.args = {
   matchCount: 0,
-  onChangeFacets: (value, checked) => {
-    console.log(value, checked);
-  },
+  onChangeFacets: () => {},
   apps: [],
   facetOptions: [
     {

--- a/src/components/UI/Display/Apps/AppList/Toolbar.tsx
+++ b/src/components/UI/Display/Apps/AppList/Toolbar.tsx
@@ -57,12 +57,7 @@ const Toolbar: React.FC<IToolbarProps> = (props) => {
       </Search>
 
       <Sort>
-        Sort by{' '}
-        <StyledSortingDropdown
-          setSortingOrder={(x: string) => {
-            console.log(x);
-          }}
-        />
+        Sort by <StyledSortingDropdown setSortingOrder={() => {}} />
       </Sort>
     </Wrapper>
   );

--- a/src/stores/appcatalog/actions.ts
+++ b/src/stores/appcatalog/actions.ts
@@ -13,9 +13,6 @@ import {
   CATALOG_LOAD_INDEX_REQUEST,
   CATALOG_LOAD_INDEX_SUCCESS,
   CATALOGS_LIST,
-  CATALOGS_LOAD_ERROR,
-  CATALOGS_LOAD_REQUEST,
-  CATALOGS_LOAD_SUCCESS,
   CLUSTER_CREATE_APP_CONFIG_ERROR,
   CLUSTER_CREATE_APP_CONFIG_REQUEST,
   CLUSTER_CREATE_APP_CONFIG_SUCCESS,
@@ -116,53 +113,6 @@ export const listCatalogs = createAsynchronousAction<
   shouldPerform: () => true,
   throwOnError: false,
 });
-
-export function catalogsLoad(): ThunkAction<
-  Promise<IAppCatalogsMap>,
-  IState,
-  void,
-  AppCatalogActions
-> {
-  return async (dispatch) => {
-    try {
-      dispatch({ type: CATALOGS_LOAD_REQUEST });
-
-      const appsApi = new GiantSwarm.AppsApi();
-      const response = await appsApi.getAppCatalogs();
-      const catalogs = Array.from(response).reduce(
-        (agg: IAppCatalogsMap, currCatalog: IAppCatalog) => {
-          const { labels } = currCatalog.metadata;
-
-          if (
-            labels &&
-            labels['application.giantswarm.io/catalog-type'] !== 'internal'
-          ) {
-            currCatalog.isFetchingIndex = true;
-            agg[currCatalog.metadata.name] = currCatalog;
-          }
-
-          return agg;
-        },
-        {}
-      );
-
-      dispatch({
-        type: CATALOGS_LOAD_SUCCESS,
-        catalogs,
-      });
-
-      return catalogs;
-    } catch (err) {
-      const message = (err as Error).message ?? (err as string);
-      dispatch({
-        type: CATALOGS_LOAD_ERROR,
-        error: message,
-      });
-
-      return Promise.reject(err);
-    }
-  };
-}
 
 export function catalogLoadIndex(
   catalog: IAppCatalog

--- a/src/stores/appcatalog/types.ts
+++ b/src/stores/appcatalog/types.ts
@@ -5,9 +5,6 @@ import {
   CATALOGS_LIST_ERROR,
   CATALOGS_LIST_REQUEST,
   CATALOGS_LIST_SUCCESS,
-  CATALOGS_LOAD_ERROR,
-  CATALOGS_LOAD_REQUEST,
-  CATALOGS_LOAD_SUCCESS,
   CLUSTER_CREATE_APP_CONFIG_ERROR,
   CLUSTER_CREATE_APP_CONFIG_REQUEST,
   CLUSTER_CREATE_APP_CONFIG_SUCCESS,
@@ -98,20 +95,6 @@ export interface IAppCatalogLoadIndexErrorAction {
   type: typeof CATALOG_LOAD_INDEX_ERROR;
   catalogName: string;
   id: string;
-  error: string;
-}
-
-export interface IAppCatalogLoadRequestAction {
-  type: typeof CATALOGS_LOAD_REQUEST;
-}
-
-export interface IAppCatalogLoadSuccessAction {
-  type: typeof CATALOGS_LOAD_SUCCESS;
-  catalogs: IAppCatalogsMap;
-}
-
-export interface IAppCatalogLoadErrorAction {
-  type: typeof CATALOGS_LOAD_ERROR;
   error: string;
 }
 
@@ -388,9 +371,6 @@ export type AppCatalogActions =
   | IAppCatalogLoadIndexRequestAction
   | IAppCatalogLoadIndexSuccessAction
   | IAppCatalogLoadIndexErrorAction
-  | IAppCatalogLoadRequestAction
-  | IAppCatalogLoadSuccessAction
-  | IAppCatalogLoadErrorAction
   | IAppCatalogLoadAppReadmeRequestAction
   | IAppCatalogLoadAppReadmeSuccessAction
   | IAppCatalogLoadAppReadmeErrorAction


### PR DESCRIPTION
Now enabling a catalog on actually causes the catalog index to load. 

I don't load the helm-stable catalog on startup, but all the other available catalogs I do.

Also fixes some unrelated linting warnings.