### PR TITLE
access control: reuse existing service accounts and display existing ones as suggestions

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
@@ -149,12 +149,10 @@ const mapValueToSetItem = (stateValue: IStateValue) => (
 };
 
 interface IAccessControlRoleSubjectsProps
-  extends Pick<
-      IAccessControlRoleItem,
-      'groups' | 'users' | 'serviceAccounts' | 'namespace'
-    >,
+  extends Pick<IAccessControlRoleItem, 'groups' | 'users' | 'serviceAccounts'>,
     React.ComponentPropsWithoutRef<typeof Box> {
   roleName: string;
+  namespace: string;
   onAdd: (type: AccessControlSubjectTypes, names: string[]) => Promise<void>;
   onDelete: (type: AccessControlSubjectTypes, name: string) => Promise<void>;
 }

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -6,6 +6,7 @@ import AccessControlRoleSubjects from '../AccessControlRoleSubjects';
 describe('AccessControlRoleSubjects', () => {
   it('renders without crashing', () => {
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {},
       users: {},
       serviceAccounts: {},
@@ -17,6 +18,7 @@ describe('AccessControlRoleSubjects', () => {
 
   it('renders all provided subjects', () => {
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {
         'test-group1': {
           name: 'test-group1',
@@ -89,6 +91,7 @@ describe('AccessControlRoleSubjects', () => {
 
   it('displays a delete button next to editable subjects', () => {
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {
         'test-group1': {
           name: 'test-group1',
@@ -174,6 +177,7 @@ describe('AccessControlRoleSubjects', () => {
     });
 
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {},
       users: {},
       serviceAccounts: {},
@@ -254,6 +258,7 @@ describe('AccessControlRoleSubjects', () => {
     });
 
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {
         'test-group1': {
           name: 'test-group1',
@@ -304,6 +309,7 @@ describe('AccessControlRoleSubjects', () => {
     const onDeleteMockFn = jest.fn();
 
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {
         'test-group1': {
           name: 'test-group1',
@@ -345,6 +351,7 @@ describe('AccessControlRoleSubjects', () => {
     });
 
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {},
       users: {},
       serviceAccounts: {},
@@ -396,6 +403,7 @@ describe('AccessControlRoleSubjects', () => {
     });
 
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {
         'test-group1': {
           name: 'test-group1',
@@ -435,6 +443,7 @@ describe('AccessControlRoleSubjects', () => {
     const onAddMockfn = jest.fn();
 
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {},
       users: {},
       serviceAccounts: {},
@@ -465,6 +474,7 @@ describe('AccessControlRoleSubjects', () => {
     const onAddMockfn = jest.fn();
 
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {
         'test-group1': {
           name: 'test-group1',
@@ -511,6 +521,7 @@ describe('AccessControlRoleSubjects', () => {
     const onAddMockfn = jest.fn();
 
     renderWithTheme(AccessControlRoleSubjects, {
+      namespace: 'org-test',
       groups: {
         'test-group1': {
           name: 'test-group1',

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -1,79 +1,132 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
-import { renderWithTheme } from 'testUtils/renderUtils';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import axios from 'axios';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import nock from 'nock';
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as corev1Mocks from 'testUtils/mockHttpCalls/corev1';
+import { getComponentWithStore } from 'testUtils/renderUtils';
 
 import AccessControlRoleSubjects from '../AccessControlRoleSubjects';
 
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <AccessControlRoleSubjects {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
 describe('AccessControlRoleSubjects', () => {
+  beforeAll(() => {
+    axios.defaults.adapter = require('axios/lib/adapters/http');
+  });
+
+  afterAll(() => {
+    axios.defaults.adapter = require('axios/lib/adapters/xhr');
+  });
+
+  afterEach(() => {
+    cache.clear();
+  });
+
   it('renders without crashing', () => {
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {},
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: jest.fn(),
-      onDelete: jest.fn(),
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {},
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: jest.fn(),
+        onDelete: jest.fn(),
+      })
+    );
   });
 
   it('renders all provided subjects', () => {
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {
-        'test-group1': {
-          name: 'test-group1',
-          isEditable: true,
-          roleBindings: [],
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {
+          'test-group1': {
+            name: 'test-group1',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-group2': {
+            name: 'test-group2',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-group3': {
+            name: 'test-group3',
+            isEditable: true,
+            roleBindings: [],
+          },
         },
-        'test-group2': {
-          name: 'test-group2',
-          isEditable: true,
-          roleBindings: [],
+        users: {
+          'test-user1@domain.com': {
+            name: 'test-user1@domain.com',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-user2': {
+            name: 'test-user2',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-user3': {
+            name: 'test-user3',
+            isEditable: true,
+            roleBindings: [],
+          },
         },
-        'test-group3': {
-          name: 'test-group3',
-          isEditable: true,
-          roleBindings: [],
+        serviceAccounts: {
+          'test-account1': {
+            name: 'test-account1',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-account2': {
+            name: 'test-account2',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-account3': {
+            name: 'test-account3',
+            isEditable: true,
+            roleBindings: [],
+          },
         },
-      },
-      users: {
-        'test-user1@domain.com': {
-          name: 'test-user1@domain.com',
-          isEditable: true,
-          roleBindings: [],
-        },
-        'test-user2': {
-          name: 'test-user2',
-          isEditable: true,
-          roleBindings: [],
-        },
-        'test-user3': {
-          name: 'test-user3',
-          isEditable: true,
-          roleBindings: [],
-        },
-      },
-      serviceAccounts: {
-        'test-account1': {
-          name: 'test-account1',
-          isEditable: true,
-          roleBindings: [],
-        },
-        'test-account2': {
-          name: 'test-account2',
-          isEditable: true,
-          roleBindings: [],
-        },
-        'test-account3': {
-          name: 'test-account3',
-          isEditable: true,
-          roleBindings: [],
-        },
-      },
-      roleName: 'test-role',
-      onAdd: jest.fn(),
-      onDelete: jest.fn(),
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+        roleName: 'test-role',
+        onAdd: jest.fn(),
+        onDelete: jest.fn(),
+      })
+    );
 
     expect(screen.getByText('test-group1')).toBeInTheDocument();
     expect(screen.getByText('test-group2')).toBeInTheDocument();
@@ -90,48 +143,50 @@ describe('AccessControlRoleSubjects', () => {
   });
 
   it('displays a delete button next to editable subjects', () => {
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {
-        'test-group1': {
-          name: 'test-group1',
-          isEditable: true,
-          roleBindings: [],
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {
+          'test-group1': {
+            name: 'test-group1',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-group2': {
+            name: 'test-group2',
+            isEditable: false,
+            roleBindings: [],
+          },
         },
-        'test-group2': {
-          name: 'test-group2',
-          isEditable: false,
-          roleBindings: [],
+        users: {
+          'test-user1': {
+            name: 'test-user1@domain.com',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-user2': {
+            name: 'test-user2',
+            isEditable: false,
+            roleBindings: [],
+          },
         },
-      },
-      users: {
-        'test-user1': {
-          name: 'test-user1@domain.com',
-          isEditable: true,
-          roleBindings: [],
+        serviceAccounts: {
+          'test-account1': {
+            name: 'test-account1',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-account2': {
+            name: 'test-account2',
+            isEditable: false,
+            roleBindings: [],
+          },
         },
-        'test-user2': {
-          name: 'test-user2',
-          isEditable: false,
-          roleBindings: [],
-        },
-      },
-      serviceAccounts: {
-        'test-account1': {
-          name: 'test-account1',
-          isEditable: true,
-          roleBindings: [],
-        },
-        'test-account2': {
-          name: 'test-account2',
-          isEditable: false,
-          roleBindings: [],
-        },
-      },
-      roleName: 'test-role',
-      onAdd: jest.fn(),
-      onDelete: jest.fn(),
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+        roleName: 'test-role',
+        onAdd: jest.fn(),
+        onDelete: jest.fn(),
+      })
+    );
 
     let subject = screen.getByLabelText('test-group1');
     let deleteButton = within(subject).getByTitle('Delete');
@@ -173,18 +228,20 @@ describe('AccessControlRoleSubjects', () => {
     jest.useFakeTimers();
     const onAddMockfn = jest.fn(() => {
       // eslint-disable-next-line no-magic-numbers
-      return new Promise((resolve) => setTimeout(resolve, 1000));
+      return new Promise<void>((resolve) => setTimeout(resolve, 1000));
     });
 
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {},
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: onAddMockfn,
-      onDelete: jest.fn(),
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {},
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: onAddMockfn,
+        onDelete: jest.fn(),
+      })
+    );
 
     const section = screen.getByLabelText('Groups');
     fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
@@ -214,7 +271,9 @@ describe('AccessControlRoleSubjects', () => {
     expect(input.readOnly).toBeTruthy();
     expect(submitButton).toBeDisabled();
 
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     await waitFor(() => {
       expect(
@@ -239,7 +298,9 @@ describe('AccessControlRoleSubjects', () => {
 
     fireEvent.click(submitButton);
 
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
@@ -254,29 +315,31 @@ describe('AccessControlRoleSubjects', () => {
     jest.useFakeTimers();
     const onDeleteMockFn = jest.fn(() => {
       // eslint-disable-next-line no-magic-numbers
-      return new Promise((resolve) => setTimeout(resolve, 1000));
+      return new Promise<void>((resolve) => setTimeout(resolve, 1000));
     });
 
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {
-        'test-group1': {
-          name: 'test-group1',
-          isEditable: true,
-          roleBindings: [],
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {
+          'test-group1': {
+            name: 'test-group1',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-group2': {
+            name: 'test-group2',
+            isEditable: false,
+            roleBindings: [],
+          },
         },
-        'test-group2': {
-          name: 'test-group2',
-          isEditable: false,
-          roleBindings: [],
-        },
-      },
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: jest.fn(),
-      onDelete: onDeleteMockFn,
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: jest.fn(),
+        onDelete: onDeleteMockFn,
+      })
+    );
 
     const subject = screen.getByLabelText('test-group1');
     const deleteButton = within(subject).getByTitle('Delete');
@@ -290,7 +353,9 @@ describe('AccessControlRoleSubjects', () => {
       expect(within(subject).queryByRole('progressbar')).toBeInTheDocument();
     });
 
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     await waitFor(() => {
       expect(
@@ -308,26 +373,28 @@ describe('AccessControlRoleSubjects', () => {
   it('can cancel deleting subjects', async () => {
     const onDeleteMockFn = jest.fn();
 
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {
-        'test-group1': {
-          name: 'test-group1',
-          isEditable: true,
-          roleBindings: [],
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {
+          'test-group1': {
+            name: 'test-group1',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-group2': {
+            name: 'test-group2',
+            isEditable: false,
+            roleBindings: [],
+          },
         },
-        'test-group2': {
-          name: 'test-group2',
-          isEditable: false,
-          roleBindings: [],
-        },
-      },
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: jest.fn(),
-      onDelete: onDeleteMockFn,
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: jest.fn(),
+        onDelete: onDeleteMockFn,
+      })
+    );
 
     const subject = screen.getByLabelText('test-group1');
     const deleteButton = within(subject).getByTitle('Delete');
@@ -350,15 +417,17 @@ describe('AccessControlRoleSubjects', () => {
       );
     });
 
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {},
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: onAddMockfn,
-      onDelete: jest.fn(),
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {},
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: onAddMockfn,
+        onDelete: jest.fn(),
+      })
+    );
 
     const section = screen.getByLabelText('Groups');
     fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
@@ -402,26 +471,28 @@ describe('AccessControlRoleSubjects', () => {
       );
     });
 
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {
-        'test-group1': {
-          name: 'test-group1',
-          isEditable: true,
-          roleBindings: [],
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {
+          'test-group1': {
+            name: 'test-group1',
+            isEditable: true,
+            roleBindings: [],
+          },
+          'test-group2': {
+            name: 'test-group2',
+            isEditable: false,
+            roleBindings: [],
+          },
         },
-        'test-group2': {
-          name: 'test-group2',
-          isEditable: false,
-          roleBindings: [],
-        },
-      },
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: jest.fn(),
-      onDelete: onDeleteMockFn,
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: jest.fn(),
+        onDelete: onDeleteMockFn,
+      })
+    );
 
     const subject = screen.getByLabelText('test-group1');
     const deleteButton = within(subject).getByTitle('Delete');
@@ -442,15 +513,17 @@ describe('AccessControlRoleSubjects', () => {
   it('closes the input if trying to add an empty subject', () => {
     const onAddMockfn = jest.fn();
 
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {},
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: onAddMockfn,
-      onDelete: jest.fn(),
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {},
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: onAddMockfn,
+        onDelete: jest.fn(),
+      })
+    );
 
     const section = screen.getByLabelText('Groups');
     fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
@@ -473,21 +546,23 @@ describe('AccessControlRoleSubjects', () => {
   it('does not allow adding a subject that is already in the list', () => {
     const onAddMockfn = jest.fn();
 
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {
-        'test-group1': {
-          name: 'test-group1',
-          isEditable: true,
-          roleBindings: [],
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {
+          'test-group1': {
+            name: 'test-group1',
+            isEditable: true,
+            roleBindings: [],
+          },
         },
-      },
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: onAddMockfn,
-      onDelete: jest.fn(),
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: onAddMockfn,
+        onDelete: jest.fn(),
+      })
+    );
 
     const section = screen.getByLabelText('Groups');
     fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
@@ -520,21 +595,23 @@ describe('AccessControlRoleSubjects', () => {
   it('does not allow adding the same subject multiple times', () => {
     const onAddMockfn = jest.fn();
 
-    renderWithTheme(AccessControlRoleSubjects, {
-      namespace: 'org-test',
-      groups: {
-        'test-group1': {
-          name: 'test-group1',
-          isEditable: true,
-          roleBindings: [],
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {
+          'test-group1': {
+            name: 'test-group1',
+            isEditable: true,
+            roleBindings: [],
+          },
         },
-      },
-      users: {},
-      serviceAccounts: {},
-      roleName: 'test-role',
-      onAdd: onAddMockfn,
-      onDelete: jest.fn(),
-    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: onAddMockfn,
+        onDelete: jest.fn(),
+      })
+    );
 
     const section = screen.getByLabelText('Groups');
     fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
@@ -567,5 +644,51 @@ describe('AccessControlRoleSubjects', () => {
     expect(
       screen.queryByText(`Subjects 'test-group1', 'test-group2' already exist.`)
     ).not.toBeInTheDocument();
+  });
+
+  it('gives the user suggestions for re-using existing service accounts', async () => {
+    jest.useFakeTimers();
+
+    nock(window.config.mapiEndpoint)
+      .get('/api/v1/namespaces/org-test/serviceaccounts/')
+      .reply(StatusCodes.Ok, corev1Mocks.serviceAccountList);
+
+    render(
+      getComponent({
+        namespace: 'org-test',
+        groups: {},
+        users: {},
+        serviceAccounts: {},
+        roleName: 'test-role',
+        onAdd: jest.fn(),
+        onDelete: jest.fn(),
+      })
+    );
+
+    const section = screen.getByLabelText('Service accounts');
+    fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
+
+    const input = within(section).getByPlaceholderText(
+      'e.g. subject1, subject2, subject3'
+    ) as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'random auto' } });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const selectedSuggestion = await screen.findByText('automation');
+    expect(selectedSuggestion).toBeInTheDocument();
+    // An existing account is not shown.
+    await waitFor(() =>
+      expect(screen.queryByText('random')).not.toBeInTheDocument()
+    );
+
+    fireEvent.click(selectedSuggestion);
+
+    await waitFor(() => expect(input).toHaveValue('random automation, '));
+
+    jest.useRealTimers();
   });
 });

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -506,4 +506,55 @@ describe('AccessControlRoleSubjects', () => {
       screen.queryByText(`Subject 'test-group1' already exists.`)
     ).not.toBeInTheDocument();
   });
+
+  it('does not allow adding the same subject multiple times', () => {
+    const onAddMockfn = jest.fn();
+
+    renderWithTheme(AccessControlRoleSubjects, {
+      groups: {
+        'test-group1': {
+          name: 'test-group1',
+          isEditable: true,
+          roleBindings: [],
+        },
+      },
+      users: {},
+      serviceAccounts: {},
+      roleName: 'test-role',
+      onAdd: onAddMockfn,
+      onDelete: jest.fn(),
+    } as React.ComponentPropsWithoutRef<typeof AccessControlRoleSubjects>);
+
+    const section = screen.getByLabelText('Groups');
+    fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
+
+    const input = within(section).getByPlaceholderText(
+      'e.g. subject1, subject2, subject3'
+    ) as HTMLInputElement;
+
+    const submitButton = screen.getByRole('button', { name: 'OK' });
+    fireEvent.change(input, {
+      target: {
+        value:
+          'test-group1 test-group2 test-group1 test-group1 test-group3 test-group2',
+      },
+    });
+
+    fireEvent.click(submitButton);
+
+    expect(
+      screen.getByText(`Subjects 'test-group1', 'test-group2' already exist.`)
+    );
+
+    expect(input).toBeInTheDocument();
+    expect(onAddMockfn).not.toHaveBeenCalled();
+
+    fireEvent.change(input, {
+      target: { value: '' },
+    });
+
+    expect(
+      screen.queryByText(`Subjects 'test-group1', 'test-group2' already exist.`)
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
@@ -1160,6 +1160,18 @@ describe('AccessControl', () => {
 
     for (let i = 0; i < serviceAccountCreationRequests.length; i++) {
       nock(window.config.mapiEndpoint)
+        .get(
+          `/api/v1/namespaces/org-giantswarm/serviceaccounts/${serviceAccountCreationRequests[i].metadata.name}/`
+        )
+        .reply(StatusCodes.NotFound, {
+          apiVersion: 'v1',
+          kind: 'Status',
+          message: 'New service account, who dis?',
+          status: metav1.K8sStatuses.Failure,
+          reason: metav1.K8sStatusErrorReasons.NotFound,
+          code: StatusCodes.NotFound,
+        });
+      nock(window.config.mapiEndpoint)
         .post(
           '/api/v1/namespaces/org-giantswarm/serviceaccounts/',
           serviceAccountCreationRequests[i]
@@ -1205,6 +1217,116 @@ describe('AccessControl', () => {
     ((Date.now as unknown) as jest.SpyInstance).mockClear();
   });
 
+  it('can re-use existing service accounts', async () => {
+    const now = 1617189262247;
+    // @ts-expect-error
+    Date.now = jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const serviceAccountCreationRequest = {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: { name: 'random', namespace: 'org-giantswarm' },
+    };
+
+    const serviceAccountCreationResponse = corev1Mocks.randomServiceAccount;
+
+    const roleBindingCreationRequest = {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'RoleBinding',
+      metadata: {
+        name: `edit-all-${now}`,
+        namespace: 'org-giantswarm',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'edit-all',
+      },
+      subjects: [
+        {
+          name: 'random',
+          kind: 'ServiceAccount',
+          apiGroup: '',
+          namespace: 'org-giantswarm',
+        },
+      ],
+    };
+
+    const roleBindingCreationResponse = {
+      kind: 'RoleBinding',
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      metadata: {
+        name: `edit-all-${now}`,
+        namespace: 'org-giantswarm',
+        selfLink: `/apis/rbac.authorization.k8s.io/v1/namespaces/org-giantswarm/rolebindings/edit-all-${now}`,
+        uid: '522ea429-9561-4d80-ba12-6eb656b51145',
+        resourceVersion: '284491712',
+        creationTimestamp: new Date(now).toISOString(),
+      },
+      subjects: [
+        {
+          name: 'random',
+          kind: 'ServiceAccount',
+          namespace: 'org-giantswarm',
+        },
+      ],
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'edit-all',
+      },
+    };
+
+    nock(window.config.mapiEndpoint)
+      .post(
+        '/apis/rbac.authorization.k8s.io/v1/namespaces/org-giantswarm/rolebindings/',
+        roleBindingCreationRequest
+      )
+      .reply(StatusCodes.Created, roleBindingCreationResponse);
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/api/v1/namespaces/org-giantswarm/serviceaccounts/${serviceAccountCreationRequest.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, serviceAccountCreationResponse);
+
+    render(
+      getComponent({
+        organizationName: 'giantswarm',
+      })
+    );
+
+    const sidebar = screen.getByRole('complementary', {
+      name: 'Role list',
+    });
+    const currentRole = await within(sidebar).findByRole('button', {
+      name: 'edit-all',
+    });
+    fireEvent.click(currentRole);
+
+    const content = screen.getByRole('main', { name: 'Role details' });
+    const section = within(content).getByLabelText('Service accounts');
+    fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
+
+    const input = within(section).getByPlaceholderText(
+      'e.g. subject1, subject2, subject3'
+    );
+    fireEvent.change(input, {
+      target: { value: 'random' },
+    });
+
+    fireEvent.click(within(section).getByRole('button', { name: 'OK' }));
+    expect(within(section).getByRole('progressbar')).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(/Subject added successfully./)
+    ).toBeInTheDocument();
+
+    expect(within(section).getByLabelText('random')).toBeInTheDocument();
+
+    ((Date.now as unknown) as jest.SpyInstance).mockClear();
+  });
+
   it('displays an error if creating service accounts fails', async () => {
     const now = 1617189262247;
     // @ts-expect-error
@@ -1239,6 +1361,18 @@ describe('AccessControl', () => {
     ];
 
     for (let i = 0; i < serviceAccountCreationRequests.length; i++) {
+      nock(window.config.mapiEndpoint)
+        .get(
+          `/api/v1/namespaces/org-giantswarm/serviceaccounts/${serviceAccountCreationRequests[i].metadata.name}/`
+        )
+        .reply(StatusCodes.NotFound, {
+          apiVersion: 'v1',
+          kind: 'Status',
+          message: 'New service account, who dis?',
+          status: metav1.K8sStatuses.Failure,
+          reason: metav1.K8sStatusErrorReasons.NotFound,
+          code: StatusCodes.NotFound,
+        });
       nock(window.config.mapiEndpoint)
         .post(
           '/api/v1/namespaces/org-giantswarm/serviceaccounts/',

--- a/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
@@ -1510,14 +1510,6 @@ describe('AccessControl', () => {
       )
       .reply(StatusCodes.Ok, rbacv1Mocks.editAllRoleBinding);
 
-    nock(window.config.mapiEndpoint)
-      .delete('/api/v1/namespaces/org-giantswarm/serviceaccounts/el-toro/')
-      .reply(StatusCodes.Ok, corev1Mocks.elToroServiceAccount);
-
-    nock(window.config.mapiEndpoint)
-      .get('/api/v1/namespaces/org-giantswarm/serviceaccounts/el-toro/')
-      .reply(StatusCodes.Ok, corev1Mocks.elToroServiceAccount);
-
     render(
       getComponent({
         organizationName: 'giantswarm',
@@ -1547,26 +1539,62 @@ describe('AccessControl', () => {
   });
 
   it('displays an error if deleting a service account fails', async () => {
+    const putRequest = {
+      metadata: {
+        name: 'edit-all-group',
+        namespace: 'org-giantswarm',
+        selfLink:
+          '/apis/rbac.authorization.k8s.io/v1/namespaces/org-giantswarm/rolebindings/edit-all-group',
+        uid: '27a1682b-c33b-42af-9489-36bf32ba6d52',
+        resourceVersion: '281804578',
+        creationTimestamp: '2020-09-29T10:42:53Z',
+        labels: {
+          'giantswarm.io/managed-by': 'rbac-operator',
+        },
+        finalizers: [
+          'operatorkit.giantswarm.io/rbac-operator-orgpermissions-controller',
+        ],
+      },
+      subjects: [
+        {
+          kind: 'Group',
+          apiGroup: 'rbac.authorization.k8s.io',
+          name: 'Admins',
+        },
+        {
+          kind: 'User',
+          apiGroup: 'rbac.authorization.k8s.io',
+          name: 'system:boss',
+        },
+      ],
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'edit-all',
+      },
+    };
+
+    const putResponse = {
+      apiVersion: 'v1',
+      kind: 'Status',
+      message: 'There was a huge problem.',
+      status: metav1.K8sStatuses.Failure,
+      reason: metav1.K8sStatusErrorReasons.InternalError,
+      code: StatusCodes.InternalServerError,
+    };
+
+    nock(window.config.mapiEndpoint)
+      .put(
+        '/apis/rbac.authorization.k8s.io/v1/namespaces/org-giantswarm/rolebindings/edit-all-group/',
+        putRequest
+      )
+      .reply(putResponse.code, putResponse);
+
     nock(window.config.mapiEndpoint)
       .get(
         '/apis/rbac.authorization.k8s.io/v1/namespaces/org-giantswarm/rolebindings/edit-all-group/'
       )
       .reply(StatusCodes.Ok, rbacv1Mocks.editAllRoleBinding);
-
-    nock(window.config.mapiEndpoint)
-      .delete('/api/v1/namespaces/org-giantswarm/serviceaccounts/el-toro/')
-      .reply(StatusCodes.InternalServerError, {
-        apiVersion: 'v1',
-        kind: 'Status',
-        message: 'There was a huge problem.',
-        status: metav1.K8sStatuses.Failure,
-        reason: metav1.K8sStatusErrorReasons.InternalError,
-        code: StatusCodes.InternalServerError,
-      });
-
-    nock(window.config.mapiEndpoint)
-      .get('/api/v1/namespaces/org-giantswarm/serviceaccounts/el-toro/')
-      .reply(StatusCodes.Ok, corev1Mocks.elToroServiceAccount);
 
     render(
       getComponent({

--- a/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
@@ -53,15 +53,16 @@ describe('AccessControl/utils', () => {
 
   describe('filterSubjectSuggestions', () => {
     test.each`
-      input      | suggestions                                           | limit | expected
-      ${''}      | ${[]}                                                 | ${3}  | ${[]}
-      ${'test'}  | ${[]}                                                 | ${3}  | ${[]}
-      ${''}      | ${['test1', 'test2']}                                 | ${3}  | ${['test1', 'test2']}
-      ${'test'}  | ${['test1', 'test2']}                                 | ${3}  | ${['test1', 'test2']}
-      ${'test1'} | ${['test1', 'test2']}                                 | ${3}  | ${[]}
-      ${'test1'} | ${['test1', 'test2']}                                 | ${3}  | ${[]}
-      ${'test'}  | ${['test1', 'test2', 'some-other']}                   | ${3}  | ${['test1', 'test2']}
-      ${'test'}  | ${['test1', 'test2', 'some-other', 'test3', 'test4']} | ${3}  | ${['test1', 'test2', 'test3']}
+      input             | suggestions                                           | limit | expected
+      ${''}             | ${[]}                                                 | ${3}  | ${[]}
+      ${'test'}         | ${[]}                                                 | ${3}  | ${[]}
+      ${''}             | ${['test1', 'test2']}                                 | ${3}  | ${['test1', 'test2']}
+      ${'test'}         | ${['test1', 'test2']}                                 | ${3}  | ${['test1', 'test2']}
+      ${'test1'}        | ${['test1', 'test2']}                                 | ${3}  | ${['test1']}
+      ${'test1 test2'}  | ${['test1', 'test2', 'test3']}                        | ${3}  | ${['test2']}
+      ${'test1 test2 '} | ${['test1', 'test2', 'test3']}                        | ${3}  | ${['test3']}
+      ${'test'}         | ${['test1', 'test2', 'some-other']}                   | ${3}  | ${['test1', 'test2']}
+      ${'test'}         | ${['test1', 'test2', 'some-other', 'test3', 'test4']} | ${3}  | ${['test1', 'test2', 'test3']}
     `(
       `filters suggestions with the '$input' input`,
       ({ input, suggestions, limit, expected }) => {
@@ -75,6 +76,7 @@ describe('AccessControl/utils', () => {
     test.each`
       value                      | suggestion | expected
       ${''}                      | ${''}      | ${''}
+      ${''}                      | ${'test1'} | ${'test1, '}
       ${'tes'}                   | ${'test1'} | ${'test1, '}
       ${'tes '}                  | ${'test1'} | ${'tes test1, '}
       ${'tes,    '}              | ${'test1'} | ${'tes,    test1, '}

--- a/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
@@ -1,4 +1,9 @@
-import { getUserNameParts, parseSubjects } from '../utils';
+import {
+  appendSubjectSuggestionToValue,
+  filterSubjectSuggestions,
+  getUserNameParts,
+  parseSubjects,
+} from '../utils';
 
 describe('AccessControl/utils', () => {
   describe('parseSubjects', () => {
@@ -39,5 +44,42 @@ describe('AccessControl/utils', () => {
       const parts = getUserNameParts(userName);
       expect(parts).toStrictEqual(expected);
     });
+  });
+
+  describe('filterSubjectSuggestions', () => {
+    test.each`
+      input      | suggestions                                           | limit | expected
+      ${''}      | ${[]}                                                 | ${3}  | ${[]}
+      ${'test'}  | ${[]}                                                 | ${3}  | ${[]}
+      ${''}      | ${['test1', 'test2']}                                 | ${3}  | ${['test1', 'test2']}
+      ${'test'}  | ${['test1', 'test2']}                                 | ${3}  | ${['test1', 'test2']}
+      ${'test1'} | ${['test1', 'test2']}                                 | ${3}  | ${[]}
+      ${'test1'} | ${['test1', 'test2']}                                 | ${3}  | ${[]}
+      ${'test'}  | ${['test1', 'test2', 'some-other']}                   | ${3}  | ${['test1', 'test2']}
+      ${'test'}  | ${['test1', 'test2', 'some-other', 'test3', 'test4']} | ${3}  | ${['test1', 'test2', 'test3']}
+    `(
+      `filters suggestions with the '$input' input`,
+      ({ input, suggestions, limit, expected }) => {
+        const result = filterSubjectSuggestions(input, suggestions, limit);
+        expect(result).toStrictEqual(expected);
+      }
+    );
+  });
+
+  describe('appendSubjectSuggestionToValue', () => {
+    test.each`
+      value                      | suggestion | expected
+      ${''}                      | ${''}      | ${''}
+      ${'tes'}                   | ${'test1'} | ${'test1, '}
+      ${'tes '}                  | ${'test1'} | ${'tes test1, '}
+      ${'tes,    '}              | ${'test1'} | ${'tes,    test1, '}
+      ${'test1, test2, test3, '} | ${'test4'} | ${'test1, test2, test3, test4, '}
+    `(
+      `appends the '$suggestion' suggestion to '$value'`,
+      ({ value, suggestion, expected }) => {
+        const result = appendSubjectSuggestionToValue(value, suggestion);
+        expect(result).toEqual(expected);
+      }
+    );
   });
 });

--- a/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
@@ -3,23 +3,25 @@ import { getUserNameParts, parseSubjects } from '../utils';
 describe('AccessControl/utils', () => {
   describe('parseSubjects', () => {
     test.each`
-      subjects                          | expected
-      ${''}                             | ${[]}
-      ${'subject1'}                     | ${['subject1']}
-      ${'subject1 subject2'}            | ${['subject1', 'subject2']}
-      ${'subject1,subject2'}            | ${['subject1', 'subject2']}
-      ${'subject1, subject2'}           | ${['subject1', 'subject2']}
-      ${'subject1 ,subject2'}           | ${['subject1', 'subject2']}
-      ${'subject1 , subject2'}          | ${['subject1', 'subject2']}
-      ${'subject1 ,subject2, subject3'} | ${['subject1', 'subject2', 'subject3']}
-      ${'subject1;subject2'}            | ${['subject1', 'subject2']}
-      ${'subject1; subject2'}           | ${['subject1', 'subject2']}
-      ${'subject1 ;subject2'}           | ${['subject1', 'subject2']}
-      ${'subject1 ; subject2'}          | ${['subject1', 'subject2']}
-      ${'subject1 ;subject2; subject3'} | ${['subject1', 'subject2', 'subject3']}
-      ${'subject1	subject2; subject3'}   | ${['subject1', 'subject2', 'subject3']}
-      ${'subject1			subject2 subject3'}    | ${['subject1', 'subject2', 'subject3']}
-      ${'subject1			subject2 subject3						'}    | ${['subject1', 'subject2', 'subject3']}
+      subjects                                            | expected
+      ${''}                                               | ${[]}
+      ${'subject1'}                                       | ${['subject1']}
+      ${'subject1 subject2'}                              | ${['subject1', 'subject2']}
+      ${'subject1,subject2'}                              | ${['subject1', 'subject2']}
+      ${'subject1, subject2'}                             | ${['subject1', 'subject2']}
+      ${'subject1 ,subject2'}                             | ${['subject1', 'subject2']}
+      ${'subject1 , subject2'}                            | ${['subject1', 'subject2']}
+      ${'subject1 ,subject2, subject3'}                   | ${['subject1', 'subject2', 'subject3']}
+      ${'subject1;subject2'}                              | ${['subject1', 'subject2']}
+      ${'subject1; subject2'}                             | ${['subject1', 'subject2']}
+      ${'subject1 ;subject2'}                             | ${['subject1', 'subject2']}
+      ${'subject1 ; subject2'}                            | ${['subject1', 'subject2']}
+      ${'subject1 ;subject2; subject3'}                   | ${['subject1', 'subject2', 'subject3']}
+      ${'subject1	subject2; subject3'}                     | ${['subject1', 'subject2', 'subject3']}
+      ${'subject1			subject2 subject3'}                      | ${['subject1', 'subject2', 'subject3']}
+      ${'subject1			subject2 subject3						'}                      | ${['subject1', 'subject2', 'subject3']}
+      ${'some-account, test1, test, test2, default, '}    | ${['some-account', 'test1', 'test', 'test2', 'default']}
+      ${'some-account, test1, test, test2, default,;,; '} | ${['some-account', 'test1', 'test', 'test2', 'default']}
     `(`gets subjects from '$subjects'`, ({ subjects, expected }) => {
       const parsed = parseSubjects(subjects);
       expect(parsed).toStrictEqual(expected);

--- a/src/components/MAPI/organizations/AccessControl/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/index.tsx
@@ -161,6 +161,7 @@ const AccessControl: React.FC<IAccessControlProps> = ({
             activeRole={activeRole}
             onAdd={handleAdd}
             onDelete={handleDelete}
+            namespace={orgNamespace}
           />
         </Box>
       </Box>

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -585,7 +585,7 @@ export function filterSubjectSuggestions(
    */
   const searchQuery = subjects[subjects.length - 1].toLowerCase();
   const newSuggestions = uniqueSuggestions.filter((suggestion) => {
-    return suggestion.toLowerCase().includes(searchQuery);
+    return suggestion.toLowerCase().startsWith(searchQuery);
   });
 
   return newSuggestions.slice(0, limit + 1);

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -576,7 +576,7 @@ export function filterSubjectSuggestions(
    * doesn't need filtering based on a search query.
    */
   if (subjects.length < 1 || isSubjectDelimiter(existing.slice(-1))) {
-    return uniqueSuggestions.slice(0, limit + 1);
+    return uniqueSuggestions.slice(0, limit);
   }
 
   /**
@@ -588,7 +588,7 @@ export function filterSubjectSuggestions(
     return suggestion.toLowerCase().startsWith(searchQuery);
   });
 
-  return newSuggestions.slice(0, limit + 1);
+  return newSuggestions.slice(0, limit);
 }
 
 /**
@@ -601,20 +601,14 @@ export function appendSubjectSuggestionToValue(
   value: string,
   suggestion: string
 ): string {
+  if (value.length < 1) return '';
+
   const subjects = parseSubjects(value);
 
   let newValue = value;
   if (subjects.length > 0 && !isSubjectDelimiter(newValue.slice(-1))) {
     const latestSubjectLength = subjects[subjects.length - 1].length;
     newValue = newValue.substr(0, newValue.length - latestSubjectLength);
-
-    /**
-     * If the latest char after trimming is not
-     * a delimiter, then let's add one.
-     */
-    if (newValue.length > 0 && !isSubjectDelimiter(newValue.slice(-1))) {
-      newValue += ', ';
-    }
   }
 
   return `${newValue}${suggestion}, `;

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -624,7 +624,7 @@ export function appendSubjectSuggestionToValue(
 export async function fetchServiceAccountSuggestions(
   client: IHttpClient,
   auth: IOAuth2Provider,
-  namespace: string
+  namespace: string = 'default'
 ): Promise<string[]> {
   const serviceAccounts = await corev1.getServiceAccountList(
     client,

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -7,7 +7,7 @@ import * as metav1 from 'model/services/mapi/metav1';
 import * as rbacv1 from 'model/services/mapi/rbacv1';
 import * as ui from 'UI/Display/MAPI/AccessControl/types';
 
-const subjectDelimiterRegexp = /\s*(?:[,\s;])\s*/;
+const subjectDelimiterRegexp = /\s*(?:[,\s;])+\s*/;
 
 /**
  * Parse subjects from a serialized value (e.g. an user input).
@@ -17,7 +17,7 @@ export function parseSubjects(from: string): string[] {
   const trimmed = from.trim();
   if (trimmed.length < 1) return [];
 
-  return trimmed.split(subjectDelimiterRegexp);
+  return trimmed.split(subjectDelimiterRegexp).filter((s) => s.length > 0);
 }
 
 /**

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -620,6 +620,13 @@ export function appendSubjectSuggestionToValue(
   return `${newValue}${suggestion}, `;
 }
 
+/**
+ * Fetch all the service accounts in a namespace, and map them
+ * into a list of names.
+ * @param client
+ * @param auth
+ * @param namespace
+ */
 export async function fetchServiceAccountSuggestions(
   client: IHttpClient,
   auth: IOAuth2Provider,
@@ -634,6 +641,10 @@ export async function fetchServiceAccountSuggestions(
   return serviceAccounts.items.map((account) => account.metadata.name);
 }
 
+/**
+ * The unique cache key for the service account suggestion fetcher.
+ * @param namespace
+ */
 export function fetchServiceAccountSuggestionsKey(
   namespace: string = 'default'
 ): string {

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -619,3 +619,23 @@ export function appendSubjectSuggestionToValue(
 
   return `${newValue}${suggestion}, `;
 }
+
+export async function fetchServiceAccountSuggestions(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string
+): Promise<string[]> {
+  const serviceAccounts = await corev1.getServiceAccountList(
+    client,
+    auth,
+    namespace
+  );
+
+  return serviceAccounts.items.map((account) => account.metadata.name);
+}
+
+export function fetchServiceAccountSuggestionsKey(
+  namespace: string = 'default'
+): string {
+  return corev1.getServiceAccountListKey(namespace);
+}

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -619,10 +619,23 @@ export function filterSubjectSuggestions(
   suggestions: string[],
   limit: number
 ): string[] {
+  const isLastCharDelimiter = isSubjectDelimiter(existing.slice(-1));
+
   const subjects = parseSubjects(existing);
   const uniqueSuggestions = suggestions.filter((suggestion) => {
-    // Don't include existing subjects.
-    return !subjects.includes(suggestion);
+    for (let i = 0; i < subjects.length; i++) {
+      // Include the subject if the user is trying to get auto-completion.
+      if (!isLastCharDelimiter && i === subjects.length - 1) {
+        return true;
+      }
+
+      // Don't include existing subjects.
+      if (suggestion === subjects[i]) {
+        return false;
+      }
+    }
+
+    return true;
   });
 
   /**
@@ -632,7 +645,7 @@ export function filterSubjectSuggestions(
    * that the user is trying to add a new value, and
    * doesn't need filtering based on a search query.
    */
-  if (subjects.length < 1 || isSubjectDelimiter(existing.slice(-1))) {
+  if (subjects.length < 1 || isLastCharDelimiter) {
     return uniqueSuggestions.slice(0, limit);
   }
 
@@ -658,7 +671,7 @@ export function appendSubjectSuggestionToValue(
   value: string,
   suggestion: string
 ): string {
-  if (value.length < 1) return '';
+  if (value.length < 1 && suggestion.length < 1) return '';
 
   const subjects = parseSubjects(value);
 

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleDetail.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleDetail.tsx
@@ -18,12 +18,14 @@ export function formatManagedBy(managedBy?: string): string {
 
 interface IAccessControlRoleDetailProps
   extends React.ComponentPropsWithoutRef<typeof Box> {
+  namespace: string;
   onAdd: (type: AccessControlSubjectTypes, names: string[]) => Promise<void>;
   onDelete: (type: AccessControlSubjectTypes, name: string) => Promise<void>;
   activeRole?: IAccessControlRoleItem;
 }
 
 const AccessControlRoleDetail: React.FC<IAccessControlRoleDetailProps> = ({
+  namespace,
   activeRole,
   onAdd,
   onDelete,
@@ -53,6 +55,7 @@ const AccessControlRoleDetail: React.FC<IAccessControlRoleDetailProps> = ({
                   groups={activeRole.groups}
                   users={activeRole.users}
                   serviceAccounts={activeRole.serviceAccounts}
+                  namespace={namespace}
                 />
               </Tab>
               <Tab eventKey='2' title='Permissions'>
@@ -69,6 +72,7 @@ const AccessControlRoleDetail: React.FC<IAccessControlRoleDetailProps> = ({
 };
 
 AccessControlRoleDetail.propTypes = {
+  namespace: PropTypes.string.isRequired,
   onAdd: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
   // @ts-expect-error

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleVerbs.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleVerbs.tsx
@@ -19,7 +19,7 @@ function formatVerbs(verbs: string[], verbMap: IVerbMap): string {
 
   const verbOrder = Object.keys(verbMap);
   // Sort verbs in the order they are in the map, and leave unknown ones at the end.
-  const orderedVerbs = verbs.sort((a, b) => {
+  const orderedVerbs = verbs.slice().sort((a, b) => {
     let aIdx = verbOrder.indexOf(a);
     if (aIdx < 0) {
       aIdx = verbOrder.length - 1;

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm.tsx
@@ -111,10 +111,6 @@ const AccessControlSubjectAddForm: React.FC<IAccessControlSubjectAddFormProps> =
   >['onSuggestionSelect'] = (e) => {
     const newValue = appendSubjectSuggestionToValue(value, e.suggestion);
     setValue(newValue);
-
-    if (suggestions) {
-      handleChangeSuggestions(newValue, suggestions);
-    }
   };
 
   useEffect(() => {

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
@@ -1,5 +1,4 @@
 import { Box } from 'grommet';
-import { parseSubjects } from 'MAPI/organizations/AccessControl/utils';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import AccessControlSubjectAddForm from 'UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm';
@@ -37,6 +36,7 @@ interface IAccessControlSubjectSetProps
   onDeleteItem: (name: string) => void;
   isAdding?: boolean;
   isLoading?: boolean;
+  inputSuggestions?: string[];
 }
 
 const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
@@ -47,6 +47,7 @@ const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
   onDeleteItem,
   isAdding,
   isLoading,
+  inputSuggestions,
   ...props
 }) => {
   const [errorMessage, setErrorMessage] = useState('');
@@ -81,17 +82,15 @@ const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
     return '';
   };
 
-  const handleAdd = (newValue: string) => {
-    const values = parseSubjects(newValue);
-
-    const error = validateSubjects(values);
+  const handleAdd = (newValue: string[]) => {
+    const error = validateSubjects(newValue);
     if (error) {
       setErrorMessage(error);
 
       return;
     }
 
-    onAdd(values);
+    onAdd(newValue);
   };
 
   return (
@@ -114,6 +113,7 @@ const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
         onToggleAdding={onToggleAdding}
         errorMessage={errorMessage}
         onClearError={clearError}
+        suggestions={inputSuggestions}
       />
     </Box>
   );
@@ -128,6 +128,7 @@ AccessControlSubjectSet.propTypes = {
   onDeleteItem: PropTypes.func.isRequired,
   isAdding: PropTypes.bool,
   isLoading: PropTypes.bool,
+  inputSuggestions: PropTypes.arrayOf(PropTypes.string.isRequired),
 };
 
 AccessControlSubjectSet.defaultProps = {

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import AccessControlSubjectAddForm from 'UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm';
 
 function gatherSubjectUsage(acc: Record<string, number>, currValue: string) {
-  if (acc[currValue]) {
+  if (acc.hasOwnProperty(currValue)) {
     acc[currValue]++;
   } else {
     acc[currValue] = 1;

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleDetail.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleDetail.tsx
@@ -6,6 +6,7 @@ import AccessControlRoleDetail from '../AccessControlRoleDetail';
 describe('AccessControlRoleDetail', () => {
   it('renders without crashing', () => {
     renderWithStore(AccessControlRoleDetail, {
+      namespace: 'org-test',
       activeRole: {
         name: '',
         namespace: '',
@@ -22,6 +23,7 @@ describe('AccessControlRoleDetail', () => {
 
   it('renders role details correctly', () => {
     const initialProps = {
+      namespace: 'org-test',
       activeRole: {
         name: 'test-role',
         namespace: '',
@@ -70,6 +72,7 @@ describe('AccessControlRoleDetail', () => {
 
   it('renders a loader if there is no data yet', () => {
     const { rerender } = renderWithStore(AccessControlRoleDetail, {
+      namespace: 'org-test',
       activeRole: undefined,
       onAdd: jest.fn(),
       onDelete: jest.fn(),
@@ -79,6 +82,7 @@ describe('AccessControlRoleDetail', () => {
 
     rerender(
       getComponentWithStore(AccessControlRoleDetail, {
+        namespace: 'org-test',
         activeRole: {
           name: 'test-role',
           namespace: '',

--- a/src/components/UI/Inputs/TextInput/index.tsx
+++ b/src/components/UI/Inputs/TextInput/index.tsx
@@ -1,7 +1,32 @@
-import { FormField, FormFieldProps, TextInput as Input } from 'grommet';
+import {
+  FormField,
+  FormFieldProps,
+  TextInput as Input,
+  ThemeContext,
+  ThemeType,
+} from 'grommet';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { useTheme } from 'styled-components';
+import { css, useTheme } from 'styled-components';
+
+const customTheme: ThemeType = {
+  global: {
+    drop: {
+      background: 'input-background',
+      shadowSize: 'none',
+      border: {
+        radius: '0px 0px 4px 4px',
+      },
+      zIndex: '9999',
+      // @ts-expect-error
+      extend: css`
+        border: 1px solid ${({ theme }) => theme.global.colors.border.dark};
+        font-size: ${({ theme }) => theme.text.small.size};
+        font-weight: 400;
+      `,
+    },
+  },
+};
 
 interface ITextInputProps extends React.ComponentPropsWithoutRef<typeof Input> {
   /**
@@ -70,30 +95,32 @@ const TextInput = React.forwardRef<HTMLInputElement, ITextInputProps>(
     }
 
     return (
-      <FormField
-        htmlFor={id}
-        label={label}
-        contentProps={patchedContentProps}
-        disabled={disabled}
-        required={required}
-        name={name}
-        error={error}
-        info={info}
-        help={help}
-        margin={margin}
-        pad={pad}
-        {...formFieldProps}
-      >
-        <Input
-          {...props}
-          id={id}
-          ref={ref}
+      <ThemeContext.Extend value={customTheme}>
+        <FormField
+          htmlFor={id}
+          label={label}
+          contentProps={patchedContentProps}
           disabled={disabled}
           required={required}
           name={name}
-        />
-        {children}
-      </FormField>
+          error={error}
+          info={info}
+          help={help}
+          margin={margin}
+          pad={pad}
+          {...formFieldProps}
+        >
+          <Input
+            {...props}
+            id={id}
+            ref={ref}
+            disabled={disabled}
+            required={required}
+            name={name}
+          />
+          {children}
+        </FormField>
+      </ThemeContext.Extend>
     );
   }
 );
@@ -116,6 +143,7 @@ TextInput.propTypes = {
 
 TextInput.defaultProps = {
   size: 'medium',
+  dropHeight: 'small',
 };
 
 export default TextInput;

--- a/src/components/UI/Inputs/TextInput/stories/Suggestions.tsx
+++ b/src/components/UI/Inputs/TextInput/stories/Suggestions.tsx
@@ -1,0 +1,43 @@
+import { Story } from '@storybook/react/types-6-0';
+import React, { ComponentPropsWithoutRef, useState } from 'react';
+
+import TextInput from '..';
+
+export const Suggestions: Story<ComponentPropsWithoutRef<typeof TextInput>> = (
+  args
+) => {
+  const [value, setValue] = useState(args.value);
+  const [suggestions, setSuggestions] = useState(args.suggestions as string[]);
+
+  const handleSuggestionSelect = (e: { suggestion: string }) => {
+    setValue(e.suggestion);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+
+    setSuggestions(suggestions.filter((s) => s.includes(e.target.value)));
+  };
+
+  return (
+    <TextInput
+      {...args}
+      value={value}
+      onChange={handleChange}
+      onSuggestionSelect={handleSuggestionSelect}
+    />
+  );
+};
+
+Suggestions.args = {
+  value: 'Hi people',
+  label: 'Some input',
+  suggestions: ['value1', 'value2', 'value3'],
+};
+
+Suggestions.argTypes = {
+  label: { control: { type: 'text' } },
+  error: { control: { type: 'text' } },
+  info: { control: { type: 'text' } },
+  help: { control: { type: 'text' } },
+};

--- a/src/components/UI/Inputs/TextInput/stories/TextInput.stories.tsx
+++ b/src/components/UI/Inputs/TextInput/stories/TextInput.stories.tsx
@@ -8,6 +8,7 @@ export { Error } from './Error';
 export { Info } from './Info';
 export { Help } from './Help';
 export { Disabled } from './Disabled';
+export { Suggestions } from './Suggestions';
 
 export default {
   title: 'Inputs/TextInput',

--- a/src/model/services/mapi/corev1/getServiceAccountList.ts
+++ b/src/model/services/mapi/corev1/getServiceAccountList.ts
@@ -1,0 +1,25 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { getResource } from '../generic/getResource';
+import { IServiceAccountList } from './types';
+
+export function getServiceAccountList(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    isCore: true,
+    kind: 'serviceaccounts',
+    namespace,
+  });
+
+  return getResource<IServiceAccountList>(client, auth, url.toString());
+}
+
+export function getServiceAccountListKey(namespace: string) {
+  return `getServiceAccountList${namespace}`;
+}

--- a/src/model/services/mapi/corev1/index.ts
+++ b/src/model/services/mapi/corev1/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './getServiceAccount';
+export * from './getServiceAccountList';
 export * from './deleteServiceAccount';
 export * from './createServiceAccount';
 export * from './getConfigMap';

--- a/src/model/services/mapi/corev1/types.ts
+++ b/src/model/services/mapi/corev1/types.ts
@@ -24,6 +24,13 @@ export interface IServiceAccount {
   automountServiceAccountToken?: boolean;
 }
 
+export const ServiceAccountList = 'ServiceAccountList';
+
+export interface IServiceAccountList extends metav1.IList<IServiceAccount> {
+  apiVersion: 'v1';
+  kind: typeof ServiceAccountList;
+}
+
 export const ConfigMap = 'ConfigMap';
 
 export interface IConfigMap {

--- a/testUtils/mockHttpCalls/corev1/serviceAccounts.ts
+++ b/testUtils/mockHttpCalls/corev1/serviceAccounts.ts
@@ -36,3 +36,9 @@ export const elToroServiceAccount = {
     creationTimestamp: '2021-03-31T15:12:35Z',
   },
 };
+
+export const serviceAccountList = {
+  kind: 'ServiceAccountList',
+  apiVersion: 'v1',
+  items: [elToroServiceAccount, randomServiceAccount, automationServiceAccount],
+};


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/16468

This PR includes a bunch of improvements for service account creation (some also apply to subject creation in general):
* you can bind existing service accounts (a new one will only get created if it doesn't exist)
* you get suggestions for existing service account names
* when you remove a service account from a role binding, the `ServiceAccount` resource no longer gets deleted
* you are no longer able to create multiple subjects with the same name at the same time (it resulted in an error)
* fix a subject name parsing bug that would try to bind subjects with empty names (e.g. `test1, ` would bind both `test1`, and ` `)

### Preview

<details>
<summary>Full suggestion list</summary>

![image](https://user-images.githubusercontent.com/13508038/114987075-0b30df00-9e95-11eb-99ed-a2ba125f1597.png)

</details>

<details>
<summary>Suggestions based on the text you entered</summary>

![image](https://user-images.githubusercontent.com/13508038/114987135-1b48be80-9e95-11eb-91b4-39a7c337884b.png)


</details>

<details>
<summary>No suggestions for a new account</summary>

![image](https://user-images.githubusercontent.com/13508038/114987282-492e0300-9e95-11eb-86fc-44e3ace3f0f4.png)

</details>

You can navigate between suggestions with the `Up` and `Down` arrow keys. Also, if you closed the suggestion box by pressing `Esc`, for example, you can re-open it by pressing the `Down` arrow key.

When you click on one of the suggestions, it will get appended to your text input.