### PR TITLE
Fix dimensions of Button style "danger"

### DIFF
--- a/src/components/UI/Controls/Button/index.js
+++ b/src/components/UI/Controls/Button/index.js
@@ -86,10 +86,15 @@ const Wrapper = styled.div`
     border-color: #278626;
   }
 
+  .btn-danger {
+    background-color: #d9534f;
+    border: 1px #d9534f solid;
+  }
+
   .btn-danger:hover,
   .btn-danger:active:hover {
     background-color: #d43f3a;
-    border-color: #d43f3a;
+    border: 1px #d43f3a solid;
   }
 
   .btn:disabled,


### PR DESCRIPTION
The Button with style `danger` was 32 pixels high instead of the 34 pixels the other styles use. This PR fixes that.