### PR TITLE
access control: extend search to look for queries EVERYWHERE

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -256,9 +256,11 @@ export function filterRoles(
     ];
 
     for (const permission of role.permissions) {
-      valuesToCheck.push(...permission.apiGroups);
-      valuesToCheck.push(...permission.resources);
-      valuesToCheck.push(...permission.resourceNames);
+      valuesToCheck.push(
+        ...permission.apiGroups,
+        ...permission.resources,
+        ...permission.resourceNames
+      );
     }
 
     return valuesToCheck.some((value: string) => {

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -248,9 +248,22 @@ export function filterRoles(
   if (!searchQuery) return roles;
 
   return roles.filter((role) => {
-    const value = role.name.toLowerCase();
+    const valuesToCheck: string[] = [
+      role.name,
+      ...Object.keys(role.groups),
+      ...Object.keys(role.users),
+      ...Object.keys(role.serviceAccounts),
+    ];
 
-    return value.includes(searchQuery);
+    for (const permission of role.permissions) {
+      valuesToCheck.push(...permission.apiGroups);
+      valuesToCheck.push(...permission.resources);
+      valuesToCheck.push(...permission.resourceNames);
+    }
+
+    return valuesToCheck.some((value: string) => {
+      return value.toLowerCase().includes(searchQuery);
+    });
   });
 }
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/16466

With this PR, we now look for the role search query in:
- the role names
- role subjects
  - group names
  - user names
  - service account names
- role permissions
  - api groups
  - resources
  - resource names

Performance is fine at the moment, but as datasets get larger, we will probably have to execute this in a web worker.