### PR TITLE
Create textarea input

### DIFF
--- a/src/components/Cluster/ClusterDetail/KeypairCreateModal/AddKeyPairSuccessTemplate.tsx
+++ b/src/components/Cluster/ClusterDetail/KeypairCreateModal/AddKeyPairSuccessTemplate.tsx
@@ -1,25 +1,6 @@
-import DownloadKubeconfigButton from 'Cluster/ClusterDetail/KeypairCreateModal/DownloadKubeconfigButton';
-import useCopyToClipboard from 'lib/hooks/useCopyToClipboard';
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'styled-components';
-import Button from 'UI/Controls/Button';
-
-const CLIPBOARD_RESET_TIME = 500;
-
-const StyledTextBox = styled.textarea`
-  height: 300px;
-  font-family: 'Inconsolata';
-  background-color: #333333;
-  padding: 9px 13px;
-  border-radius: 10px;
-  position: relative;
-  transition: background-color 0.02s linear;
-  border: none;
-  line-height: initial;
-  padding-right: 55px;
-  overflow: visible;
-`;
+import FileBlock from 'UI/Display/Documentation/FileBlock';
 
 interface IAddKeyPairSuccessTemplateProps {
   kubeconfig: string;
@@ -28,17 +9,6 @@ interface IAddKeyPairSuccessTemplateProps {
 const AddKeyPairSuccessTemplate: React.FC<IAddKeyPairSuccessTemplateProps> = ({
   kubeconfig,
 }) => {
-  const [hasContentInClipboard, setClipboardContent] = useCopyToClipboard();
-
-  const copyKubeconfig = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-
-    setClipboardContent(kubeconfig);
-    setTimeout(() => {
-      setClipboardContent(null);
-    }, CLIPBOARD_RESET_TIME);
-  };
-
   return (
     <>
       <p>
@@ -51,25 +21,7 @@ const AddKeyPairSuccessTemplate: React.FC<IAddKeyPairSuccessTemplateProps> = ({
         it enables for complete administrative access to your cluster.
       </p>
 
-      <StyledTextBox readOnly value={kubeconfig} title='kubeconfig' />
-
-      {hasContentInClipboard ? (
-        <Button bsStyle='default' onClick={copyKubeconfig}>
-          &nbsp;&nbsp;
-          <i
-            aria-hidden='true'
-            className='fa fa-done'
-            title='Content copied to clipboard'
-          />
-          &nbsp;&nbsp;
-        </Button>
-      ) : (
-        <Button bsStyle='default' onClick={copyKubeconfig}>
-          Copy
-        </Button>
-      )}
-
-      <DownloadKubeconfigButton content={kubeconfig} />
+      <FileBlock fileName='config.yaml'>{kubeconfig}</FileBlock>
     </>
   );
 };

--- a/src/components/Cluster/ClusterDetail/KeypairCreateModal/KeyPairCreateModal.tsx
+++ b/src/components/Cluster/ClusterDetail/KeypairCreateModal/KeyPairCreateModal.tsx
@@ -11,7 +11,7 @@ import {
   MODAL_CHANGE_TIMEOUT,
   VALIDATION_DEBOUNCE_RATE,
 } from 'Cluster/ClusterDetail/KeypairCreateModal/Utils';
-import { dedent, makeKubeConfigTextFile } from 'lib/helpers';
+import { makeKubeConfigTextFile } from 'lib/helpers';
 import useDebounce from 'lib/hooks/useDebounce';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
@@ -80,7 +80,7 @@ const KeyPairCreateModal: React.FC<IKeyPairCreateModalProps> = (props) => {
         }
       );
       setKubeconfig(
-        dedent(makeKubeConfigTextFile(props.cluster, keypair, useInternalAPI))
+        makeKubeConfigTextFile(props.cluster, keypair, useInternalAPI)
       );
       setModal({
         visible: true,

--- a/src/components/Cluster/ClusterDetail/KeypairCreateModal/__tests__/KeyPairCreateModal.tsx
+++ b/src/components/Cluster/ClusterDetail/KeypairCreateModal/__tests__/KeyPairCreateModal.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, RenderResult } from '@testing-library/react';
 import KeyPairCreateModal from 'Cluster/ClusterDetail/KeypairCreateModal/KeyPairCreateModal';
-import useCopyToClipboard from 'lib/hooks/useCopyToClipboard';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { Providers, StatusCodes } from 'shared/constants';
@@ -10,8 +9,6 @@ import {
   v4AzureClusterResponse,
 } from 'testUtils/mockHttpCalls';
 import { getComponentWithTheme } from 'testUtils/renderUtils';
-
-jest.mock('lib/hooks/useCopyToClipboard');
 
 const mockUser = {
   email: USER_EMAIL,
@@ -197,17 +194,9 @@ describe('KeyPairCreateModal', () => {
     jest.useFakeTimers();
 
     window.URL.createObjectURL = jest.fn();
-    const setClipboardContentMockFn = jest.fn();
-    // @ts-ignore
-    useCopyToClipboard.mockReturnValueOnce([false, setClipboardContentMockFn]);
     mockActions.clusterCreateKeyPair.mockResolvedValueOnce({});
 
-    const {
-      getByText,
-      getByLabelText,
-      findByText,
-      getByTitle,
-    } = renderComponent();
+    const { getByText, getByLabelText, findByText } = renderComponent();
 
     const openButton = getByText(/create key pair and kubeconfig/i);
     fireEvent.click(openButton);
@@ -236,22 +225,5 @@ describe('KeyPairCreateModal', () => {
 
     expect(mockActions.clusterCreateKeyPair).toHaveBeenCalled();
     expect(mockActions.clusterLoadKeyPairs).toHaveBeenCalled();
-
-    const kubeconfigContent = getByTitle(/kubeconfig/i).textContent;
-    const copyButton = getByText(/^copy$/i);
-    fireEvent.click(copyButton);
-    expect(setClipboardContentMockFn).toHaveBeenCalledWith(kubeconfigContent);
-    // @ts-ignore
-    useCopyToClipboard.mockReturnValueOnce([true, setClipboardContentMockFn]);
-
-    act(() => {
-      jest.runAllTimers();
-    });
-
-    const copiedSuccessLabel = getByTitle(/content copied to clipboard/i);
-    expect(copiedSuccessLabel).toBeInTheDocument();
-
-    // @ts-ignore
-    useCopyToClipboard.mockClear();
   });
 });

--- a/src/components/UI/Inputs/TextArea/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/TextArea/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,175 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextArea renders a disabled input 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 yBlmn"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 breHlv"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 jazqMc FormField__FormFieldBox-m9hood-0 jGEMXj"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 fwONFA FormField__FormFieldContentBox-m9hood-1"
+      >
+        <textarea
+          class="StyledTextArea-sc-17i3mwp-0 jYpoen"
+          disabled=""
+          rows="5"
+        >
+          The quick brown fox jumps over the lazy dog
+        </textarea>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TextArea renders a simple input 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 yBlmn"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 breHlv"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 jazqMc FormField__FormFieldBox-m9hood-0 jGEMXj"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 drdhXT FormField__FormFieldContentBox-m9hood-1"
+      >
+        <textarea
+          class="StyledTextArea-sc-17i3mwp-0 cDfWLK"
+          placeholder="Please write a story"
+          rows="5"
+        >
+          The quick brown fox jumps over the lazy dog
+        </textarea>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TextArea renders an input with a help message 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 yBlmn"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 breHlv"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 jazqMc FormField__FormFieldBox-m9hood-0 jGEMXj"
+    >
+      <span
+        class="StyledText-sc-1sadyjn-0 erMGdB"
+      >
+        A helpful message
+      </span>
+      <div
+        class="StyledBox-sc-13pk1d4-0 drdhXT FormField__FormFieldContentBox-m9hood-1"
+      >
+        <textarea
+          class="StyledTextArea-sc-17i3mwp-0 cDfWLK"
+          rows="5"
+        >
+          The quick brown fox jumps over the lazy dog
+        </textarea>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TextArea renders an input with a label 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 yBlmn"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 breHlv"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 jazqMc FormField__FormFieldBox-m9hood-0 jGEMXj"
+    >
+      <label
+        class="StyledText-sc-1sadyjn-0 esuSAl"
+        for="some-text"
+      >
+        A helpful area of text
+      </label>
+      <div
+        class="StyledBox-sc-13pk1d4-0 drdhXT FormField__FormFieldContentBox-m9hood-1"
+      >
+        <textarea
+          class="StyledTextArea-sc-17i3mwp-0 cDfWLK"
+          id="some-text"
+          rows="5"
+        >
+          The quick brown fox jumps over the lazy dog
+        </textarea>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TextArea renders an input with a validation error 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 yBlmn"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 breHlv"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 jazqMc FormField__FormFieldBox-m9hood-0 jGEMXj"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 dfycIj FormField__FormFieldContentBox-m9hood-1"
+      >
+        <textarea
+          class="StyledTextArea-sc-17i3mwp-0 cDfWLK"
+          rows="5"
+        >
+          The quick brown fox jumps over the lazy dog
+        </textarea>
+      </div>
+      <span
+        class="StyledText-sc-1sadyjn-0 dxYrxD"
+      >
+        There is something very wrong!
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TextArea renders an input with an info message 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 yBlmn"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 breHlv"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 jazqMc FormField__FormFieldBox-m9hood-0 jGEMXj"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 drdhXT FormField__FormFieldContentBox-m9hood-1"
+      >
+        <textarea
+          class="StyledTextArea-sc-17i3mwp-0 cDfWLK"
+          rows="5"
+        >
+          The quick brown fox jumps over the lazy dog
+        </textarea>
+      </div>
+      <span
+        class="StyledText-sc-1sadyjn-0 fmFxNm"
+      >
+        Some useful information
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/UI/Inputs/TextArea/__tests__/index.tsx
+++ b/src/components/UI/Inputs/TextArea/__tests__/index.tsx
@@ -1,0 +1,54 @@
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import TextArea from '..';
+
+describe('TextArea', () => {
+  it('renders a simple input', () => {
+    const { container } = renderWithTheme(TextArea, {
+      value: 'The quick brown fox jumps over the lazy dog',
+      placeholder: 'Please write a story',
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders an input with a label', () => {
+    const { container } = renderWithTheme(TextArea, {
+      value: 'The quick brown fox jumps over the lazy dog',
+      label: 'A helpful area of text',
+      id: 'some-text',
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders an input with a validation error', () => {
+    const { container } = renderWithTheme(TextArea, {
+      value: 'The quick brown fox jumps over the lazy dog',
+      error: 'There is something very wrong!',
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders an input with a help message', () => {
+    const { container } = renderWithTheme(TextArea, {
+      value: 'The quick brown fox jumps over the lazy dog',
+      help: 'A helpful message',
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders an input with an info message', () => {
+    const { container } = renderWithTheme(TextArea, {
+      value: 'The quick brown fox jumps over the lazy dog',
+      info: 'Some useful information',
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a disabled input', () => {
+    const { container } = renderWithTheme(TextArea, {
+      value: 'The quick brown fox jumps over the lazy dog',
+      disabled: true,
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/UI/Inputs/TextArea/index.tsx
+++ b/src/components/UI/Inputs/TextArea/index.tsx
@@ -1,0 +1,113 @@
+import { FormField, FormFieldProps, TextArea as Input } from 'grommet';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+
+interface ITextAreaProps extends React.ComponentPropsWithoutRef<typeof Input> {
+  /**
+   * The description text displayed above the input.
+   */
+  label?: FormFieldProps['label'];
+  /**
+   * Props to be passed to the text input wrapper.
+   */
+  contentProps?: FormFieldProps['contentProps'];
+  /**
+   * Props to be passed to the form field.
+   */
+  formFieldProps?: FormFieldProps & { className?: string };
+  /**
+   * Whether the input is required or not.
+   */
+  required?: FormFieldProps['required'];
+  /**
+   * An error to be displayed below the input.
+   */
+  error?: FormFieldProps['error'];
+  /**
+   * A description to be displayed below the input.
+   */
+  info?: FormFieldProps['info'];
+  /**
+   * A help text to be displayed between the label
+   * and the input.
+   */
+  help?: FormFieldProps['help'];
+  /**
+   * The margin between the form field and other elements.
+   */
+  margin?: FormFieldProps['margin'];
+  /**
+   * Whether the input should have some extra padding or not.
+   */
+  pad?: FormFieldProps['pad'];
+}
+
+const TextArea = React.forwardRef<HTMLTextAreaElement, ITextAreaProps>(
+  (
+    {
+      id,
+      label,
+      contentProps,
+      formFieldProps,
+      disabled,
+      required,
+      error,
+      info,
+      help,
+      name,
+      margin,
+      pad,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <FormField
+        htmlFor={id}
+        label={label}
+        contentProps={contentProps}
+        disabled={disabled}
+        required={required}
+        name={name}
+        error={error}
+        info={info}
+        help={help}
+        margin={margin}
+        pad={pad}
+        {...formFieldProps}
+      >
+        <Input
+          {...props}
+          id={id}
+          ref={ref}
+          disabled={disabled}
+          required={required}
+          name={name}
+        />
+      </FormField>
+    );
+  }
+);
+
+TextArea.propTypes = {
+  id: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  contentProps: PropTypes.object,
+  formFieldProps: PropTypes.object,
+  disabled: PropTypes.bool,
+  required: PropTypes.bool,
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  info: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  help: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  name: PropTypes.string,
+  margin: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  pad: PropTypes.bool,
+};
+
+TextArea.defaultProps = {
+  size: 'medium',
+  rows: 5,
+  resize: 'vertical',
+};
+
+export default TextArea;

--- a/src/components/UI/Inputs/TextArea/stories/Disabled.tsx
+++ b/src/components/UI/Inputs/TextArea/stories/Disabled.tsx
@@ -1,0 +1,30 @@
+import { Story } from '@storybook/react/types-6-0';
+import React, { ComponentPropsWithoutRef, useState } from 'react';
+
+import TextArea from '..';
+
+export const Disabled: Story<ComponentPropsWithoutRef<typeof TextArea>> = (
+  args
+) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <TextArea
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+Disabled.args = {
+  value: 'The quick brown fox jumps over the lazy dog',
+  disabled: true,
+};
+
+Disabled.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/TextArea/stories/Error.tsx
+++ b/src/components/UI/Inputs/TextArea/stories/Error.tsx
@@ -1,0 +1,30 @@
+import { Story } from '@storybook/react/types-6-0';
+import React, { ComponentPropsWithoutRef, useState } from 'react';
+
+import TextArea from '..';
+
+export const Error: Story<ComponentPropsWithoutRef<typeof TextArea>> = (
+  args
+) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <TextArea
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+Error.args = {
+  value: 'The quick brown fox jumps over the lazy dog',
+  error: 'There is something very wrong!',
+};
+
+Error.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/TextArea/stories/Help.tsx
+++ b/src/components/UI/Inputs/TextArea/stories/Help.tsx
@@ -1,0 +1,30 @@
+import { Story } from '@storybook/react/types-6-0';
+import React, { ComponentPropsWithoutRef, useState } from 'react';
+
+import TextArea from '..';
+
+export const Help: Story<ComponentPropsWithoutRef<typeof TextArea>> = (
+  args
+) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <TextArea
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+Help.args = {
+  value: 'The quick brown fox jumps over the lazy dog',
+  help: 'A helpful message',
+};
+
+Help.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/TextArea/stories/Info.tsx
+++ b/src/components/UI/Inputs/TextArea/stories/Info.tsx
@@ -1,0 +1,30 @@
+import { Story } from '@storybook/react/types-6-0';
+import React, { ComponentPropsWithoutRef, useState } from 'react';
+
+import TextArea from '..';
+
+export const Info: Story<ComponentPropsWithoutRef<typeof TextArea>> = (
+  args
+) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <TextArea
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+Info.args = {
+  value: 'The quick brown fox jumps over the lazy dog',
+  info: 'Some useful information',
+};
+
+Info.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/TextArea/stories/Label.tsx
+++ b/src/components/UI/Inputs/TextArea/stories/Label.tsx
@@ -20,6 +20,7 @@ export const Label: Story<ComponentPropsWithoutRef<typeof TextArea>> = (
 Label.args = {
   value: 'The quick brown fox jumps over the lazy dog',
   label: 'A helpful area of text',
+  id: 'some-text',
 };
 
 Label.argTypes = {

--- a/src/components/UI/Inputs/TextArea/stories/Label.tsx
+++ b/src/components/UI/Inputs/TextArea/stories/Label.tsx
@@ -1,0 +1,30 @@
+import { Story } from '@storybook/react/types-6-0';
+import React, { ComponentPropsWithoutRef, useState } from 'react';
+
+import TextArea from '..';
+
+export const Label: Story<ComponentPropsWithoutRef<typeof TextArea>> = (
+  args
+) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <TextArea
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+Label.args = {
+  value: 'The quick brown fox jumps over the lazy dog',
+  label: 'A helpful area of text',
+};
+
+Label.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/TextArea/stories/Simple.tsx
+++ b/src/components/UI/Inputs/TextArea/stories/Simple.tsx
@@ -1,0 +1,30 @@
+import { Story } from '@storybook/react/types-6-0';
+import React, { ComponentPropsWithoutRef, useState } from 'react';
+
+import TextArea from '..';
+
+export const Simple: Story<ComponentPropsWithoutRef<typeof TextArea>> = (
+  args
+) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <TextArea
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+Simple.args = {
+  value: 'The quick brown fox jumps over the lazy dog',
+  placeholder: 'Please write a story',
+};
+
+Simple.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/TextArea/stories/TextArea.stories.tsx
+++ b/src/components/UI/Inputs/TextArea/stories/TextArea.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta } from '@storybook/react/types-6-0';
+
+import TextArea from '..';
+
+export { Simple } from './Simple';
+export { Label } from './Label';
+export { Error } from './Error';
+export { Info } from './Info';
+export { Help } from './Help';
+export { Disabled } from './Disabled';
+
+export default {
+  title: 'Inputs/TextArea',
+  component: TextArea,
+} as Meta;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,7 @@
 import { generate, ThemeType } from 'grommet';
 import { deepMerge } from 'grommet/utils';
 import { CSSBreakpoints } from 'shared/constants';
+import { css } from 'styled-components';
 
 /* eslint-disable no-magic-numbers */
 
@@ -307,6 +308,13 @@ const theme = deepMerge(generate(16), {
       lineHeight: 1.11,
       daySize: '91.43px',
     },
+  },
+  textArea: {
+    extend: () => css`
+      background: ${(props) => props.theme.global.colors['input-background']};
+      min-width: 100%;
+      min-height: 40px;
+    `,
   },
   checkBox: {
     color: {


### PR DESCRIPTION
Towards giantswarm/giantswarm#11004 and towards the grommet migration

This PR includes a new `textarea` input. There were no components that I could add it to. There was one old usage of `textarea` in the keypair creation success modal, which was also not displayed correctly, and I replaced it with the `FileBlock` component.

### Preview

<details>
<summary>With label</summary>

![image](https://user-images.githubusercontent.com/13508038/108710452-5e7d5580-7514-11eb-9860-e79d3fc50458.png)

</details>

<details>
<summary>With error</summary>

![image](https://user-images.githubusercontent.com/13508038/108710473-663cfa00-7514-11eb-8ed8-7ad78a914ef3.png)

</details>

<details>
<summary>With info message</summary>

![image](https://user-images.githubusercontent.com/13508038/108710515-7523ac80-7514-11eb-987f-0f367e257d4a.png)

</details>

<details>
<summary>With help message</summary>

![image](https://user-images.githubusercontent.com/13508038/108710594-908eb780-7514-11eb-83f9-5e426262cda8.png)

</details>

<details>
<summary>Disabled</summary>

![image](https://user-images.githubusercontent.com/13508038/108710620-9a181f80-7514-11eb-9ce7-5aedc590a319.png)

</details>

<details>
<summary>Keypair creation success modal - BEFORE</summary>

![image](https://user-images.githubusercontent.com/13508038/108710402-49082b80-7514-11eb-8ac5-b2a88bb413c8.png)

</details>

<details>
<summary>Keypair creation success modal - AFTER</summary>

![image](https://user-images.githubusercontent.com/13508038/108710322-3261d480-7514-11eb-9e45-48f6afc06737.png)

</details>