### PR TITLE
Make currency input have consistent layout on all major browsers

### DIFF
--- a/src/components/UI/Inputs/CurrencyInput/index.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/index.tsx
@@ -22,6 +22,9 @@ const StyledInput = styled(InputElement)`
   border: 0;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+  flex: 1 1 0;
+  width: calc(100% - 36px);
+  height: 32px;
 `;
 
 const CurrencyLabel = styled.div<{ disabled?: boolean }>`
@@ -33,6 +36,9 @@ const CurrencyLabel = styled.div<{ disabled?: boolean }>`
   padding: 8px 10px;
   line-height: 1rem;
   font-size: 14px;
+  height: 32px;
+  width: 36px;
+  flex: 0 0 0;
 `;
 
 const LabelText = styled.label`

--- a/src/components/UI/Inputs/CurrencyInput/index.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/index.tsx
@@ -25,6 +25,7 @@ const StyledInput = styled(InputElement)`
   flex: 1 1 0;
   width: calc(100% - 36px);
   height: 32px;
+  border-radius: 0;
 `;
 
 const CurrencyLabel = styled.div<{ disabled?: boolean }>`


### PR DESCRIPTION
#### The problem

![image](https://user-images.githubusercontent.com/13508038/107021671-bdb53900-67a4-11eb-9016-c8aedd11e164.png)

#### The solution

<details>
<summary>Chrome</summary>

![image](https://user-images.githubusercontent.com/13508038/107021960-14227780-67a5-11eb-98f6-673f7c1eb6c1.png)

</details>

<details>
<summary>Firefox</summary>

![image](https://user-images.githubusercontent.com/13508038/107021978-197fc200-67a5-11eb-99ea-c8d8706d50af.png)

</details>

<details>
<summary>Safari</summary>

![image](https://user-images.githubusercontent.com/13508038/107021989-1e447600-67a5-11eb-86a7-695f36966d70.png)

</details>