### PR TITLE
access control: fix role loading animation content

### DIFF
--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItemLoadingPlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItemLoadingPlaceholder.tsx
@@ -14,17 +14,16 @@ const AccessControlRoleListItemLoadingPlaceholder: React.FC<IAccessControlRoleLi
   return (
     <Box background='background-front' round='small' {...props}>
       <ContentLoader
-        viewBox='0 0 400 65'
+        viewBox='0 0 260 65'
         speed={2}
         height='65'
         width='100%'
         backgroundColor={theme.global.colors['text-xweak'].dark}
         foregroundColor={theme.global.colors['text-weak'].dark}
       >
-        <rect x='18' y='12' rx='4' ry='4' width='365' height='15' />
-        <rect x='18' y='38' rx='4' ry='4' width='125' height='15' />
-        <rect x='158' y='38' rx='4' ry='4' width='105' height='15' />
-        <rect x='278' y='38' rx='4' ry='4' width='105' height='15' />
+        <rect x='18' y='12' rx='4' ry='4' width='225' height='15' />
+        <rect x='18' y='38' rx='4' ry='4' width='105' height='15' />
+        <rect x='138' y='38' rx='4' ry='4' width='105' height='15' />
       </ContentLoader>
     </Box>
   );


### PR DESCRIPTION
Looks like since the role column was made narrower, the loading animation no longer looks like the content.

<details>
<summary>Content</summary>

![image](https://user-images.githubusercontent.com/13508038/114994893-8eeec980-9e9d-11eb-920f-0be2d2f2e70a.png)

</details>

<details>
<summary>Loading animation before</summary>

![image](https://user-images.githubusercontent.com/13508038/114995045-b5ad0000-9e9d-11eb-8ee3-6a6fec314687.png)

</details>

<details>
<summary>Loading animation after</summary>

![image](https://user-images.githubusercontent.com/13508038/114994968-a4fc8a00-9e9d-11eb-9584-4867d1703b21.png)

</details>