### PR TITLE
access control: add components necessary for the 'Subjects' tab

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
@@ -1,0 +1,377 @@
+import { Box, Text } from 'grommet';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import PropTypes from 'prop-types';
+import React, { useEffect, useReducer } from 'react';
+import AccessControlSubjectSet, {
+  IAccessControlSubjectSetItem,
+} from 'UI/Display/MAPI/AccessControl/AccessControlSubjectSet';
+import AccessControlSubjectSetItem from 'UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem';
+
+import {
+  AccessControlSubjectTypes,
+  IAccessControlRoleItem,
+  IAccessControlRoleSubjectItem,
+} from '../../../UI/Display/MAPI/AccessControl/types';
+import { getUserNameParts } from './utils';
+
+interface IStateValue {
+  isAdding: boolean;
+  isLoading: boolean;
+  namesLoading: string[];
+}
+
+type State = Record<AccessControlSubjectTypes, IStateValue>;
+
+interface IAction {
+  type: 'startAdding' | 'stopAdding' | 'startLoading' | 'stopLoading' | 'reset';
+  subjectType: AccessControlSubjectTypes;
+  subjectName?: string;
+}
+
+const initialState: State = {
+  [AccessControlSubjectTypes.Group]: {
+    isAdding: false,
+    isLoading: false,
+    namesLoading: [],
+  },
+  [AccessControlSubjectTypes.User]: {
+    isAdding: false,
+    isLoading: false,
+    namesLoading: [],
+  },
+  [AccessControlSubjectTypes.ServiceAccount]: {
+    isAdding: false,
+    isLoading: false,
+    namesLoading: [],
+  },
+};
+
+const reducer: React.Reducer<State, IAction> = (state, action) => {
+  const currSubject = state[action.subjectType];
+
+  switch (action.type) {
+    case 'startAdding':
+      return {
+        ...state,
+        [action.subjectType]: {
+          ...currSubject,
+          isAdding: true,
+        },
+      };
+
+    case 'stopAdding':
+      return {
+        ...state,
+        [action.subjectType]: {
+          ...currSubject,
+          isAdding: false,
+        },
+      };
+
+    case 'startLoading':
+      if (action.subjectName) {
+        const namesLoading = [...currSubject.namesLoading];
+        if (!namesLoading.includes(action.subjectName)) {
+          namesLoading.push(action.subjectName);
+        }
+
+        return {
+          ...state,
+          [action.subjectType]: {
+            ...currSubject,
+            namesLoading,
+          },
+        };
+      }
+
+      return {
+        ...state,
+        [action.subjectType]: {
+          ...currSubject,
+          isLoading: true,
+        },
+      };
+
+    case 'stopLoading':
+      if (action.subjectName) {
+        const namesLoading = currSubject.namesLoading.filter(
+          (name) => name !== action.subjectName
+        );
+
+        return {
+          ...state,
+          [action.subjectType]: {
+            ...currSubject,
+            namesLoading,
+          },
+        };
+      }
+
+      return {
+        ...state,
+        [action.subjectType]: {
+          ...currSubject,
+          isLoading: false,
+        },
+      };
+
+    case 'reset':
+      return {
+        ...state,
+        [action.subjectType]: {
+          ...initialState[action.subjectType],
+        },
+      };
+
+    default:
+      return state;
+  }
+};
+
+const mapValueToSetItem = (stateValue: IStateValue) => (
+  value: IAccessControlRoleSubjectItem
+): IAccessControlSubjectSetItem => {
+  const isLoading = stateValue.namesLoading.includes(value.name);
+
+  return {
+    name: value.name,
+    isEditable: value.isEditable,
+    isLoading,
+  };
+};
+
+interface IAccessControlRoleSubjectsProps
+  extends Pick<IAccessControlRoleItem, 'groups' | 'users' | 'serviceAccounts'>,
+    React.ComponentPropsWithoutRef<typeof Box> {
+  roleName: string;
+  onAdd: (type: AccessControlSubjectTypes, names: string[]) => Promise<void>;
+  onDelete: (type: AccessControlSubjectTypes, name: string) => Promise<void>;
+}
+
+const AccessControlRoleSubjects: React.FC<IAccessControlRoleSubjectsProps> = ({
+  roleName,
+  groups,
+  users,
+  serviceAccounts,
+  onAdd,
+  onDelete,
+  ...props
+}) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const handleToggleAdding = (type: AccessControlSubjectTypes) => () => {
+    if (state[type].isAdding) {
+      dispatch({ type: 'stopAdding', subjectType: type });
+    } else {
+      dispatch({ type: 'startAdding', subjectType: type });
+    }
+  };
+
+  const handleAdd = (type: AccessControlSubjectTypes) => async (
+    values: string[]
+  ) => {
+    if (values.length < 1) {
+      dispatch({ type: 'stopAdding', subjectType: type });
+
+      return;
+    }
+
+    try {
+      dispatch({ type: 'startLoading', subjectType: type });
+      await onAdd(type, values);
+      dispatch({ type: 'stopAdding', subjectType: type });
+
+      let message = '';
+      if (values.length > 1) {
+        message = 'Subjects added successfully.';
+      } else {
+        message = 'Subject added successfully.';
+      }
+
+      new FlashMessage(message, messageType.SUCCESS, messageTTL.SHORT);
+    } catch (err: unknown) {
+      let message = '';
+      if (values.length > 1) {
+        message = 'Could not add subjects:';
+      } else {
+        message = 'Could not add subject:';
+      }
+      const errorMessage = (err as Error).message;
+
+      new FlashMessage(
+        message,
+        messageType.ERROR,
+        messageTTL.LONG,
+        errorMessage
+      );
+    } finally {
+      dispatch({ type: 'stopLoading', subjectType: type });
+    }
+  };
+
+  const handleDeleting = (type: AccessControlSubjectTypes) => async (
+    name: string
+  ) => {
+    try {
+      dispatch({ type: 'startLoading', subjectType: type, subjectName: name });
+      await onDelete(type, name);
+
+      new FlashMessage(
+        `Subject ${name} deleted successfully.`,
+        messageType.SUCCESS,
+        messageTTL.SHORT
+      );
+    } catch (err: unknown) {
+      const message = (err as Error).message;
+
+      new FlashMessage(
+        `Could not delete subject ${name}:`,
+        messageType.ERROR,
+        messageTTL.LONG,
+        message
+      );
+    } finally {
+      dispatch({ type: 'stopLoading', subjectType: type, subjectName: name });
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      dispatch({ type: 'reset', subjectType: AccessControlSubjectTypes.Group });
+      dispatch({ type: 'reset', subjectType: AccessControlSubjectTypes.User });
+      dispatch({
+        type: 'reset',
+        subjectType: AccessControlSubjectTypes.ServiceAccount,
+      });
+    };
+  }, [roleName]);
+
+  const groupType = state[AccessControlSubjectTypes.Group];
+  const userType = state[AccessControlSubjectTypes.User];
+  const serviceAccountType = state[AccessControlSubjectTypes.ServiceAccount];
+
+  return (
+    <Box direction='column' gap='medium' pad={{ top: 'small' }} {...props}>
+      <Box gap='small' direction='column' aria-label='Groups'>
+        <Box>
+          <Text size='medium' weight='bold'>
+            <i className='fa fa-group' /> Groups
+          </Text>
+        </Box>
+        <AccessControlSubjectSet
+          items={Object.values(groups).map(mapValueToSetItem(groupType))}
+          renderItem={(params) => (
+            <AccessControlSubjectSetItem
+              aria-label={params.name}
+              deleteTooltipMessage="Remove this group's binding to this role"
+              {...params}
+            />
+          )}
+          onAdd={handleAdd(AccessControlSubjectTypes.Group)}
+          onToggleAdding={handleToggleAdding(AccessControlSubjectTypes.Group)}
+          onDeleteItem={handleDeleting(AccessControlSubjectTypes.Group)}
+          isAdding={groupType.isAdding}
+          isLoading={groupType.isLoading}
+        />
+        {groupType.isAdding && (
+          <Box>
+            <Text>
+              Enter one or more group identifiers, exactly as defined in your
+              identity provider, including upper/lowercase spelling.
+            </Text>
+          </Box>
+        )}
+      </Box>
+      <Box gap='small' direction='column' aria-label='Users'>
+        <Box>
+          <Text size='medium' weight='bold'>
+            <i className='fa fa-user' /> Users
+          </Text>
+        </Box>
+        <AccessControlSubjectSet
+          items={Object.values(users).map(mapValueToSetItem(userType))}
+          renderItem={(params) => {
+            const [name, domain] = getUserNameParts(params.name);
+
+            return (
+              <AccessControlSubjectSetItem
+                aria-label={params.name}
+                deleteTooltipMessage="Remove this user's binding to this role"
+                {...params}
+                name={
+                  <Box direction='row'>
+                    <Text color='text-weak'>{name}</Text>
+                    {domain && <Text color='text-xweak'>{`@${domain}`}</Text>}
+                  </Box>
+                }
+              />
+            );
+          }}
+          onAdd={handleAdd(AccessControlSubjectTypes.User)}
+          onToggleAdding={handleToggleAdding(AccessControlSubjectTypes.User)}
+          onDeleteItem={handleDeleting(AccessControlSubjectTypes.User)}
+          isAdding={userType.isAdding}
+          isLoading={userType.isLoading}
+        />
+        {userType.isAdding && (
+          <Box>
+            <Text>
+              Enter one or more email addresses, exactly as defined in your
+              identity provider, including upper/lowercase spelling.
+            </Text>
+          </Box>
+        )}
+      </Box>
+      <Box gap='small' direction='column' aria-label='Service accounts'>
+        <Box>
+          <Text size='medium' weight='bold'>
+            <i className='fa fa-service-account' /> Service accounts
+          </Text>
+        </Box>
+        <AccessControlSubjectSet
+          items={Object.values(serviceAccounts).map(
+            mapValueToSetItem(serviceAccountType)
+          )}
+          renderItem={(params) => (
+            <AccessControlSubjectSetItem
+              aria-label={params.name}
+              deleteTooltipMessage="Remove this service account's binding to this role"
+              {...params}
+            />
+          )}
+          onAdd={handleAdd(AccessControlSubjectTypes.ServiceAccount)}
+          onToggleAdding={handleToggleAdding(
+            AccessControlSubjectTypes.ServiceAccount
+          )}
+          onDeleteItem={handleDeleting(
+            AccessControlSubjectTypes.ServiceAccount
+          )}
+          isAdding={serviceAccountType.isAdding}
+          isLoading={serviceAccountType.isLoading}
+        />
+        {serviceAccountType.isAdding && (
+          <Box>
+            <Text>
+              Enter one or more account identifiers, including upper/lowercase
+              spelling.
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+AccessControlRoleSubjects.propTypes = {
+  roleName: PropTypes.string.isRequired,
+  // @ts-expect-error
+  groups: PropTypes.object.isRequired,
+  // @ts-expect-error
+  users: PropTypes.object.isRequired,
+  // @ts-expect-error
+  serviceAccounts: PropTypes.object.isRequired,
+  onAdd: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+export default AccessControlRoleSubjects;

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -1,0 +1,509 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import AccessControlRoleSubjects from '../AccessControlRoleSubjects';
+
+describe('AccessControlRoleSubjects', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {},
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: jest.fn(),
+      onDelete: jest.fn(),
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+  });
+
+  it('renders all provided subjects', () => {
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {
+        'test-group1': {
+          name: 'test-group1',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-group2': {
+          name: 'test-group2',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-group3': {
+          name: 'test-group3',
+          isEditable: true,
+          roleBindings: [],
+        },
+      },
+      users: {
+        'test-user1@domain.com': {
+          name: 'test-user1@domain.com',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-user2': {
+          name: 'test-user2',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-user3': {
+          name: 'test-user3',
+          isEditable: true,
+          roleBindings: [],
+        },
+      },
+      serviceAccounts: {
+        'test-account1': {
+          name: 'test-account1',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-account2': {
+          name: 'test-account2',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-account3': {
+          name: 'test-account3',
+          isEditable: true,
+          roleBindings: [],
+        },
+      },
+      roleName: 'test-role',
+      onAdd: jest.fn(),
+      onDelete: jest.fn(),
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    expect(screen.getByText('test-group1')).toBeInTheDocument();
+    expect(screen.getByText('test-group2')).toBeInTheDocument();
+    expect(screen.getByText('test-group3')).toBeInTheDocument();
+
+    expect(screen.getByText('test-user1')).toBeInTheDocument();
+    expect(screen.getByText('@domain.com')).toBeInTheDocument();
+    expect(screen.getByText('test-user2')).toBeInTheDocument();
+    expect(screen.getByText('test-user3')).toBeInTheDocument();
+
+    expect(screen.getByText('test-account1')).toBeInTheDocument();
+    expect(screen.getByText('test-account2')).toBeInTheDocument();
+    expect(screen.getByText('test-account3')).toBeInTheDocument();
+  });
+
+  it('displays a delete button next to editable subjects', () => {
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {
+        'test-group1': {
+          name: 'test-group1',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-group2': {
+          name: 'test-group2',
+          isEditable: false,
+          roleBindings: [],
+        },
+      },
+      users: {
+        'test-user1': {
+          name: 'test-user1@domain.com',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-user2': {
+          name: 'test-user2',
+          isEditable: false,
+          roleBindings: [],
+        },
+      },
+      serviceAccounts: {
+        'test-account1': {
+          name: 'test-account1',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-account2': {
+          name: 'test-account2',
+          isEditable: false,
+          roleBindings: [],
+        },
+      },
+      roleName: 'test-role',
+      onAdd: jest.fn(),
+      onDelete: jest.fn(),
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    let subject = screen.getByLabelText('test-group1');
+    let deleteButton = within(subject).getByTitle('Delete');
+
+    expect(deleteButton).toBeInTheDocument();
+    fireEvent.mouseEnter(deleteButton);
+    expect(screen.getByText(`Remove this group's binding to this role`));
+    fireEvent.mouseLeave(deleteButton);
+
+    subject = screen.getByLabelText('test-group2');
+    expect(within(subject).queryByTitle('Delete')).not.toBeInTheDocument();
+
+    subject = screen.getByLabelText('test-user1@domain.com');
+    deleteButton = within(subject).getByTitle('Delete');
+
+    expect(deleteButton).toBeInTheDocument();
+    fireEvent.mouseEnter(deleteButton);
+    expect(screen.getByText(`Remove this user's binding to this role`));
+    fireEvent.mouseLeave(deleteButton);
+
+    subject = screen.getByLabelText('test-user2');
+    expect(within(subject).queryByTitle('Delete')).not.toBeInTheDocument();
+
+    subject = screen.getByLabelText('test-account1');
+    deleteButton = within(subject).getByTitle('Delete');
+
+    expect(deleteButton).toBeInTheDocument();
+    fireEvent.mouseEnter(deleteButton);
+    expect(
+      screen.getByText(`Remove this service account's binding to this role`)
+    );
+    fireEvent.mouseLeave(deleteButton);
+
+    subject = screen.getByLabelText('test-account2');
+    expect(within(subject).queryByTitle('Delete')).not.toBeInTheDocument();
+  });
+
+  it('can add subjects', async () => {
+    jest.useFakeTimers();
+    const onAddMockfn = jest.fn(() => {
+      // eslint-disable-next-line no-magic-numbers
+      return new Promise((resolve) => setTimeout(resolve, 1000));
+    });
+
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {},
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: onAddMockfn,
+      onDelete: jest.fn(),
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    const section = screen.getByLabelText('Groups');
+    fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
+
+    let input = within(section).getByPlaceholderText(
+      'e.g. subject1, subject2, subject3'
+    ) as HTMLInputElement;
+    expect(document.activeElement).toBe(input);
+
+    expect(
+      screen.getByText(
+        'Enter one or more group identifiers, exactly as defined in your identity provider, including upper/lowercase spelling.'
+      )
+    ).toBeInTheDocument();
+
+    let submitButton = screen.getByRole('button', { name: 'OK' });
+    fireEvent.change(input, {
+      target: { value: 'group1, group2, group3' },
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(within(section).queryByRole('progressbar')).toBeInTheDocument();
+    });
+
+    expect(input.readOnly).toBeTruthy();
+    expect(submitButton).toBeDisabled();
+
+    jest.runAllTimers();
+
+    await waitFor(() => {
+      expect(
+        within(section).queryByRole('progressbar')
+      ).not.toBeInTheDocument();
+    });
+    expect(input).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Subjects added successfully./)
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
+
+    input = within(section).getByPlaceholderText(
+      'e.g. subject1, subject2, subject3'
+    ) as HTMLInputElement;
+    submitButton = screen.getByRole('button', { name: 'OK' });
+    fireEvent.change(input, {
+      target: { value: 'group1' },
+    });
+
+    fireEvent.click(submitButton);
+
+    jest.runAllTimers();
+
+    await waitFor(() => {
+      expect(input).not.toBeInTheDocument();
+    });
+
+    screen.getByText(/Subject added successfully./);
+
+    jest.useRealTimers();
+  });
+
+  it('can delete subjects', async () => {
+    jest.useFakeTimers();
+    const onDeleteMockFn = jest.fn(() => {
+      // eslint-disable-next-line no-magic-numbers
+      return new Promise((resolve) => setTimeout(resolve, 1000));
+    });
+
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {
+        'test-group1': {
+          name: 'test-group1',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-group2': {
+          name: 'test-group2',
+          isEditable: false,
+          roleBindings: [],
+        },
+      },
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: jest.fn(),
+      onDelete: onDeleteMockFn,
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    const subject = screen.getByLabelText('test-group1');
+    const deleteButton = within(subject).getByTitle('Delete');
+
+    fireEvent.click(deleteButton);
+
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Yes, delete it'));
+
+    await waitFor(() => {
+      expect(within(subject).queryByRole('progressbar')).toBeInTheDocument();
+    });
+
+    jest.runAllTimers();
+
+    await waitFor(() => {
+      expect(
+        within(subject).queryByRole('progressbar')
+      ).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Subject test-group1 deleted successfully./)
+    ).toBeInTheDocument();
+
+    jest.useRealTimers();
+  });
+
+  it('can cancel deleting subjects', async () => {
+    const onDeleteMockFn = jest.fn();
+
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {
+        'test-group1': {
+          name: 'test-group1',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-group2': {
+          name: 'test-group2',
+          isEditable: false,
+          roleBindings: [],
+        },
+      },
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: jest.fn(),
+      onDelete: onDeleteMockFn,
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    const subject = screen.getByLabelText('test-group1');
+    const deleteButton = within(subject).getByTitle('Delete');
+
+    fireEvent.click(deleteButton);
+
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
+    });
+    expect(onDeleteMockFn).not.toHaveBeenCalled();
+  });
+
+  it('displays an error if adding subjects fails', async () => {
+    const onAddMockfn = jest.fn(() => {
+      return Promise.reject(
+        new Error('There was a huge error. Abort the mission.')
+      );
+    });
+
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {},
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: onAddMockfn,
+      onDelete: jest.fn(),
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    const section = screen.getByLabelText('Groups');
+    fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
+
+    const input = within(section).getByPlaceholderText(
+      'e.g. subject1, subject2, subject3'
+    ) as HTMLInputElement;
+
+    const submitButton = screen.getByRole('button', { name: 'OK' });
+    fireEvent.change(input, {
+      target: { value: 'group1, group2, group3' },
+    });
+
+    fireEvent.click(submitButton);
+
+    expect(
+      await screen.findByText(/Could not add subjects:/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/There was a huge error. Abort the mission./)
+    ).toBeInTheDocument();
+
+    fireEvent.change(input, {
+      target: { value: 'group1' },
+    });
+
+    fireEvent.click(submitButton);
+
+    expect(
+      await screen.findByText(/Could not add subject:/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/There was a huge error. Abort the mission./)
+    ).toHaveLength(2);
+  });
+
+  it('displays an error if deleting subjects fails', async () => {
+    const onDeleteMockFn = jest.fn(() => {
+      return Promise.reject(
+        new Error('There was a huge error. Abort the mission.')
+      );
+    });
+
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {
+        'test-group1': {
+          name: 'test-group1',
+          isEditable: true,
+          roleBindings: [],
+        },
+        'test-group2': {
+          name: 'test-group2',
+          isEditable: false,
+          roleBindings: [],
+        },
+      },
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: jest.fn(),
+      onDelete: onDeleteMockFn,
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    const subject = screen.getByLabelText('test-group1');
+    const deleteButton = within(subject).getByTitle('Delete');
+
+    fireEvent.click(deleteButton);
+
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Yes, delete it'));
+
+    expect(
+      await screen.findByText(/Could not delete subject test-group1/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/There was a huge error. Abort the mission./)
+    ).toBeInTheDocument();
+  });
+
+  it('closes the input if trying to add an empty subject', () => {
+    const onAddMockfn = jest.fn();
+
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {},
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: onAddMockfn,
+      onDelete: jest.fn(),
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    const section = screen.getByLabelText('Groups');
+    fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
+
+    const input = within(section).getByPlaceholderText(
+      'e.g. subject1, subject2, subject3'
+    ) as HTMLInputElement;
+
+    const submitButton = screen.getByRole('button', { name: 'OK' });
+    fireEvent.change(input, {
+      target: { value: '' },
+    });
+
+    fireEvent.click(submitButton);
+
+    expect(input).not.toBeInTheDocument();
+    expect(onAddMockfn).not.toHaveBeenCalled();
+  });
+
+  it('does not allow adding a subject that is already in the list', () => {
+    const onAddMockfn = jest.fn();
+
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {
+        'test-group1': {
+          name: 'test-group1',
+          isEditable: true,
+          roleBindings: [],
+        },
+      },
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: onAddMockfn,
+      onDelete: jest.fn(),
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    const section = screen.getByLabelText('Groups');
+    fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
+
+    const input = within(section).getByPlaceholderText(
+      'e.g. subject1, subject2, subject3'
+    ) as HTMLInputElement;
+
+    const submitButton = screen.getByRole('button', { name: 'OK' });
+    fireEvent.change(input, {
+      target: { value: 'test-group1' },
+    });
+
+    fireEvent.click(submitButton);
+
+    expect(screen.getByText(`Subject 'test-group1' already exists.`));
+
+    expect(input).toBeInTheDocument();
+    expect(onAddMockfn).not.toHaveBeenCalled();
+
+    fireEvent.change(input, {
+      target: { value: '' },
+    });
+
+    expect(
+      screen.queryByText(`Subject 'test-group1' already exists.`)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
@@ -1,0 +1,41 @@
+import { getUserNameParts, parseSubjects } from '../utils';
+
+describe('AccessControl/utils', () => {
+  describe('parseSubjects', () => {
+    test.each`
+      subjects                          | expected
+      ${''}                             | ${[]}
+      ${'subject1'}                     | ${['subject1']}
+      ${'subject1 subject2'}            | ${['subject1', 'subject2']}
+      ${'subject1,subject2'}            | ${['subject1', 'subject2']}
+      ${'subject1, subject2'}           | ${['subject1', 'subject2']}
+      ${'subject1 ,subject2'}           | ${['subject1', 'subject2']}
+      ${'subject1 , subject2'}          | ${['subject1', 'subject2']}
+      ${'subject1 ,subject2, subject3'} | ${['subject1', 'subject2', 'subject3']}
+      ${'subject1;subject2'}            | ${['subject1', 'subject2']}
+      ${'subject1; subject2'}           | ${['subject1', 'subject2']}
+      ${'subject1 ;subject2'}           | ${['subject1', 'subject2']}
+      ${'subject1 ; subject2'}          | ${['subject1', 'subject2']}
+      ${'subject1 ;subject2; subject3'} | ${['subject1', 'subject2', 'subject3']}
+      ${'subject1	subject2; subject3'}   | ${['subject1', 'subject2', 'subject3']}
+      ${'subject1			subject2 subject3'}    | ${['subject1', 'subject2', 'subject3']}
+      ${'subject1			subject2 subject3						'}    | ${['subject1', 'subject2', 'subject3']}
+    `(`gets subjects from '$subjects'`, ({ subjects, expected }) => {
+      const parsed = parseSubjects(subjects);
+      expect(parsed).toStrictEqual(expected);
+    });
+  });
+
+  describe('getUserNameParts', () => {
+    test.each`
+      userName                             | expected
+      ${''}                                | ${['']}
+      ${'test'}                            | ${['test']}
+      ${'test@test.com'}                   | ${['test', 'test.com']}
+      ${'test@other-test@some-other-test'} | ${['test', 'other-test']}
+    `(`gets userName parts from '$userName'`, ({ userName, expected }) => {
+      const parts = getUserNameParts(userName);
+      expect(parts).toStrictEqual(expected);
+    });
+  });
+});

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -1,5 +1,30 @@
 import * as ui from 'UI/Display/MAPI/AccessControl/types';
 
+const subjectDelimiterRegexp = /\s*(?:[,\s;])\s*/;
+
+/**
+ * Parse subjects from a serialized value (e.g. an user input).
+ * @param from
+ */
+export function parseSubjects(from: string): string[] {
+  const trimmed = from.trim();
+  if (trimmed.length < 1) return [];
+
+  return trimmed.split(subjectDelimiterRegexp);
+}
+
+/**
+ * Get the username and domain out of a subject username.
+ * @param user
+ */
+export function getUserNameParts(
+  user: string
+): [userName: string, domain?: string] {
+  const userParts = user.split('@');
+
+  return userParts.slice(0, 2) as [string, string];
+}
+
 /**
  * Filter roles based on a search query.
  * @param roles

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm.tsx
@@ -1,0 +1,148 @@
+import { Box, Keyboard } from 'grommet';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import styled from 'styled-components';
+import Button from 'UI/Controls/Button';
+import LoadingIndicator from 'UI/Display/Loading/LoadingIndicator';
+import TextInput from 'UI/Inputs/TextInput';
+
+const StyledButton = styled(Button)`
+  &.btn {
+    height: 38px;
+    margin-left: 0;
+  }
+`;
+
+const StyledBox = styled(Box)`
+  .button-wrapper {
+    margin-right: 0;
+  }
+`;
+
+const SaveButton = styled(Button)`
+  &.btn {
+    height: 36px;
+    border: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+    margin-left: 0;
+  }
+`;
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  display: block;
+
+  img {
+    display: inline-block;
+    vertical-align: middle;
+    width: 24px;
+  }
+`;
+
+interface IAccessControlSubjectAddFormProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  onAdd: (newValue: string) => void;
+  onToggleAdding: () => void;
+  onClearError: () => void;
+  errorMessage?: string;
+  isAdding?: boolean;
+  isLoading?: boolean;
+}
+
+const AccessControlSubjectAddForm: React.FC<IAccessControlSubjectAddFormProps> = ({
+  onAdd,
+  onToggleAdding,
+  isAdding,
+  isLoading,
+  errorMessage,
+  onClearError,
+  ...props
+}) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    onAdd(
+      ((e.target as HTMLFormElement).elements.namedItem(
+        'values'
+      ) as HTMLInputElement).value
+    );
+  };
+
+  const handleOnEsc = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.preventDefault();
+
+    onToggleAdding();
+  };
+
+  const handleChange = () => {
+    if (errorMessage) {
+      onClearError();
+    }
+  };
+
+  return (
+    <Box {...props}>
+      {isAdding ? (
+        <StyledBox direction='row' gap='small' align='center'>
+          <Keyboard onEsc={handleOnEsc}>
+            <form onSubmit={handleSubmit} aria-label='Subjects to add'>
+              <TextInput
+                name='values'
+                id='values'
+                size='small'
+                margin='none'
+                contentProps={{
+                  width: 'medium',
+                  direction: 'row',
+                  round: 'xxsmall',
+                }}
+                readOnly={isLoading}
+                autoFocus={true}
+                onChange={handleChange}
+                error={errorMessage}
+                placeholder='e.g. subject1, subject2, subject3'
+              >
+                <SaveButton
+                  type='submit'
+                  bsStyle='primary'
+                  disabled={isLoading}
+                >
+                  OK
+                </SaveButton>
+              </TextInput>
+            </form>
+          </Keyboard>
+          {isLoading && (
+            <StyledLoadingIndicator
+              loading={true}
+              loadingPosition='right'
+              timeout={0}
+            />
+          )}
+        </StyledBox>
+      ) : (
+        <StyledButton onClick={onToggleAdding}>
+          <i className='fa fa-add-circle' />
+          Add
+        </StyledButton>
+      )}
+    </Box>
+  );
+};
+
+AccessControlSubjectAddForm.propTypes = {
+  onAdd: PropTypes.func.isRequired,
+  onToggleAdding: PropTypes.func.isRequired,
+  onClearError: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string,
+  isAdding: PropTypes.bool,
+  isLoading: PropTypes.bool,
+};
+
+AccessControlSubjectAddForm.defaultProps = {
+  errorMessage: '',
+  isAdding: false,
+  isLoading: false,
+};
+
+export default AccessControlSubjectAddForm;

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
@@ -1,0 +1,118 @@
+import { Box } from 'grommet';
+import { parseSubjects } from 'MAPI/organizations/AccessControl/utils';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import AccessControlSubjectAddForm from 'UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm';
+
+export interface IAccessControlSubjectSetRenderer
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  name: string;
+  isEditable: boolean;
+  isLoading: boolean;
+  onDelete: () => void;
+}
+
+export interface IAccessControlSubjectSetItem {
+  name: string;
+  isEditable: boolean;
+  isLoading: boolean;
+}
+
+interface IAccessControlSubjectSetProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  items: IAccessControlSubjectSetItem[];
+  renderItem: (params: IAccessControlSubjectSetRenderer) => React.ReactNode;
+  onAdd: (values: string[]) => void;
+  onToggleAdding: () => void;
+  onDeleteItem: (name: string) => void;
+  isAdding?: boolean;
+  isLoading?: boolean;
+}
+
+const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
+  items,
+  renderItem,
+  onAdd,
+  onToggleAdding,
+  onDeleteItem,
+  isAdding,
+  isLoading,
+  ...props
+}) => {
+  const [errorMessage, setErrorMessage] = useState('');
+  const clearError = () => {
+    setErrorMessage('');
+  };
+
+  const validateSubjects = (values: string[]): string => {
+    const existingNames = [];
+
+    for (const item of items) {
+      if (values.includes(item.name)) {
+        existingNames.push(item.name);
+      }
+    }
+
+    if (existingNames.length === 1) {
+      return `Subject '${existingNames[0]}' already exists.`;
+    } else if (existingNames.length > 1) {
+      return `Subjects '${existingNames.join(', ')}' already exist.`;
+    }
+
+    return '';
+  };
+
+  const handleAdd = (newValue: string) => {
+    const values = parseSubjects(newValue);
+
+    const error = validateSubjects(values);
+    if (error) {
+      setErrorMessage(error);
+
+      return;
+    }
+
+    onAdd(values);
+  };
+
+  return (
+    <Box direction='row' wrap={true} align='start' {...props}>
+      {items.map(({ name, isEditable, isLoading: isItemLoading }) => (
+        <React.Fragment key={name}>
+          {renderItem({
+            name,
+            isEditable,
+            isLoading: isItemLoading,
+            onDelete: () => onDeleteItem(name),
+          })}
+        </React.Fragment>
+      ))}
+      <AccessControlSubjectAddForm
+        margin={{ right: 'small', bottom: 'small' }}
+        isAdding={isAdding}
+        isLoading={isLoading}
+        onAdd={handleAdd}
+        onToggleAdding={onToggleAdding}
+        errorMessage={errorMessage}
+        onClearError={clearError}
+      />
+    </Box>
+  );
+};
+
+AccessControlSubjectSet.propTypes = {
+  // @ts-expect-error
+  items: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
+  renderItem: PropTypes.func.isRequired,
+  onAdd: PropTypes.func.isRequired,
+  onToggleAdding: PropTypes.func.isRequired,
+  onDeleteItem: PropTypes.func.isRequired,
+  isAdding: PropTypes.bool,
+  isLoading: PropTypes.bool,
+};
+
+AccessControlSubjectSet.defaultProps = {
+  isLoading: false,
+};
+
+export default AccessControlSubjectSet;

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
@@ -1,0 +1,184 @@
+import { Anchor, Box, Drop, Keyboard, Text } from 'grommet';
+import PropTypes from 'prop-types';
+import React, { useRef, useState } from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import styled from 'styled-components';
+import Button from 'UI/Controls/Button';
+import LoadingIndicator from 'UI/Display/Loading/LoadingIndicator';
+import { IAccessControlSubjectSetRenderer } from 'UI/Display/MAPI/AccessControl/AccessControlSubjectSet';
+
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  margin-left: 3px;
+  display: block;
+  height: 23px;
+
+  img {
+    display: inline-block;
+    vertical-align: middle;
+    width: 15px;
+  }
+`;
+
+const StyledAnchor = styled(Anchor)`
+  :focus {
+    outline: 0;
+  }
+
+  :focus:not(:focus-visible) {
+    box-shadow: none;
+  }
+
+  i:focus {
+    outline: 0;
+  }
+`;
+
+interface IAccessControlSubjectSetItemProps
+  extends Omit<IAccessControlSubjectSetRenderer, 'name'>,
+    React.ComponentPropsWithoutRef<typeof Box> {
+  name: React.ReactNode;
+  deleteTooltipMessage?: string;
+}
+
+const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> = ({
+  name,
+  isEditable,
+  isLoading,
+  onDelete,
+  deleteTooltipMessage,
+  ...props
+}) => {
+  const deleteButtonRef = useRef<HTMLAnchorElement>(null);
+
+  const [confirmationVisible, setConfirmationVisible] = useState(false);
+  const showConfirmation = (
+    e?:
+      | React.MouseEvent<HTMLElement>
+      | React.FocusEvent<HTMLElement>
+      | React.KeyboardEvent<HTMLElement>
+  ) => {
+    e?.preventDefault();
+
+    setConfirmationVisible(true);
+  };
+
+  const hideConfirmation = (
+    e?:
+      | React.MouseEvent<HTMLElement>
+      | React.FocusEvent<HTMLElement>
+      | React.KeyboardEvent<HTMLElement>
+  ) => {
+    e?.preventDefault();
+
+    window.setTimeout(() => {
+      setConfirmationVisible(false);
+    });
+  };
+
+  const handleDelete = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+
+    setConfirmationVisible(false);
+    onDelete();
+  };
+
+  return (
+    <Box
+      direction='row'
+      pad={{ vertical: 'xsmall', horizontal: 'small' }}
+      height='38px'
+      background='border'
+      round='xxsmall'
+      align='center'
+      margin={{ right: 'small', bottom: 'small' }}
+      {...props}
+    >
+      {typeof name === 'string' ? <Text color='text-weak'>{name}</Text> : name}
+
+      {isLoading && (
+        <StyledLoadingIndicator
+          loading={true}
+          loadingPosition='right'
+          timeout={0}
+        />
+      )}
+
+      {isEditable && !isLoading && deleteTooltipMessage && (
+        <OverlayTrigger
+          overlay={
+            <Tooltip id='delete'>
+              <Text size='xsmall'>{deleteTooltipMessage}</Text>
+            </Tooltip>
+          }
+          placement='top'
+        >
+          <StyledAnchor
+            ref={deleteButtonRef}
+            size='large'
+            color='text-weak'
+            onClick={showConfirmation}
+            margin={{ left: 'xsmall' }}
+            tabIndex={0}
+          >
+            <i className='fa fa-close' role='presentation' title='Delete' />
+          </StyledAnchor>
+        </OverlayTrigger>
+      )}
+
+      {isEditable && !isLoading && !deleteTooltipMessage && (
+        <StyledAnchor
+          ref={deleteButtonRef}
+          size='large'
+          color='text-weak'
+          onClick={showConfirmation}
+          margin={{ left: 'xsmall' }}
+          tabIndex={0}
+        >
+          <i className='fa fa-close' role='presentation' title='Delete' />
+        </StyledAnchor>
+      )}
+
+      {confirmationVisible && deleteButtonRef.current && (
+        <Keyboard onEsc={hideConfirmation}>
+          <Drop
+            align={{ bottom: 'top', right: 'right' }}
+            target={deleteButtonRef.current}
+            plain={true}
+            trapFocus={true}
+          >
+            <Box
+              background='background-front'
+              pad='medium'
+              round='small'
+              direction='column'
+              gap='small'
+              border={{ color: 'text-xweak' }}
+            >
+              <Box>
+                <Text>Are you sure?</Text>
+              </Box>
+              <Box direction='row'>
+                <Button bsStyle='danger' onClick={handleDelete}>
+                  Yes, delete it
+                </Button>
+                <Button bsStyle='link' onClick={hideConfirmation}>
+                  Cancel
+                </Button>
+              </Box>
+            </Box>
+          </Drop>
+        </Keyboard>
+      )}
+    </Box>
+  );
+};
+
+AccessControlSubjectSetItem.propTypes = {
+  name: PropTypes.node.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  isEditable: PropTypes.bool.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  deleteTooltipMessage: PropTypes.string,
+};
+
+export default AccessControlSubjectSetItem;


### PR DESCRIPTION
Towards giantswarm/giantswarm#16306

This PR adds all the components and utility functions necessary for rendering the `Subjects` tab of the Access Control UI.