### PR TITLE
Fix a crash when delete dates are somehow invalid

### DIFF
--- a/src/@types/clusters.d.ts
+++ b/src/@types/clusters.d.ts
@@ -16,7 +16,7 @@ interface IBaseCluster {
 
   path?: string;
   credential_id?: string;
-  delete_date?: string | null;
+  delete_date?: Date | null;
 
   // Injected by client-side.
   capabilities?: IClusterCapabilities;

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -201,7 +201,8 @@ function ClusterDashboardItem({
             <NameWrapper>{cluster.name}</NameWrapper>
           </TitleWrapper>
           <DeleteDateWrapper>
-            Deleted {relativeDate(cluster.delete_date)}
+            Deleted{' '}
+            {!isNaN(cluster.delete_date) && relativeDate(cluster.delete_date)}
           </DeleteDateWrapper>
         </ContentWrapper>
       </WrapperDeleted>

--- a/src/components/Home/__tests__/ClusterStatus.tsx
+++ b/src/components/Home/__tests__/ClusterStatus.tsx
@@ -206,7 +206,7 @@ describe('ClusterStatus', () => {
       {
         id: 'as129',
         release_version: nodePoolRelease.version,
-        delete_date: '123123',
+        delete_date: new Date('2021-02-10T16:39:27Z'),
       },
       {
         [nodePoolRelease.version]: nodePoolRelease as IRelease,

--- a/src/stores/cluster/__tests__/utils.ts
+++ b/src/stores/cluster/__tests__/utils.ts
@@ -1181,7 +1181,7 @@ describe('cluster::utils', () => {
 
     it('ignores clusters that are currently being deleted', () => {
       const v4Cluster = Object.assign({}, v4AWSClusterResponse, {
-        delete_date: '1970-01-01',
+        delete_date: new Date('1970-01-01'),
       });
 
       const clusters: IClusterMap = {

--- a/src/stores/cluster/reducer.ts
+++ b/src/stores/cluster/reducer.ts
@@ -142,7 +142,7 @@ const clusterReducer = produce(
       case CLUSTER_DELETE_SUCCESS: {
         const cluster = draft.items[action.clusterId];
         if (cluster) {
-          cluster.delete_date = action.timestamp;
+          cluster.delete_date = new Date(action.timestamp);
           draft.lastUpdated = Date.now();
         }
         draft.idsAwaitingUpgrade = reconcileClustersAwaitingUpgrade(


### PR DESCRIPTION
Fixes an exception I've noticed recently.

It looks like the delete_date of a cluster can be "Invalid Date" for a while.