### PR TITLE
Use what's in the ui annotation for org name if it's there.

### DIFF
--- a/__tests__/Login.tsx
+++ b/__tests__/Login.tsx
@@ -4,6 +4,7 @@ import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
 import { getInstallationInfo } from 'model/services/giantSwarm/info';
 import { selfSubjectAccessReview } from 'model/services/mapi/authorizationv1/selfSubjectAccessReview';
 import { selfSubjectRulesReview } from 'model/services/mapi/authorizationv1/selfSubjectRulesReview';
+import { getOrganization } from 'model/services/mapi/organizations/';
 import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
@@ -19,6 +20,7 @@ import {
   noOrgsSubjectRulesReview,
   postMockCall,
   releasesResponse,
+  singleMAPIOrgResponse,
   someOrgsSubjectRulesReview,
   userResponse,
 } from 'testUtils/mockHttpCalls';
@@ -183,6 +185,9 @@ describe('Login', () => {
     (selfSubjectAccessReview as jest.Mock).mockReturnValue(() =>
       Promise.resolve(cantListOrgs)
     );
+    (getOrganization as jest.Mock).mockReturnValue(() =>
+      Promise.resolve(singleMAPIOrgResponse)
+    );
 
     (selfSubjectRulesReview as jest.Mock).mockReturnValue(() =>
       Promise.resolve(someOrgsSubjectRulesReview)
@@ -248,6 +253,9 @@ describe('Login', () => {
     (selfSubjectAccessReview as jest.Mock).mockReturnValue(() =>
       Promise.resolve(cantListOrgs)
     );
+    (getOrganization as jest.Mock).mockReturnValue(() =>
+      Promise.resolve(singleMAPIOrgResponse)
+    );
 
     (selfSubjectRulesReview as jest.Mock).mockReturnValue(() =>
       Promise.resolve(noOrgsSubjectRulesReview)
@@ -279,6 +287,9 @@ describe('Login', () => {
   it('renews the token if it expired and automatic renewal failed', async () => {
     (selfSubjectAccessReview as jest.Mock).mockReturnValue(() =>
       Promise.resolve(cantListOrgs)
+    );
+    (getOrganization as jest.Mock).mockReturnValue(() =>
+      Promise.resolve(singleMAPIOrgResponse)
     );
 
     (selfSubjectRulesReview as jest.Mock).mockReturnValue(() =>
@@ -322,11 +333,15 @@ describe('Login', () => {
     (selfSubjectAccessReview as jest.Mock).mockReturnValue(() =>
       Promise.resolve(cantListOrgs)
     );
+    (getOrganization as jest.Mock).mockReturnValue(() =>
+      Promise.resolve(singleMAPIOrgResponse)
+    );
 
     (selfSubjectRulesReview as jest.Mock).mockReturnValue(() =>
       Promise.resolve(someOrgsSubjectRulesReview)
     );
     (getInstallationInfo as jest.Mock).mockResolvedValueOnce(AWSInfoResponse);
+
     getMockCall('/v4/clusters/');
     getMockCall('/v4/appcatalogs/');
     getMockCall('/v4/releases/', releasesResponse);

--- a/src/model/services/mapi/k8sUrl.ts
+++ b/src/model/services/mapi/k8sUrl.ts
@@ -43,7 +43,7 @@ export interface IK8sGetOptions extends IK8sBaseOptions {
   /**
    * The namespace that the resource lives in.
    */
-  namespace: string;
+  namespace?: string;
 }
 
 export interface IK8sListOptions extends IK8sBaseOptions {

--- a/src/model/services/mapi/organizations/__tests__/key.ts
+++ b/src/model/services/mapi/organizations/__tests__/key.ts
@@ -1,0 +1,65 @@
+import { getOrganizationUIName } from '../key';
+import { IOrganization } from '../types';
+
+describe('getOrganizationUIName', () => {
+  describe('create', () => {
+    interface ITestCase {
+      description: string;
+      organization: IOrganization;
+      expected: string;
+    }
+
+    const testCases: ITestCase[] = [
+      {
+        description: 'a CR without any annotation',
+        organization: {
+          apiVersion: 'security.giantswarm.io/v1alpha1',
+          kind: 'Organization',
+          metadata: {
+            name: 'yolo',
+          },
+          spec: {},
+        },
+        expected: 'yolo',
+      },
+      {
+        description: 'a CR with an annotation',
+        organization: {
+          apiVersion: 'security.giantswarm.io/v1alpha1',
+          kind: 'Organization',
+          metadata: {
+            name: 'yolo',
+            annotations: {
+              'ui.giantswarm.io/original-organization-name': 'YOLO',
+            },
+          },
+          spec: {},
+        },
+        expected: 'YOLO',
+      },
+      {
+        description: 'a CR with an empty annotation',
+        organization: {
+          apiVersion: 'security.giantswarm.io/v1alpha1',
+          kind: 'Organization',
+          metadata: {
+            name: 'yolo',
+            annotations: {
+              'ui.giantswarm.io/original-organization-name': '',
+            },
+          },
+          spec: {},
+        },
+        expected: 'yolo',
+      },
+    ];
+
+    for (const { organization, description, expected } of testCases) {
+      it(`figures out the right UI name for ${description}`, () => {
+        const result = getOrganizationUIName(organization);
+
+        expect(result).toEqual(expected);
+      });
+    }
+  });
+});

--- a/src/model/services/mapi/organizations/getOrganization.ts
+++ b/src/model/services/mapi/organizations/getOrganization.ts
@@ -1,0 +1,28 @@
+import { HttpRequestMethods, IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { IOrganization } from './types';
+
+export function getOrganization(
+  client: IHttpClient,
+  user: ILoggedInUser,
+  name: string
+) {
+  return async () => {
+    const url = k8sUrl.create({
+      baseUrl: window.config.mapiEndpoint,
+      apiVersion: 'security.giantswarm.io/v1alpha1',
+      kind: 'organizations',
+      name: name,
+    });
+
+    client.setURL(url.toString());
+    client.setHeader('Accept', 'application/json');
+    client.setRequestMethod(HttpRequestMethods.GET);
+    client.setAuthorizationToken(user.auth.scheme, user.auth.token);
+
+    const response = await client.execute<IOrganization>();
+
+    return response.data;
+  };
+}

--- a/src/model/services/mapi/organizations/index.ts
+++ b/src/model/services/mapi/organizations/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './getOrganizationList';
+export * from './getOrganization';
 export * from './createOrganization';

--- a/src/model/services/mapi/organizations/key.ts
+++ b/src/model/services/mapi/organizations/key.ts
@@ -6,3 +6,12 @@ export function getOrganizationName(organization: IOrganization): string {
 
   return name;
 }
+
+export function getOrganizationUIName(organization: IOrganization): string {
+  const uiAnnotation =
+    organization.metadata.annotations?.[
+      'ui.giantswarm.io/original-organization-name'
+    ];
+
+  return uiAnnotation || getOrganizationName(organization);
+}

--- a/src/stores/organization/actions.ts
+++ b/src/stores/organization/actions.ts
@@ -7,6 +7,8 @@ import {
   selfSubjectAccessReview,
 } from 'model/services/mapi/authorizationv1/';
 import { getOrganizationList } from 'model/services/mapi/organizations/';
+import { getOrganization } from 'model/services/mapi/organizations/';
+import { getOrganizationUIName } from 'model/services/mapi/organizations/key';
 import { ThunkAction } from 'redux-thunk';
 import { Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
@@ -138,7 +140,7 @@ export function organizationsLoadMAPI(): ThunkAction<
         // The user can list all orgs. So list them all and dispatch the action that
         // updates the global state with all the orgs
         const orgListResponse = await getOrganizationList(client, user)();
-        orgs = orgListResponse.items.map((o) => o.metadata.name);
+        orgs = orgListResponse.items.map((o) => getOrganizationUIName(o));
       } else {
         // The user can't list all orgs. So do a selfSubjectRulesReview to figure out
         // which ones they can get.
@@ -155,6 +157,17 @@ export function organizationsLoadMAPI(): ThunkAction<
             orgs.push(...rule.resourceNames);
           }
         });
+
+        // We now know what orgs they can get. We still need to fetch them
+        // to check if the orgs have a 'ui.giantswarm.io/original-organization-name'
+        // annotation.
+        const orgGetRequests = orgs.map((orgName) =>
+          getOrganization(client, user, orgName)()
+        );
+
+        const orgGetResponses = await Promise.all(orgGetRequests);
+
+        orgs = orgGetResponses.map((org) => getOrganizationUIName(org));
       }
 
       const uniqueOrgs = orgs.filter((v, i, a) => a.indexOf(v) === i);

--- a/testUtils/mockHttpCalls/mapiOrganizations.js
+++ b/testUtils/mockHttpCalls/mapiOrganizations.js
@@ -1,3 +1,12 @@
+export const singleMAPIOrgResponse = {
+  apiVersion: 'security.giantswarm.io/v1alpha1',
+  kind: 'Organization',
+  metadata: {
+    name: 'org1',
+  },
+  spec: {},
+};
+
 export const emptyMAPIOrgsResponse = {
   apiVersion: 'security.giantswarm.io/v1alpha1',
   items: [],

--- a/testUtils/modelMocks.js
+++ b/testUtils/modelMocks.js
@@ -4,3 +4,4 @@ jest.mock('model/services/metadata/configuration');
 jest.mock('model/services/mapi/authorizationv1/selfSubjectAccessReview');
 jest.mock('model/services/mapi/authorizationv1/selfSubjectRulesReview');
 jest.mock('model/services/mapi/organizations/getOrganizationList');
+jest.mock('model/services/mapi/organizations/getOrganization');


### PR DESCRIPTION
For users logged in through a SSO, we have transitioned to relying on the MAPI for the source of truth for the organisations list.

This adjusts that logic to support the new `ui.giantswarm.io/original-organization-name`