### PR TITLE
Rely on API to set the default max price for spot instances on Azure

### DIFF
--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePool.js
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePool.js
@@ -355,7 +355,8 @@ class AddNodePool extends Component {
       }
 
       case Providers.AZURE: {
-        let spotInstancesMaxPrice = 0;
+        // eslint-disable-next-line @typescript-eslint/init-declarations
+        let spotInstancesMaxPrice;
         if (spotInstancesEnabled && !azure.spotInstances.onDemandPricing) {
           spotInstancesMaxPrice = azure.spotInstances.maxPrice;
         }

--- a/src/components/Cluster/ClusterDetail/AddNodePool/__tests__/AddNodePool.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/__tests__/AddNodePool.tsx
@@ -85,7 +85,7 @@ describe('AddNodePool', () => {
             azure: {
               spot_instances: {
                 enabled: true,
-                max_price: 0,
+                max_price: undefined,
               },
               vm_size: 'Standard_D4s_v3',
             },


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15310

With this change, we let the API default the value it wants when using on-demand as maximum price, instead of setting the value to `0`.