### PR TITLE
Refactor CurrencyInput to use the new input and structure

### DIFF
--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstancesAzure.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstancesAzure.tsx
@@ -9,14 +9,6 @@ const AzureSpotInstances = styled.div`
   position: relative;
 `;
 
-const MaxPriceWrapper = styled.div`
-  margin-top: ${({ theme }) => theme.spacingPx * 2}px;
-
-  .max-price__currency-wrapper {
-    width: 160px;
-  }
-`;
-
 const CheckboxWrapper = styled.div`
   position: absolute;
   left: 170px;
@@ -44,23 +36,26 @@ const AddNodePoolSpotInstancesAzure: React.FC<IAddNodePoolSpotInstancesAzureProp
 }) => {
   return (
     <AzureSpotInstances>
-      <MaxPriceWrapper>
-        <CurrencyInput
-          id='spot-instances-max-price'
-          onChange={setMaxPrice}
-          value={maxPrice}
-          /* Minimum value is set to `0` to allow user to type `0.xxx` values using their keyboard. */
-          min={0}
-          max={Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_MAX}
-          precision={Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_PRECISION}
-          label='Maximum price per hour'
-          validationError={maxPriceValidationError}
-          disabled={useOnDemandPricing}
-          inputWrapperProps={{
-            className: 'max-price__currency-wrapper',
-          }}
-        />
-      </MaxPriceWrapper>
+      <CurrencyInput
+        id='spot-instances-max-price'
+        onChange={setMaxPrice}
+        value={maxPrice}
+        /* Minimum value is set to `0` to allow user to type `0.xxx` values using their keyboard. */
+        min={0}
+        max={Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_MAX}
+        precision={Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_PRECISION}
+        label='Maximum price per hour'
+        error={maxPriceValidationError}
+        disabled={useOnDemandPricing}
+        contentProps={{
+          width: 'small',
+        }}
+        formFieldProps={{
+          margin: {
+            top: 'small',
+          },
+        }}
+      />
       <CheckboxWrapper>
         <CheckBoxInput
           checked={useOnDemandPricing}

--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstancesAzure.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstancesAzure.tsx
@@ -12,11 +12,7 @@ const AzureSpotInstances = styled.div`
 const CheckboxWrapper = styled.div`
   position: absolute;
   left: 170px;
-  top: 27px;
-`;
-
-const Description = styled.small`
-  margin-top: ${({ theme }) => theme.spacingPx}px;
+  bottom: -5px;
 `;
 
 interface IAddNodePoolSpotInstancesAzureProps {
@@ -47,6 +43,7 @@ const AddNodePoolSpotInstancesAzure: React.FC<IAddNodePoolSpotInstancesAzureProp
         label='Maximum price per hour'
         error={maxPriceValidationError}
         disabled={useOnDemandPricing}
+        help='The maximum price per hour that a single node pool VM instance can reach before it is deallocated.'
         contentProps={{
           width: 'small',
         }}
@@ -63,10 +60,6 @@ const AddNodePoolSpotInstancesAzure: React.FC<IAddNodePoolSpotInstancesAzureProp
           label='Use current on-demand pricing as max'
         />
       </CheckboxWrapper>
-      <Description>
-        The maximum price per hour that a single node pool VM instance can reach
-        before it is deallocated.
-      </Description>
     </AzureSpotInstances>
   );
 };

