### PR TITLE
Move happaapi resources from namespace 'default' to 'giantswarm'

### DIFF
--- a/helm/happa/templates/certs-secret.yaml
+++ b/helm/happa/templates/certs-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: happa-certs
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: happa
 data:

--- a/helm/happa/templates/configmap.yaml
+++ b/helm/happa/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: happa-configmap
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: happa
 data:

--- a/helm/happa/templates/deployment.yaml
+++ b/helm/happa/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: happa
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: happa
 spec:

--- a/helm/happa/templates/happaapi-certs-secret.yaml
+++ b/helm/happa/templates/happaapi-certs-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: happaapi-certs
-  namespace: default
+  namespace: {{ .Values.namespace }}
   labels:
     app: happa
 data:

--- a/helm/happa/templates/happaapi-ingress.yaml
+++ b/helm/happa/templates/happaapi-ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: happaapi
-  namespace: default
+  namespace: {{ .Values.namespace }}
   labels:
     app: happa
   annotations:

--- a/helm/happa/templates/ingress.yaml
+++ b/helm/happa/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: happa
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: happa
   annotations:

--- a/helm/happa/templates/pull-secret.yml
+++ b/helm/happa/templates/pull-secret.yml
@@ -3,7 +3,7 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   name: happa-pull-secret
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: happa
 data:


### PR DESCRIPTION
This moves two resources related to the `happaapi` proxy into the `giantswarm` namespace, instead of the `default` namespace.