### PR TITLE
Use the right config key for happaapi letsencrypt

### DIFF
--- a/helm/happa/templates/happaapi-ingress.yaml
+++ b/helm/happa/templates/happaapi-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-origin: {{ .Values.Installation.V1.GiantSwarm.Happa.Address | quote }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
 
-    {{- if .Values.Installation.V1.GiantSwarm.Happa.Letsencrypt }}
+    {{- if .Values.Installation.V1.GiantSwarm.Happa.API.Letsencrypt }}
     kubernetes.io/tls-acme: "true"
     {{- end }}
 


### PR DESCRIPTION
This configuration change uses `.Values.Installation.V1.GiantSwarm.Happa.API.Letsencrypt` instead of `.Values.Installation.V1.GiantSwarm.Happa.Letsencrypt` to decide whether or not to activate Let's encrypt certificates.