### PR TITLE
Disable airbrake remoteConfig to prevent requests to notifier-configs.airbrake.io

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -55,6 +55,8 @@ if (window.config.environment !== GlobalEnvironment.Dev) {
     projectId: 1,
     projectKey: 'happa',
     environment: window.config.environment,
+    // turn off attempt to fetch config from server
+    remoteConfig: false,
   });
 
   // Reach into the airbrake notifier instance and modify the private _url and


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/16339

This PR turns off the airbrake remote configuration feature. Having this on by default caused requests to an airbrake.io server, which resulted in 403 responses.