### PR TITLE
Use dark bg app icons if possible

### DIFF
--- a/src/components/UI/Display/Apps/AppList/App.tsx
+++ b/src/components/UI/Display/Apps/AppList/App.tsx
@@ -55,7 +55,7 @@ const StyledCatalogLabel = styled(CatalogLabel)`
 export interface IAppProps {
   to: string;
   name: string;
-  appIconURL: string;
+  appIconURL?: string;
   catalogTitle: string;
   catalogIconUrl: string;
   catalogIsManaged?: boolean;
@@ -82,7 +82,7 @@ const App: React.FC<IAppProps> = (props) => {
 App.propTypes = {
   to: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  appIconURL: PropTypes.string.isRequired,
+  appIconURL: PropTypes.string,
   catalogTitle: PropTypes.string.isRequired,
   catalogIconUrl: PropTypes.string.isRequired,
   catalogIsManaged: PropTypes.bool,

--- a/src/components/UI/Display/Apps/AppList/AppIcon.tsx
+++ b/src/components/UI/Display/Apps/AppList/AppIcon.tsx
@@ -48,11 +48,11 @@ const StyledImageWithFallback = styled(
 
 interface IIconProps extends React.ComponentPropsWithoutRef<'div'> {
   name: string;
-  src: string;
+  src?: string;
 }
 
 const Icon: React.FC<IIconProps> = ({ name, src, ...rest }) => {
-  if (src.endsWith('light.png')) {
+  if (src?.endsWith('light.png')) {
     src = src.replace('light.png', 'dark.png');
   }
 
@@ -74,7 +74,7 @@ const Icon: React.FC<IIconProps> = ({ name, src, ...rest }) => {
 
 Icon.propTypes = {
   name: PropTypes.string.isRequired,
-  src: PropTypes.string.isRequired,
+  src: PropTypes.string,
 };
 
 export default Icon;

--- a/src/components/UI/Display/Apps/AppList/AppIcon.tsx
+++ b/src/components/UI/Display/Apps/AppList/AppIcon.tsx
@@ -37,6 +37,7 @@ const StyledImageWithFallback = styled(
   align-items: center;
   font-weight: 800;
   justify-content: center;
+  margin: auto;
   max-width: 100px;
   max-height: 100%;
   text-shadow: -1px -1px 0 ${({ outlinecolor }) => outlinecolor},
@@ -51,6 +52,10 @@ interface IIconProps extends React.ComponentPropsWithoutRef<'div'> {
 }
 
 const Icon: React.FC<IIconProps> = ({ name, src, ...rest }) => {
+  if (src.endsWith('light.png')) {
+    src = src.replace('light.png', 'dark.png');
+  }
+
   return (
     <StyledImageWithFallback
       outlinecolor={colorHash.calculateColor(name)}

--- a/src/components/UI/Display/Apps/AppList/AppIcon.tsx
+++ b/src/components/UI/Display/Apps/AppList/AppIcon.tsx
@@ -52,14 +52,15 @@ interface IIconProps extends React.ComponentPropsWithoutRef<'div'> {
 }
 
 const Icon: React.FC<IIconProps> = ({ name, src, ...rest }) => {
-  if (src?.endsWith('light.png')) {
-    src = src.replace('light.png', 'dark.png');
+  let imagesrc = src;
+  if (imagesrc?.endsWith('light.png')) {
+    imagesrc = imagesrc.replace('light.png', 'dark.png');
   }
 
   return (
     <StyledImageWithFallback
       outlinecolor={colorHash.calculateColor(name)}
-      src={src}
+      src={imagesrc}
       alt={name}
       fallback={{
         label: acronymize(name),


### PR DESCRIPTION
[When I made all the app icons myself](https://github.com/giantswarm/web-assets/tree/master/assets/app-icons/1/png), I made two versions, for dark and light backgrounds.

Now that we're switching, I'd like it to already look good, instead of forcing all apps to change the URL and release a new version. This way we let Happa detect apps which would have a dark-bg version of their logo, and use that instead

