### PR TITLE
Wire apps into the applist

### DIFF
--- a/src/@types/appcatalogs.d.ts
+++ b/src/@types/appcatalogs.d.ts
@@ -16,6 +16,14 @@ interface IAppCatalogStorage {
 }
 
 interface IAppCatalogApp {
+  name: string;
+  catalogName: string;
+  catalogIconURL: string;
+  appIconURL: string;
+  versions: IAppCatalogAppVersion[];
+}
+
+interface IAppCatalogAppVersion {
   apiVersion: string;
   appVersion: string;
   version: string;
@@ -38,7 +46,7 @@ interface IAppCatalogAppAnnotations {
 }
 
 interface IAppCatalogAppMap {
-  [name: string]: IAppCatalogApp[];
+  [name: string]: IAppCatalogAppVersion[];
 }
 
 interface IAppCatalog {

--- a/src/components/Apps/AppsList/AppsList.tsx
+++ b/src/components/Apps/AppsList/AppsList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { disableCatalog, enableCatalog } from 'stores/appcatalog/actions';
 import { CATALOG_LOAD_INDEX_REQUEST } from 'stores/appcatalog/constants';
-import { selectCatalogs } from 'stores/appcatalog/selectors';
+import { selectApps, selectCatalogs } from 'stores/appcatalog/selectors';
 import { selectErrorsByIdsAndAction } from 'stores/entityerror/selectors';
 import { getUserIsAdmin } from 'stores/main/selectors';
 import AppsListPage from 'UI/Display/Apps/AppList/AppsListPage';
@@ -21,9 +21,11 @@ const AppsList: React.FC = () => {
     )
   );
 
+  const apps = useSelector(selectApps);
+
   return (
     <AppsListPage
-      matchCount={0}
+      matchCount={apps.length}
       onChangeFacets={(value, checked) => {
         if (checked) {
           dispatch(enableCatalog(value));
@@ -31,7 +33,12 @@ const AppsList: React.FC = () => {
           dispatch(disableCatalog(value));
         }
       }}
-      apps={[]}
+      apps={apps.map((app) => ({
+        name: app.name,
+        catalogName: app.catalogName,
+        to: '/example',
+        catalogIconUrl: app.catalogIconURL,
+      }))}
       facetOptions={catalogsToFacets(catalogs, catalogErrors, isAdmin)}
     />
   );

--- a/src/components/UI/Display/Apps/AppList/App.tsx
+++ b/src/components/UI/Display/Apps/AppList/App.tsx
@@ -71,7 +71,7 @@ const App: React.FC<IAppProps> = (props) => {
         <StyledCatalogLabel
           catalogName={props.catalogName}
           isManaged={props.catalogIsManaged}
-          iconUrl='https://dummyimage.com/125/125/fff'
+          iconUrl={props.catalogIconUrl}
         />
       </DetailWrapper>
     </Wrapper>

--- a/src/components/UI/Display/Apps/AppList/AppsListPage.tsx
+++ b/src/components/UI/Display/Apps/AppList/AppsListPage.tsx
@@ -82,12 +82,12 @@ const AppsList: React.FC<IAppsListPageProps> = (props) => {
 
         {props.apps && props.apps.length > 0 && (
           <List>
-            {props.apps.map((app) => (
+            {props.apps.map((app, i) => (
               <App
-                key={app.name}
+                key={app.name + i.toString()}
                 name={app.name}
                 catalogName={app.catalogName}
-                catalogIconUrl=''
+                catalogIconUrl={app.catalogIconUrl}
                 to='/apps/catalogName/appName/v1.2.3/'
               />
             ))}

--- a/src/stores/appcatalog/__tests__/actions.ts
+++ b/src/stores/appcatalog/__tests__/actions.ts
@@ -48,7 +48,7 @@ describe('appcatalog::actions', () => {
     it('dispatches an error if receiving an appVersion without a sources field to check for README URLs', async () => {
       const initialState = {} as IState;
       const store = mockStore(initialState);
-      const invalidAppVersion = {} as IAppCatalogApp;
+      const invalidAppVersion = {} as IAppCatalogAppVersion;
 
       await store.dispatch(loadAppReadme('notUnderTest', invalidAppVersion));
 
@@ -72,7 +72,7 @@ describe('appcatalog::actions', () => {
     it('dispatches an error if receiving an appVersion without a README annotation', async () => {
       const initialState = {} as IState;
       const store = mockStore(initialState);
-      const appVersionWithEmptySources = ({} as unknown) as IAppCatalogApp;
+      const appVersionWithEmptySources = ({} as unknown) as IAppCatalogAppVersion;
 
       await store.dispatch(
         loadAppReadme('notUnderTest', appVersionWithEmptySources)
@@ -100,7 +100,7 @@ describe('appcatalog::actions', () => {
       const store = mockStore(initialState);
       const appVersionWithEmptySources = ({
         sources: [],
-      } as unknown) as IAppCatalogApp;
+      } as unknown) as IAppCatalogAppVersion;
 
       await store.dispatch(
         loadAppReadme('notUnderTest', appVersionWithEmptySources)
@@ -135,7 +135,7 @@ describe('appcatalog::actions', () => {
 
       const appVersionWithReadmeInSources = {
         sources: ['http://mockserver.fake/README.md'],
-      } as IAppCatalogApp;
+      } as IAppCatalogAppVersion;
 
       await store.dispatch(
         loadAppReadme('notUnderTest', appVersionWithReadmeInSources)
@@ -174,7 +174,7 @@ describe('appcatalog::actions', () => {
           'application.giantswarm.io/readme':
             'http://mockserver.fake/README.md',
         },
-      } as IAppCatalogApp;
+      } as IAppCatalogAppVersion;
 
       await store.dispatch(
         loadAppReadme('notUnderTest', appVersionWithReadmeInSources)
@@ -213,7 +213,7 @@ describe('appcatalog::actions', () => {
         sources: [
           'http://mockserver.fake/1.2.3-REALLY-LONG-COMMIT-SHA/README.md',
         ],
-      } as IAppCatalogApp;
+      } as IAppCatalogAppVersion;
 
       await store.dispatch(
         loadAppReadme('notUnderTest', appVersionWithTestVersionReadmeInSources)
@@ -252,7 +252,7 @@ describe('appcatalog::actions', () => {
         sources: [
           'http://mockserver.fake/v1.2.3-REALLY-LONG-COMMIT-SHA/README.md',
         ],
-      } as IAppCatalogApp;
+      } as IAppCatalogAppVersion;
 
       await store.dispatch(
         loadAppReadme('notUnderTest', appVersionWithTestVersionReadmeInSources)

--- a/src/stores/appcatalog/actions.ts
+++ b/src/stores/appcatalog/actions.ts
@@ -201,7 +201,7 @@ async function loadIndexForCatalog(catalog: IAppCatalog): Promise<IAppCatalog> {
  */
 export function loadAppReadme(
   catalogName: string,
-  appVersion: IAppCatalogApp
+  appVersion: IAppCatalogAppVersion
 ): ThunkAction<Promise<void>, IState, void, AppCatalogActions> {
   return async (dispatch) => {
     dispatch({

--- a/src/stores/appcatalog/types.ts
+++ b/src/stores/appcatalog/types.ts
@@ -101,20 +101,20 @@ export interface IAppCatalogLoadIndexErrorAction {
 export interface IAppCatalogLoadAppReadmeRequestAction {
   type: typeof CLUSTER_LOAD_APP_README_REQUEST;
   catalogName: string;
-  appVersion: IAppCatalogApp;
+  appVersion: IAppCatalogAppVersion;
 }
 
 export interface IAppCatalogLoadAppReadmeSuccessAction {
   type: typeof CLUSTER_LOAD_APP_README_SUCCESS;
   catalogName: string;
-  appVersion: IAppCatalogApp;
+  appVersion: IAppCatalogAppVersion;
   readmeText: string;
 }
 
 export interface IAppCatalogLoadAppReadmeErrorAction {
   type: typeof CLUSTER_LOAD_APP_README_ERROR;
   catalogName: string;
-  appVersion: IAppCatalogApp;
+  appVersion: IAppCatalogAppVersion;
   error: string;
 }
 


### PR DESCRIPTION
Trying to keep PR's small, this one focuses on the selector used to get all the apps that belong to the catalogs that the user selected in the facets.

<img width="1551" alt="Screenshot 2021-02-05 at 10 06 40 PM" src="https://user-images.githubusercontent.com/455309/107043872-87a4a300-67fe-11eb-8d84-ce2de32e579b.png">

I renamed `IAppCatalogApp` to `IAppCatalogAppVersion`, and created a new `IAppCatalogApp` interface.

What used to be `IAppCatalogApp` was actually just a single version of an app. Catalogs contain all known versions of an app, so I created a new interface which kind of wraps all the known versions and surfaces the name and other details relevant for rendering in the AppList component.