### PR TITLE
Managed app label & Catalog description tooltip

### DIFF
--- a/src/components/Apps/AppDetail/AppDetail.tsx
+++ b/src/components/Apps/AppDetail/AppDetail.tsx
@@ -77,6 +77,7 @@ const AppDetail: React.FC = () => {
           appTitle={app.name}
           appIconURL={app.icon}
           catalogName={catalog.spec.title}
+          catalogDescription={catalog.spec.description}
           catalogIcon={catalog.spec.logoURL}
           otherVersions={otherVersions.map((v) => ({
             chartVersion: v.version,

--- a/src/components/Apps/AppsList/utils.tsx
+++ b/src/components/Apps/AppsList/utils.tsx
@@ -77,6 +77,7 @@ export function catalogsToFacets(
           <CatalogLabel
             catalogName={catalog.spec.title}
             iconUrl={catalog.spec.logoURL}
+            description={catalog.spec.description}
             error={catalogErrors[catalog.metadata.name]}
           />
         ),

--- a/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
+++ b/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
@@ -176,6 +176,7 @@ export interface IAppDetailPageProps {
   appTitle: string;
   appIconURL: string;
   catalogName: string;
+  catalogDescription: string;
   otherVersions: IVersion[];
   catalogIcon?: string;
   chartVersion: string;
@@ -211,6 +212,7 @@ const AppDetail: React.FC<IAppDetailPageProps> = (props) => {
           <Lower>
             <CatalogLabel
               catalogName={props.catalogName}
+              description={props.catalogDescription}
               iconUrl={props.catalogIcon}
             />
           </Lower>
@@ -311,6 +313,7 @@ AppDetail.propTypes = {
   appTitle: PropTypes.string.isRequired,
   appIconURL: PropTypes.string.isRequired,
   catalogName: PropTypes.string.isRequired,
+  catalogDescription: PropTypes.string.isRequired,
   catalogIcon: PropTypes.string,
   chartVersion: PropTypes.string.isRequired,
   createDate: PropTypes.string.isRequired,

--- a/src/components/UI/Display/Apps/AppList/App.tsx
+++ b/src/components/UI/Display/Apps/AppList/App.tsx
@@ -70,7 +70,7 @@ const App: React.FC<IAppProps> = (props) => {
         <Name>{props.name}</Name>
         <StyledCatalogLabel
           catalogName={props.catalogTitle}
-          description={''}
+          description=''
           isManaged={props.catalogIsManaged}
           iconUrl={props.catalogIconUrl}
         />

--- a/src/components/UI/Display/Apps/AppList/App.tsx
+++ b/src/components/UI/Display/Apps/AppList/App.tsx
@@ -70,6 +70,7 @@ const App: React.FC<IAppProps> = (props) => {
         <Name>{props.name}</Name>
         <StyledCatalogLabel
           catalogName={props.catalogTitle}
+          description={''}
           isManaged={props.catalogIsManaged}
           iconUrl={props.catalogIconUrl}
         />

--- a/src/components/UI/Display/Apps/AppList/App.tsx
+++ b/src/components/UI/Display/Apps/AppList/App.tsx
@@ -70,7 +70,6 @@ const App: React.FC<IAppProps> = (props) => {
         <Name>{props.name}</Name>
         <StyledCatalogLabel
           catalogName={props.catalogTitle}
-          description=''
           isManaged={props.catalogIsManaged}
           iconUrl={props.catalogIconUrl}
         />

--- a/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
+++ b/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
@@ -93,7 +93,7 @@ const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
           </OverlayTrigger>
         )}
 
-        {(!props.description || props.description === '') && text}
+        {!props.description && text}
 
         {props.error && <ErrorIcon name={props.catalogName} />}
       </Text>

--- a/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
+++ b/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
@@ -68,7 +68,7 @@ const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
     <span>
       {props.catalogName}
       {props.isManaged && <CatalogType>MANAGED</CatalogType>}
-      {props.catalogName == 'Giant Swarm Catalog' && (
+      {props.catalogName === 'Giant Swarm Catalog' && (
         <CatalogType>MANAGED</CatalogType>
       )}
     </span>
@@ -93,7 +93,7 @@ const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
           </OverlayTrigger>
         )}
 
-        {(!props.description || props.description == '') && text}
+        {(!props.description || props.description === '') && text}
 
         {props.error && <ErrorIcon name={props.catalogName} />}
       </Text>

--- a/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
+++ b/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
@@ -38,7 +38,7 @@ const Text = styled.div``;
 export interface ICatalogLabelProps {
   iconUrl?: string;
   catalogName: string;
-  description: string;
+  description?: string;
   isManaged?: boolean;
   error?: string;
 }
@@ -104,7 +104,7 @@ const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
 CatalogLabel.propTypes = {
   iconUrl: PropTypes.string,
   catalogName: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  description: PropTypes.string,
   isManaged: PropTypes.bool,
   error: PropTypes.string,
 };

--- a/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
+++ b/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
@@ -38,6 +38,7 @@ const Text = styled.div``;
 export interface ICatalogLabelProps {
   iconUrl?: string;
   catalogName: string;
+  description: string;
   isManaged?: boolean;
   error?: string;
 }
@@ -63,14 +64,37 @@ ErrorIcon.propTypes = {
 };
 
 const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
+  const text = (
+    <span>
+      {props.catalogName}
+      {props.isManaged && <CatalogType>MANAGED</CatalogType>}
+      {props.catalogName == 'Giant Swarm Catalog' && (
+        <CatalogType>MANAGED</CatalogType>
+      )}
+    </span>
+  );
+
   return (
     <Wrapper {...props} hasError={Boolean(props.error)}>
       <IconArea>
         <Icon src={props.iconUrl} />
       </IconArea>
       <Text>
-        {props.catalogName}
-        {props.isManaged && <CatalogType>MANAGED</CatalogType>}&nbsp;
+        {props.description && (
+          <OverlayTrigger
+            placement='top'
+            overlay={
+              <Tooltip id={`app-catalog-description-${props.catalogName}`}>
+                {props.description}
+              </Tooltip>
+            }
+          >
+            {text}
+          </OverlayTrigger>
+        )}
+
+        {(!props.description || props.description == '') && text}
+
         {props.error && <ErrorIcon name={props.catalogName} />}
       </Text>
     </Wrapper>
@@ -80,6 +104,7 @@ const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
 CatalogLabel.propTypes = {
   iconUrl: PropTypes.string,
   catalogName: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
   isManaged: PropTypes.bool,
   error: PropTypes.string,
 };


### PR DESCRIPTION
This adds a little tooltip with the description of the catalog for each facet. 

(I don't really like the UX of this btw, ping @marians, this was specced but now that I see it in action im not sure it feels that great. if you want me to deploy it somewhere so you can see, let me know)

It also adds the managed label to the giant swarm catalog, currently the logic for determining that is just based on the name of the catalog. Eventually it will be a specific label on the AppCatalogCR, but we haven't specced that and agreed on it yet.

<img width="1545" alt="Screenshot 2021-02-12 at 1 12 54 AM" src="https://user-images.githubusercontent.com/455309/107672076-79a7c400-6ccf-11eb-950d-1da7bc9e68ad.png">
&