### PR TITLE
access control: add components needed for displaying the role list sidebar

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -1,0 +1,20 @@
+import * as ui from 'UI/Display/MAPI/AccessControl/types';
+
+/**
+ * Filter roles based on a search query.
+ * @param roles
+ * @param query
+ */
+export function filterRoles(
+  roles: ui.IAccessControlRoleItem[],
+  query: string
+): ui.IAccessControlRoleItem[] {
+  return roles.filter((role) => {
+    const searchQuery = query.trim().toLowerCase();
+    if (!searchQuery) return true;
+
+    const value = role.name.toLowerCase();
+
+    return value.includes(searchQuery);
+  });
+}

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -9,10 +9,10 @@ export function filterRoles(
   roles: ui.IAccessControlRoleItem[],
   query: string
 ): ui.IAccessControlRoleItem[] {
-  return roles.filter((role) => {
-    const searchQuery = query.trim().toLowerCase();
-    if (!searchQuery) return true;
+  const searchQuery = query.trim().toLowerCase();
+  if (!searchQuery) return roles;
 
+  return roles.filter((role) => {
     const value = role.name.toLowerCase();
 
     return value.includes(searchQuery);

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
@@ -1,0 +1,145 @@
+import { Box, InfiniteScroll, Keyboard, Sidebar } from 'grommet';
+import useDebounce from 'lib/hooks/useDebounce';
+import { filterRoles } from 'MAPI/organizations/AccessControl/utils';
+import PropTypes from 'prop-types';
+import React, { useCallback, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import TextInput from 'UI/Inputs/TextInput';
+
+import AccessControlRoleListItem from './AccessControlRoleListItem';
+import AccessControlRoleListItemLoadingPlaceholder from './AccessControlRoleListItemLoadingPlaceholder';
+import AccessControlRolePlaceholder from './AccessControlRolePlaceholder';
+import AccessControlRoleSearchPlaceholder from './AccessControlRoleSearchPlaceholder';
+import { IAccessControlRoleItem } from './types';
+
+const SEARCH_DEBOUNCE_RATE_MS = 250;
+/**
+ * A bunch of placeholder components used for the loading
+ * animation. Replace `6` with the number of components you
+ * want to show.
+ */
+const LOADING_COMPONENTS = new Array(6).fill(0).map((_, idx) => idx);
+
+const Content = styled(Box)`
+  position: sticky;
+  top: 110px;
+`;
+
+interface IAccessControlRoleListProps
+  extends React.ComponentPropsWithoutRef<typeof Sidebar> {
+  activeRoleName: string;
+  setActiveRoleName: (newName: string) => void;
+  roles?: IAccessControlRoleItem[];
+  errorMessage?: string;
+}
+
+const AccessControlRoleList: React.FC<IAccessControlRoleListProps> = ({
+  roles,
+  activeRoleName,
+  setActiveRoleName,
+  errorMessage,
+  ...props
+}) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const debouncedSearchQuery = useDebounce(
+    searchQuery,
+    SEARCH_DEBOUNCE_RATE_MS
+  );
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+  const filteredRoles = useMemo(() => {
+    if (!roles) return [];
+
+    return filterRoles(roles, debouncedSearchQuery);
+  }, [debouncedSearchQuery, roles]);
+
+  const handleItemClick = useCallback(
+    (name: string) => (e: React.MouseEvent<HTMLElement>) => {
+      e.preventDefault();
+
+      setActiveRoleName(name);
+    },
+    [setActiveRoleName]
+  );
+
+  let loadingErrorMessage = errorMessage;
+  if (loadingErrorMessage) {
+    loadingErrorMessage = `Error loading roles: ${loadingErrorMessage}`;
+  }
+
+  return (
+    <Sidebar responsive={false} {...props}>
+      <Content>
+        <Box margin={{ bottom: 'small' }}>
+          <TextInput
+            icon={
+              <i
+                className='fa fa-search'
+                role='presentation'
+                aria-hidden={true}
+                title='Find role'
+              />
+            }
+            placeholder='Find role'
+            value={searchQuery}
+            onChange={handleSearch}
+            readOnly={!roles}
+            error={loadingErrorMessage}
+          />
+        </Box>
+        <Keyboard
+          onSpace={(e) => {
+            e.preventDefault();
+
+            (e.target as HTMLElement).click();
+          }}
+        >
+          <Box
+            height={{ max: '60vh' }}
+            overflow={{ vertical: 'auto' }}
+            pad='small'
+          >
+            {!roles &&
+              LOADING_COMPONENTS.map((idx) => (
+                <AccessControlRoleListItemLoadingPlaceholder
+                  key={idx}
+                  margin={{ bottom: 'small' }}
+                />
+              ))}
+
+            {roles && roles.length < 1 && <AccessControlRolePlaceholder />}
+
+            {roles && roles.length > 0 && filteredRoles.length < 1 && (
+              <AccessControlRoleSearchPlaceholder />
+            )}
+
+            <InfiniteScroll replace={true} items={filteredRoles} step={50}>
+              {(role: IAccessControlRoleItem) => (
+                <AccessControlRoleListItem
+                  key={role.name}
+                  margin={{ bottom: 'small' }}
+                  active={activeRoleName === role.name}
+                  onClick={handleItemClick(role.name)}
+                  {...role}
+                />
+              )}
+            </InfiniteScroll>
+          </Box>
+        </Keyboard>
+      </Content>
+    </Sidebar>
+  );
+};
+
+AccessControlRoleList.propTypes = {
+  activeRoleName: PropTypes.string.isRequired,
+  setActiveRoleName: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
+  // @ts-expect-error
+  roles: PropTypes.arrayOf(PropTypes.object.isRequired),
+  errorMessage: PropTypes.string,
+};
+
+export default AccessControlRoleList;

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -1,0 +1,130 @@
+import { Box, Card, CardBody, CardHeader, Heading, Text } from 'grommet';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import styled from 'styled-components';
+
+import {
+  IAccessControlRoleItem,
+  IAccessControlRoleItemPermission,
+} from './types';
+
+function formatResourceCounter(
+  permissions: IAccessControlRoleItemPermission[]
+): string {
+  let totalCount = 0;
+  for (const perm of permissions) {
+    for (const group of perm.apiGroups) {
+      if (group === '*') return 'All';
+    }
+    for (const resource of perm.resources) {
+      if (resource === '*') return 'All';
+    }
+
+    totalCount += perm.resourceNames.length + perm.resources.length;
+  }
+
+  return formatCounter(totalCount);
+}
+
+function formatCounter(fromValue: number): string {
+  switch (true) {
+    case fromValue === 0:
+      return 'None';
+    // eslint-disable-next-line no-magic-numbers
+    case fromValue > 99:
+      return '99+';
+    default:
+      return fromValue.toString();
+  }
+}
+
+const StyledCard = styled(Card)`
+  min-height: auto;
+  box-shadow: ${(props) =>
+    props['aria-selected']
+      ? `0 0 0 1px ${props.theme.global.colors.text.dark}`
+      : 'none'};
+  outline: ${(props) => props['aria-selected'] && 'none'};
+  transition: opacity 0.1s ease-out, box-shadow 0.1s ease-in-out;
+
+  :hover,
+  :focus {
+    box-shadow: ${(props) =>
+      `0 0 0 1px ${props.theme.global.colors.text.dark}`};
+  }
+
+  :active {
+    opacity: 0.7;
+  }
+`;
+
+interface IAccessControlRoleListItemProps
+  extends IAccessControlRoleItem,
+    React.ComponentPropsWithoutRef<typeof Card> {
+  active?: boolean;
+}
+
+const AccessControlRoleListItem = React.forwardRef<
+  HTMLDivElement,
+  IAccessControlRoleListItemProps
+>(({ name, namespace, active, permissions, groups, users, ...props }, ref) => {
+  const resourceCount = formatResourceCounter(permissions);
+  const groupCount = formatCounter(Object.values(groups).length);
+  const userCount = formatCounter(Object.values(users).length);
+
+  return (
+    <StyledCard
+      pad={{ vertical: 'small', horizontal: 'medium' }}
+      round='xsmall'
+      elevation='none'
+      overflow='visible'
+      background='background-front'
+      aria-selected={active}
+      role='button'
+      tabIndex={active ? -1 : 0}
+      {...props}
+      ref={ref}
+    >
+      <CardHeader>
+        <Heading level={5} margin='none'>
+          <Box direction='row' align='center'>
+            <Text truncate={true}>{name}</Text>
+
+            {namespace.length < 1 && (
+              <Text margin={{ left: 'xxsmall' }}>
+                <i className='fa fa-globe' aria-label='Cluster role' />
+              </Text>
+            )}
+          </Box>
+        </Heading>
+      </CardHeader>
+      <CardBody margin={{ top: 'xsmall' }}>
+        <Box justify='between' direction='row'>
+          <Box width='120px'>
+            <Text color='text-weak'>Resources: {resourceCount}</Text>
+          </Box>
+          <Box width='100px'>
+            <Text color='text-weak'>Groups: {groupCount}</Text>
+          </Box>
+          <Box width='100px'>
+            <Text color='text-weak'>Users: {userCount}</Text>
+          </Box>
+        </Box>
+      </CardBody>
+    </StyledCard>
+  );
+});
+
+AccessControlRoleListItem.propTypes = {
+  name: PropTypes.string.isRequired,
+  namespace: PropTypes.string.isRequired,
+  active: PropTypes.bool.isRequired,
+  // @ts-expect-error
+  permissions: PropTypes.arrayOf(PropTypes.object.isRequired),
+  // @ts-expect-error
+  groups: PropTypes.object.isRequired,
+  // @ts-expect-error
+  users: PropTypes.object.isRequired,
+};
+
+export default AccessControlRoleListItem;

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItemLoadingPlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItemLoadingPlaceholder.tsx
@@ -1,0 +1,35 @@
+import { Box } from 'grommet';
+import * as React from 'react';
+import ContentLoader from 'react-content-loader';
+import { useTheme } from 'styled-components';
+
+interface IAccessControlRoleListItemLoadingPlaceholderProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {}
+
+const AccessControlRoleListItemLoadingPlaceholder: React.FC<IAccessControlRoleListItemLoadingPlaceholderProps> = (
+  props
+) => {
+  const theme = useTheme();
+
+  return (
+    <Box background='background-front' round='small' {...props}>
+      <ContentLoader
+        viewBox='0 0 400 65'
+        speed={2}
+        height='65'
+        width='100%'
+        backgroundColor={theme.global.colors['text-xweak'].dark}
+        foregroundColor={theme.global.colors['text-weak'].dark}
+      >
+        <rect x='18' y='12' rx='4' ry='4' width='365' height='15' />
+        <rect x='18' y='38' rx='4' ry='4' width='125' height='15' />
+        <rect x='158' y='38' rx='4' ry='4' width='105' height='15' />
+        <rect x='278' y='38' rx='4' ry='4' width='105' height='15' />
+      </ContentLoader>
+    </Box>
+  );
+};
+
+AccessControlRoleListItemLoadingPlaceholder.propTypes = {};
+
+export default React.memo(AccessControlRoleListItemLoadingPlaceholder);

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRolePlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRolePlaceholder.tsx
@@ -1,0 +1,39 @@
+import { Card, CardBody, Heading, Text } from 'grommet';
+import * as React from 'react';
+
+interface IAccessControlRolePlaceholderProps
+  extends React.ComponentPropsWithoutRef<typeof Card> {}
+
+const AccessControlRolePlaceholder: React.FC<IAccessControlRolePlaceholderProps> = (
+  props
+) => {
+  return (
+    <Card
+      pad='medium'
+      round='xsmall'
+      elevation='none'
+      background='background-contrast'
+      {...props}
+    >
+      <CardBody>
+        <Heading level={4} margin={{ top: 'none' }}>
+          <Text size='xlarge' margin={{ right: 'small' }}>
+            <i
+              className='fa fa-close-circle'
+              role='presentation'
+              aria-hidden='true'
+            />
+          </Text>
+          No roles available
+        </Heading>
+        <Text color='text-weak'>
+          Please get in touch with your support engineer to set up one.
+        </Text>
+      </CardBody>
+    </Card>
+  );
+};
+
+AccessControlRolePlaceholder.propTypes = {};
+
+export default AccessControlRolePlaceholder;

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleSearchPlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleSearchPlaceholder.tsx
@@ -1,0 +1,35 @@
+import { Card, CardBody, Heading, Text } from 'grommet';
+import * as React from 'react';
+
+interface IAccessControlRoleSearchPlaceholderProps
+  extends React.ComponentPropsWithoutRef<typeof Card> {}
+
+const AccessControlRoleSearchPlaceholder: React.FC<IAccessControlRoleSearchPlaceholderProps> = (
+  props
+) => {
+  return (
+    <Card
+      pad='medium'
+      round='xsmall'
+      elevation='none'
+      background='background-contrast'
+      {...props}
+    >
+      <CardBody>
+        <Heading level={4} margin={{ top: 'none' }}>
+          <Text size='xlarge' margin={{ right: 'small' }}>
+            <i className='fa fa-info' role='presentation' aria-hidden='true' />
+          </Text>
+          No roles found for your search
+        </Heading>
+        <Text color='text-weak'>
+          Please verify that your search query is correct.
+        </Text>
+      </CardBody>
+    </Card>
+  );
+};
+
+AccessControlRoleSearchPlaceholder.propTypes = {};
+
+export default AccessControlRoleSearchPlaceholder;

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleList.tsx
@@ -1,0 +1,330 @@
+import {
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from '@testing-library/react';
+import { getComponentWithTheme, renderWithTheme } from 'testUtils/renderUtils';
+
+import AccessControlRoleList from '../AccessControlRoleList';
+import { IAccessControlRoleSubjectItem } from '../types';
+
+function makeSubjects(
+  count: number,
+  prefix: string = 'subject'
+): Record<string, IAccessControlRoleSubjectItem> {
+  const subjects: Record<string, IAccessControlRoleSubjectItem> = {};
+
+  for (let i = 0; i < count; i++) {
+    const name = `${prefix}-${i}`;
+    subjects[name] = {
+      name,
+      isEditable: true,
+      roleBindings: [],
+    };
+  }
+
+  return subjects;
+}
+
+describe('AccessControlRoleList', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(AccessControlRoleList, {
+      activeRoleName: '',
+      setActiveRoleName: jest.fn(),
+      roles: [],
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleList>);
+  });
+
+  it('renders various roles correctly', () => {
+    renderWithTheme(AccessControlRoleList, {
+      activeRoleName: '',
+      setActiveRoleName: jest.fn(),
+      roles: [
+        {
+          name: 'some-role',
+          managedBy: '',
+          namespace: '',
+          groups: {},
+          users: {},
+          serviceAccounts: {},
+          permissions: [],
+        },
+        {
+          name: 'some-other-role',
+          managedBy: '',
+          namespace: 'test-namespace',
+          groups: {
+            'group-1': {
+              name: 'group-1',
+              isEditable: true,
+              roleBindings: [],
+            },
+          },
+          users: {
+            'user-1': {
+              name: 'user-1',
+              isEditable: true,
+              roleBindings: [],
+            },
+          },
+          serviceAccounts: {},
+          permissions: [
+            {
+              apiGroups: ['*'],
+              resources: ['*'],
+              resourceNames: [],
+              verbs: ['*'],
+            },
+          ],
+        },
+        {
+          name: 'some-cool-role',
+          managedBy: '',
+          namespace: 'test-namespace',
+          groups: {},
+          // eslint-disable-next-line no-magic-numbers
+          users: makeSubjects(150),
+          serviceAccounts: {},
+          permissions: [
+            {
+              apiGroups: ['*'],
+              resources: ['*'],
+              resourceNames: [],
+              verbs: ['*'],
+            },
+          ],
+        },
+      ],
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleList>);
+
+    let role = screen
+      .getByText('some-role')
+      .closest('[role=button]') as HTMLElement;
+    expect(within(role).getByLabelText('Cluster role')).toBeInTheDocument();
+    expect(within(role).getByText('Resources: None')).toBeInTheDocument();
+    expect(within(role).getByText('Groups: None')).toBeInTheDocument();
+    expect(within(role).getByText('Users: None')).toBeInTheDocument();
+
+    role = screen
+      .getByText('some-other-role')
+      .closest('[role=button]') as HTMLElement;
+    expect(
+      within(role).queryByLabelText('Cluster role')
+    ).not.toBeInTheDocument();
+    expect(within(role).getByText('Resources: All')).toBeInTheDocument();
+    expect(within(role).getByText('Groups: 1')).toBeInTheDocument();
+    expect(within(role).getByText('Users: 1')).toBeInTheDocument();
+
+    role = screen
+      .getByText('some-cool-role')
+      .closest('[role=button]') as HTMLElement;
+    expect(
+      within(role).queryByLabelText('Cluster role')
+    ).not.toBeInTheDocument();
+    expect(within(role).getByText('Resources: All')).toBeInTheDocument();
+    expect(within(role).getByText('Groups: None')).toBeInTheDocument();
+    expect(within(role).getByText('Users: 99+')).toBeInTheDocument();
+  });
+
+  it('renders a loading placeholder if the data is not present', () => {
+    const { rerender } = renderWithTheme(AccessControlRoleList, {
+      activeRoleName: '',
+      setActiveRoleName: jest.fn(),
+      roles: undefined,
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleList>);
+    expect(screen.getAllByTitle('Loading...').length).toBeGreaterThan(0);
+
+    rerender(
+      getComponentWithTheme(AccessControlRoleList, {
+        activeRoleName: '',
+        setActiveRoleName: jest.fn(),
+        roles: [],
+      })
+    );
+
+    expect(screen.queryByTitle('Loading...')).not.toBeInTheDocument();
+  });
+
+  it('renders a placeholder if the data is present, but empty', () => {
+    renderWithTheme(AccessControlRoleList, {
+      activeRoleName: '',
+      setActiveRoleName: jest.fn(),
+      roles: [],
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleList>);
+
+    expect(screen.getByText('No roles available')).toBeInTheDocument();
+  });
+
+  it('can select a specific active role', () => {
+    const setActiveRoleNameMockFn = jest.fn();
+    renderWithTheme(AccessControlRoleList, {
+      activeRoleName: '',
+      setActiveRoleName: setActiveRoleNameMockFn,
+      roles: [
+        {
+          name: 'some-role',
+          managedBy: '',
+          namespace: '',
+          groups: {},
+          users: {},
+          serviceAccounts: {},
+          permissions: [],
+        },
+        {
+          name: 'some-other-role',
+          managedBy: '',
+          namespace: 'test-namespace',
+          groups: {
+            'group-1': {
+              name: 'group-1',
+              isEditable: true,
+              roleBindings: [],
+            },
+          },
+          users: {
+            'user-1': {
+              name: 'user-1',
+              isEditable: true,
+              roleBindings: [],
+            },
+          },
+          serviceAccounts: {},
+          permissions: [
+            {
+              apiGroups: ['some-group.domain.com'],
+              resources: ['*'],
+              resourceNames: [],
+              verbs: ['*'],
+            },
+          ],
+        },
+      ],
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleList>);
+
+    fireEvent.click(screen.getByText('some-role').closest('[role=button]')!);
+
+    expect(setActiveRoleNameMockFn).toHaveBeenCalledWith('some-role');
+  });
+
+  it('can search for a specific role', async () => {
+    renderWithTheme(AccessControlRoleList, {
+      activeRoleName: '',
+      setActiveRoleName: jest.fn(),
+      roles: [
+        {
+          name: 'some-role',
+          managedBy: '',
+          namespace: '',
+          groups: {},
+          users: {},
+          serviceAccounts: {},
+          permissions: [],
+        },
+        {
+          name: 'some-other-role',
+          managedBy: '',
+          namespace: 'test-namespace',
+          groups: {
+            'group-1': {
+              name: 'group-1',
+              isEditable: true,
+              roleBindings: [],
+            },
+          },
+          users: {
+            'user-1': {
+              name: 'user-1',
+              isEditable: true,
+              roleBindings: [],
+            },
+          },
+          serviceAccounts: {},
+          permissions: [
+            {
+              apiGroups: ['*'],
+              resources: ['*'],
+              resourceNames: [],
+              verbs: ['*'],
+            },
+          ],
+        },
+      ],
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleList>);
+
+    const searchInput = screen.getByPlaceholderText('Find role');
+    fireEvent.change(searchInput, { target: { value: 'some-role' } });
+
+    expect(screen.getByText('some-role')).toBeInTheDocument();
+    await waitForElementToBeRemoved(() => screen.getByText('some-other-role'));
+  });
+
+  it('displays a placeholder if searching for something returned no values', async () => {
+    renderWithTheme(AccessControlRoleList, {
+      activeRoleName: '',
+      setActiveRoleName: jest.fn(),
+      roles: [
+        {
+          name: 'some-role',
+          managedBy: '',
+          namespace: '',
+          groups: {},
+          users: {},
+          serviceAccounts: {},
+          permissions: [],
+        },
+        {
+          name: 'some-other-role',
+          managedBy: '',
+          namespace: 'test-namespace',
+          groups: {
+            'group-1': {
+              name: 'group-1',
+              isEditable: true,
+              roleBindings: [],
+            },
+          },
+          users: {
+            'user-1': {
+              name: 'user-1',
+              isEditable: true,
+              roleBindings: [],
+            },
+          },
+          serviceAccounts: {},
+          permissions: [
+            {
+              apiGroups: ['*'],
+              resources: ['*'],
+              resourceNames: [],
+              verbs: ['*'],
+            },
+          ],
+        },
+      ],
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleList>);
+
+    const searchInput = screen.getByPlaceholderText('Find role');
+    fireEvent.change(searchInput, { target: { value: 'randomjajaja' } });
+
+    await waitForElementToBeRemoved(() => screen.getByText('some-role'));
+    expect(screen.queryByText('some-other-role')).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('No roles found for your search')
+    ).toBeInTheDocument();
+  });
+
+  it('displays a provided error', () => {
+    renderWithTheme(AccessControlRoleList, {
+      activeRoleName: '',
+      setActiveRoleName: jest.fn(),
+      roles: undefined,
+      errorMessage: 'Oh no! There was an error.',
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleList>);
+
+    expect(
+      screen.getByText('Error loading roles: Oh no! There was an error.')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/UI/Display/MAPI/AccessControl/types.ts
+++ b/src/components/UI/Display/MAPI/AccessControl/types.ts
@@ -1,0 +1,44 @@
+export enum AccessControlSubjectTypes {
+  Group,
+  User,
+  ServiceAccount,
+}
+
+export interface IAccessControlRoleSubjectRoleBinding {
+  name: string;
+  namespace: string;
+}
+
+export interface IAccessControlRoleSubjectItem {
+  name: string;
+  isEditable: boolean;
+  roleBindings: IAccessControlRoleSubjectRoleBinding[];
+}
+
+export type AccessControlRoleItemVerb =
+  | 'get'
+  | 'watch'
+  | 'list'
+  | 'create'
+  | 'update'
+  | 'patch'
+  | 'delete'
+  | '*'
+  | string;
+
+export interface IAccessControlRoleItemPermission {
+  apiGroups: string[];
+  resources: string[];
+  resourceNames: string[];
+  verbs: AccessControlRoleItemVerb[];
+}
+
+export interface IAccessControlRoleItem {
+  name: string;
+  namespace: string;
+  managedBy: string;
+  groups: Record<string, IAccessControlRoleSubjectItem>;
+  users: Record<string, IAccessControlRoleSubjectItem>;
+  serviceAccounts: Record<string, IAccessControlRoleSubjectItem>;
+  permissions: IAccessControlRoleItemPermission[];
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#16306

This PR adds the UI components, UI types, and business logic required to render the role list sidebar in the `Access control` page.