### PR TITLE
access control: display 'All (*)' where all verbs are supported

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
@@ -118,7 +118,7 @@ describe('AccessControl', () => {
     expect(within(cells[1]).getByText('All')).toBeInTheDocument();
     expect(within(cells[2]).getByText('All')).toBeInTheDocument();
     expect(
-      within(cells[3]).getByLabelText('Supported verbs: All')
+      within(cells[3]).getByLabelText('Supported verbs: All (*)')
     ).toBeInTheDocument();
   });
 

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleVerbs.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleVerbs.tsx
@@ -14,7 +14,7 @@ function formatVerbs(verbs: string[]): string {
   }
 
   for (const verb of verbs) {
-    if (verb === '*') return 'All';
+    if (verb === '*') return 'All (*)';
   }
 
   return verbs.join(', ');

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRolePermissions.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRolePermissions.tsx
@@ -80,7 +80,10 @@ describe('AccessControlRolePermissions', () => {
             content: 'pods',
           },
           { content: 'All' },
-          { tooltipContent: 'All', labelContent: 'Supported verbs: All' },
+          {
+            tooltipContent: 'All (*)',
+            labelContent: 'Supported verbs: All (*)',
+          },
         ],
       },
       {
@@ -217,8 +220,8 @@ describe('AccessControlRolePermissions', () => {
           },
           { content: 'All' },
           {
-            tooltipContent: 'All',
-            labelContent: 'Supported verbs: All',
+            tooltipContent: 'All (*)',
+            labelContent: 'Supported verbs: All (*)',
           },
         ],
       },


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/16464

With this PR, we now display `All (*)`, instead of `All`, where all verbs are supported for a role, in the `Permissions` tab.

### Preview 

![image](https://user-images.githubusercontent.com/13508038/114991531-f7d44280-9e99-11eb-9754-59fc461ee46a.png)