--- a/src/components/UI/Inputs/CurrencyInput/__tests__/CurrencyInput.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/__tests__/CurrencyInput.tsx
@@ -5,7 +5,8 @@ import CurrencyInput from '..';
 
 describe('CurrencyInput', () => {
   it('renders without crashing', () => {
-    renderWithTheme(CurrencyInput, {});
+    const { container } = renderWithTheme(CurrencyInput, {});
+    expect(container.firstChild).toMatchSnapshot();
   });
 
   it('only allows base 10 number values', () => {
@@ -111,7 +112,7 @@ describe('CurrencyInput', () => {
       id: 'test-input',
       label: 'Test input',
       value: 1,
-      validationError: 'Naah. Wrong value',
+      error: 'Naah. Wrong value',
     });
 
     expect(screen.getByText('Naah. Wrong value')).toBeInTheDocument();

--- a/src/components/UI/Inputs/CurrencyInput/__tests__/__snapshots__/CurrencyInput.tsx.snap
+++ b/src/components/UI/Inputs/CurrencyInput/__tests__/__snapshots__/CurrencyInput.tsx.snap
@@ -19,12 +19,11 @@ exports[`CurrencyInput renders without crashing 1`] = `
           <div
             class="StyledTextInput__StyledIcon-sc-1x30a0s-3 dEEIJB"
           >
-            <div
-              class="StyledBox-sc-13pk1d4-0 dYebPD"
-              color="text-xweak"
+            <span
+              class="StyledText-sc-1sadyjn-0 jxyUHc"
             >
               $
-            </div>
+            </span>
           </div>
           <input
             autocomplete="off"

--- a/src/components/UI/Inputs/CurrencyInput/__tests__/__snapshots__/CurrencyInput.tsx.snap
+++ b/src/components/UI/Inputs/CurrencyInput/__tests__/__snapshots__/CurrencyInput.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CurrencyInput renders without crashing 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 yBlmn"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 breHlv"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 jazqMc FormField__FormFieldBox-m9hood-0 jGEMXj"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 daSUHp FormField__FormFieldContentBox-m9hood-1"
+      >
+        <div
+          class="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 dpaJQp"
+        >
+          <div
+            class="StyledTextInput__StyledIcon-sc-1x30a0s-3 dEEIJB"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 dYebPD"
+              color="text-xweak"
+            >
+              $
+            </div>
+          </div>
+          <input
+            autocomplete="off"
+            class="StyledTextInput-sc-1x30a0s-0 laxThg"
+            step="1"
+            type="number"
+            value="0"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/UI/Inputs/CurrencyInput/index.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/index.tsx
@@ -1,60 +1,23 @@
+import { Box } from 'grommet';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import styled from 'styled-components';
 
-import { InputElement } from '../Input';
+import TextInput from '../TextInput';
 
-const InputWrapper = styled.div<{ disabled?: boolean }>`
-  border: 1px solid
-    ${({ theme, disabled }) =>
-      disabled ? theme.colors.darkBlueLighter2 : theme.colors.darkBlueLighter1};
-  border-radius: ${({ theme }) => theme.border_radius};
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.gray : theme.colors.whiteInput};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-`;
+function formatNumberWithPrecision(num: number, precision: number): number {
+  if (Number.isNaN(num)) {
+    return 0;
+  }
 
-const StyledInput = styled(InputElement)`
-  border-radius: ${({ theme }) => theme.border_radius};
-  border: 0;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  flex: 1 1 0;
-  width: calc(100% - 36px);
-  height: 32px;
-  border-radius: 0;
-`;
+  // eslint-disable-next-line no-magic-numbers
+  const precisionFactor = 10 ** precision;
 
-const CurrencyLabel = styled.div<{ disabled?: boolean }>`
-  color: ${(props) => props.theme.colors.whiteInput};
-  background: ${({ theme, disabled }) =>
-    disabled ? theme.colors.darkBlueLighter2 : theme.colors.darkBlueLighter1};
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.white3 : theme.colors.white5};
-  padding: 8px 10px;
-  line-height: 1rem;
-  font-size: 14px;
-  height: 32px;
-  width: 36px;
-  flex: 0 0 0;
-`;
-
-const LabelText = styled.label`
-  font-size: 14px;
-  color: ${(props) => props.theme.colors.white2};
-`;
-
-const ValidationError = styled.span`
-  font-size: 12px;
-  color: ${(props) => props.theme.colors.yellow1};
-`;
+  return Math.round(num * precisionFactor) / precisionFactor;
+}
 
 interface ICurrencyInputProps
   extends Omit<
-    React.ComponentPropsWithRef<'input'>,
+    React.ComponentPropsWithRef<typeof TextInput>,
     'type' | 'onChange' | 'step'
   > {
   /**
@@ -71,10 +34,6 @@ interface ICurrencyInputProps
    */
   value?: number;
   /**
-   * The label displayed above the input.
-   */
-  label?: string;
-  /**
    * The minimum allowed value.
    */
   min?: number;
@@ -83,107 +42,68 @@ interface ICurrencyInputProps
    */
   max?: number;
   /**
-   * Props to be passed to the label element.
-   */
-  labelTextProps?: React.ComponentPropsWithRef<'label'>;
-  /**
-   * Props to be passed to the input element's parent element.
-   */
-  inputWrapperProps?: React.ComponentPropsWithRef<'div'>;
-  /**
-   * Props to be passed to the root element.
-   */
-  rootProps?: Omit<React.ComponentPropsWithRef<'div'>, 'htmlFor'>;
-  /**
    * The value change event handler.
    */
   onChange?: (newValue: number) => void;
-  /**
-   * An error message to be displayed near the input.
-   */
-  validationError?: string;
 }
 
-const CurrencyInput: React.FC<ICurrencyInputProps> = ({
-  currencyLabel,
-  precision,
-  label,
-  labelTextProps,
-  inputWrapperProps,
-  rootProps,
-  value,
-  id,
-  min,
-  max,
-  onChange,
-  validationError,
-  disabled,
-  ...rest
-}) => {
-  // eslint-disable-next-line no-magic-numbers
-  const step = 1 / 10 ** precision!;
+const CurrencyInput = React.forwardRef<HTMLInputElement, ICurrencyInputProps>(
+  (
+    { currencyLabel, precision, value, min, max, onChange, disabled, ...props },
+    ref
+  ) => {
+    // eslint-disable-next-line no-magic-numbers
+    const step = 1 / 10 ** precision!;
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    let valueConvertedToPrecision = formatNumberWithPrecision(
-      e.target.valueAsNumber,
-      precision!
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      let valueConvertedToPrecision = formatNumberWithPrecision(
+        e.target.valueAsNumber,
+        precision!
+      );
+
+      if (min) {
+        valueConvertedToPrecision = Math.max(valueConvertedToPrecision, min);
+      }
+      if (max) {
+        valueConvertedToPrecision = Math.min(valueConvertedToPrecision, max);
+      }
+
+      onChange?.(valueConvertedToPrecision);
+    };
+
+    const visibleValue = formatNumberWithPrecision(value ?? 0, precision!);
+
+    return (
+      <TextInput
+        icon={
+          <Box
+            /* FIXME: Add disabled style */
+            color='text-xweak'
+          >
+            {currencyLabel}
+          </Box>
+        }
+        value={visibleValue}
+        type='number'
+        step={step}
+        onChange={handleChange}
+        min={min}
+        max={max}
+        disabled={disabled}
+        {...props}
+        ref={ref}
+      />
     );
-
-    if (min) {
-      valueConvertedToPrecision = Math.max(valueConvertedToPrecision, min);
-    }
-    if (max) {
-      valueConvertedToPrecision = Math.min(valueConvertedToPrecision, max);
-    }
-
-    onChange?.(valueConvertedToPrecision);
-  };
-
-  const visibleValue = formatNumberWithPrecision(value ?? 0, precision!);
-
-  return (
-    <div {...rootProps}>
-      {label && (
-        <LabelText {...labelTextProps} htmlFor={id}>
-          {label}
-        </LabelText>
-      )}
-      <InputWrapper {...inputWrapperProps} disabled={disabled}>
-        <CurrencyLabel disabled={disabled}>{currencyLabel}</CurrencyLabel>
-        <StyledInput
-          {...rest}
-          id={id}
-          value={visibleValue}
-          type='number'
-          step={step}
-          onChange={handleChange}
-          min={min}
-          max={max}
-          disabled={disabled}
-        />
-      </InputWrapper>
-      {validationError && (
-        <ValidationError>
-          <i className='fa fa-warning' /> {validationError}
-        </ValidationError>
-      )}
-    </div>
-  );
-};
+  }
+);
 
 CurrencyInput.propTypes = {
   currencyLabel: PropTypes.string,
   precision: PropTypes.number,
   value: PropTypes.number,
-  id: PropTypes.string,
-  label: PropTypes.string,
   min: PropTypes.number,
   max: PropTypes.number,
-  labelTextProps: PropTypes.object,
-  inputWrapperProps: PropTypes.object,
-  rootProps: PropTypes.object,
   onChange: PropTypes.func,
-  validationError: PropTypes.string,
   disabled: PropTypes.bool,
 };
 
@@ -193,14 +113,3 @@ CurrencyInput.defaultProps = {
 };
 
 export default CurrencyInput;
-
-function formatNumberWithPrecision(num: number, precision: number): number {
-  if (Number.isNaN(num)) {
-    return 0;
-  }
-
-  // eslint-disable-next-line no-magic-numbers
-  const precisionFactor = 10 ** precision;
-
-  return Math.round(num * precisionFactor) / precisionFactor;
-}

--- a/src/components/UI/Inputs/CurrencyInput/index.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/index.tsx
@@ -1,4 +1,4 @@
-import { Box } from 'grommet';
+import { Text } from 'grommet';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 
@@ -76,12 +76,9 @@ const CurrencyInput = React.forwardRef<HTMLInputElement, ICurrencyInputProps>(
     return (
       <TextInput
         icon={
-          <Box
-            /* FIXME: Add disabled style */
-            color='text-xweak'
-          >
+          <Text color={disabled ? 'text-xweak' : 'text-weak'}>
             {currencyLabel}
-          </Box>
+          </Text>
         }
         value={visibleValue}
         type='number'

--- a/src/components/UI/Inputs/CurrencyInput/stories/Constraints.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/stories/Constraints.tsx
@@ -16,3 +16,10 @@ Constraints.args = {
   max: 10,
   min: 2,
 };
+
+Constraints.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/CurrencyInput/stories/Currencies.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/stories/Currencies.tsx
@@ -18,4 +18,8 @@ Currencies.args = {
 
 Currencies.argTypes = {
   currencyLabel: { control: { type: 'select', options: ['€', '$', '£'] } },
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
 };

--- a/src/components/UI/Inputs/CurrencyInput/stories/FloatValues.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/stories/FloatValues.tsx
@@ -15,3 +15,10 @@ FloatValues.args = {
   value: 13.5000000004,
   precision: 5,
 };
+
+FloatValues.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/CurrencyInput/stories/Label.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/stories/Label.tsx
@@ -15,3 +15,10 @@ Label.args = {
   value: 1,
   label: 'Rent price',
 };
+
+Label.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/CurrencyInput/stories/Simple.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/stories/Simple.tsx
@@ -14,3 +14,10 @@ export const Simple: Story<ComponentPropsWithoutRef<typeof CurrencyInput>> = (
 Simple.args = {
   value: 1,
 };
+
+Simple.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/CurrencyInput/stories/ValidationError.tsx
+++ b/src/components/UI/Inputs/CurrencyInput/stories/ValidationError.tsx
@@ -13,5 +13,12 @@ export const ValidationError: Story<
 
 ValidationError.args = {
   value: 1,
-  validationError: 'Naah. Wrong value',
+  error: 'Naah. Wrong value',
+};
+
+ValidationError.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
 };


### PR DESCRIPTION
Towards the `grommet` migration

The new component keeps the same functionality as the old one, but adds consistency to the visual and programmatical interface with the other inputs.