### PR TITLE
Show an error and reduce opacity of facet if catalog index failed to …

### DIFF
--- a/src/components/Apps/AppsList/AppsList.tsx
+++ b/src/components/Apps/AppsList/AppsList.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { disableCatalog, enableCatalog } from 'stores/appcatalog/actions';
+import { CATALOG_LOAD_INDEX_REQUEST } from 'stores/appcatalog/constants';
 import { selectCatalogs } from 'stores/appcatalog/selectors';
+import { selectErrorsByIdsAndAction } from 'stores/entityerror/selectors';
 import { getUserIsAdmin } from 'stores/main/selectors';
 import AppsListPage from 'UI/Display/Apps/AppList/AppsListPage';
 
@@ -11,6 +13,13 @@ const AppsList: React.FC = () => {
   const dispatch = useDispatch();
   const isAdmin = useSelector(getUserIsAdmin);
   const catalogs = useSelector(selectCatalogs);
+
+  const catalogErrors = useSelector(
+    selectErrorsByIdsAndAction(
+      Object.keys(catalogs.items),
+      CATALOG_LOAD_INDEX_REQUEST
+    )
+  );
 
   return (
     <AppsListPage
@@ -23,7 +32,7 @@ const AppsList: React.FC = () => {
         }
       }}
       apps={[]}
-      facetOptions={catalogsToFacets(catalogs, isAdmin)}
+      facetOptions={catalogsToFacets(catalogs, catalogErrors, isAdmin)}
     />
   );
 };

--- a/src/components/Apps/AppsList/utils.tsx
+++ b/src/components/Apps/AppsList/utils.tsx
@@ -63,6 +63,7 @@ const sortFunc = (
 
 export function catalogsToFacets(
   catalogs: IAppCatalogsState,
+  catalogErrors: { [key: string]: string },
   isAdmin: boolean
 ): IFacetOption[] {
   return Object.entries(catalogs.items)
@@ -76,6 +77,7 @@ export function catalogsToFacets(
           <CatalogLabel
             catalogName={catalog.spec.title}
             iconUrl={catalog.spec.logoURL}
+            error={catalogErrors[catalog.metadata.name]}
           />
         ),
       };

--- a/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
+++ b/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
@@ -4,10 +4,11 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
-  &.hasError {
-    opacity: 0.4;
-  }
+const LOW_OPACITY = 0.4;
+const NORMAL_OPACITY = 1;
+
+const Wrapper = styled.div<{ hasError: boolean }>`
+  opacity: ${({ hasError }) => (hasError ? LOW_OPACITY : NORMAL_OPACITY)};
 `;
 
 const Icon = styled.img`
@@ -58,7 +59,7 @@ ErrorIcon.propTypes = {
 
 const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
   return (
-    <Wrapper {...props} className={props.error ? 'hasError' : ''}>
+    <Wrapper {...props} hasError={Boolean(props.error)}>
       <Icon src={props.iconUrl} />
       {props.catalogName}
       {props.isManaged && <CatalogType>MANAGED</CatalogType>}&nbsp;

--- a/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
+++ b/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
@@ -1,8 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
 import styled from 'styled-components';
 
-const Wrapper = styled.div``;
+const Wrapper = styled.div`
+  &.hasError {
+    opacity: 0.4;
+  }
+`;
 
 const Icon = styled.img`
   width: 20px;
@@ -19,18 +25,44 @@ const CatalogType = styled.span`
   color: #222;
 `;
 
+const RedIcon = styled.i`
+  color: ${({ theme }) => theme.colors.redOld};
+`;
+
 export interface ICatalogLabelProps {
   iconUrl: string;
   catalogName: string;
   isManaged?: boolean;
+  error?: string;
 }
+
+const ErrorIcon: React.FC<{ name: string }> = ({ name }) => {
+  return (
+    <OverlayTrigger
+      overlay={
+        <Tooltip id={`app-catalog-load-error-${name}`}>
+          This app catalog could not be loaded. Apps from this catalog cannot be
+          displayed.
+        </Tooltip>
+      }
+      placement='top'
+    >
+      <RedIcon className='fa fa-warning' />
+    </OverlayTrigger>
+  );
+};
+
+ErrorIcon.propTypes = {
+  name: PropTypes.string.isRequired,
+};
 
 const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
   return (
-    <Wrapper {...props}>
+    <Wrapper {...props} className={props.error ? 'hasError' : ''}>
       <Icon src={props.iconUrl} />
       {props.catalogName}
-      {props.isManaged && <CatalogType>MANAGED</CatalogType>}
+      {props.isManaged && <CatalogType>MANAGED</CatalogType>}&nbsp;
+      {props.error && <ErrorIcon name={props.catalogName} />}
     </Wrapper>
   );
 };
@@ -39,6 +71,7 @@ CatalogLabel.propTypes = {
   iconUrl: PropTypes.string.isRequired,
   catalogName: PropTypes.string.isRequired,
   isManaged: PropTypes.bool,
+  error: PropTypes.string,
 };
 
 export default CatalogLabel;

--- a/src/stores/entityerror/selectors.ts
+++ b/src/stores/entityerror/selectors.ts
@@ -8,3 +8,16 @@ export function selectErrorByIdAndAction(
 ) {
   return state.errorsByEntity[id]?.[typeWithoutSuffix(actionType)] ?? null;
 }
+
+export function selectErrorsByIdsAndAction(ids: string[], actionType: string) {
+  return function (state: IState) {
+    const errors: { [key: string]: string } = {};
+
+    ids.forEach((id) => {
+      errors[id] =
+        state.errorsByEntity[id]?.[typeWithoutSuffix(actionType)] ?? null;
+    });
+
+    return errors;
+  };
+}


### PR DESCRIPTION
This adds some error visibility to the catalog load index action. If a catalog fails to load, we reduce the opacity of its facet and add a red warning icon with a tooltip explaining something went wrong.

<img width="1251" alt="Screenshot 2021-02-03 at 11 48 45 PM" src="https://user-images.githubusercontent.com/455309/106773802-70d64300-667c-11eb-9424-5f2b7ce2ba5c.png">
