### PR TITLE
Add mapi service for performing selfSubjectRulesReview

### DIFF
--- a/src/model/services/mapi/authorization/index.ts
+++ b/src/model/services/mapi/authorization/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './selfSubjectRulesReview';

--- a/src/model/services/mapi/authorization/selfSubjectRulesReview.ts
+++ b/src/model/services/mapi/authorization/selfSubjectRulesReview.ts
@@ -1,0 +1,36 @@
+import { HttpRequestMethods, IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { ISelfSubjectRulesReview } from './';
+
+export function selfSubjectRulesReview(
+  client: IHttpClient,
+  user: ILoggedInUser
+) {
+  return async () => {
+    const url = k8sUrl.create({
+      baseUrl: window.config.mapiEndpoint,
+      apiVersion: 'authorization.k8s.io/v1',
+      kind: 'SelfSubjectRulesReviews',
+    });
+
+    const requestBody: ISelfSubjectRulesReview = {
+      apiVersion: 'authorization.k8s.io/v1',
+      kind: 'SelfSubjectRulesReview',
+      spec: {
+        namespace: 'default',
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client.setBody(requestBody as Record<string, any>);
+
+    client.setURL(url.toString());
+    client.setHeader('Accept', 'application/json');
+    client.setRequestMethod(HttpRequestMethods.POST);
+    client.setAuthorizationToken(user.auth.scheme, user.auth.token);
+
+    const response = await client.execute<ISelfSubjectRulesReview>();
+
+    return response.data;
+  };
+}

--- a/src/model/services/mapi/authorization/types.ts
+++ b/src/model/services/mapi/authorization/types.ts
@@ -1,0 +1,56 @@
+import * as metav1 from '../metav1';
+
+export interface ISelfSubjectRulesReviewSpec {
+  namespace: string;
+}
+
+// https://github.com/kubernetes/kubernetes/blob/2eb6911e832152abb1cbfd31ae15ceceb4e844a0/pkg/apis/authorization/types.go#L179
+
+// ResourceRule is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant,
+// may contain duplicates, and possibly be incomplete.
+export interface IResourceRule {
+  // Verb is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+  verbs: string[];
+  // APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
+  // the enumerated resources in any API group will be allowed.  "*" means all.
+  apiGroups: string[];
+  // Resources is a list of resources this rule applies to.  "*" means all in the specified apiGroups.
+  //  "*/foo" represents the subresource 'foo' for all resources in the specified apiGroups.
+  resources: string[];
+  // ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.  "*" means all.
+  resourceNames: string[];
+}
+
+// NonResourceRule holds information that describes a rule for the non-resource
+interface INonResourceRule {
+  // Verb is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+  Verbs: string[];
+
+  // NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full,
+  // final step in the path.  "*" means all.
+  NonResourceURLs: string[];
+}
+
+export interface ISelfSubjectRulesReviewStatus {
+  // ResourceRules is the list of actions the subject is allowed to perform on resources.
+  // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  resourceRules: IResourceRule[];
+  // NonResourceRules is the list of actions the subject is allowed to perform on non-resources.
+  // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  nonResourceRules: INonResourceRule[];
+  // Incomplete is true when the rules returned by this call are incomplete. This is most commonly
+  // encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+  incomplete: boolean;
+  // EvaluationError can appear in combination with Rules. It indicates an error occurred during
+  // rule evaluation, such as an authorizer that doesn't support rule evaluation, and that
+  // ResourceRules and/or NonResourceRules may be incomplete.
+  evaluationError: string;
+}
+
+export interface ISelfSubjectRulesReview {
+  apiVersion: string;
+  kind: string;
+  metadata?: metav1.IObjectMeta;
+  spec: ISelfSubjectRulesReviewSpec;
+  status?: ISelfSubjectRulesReviewStatus;
+}

--- a/src/stores/batchActions.ts
+++ b/src/stores/batchActions.ts
@@ -4,6 +4,8 @@ import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
 import RoutePath from 'lib/routePath';
+import { HttpClientImpl } from 'model/clients/HttpClient';
+import { selfSubjectRulesReview } from 'model/services/mapi/authorization';
 import { AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
@@ -36,6 +38,7 @@ import {
   refreshUserInfo,
 } from 'stores/main/actions';
 import { getInfo, resumeLogin } from 'stores/main/actions';
+import { getLoggedInUser } from 'stores/main/selectors';
 import { getHasAccessToResources, getUserIsAdmin } from 'stores/main/selectors';
 import { modalHide } from 'stores/modal/actions';
 import {
@@ -61,6 +64,14 @@ export function batchedLayout(
 
     try {
       await dispatch(resumeLogin(auth));
+
+      const client = new HttpClientImpl();
+      const user = getLoggedInUser(getState());
+
+      if (user) {
+        const data = await selfSubjectRulesReview(client, user)();
+        console.log(data);
+      }
 
       try {
         await dispatch(organizationsLoad());


### PR DESCRIPTION
@axbarsan I'm looking to make the `getHasAccessToResources` function check if the user can LIST Organizations by actually checking for the permission instead of checking the organization count. This would help in the case of a new cluster like @whites11 ran into yesterday on `flamingo`

I started with setting up the MAPI call that does the selfSubjectRulesReview, and am getting back a good response. Basically from this I can figure out if they have access to listing orgs. 

(verbs: *, apiGroups: *, resources: *) would be an instant yes, and I can write something that figures out if they specifically have the list orgs permission too.

but I'm wondering how to integrate this into the app... right now Ive added it to `batchActions.ts`, and will probably write an action to add it to the global state. This seems to make sense to me.. we're not going to completely remove redux I think? We still need some global state for things like the user.

Also am I initialising the http client correctly in this case?