### PR TITLE
access control: aggregate similar permission rules

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
@@ -1,4 +1,7 @@
-import { getUserNameParts, parseSubjects } from '../utils';
+import * as rbacv1 from 'model/services/mapi/rbacv1';
+import * as ui from 'UI/Display/MAPI/AccessControl/types';
+
+import { getRolePermissions, getUserNameParts, parseSubjects } from '../utils';
 
 describe('AccessControl/utils', () => {
   describe('parseSubjects', () => {
@@ -36,6 +39,78 @@ describe('AccessControl/utils', () => {
     `(`gets userName parts from '$userName'`, ({ userName, expected }) => {
       const parts = getUserNameParts(userName);
       expect(parts).toStrictEqual(expected);
+    });
+  });
+
+  describe('getRolePermissions', () => {
+    it('aggregates similar permissions', () => {
+      const role: rbacv1.IClusterRole = {
+        kind: rbacv1.ClusterRole,
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        metadata: {
+          name: 'tenant-boss',
+          labels: {
+            'ui.giantswarm.io/display': 'true',
+          },
+        },
+        rules: [
+          {
+            verbs: ['get', 'list'],
+            apiGroups: ['test.giantswarm.io'],
+            resources: ['supertest', 'superboss'],
+          },
+          {
+            verbs: ['watch', 'delete'],
+            apiGroups: ['test.giantswarm.io'],
+            resources: ['supertest', 'superboss'],
+          },
+          {
+            verbs: ['patch'],
+            apiGroups: ['test.giantswarm.io'],
+            resources: ['supertest'],
+          },
+          {
+            verbs: ['create'],
+            apiGroups: ['test.giantswarm.io'],
+            resources: ['otherthing'],
+          },
+          {
+            verbs: ['get'],
+            apiGroups: ['test2.giantswarm.io'],
+            resources: ['supertest'],
+          },
+        ],
+      };
+
+      const expectedPermissions: ui.IAccessControlRoleItemPermission[] = [
+        {
+          apiGroups: ['test.giantswarm.io'],
+          resources: ['supertest', 'superboss'],
+          resourceNames: [],
+          verbs: ['get', 'list', 'watch', 'delete'],
+        },
+        {
+          apiGroups: ['test.giantswarm.io'],
+          resources: ['supertest'],
+          resourceNames: [],
+          verbs: ['patch'],
+        },
+        {
+          apiGroups: ['test.giantswarm.io'],
+          resources: ['otherthing'],
+          resourceNames: [],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['test2.giantswarm.io'],
+          resources: ['supertest'],
+          resourceNames: [],
+          verbs: ['get'],
+        },
+      ];
+
+      const result = getRolePermissions(role);
+      expect(result).toStrictEqual(expectedPermissions);
     });
   });
 });

--- a/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/utils.ts
@@ -1,7 +1,12 @@
 import * as rbacv1 from 'model/services/mapi/rbacv1';
 import * as ui from 'UI/Display/MAPI/AccessControl/types';
 
-import { getRolePermissions, getUserNameParts, parseSubjects } from '../utils';
+import {
+  getRolePermissions,
+  getUserNameParts,
+  parseSubjects,
+  sortPermissions,
+} from '../utils';
 
 describe('AccessControl/utils', () => {
   describe('parseSubjects', () => {
@@ -85,9 +90,9 @@ describe('AccessControl/utils', () => {
       const expectedPermissions: ui.IAccessControlRoleItemPermission[] = [
         {
           apiGroups: ['test.giantswarm.io'],
-          resources: ['supertest', 'superboss'],
+          resources: ['otherthing'],
           resourceNames: [],
-          verbs: ['get', 'list', 'watch', 'delete'],
+          verbs: ['create'],
         },
         {
           apiGroups: ['test.giantswarm.io'],
@@ -97,9 +102,9 @@ describe('AccessControl/utils', () => {
         },
         {
           apiGroups: ['test.giantswarm.io'],
-          resources: ['otherthing'],
+          resources: ['supertest', 'superboss'],
           resourceNames: [],
-          verbs: ['create'],
+          verbs: ['get', 'list', 'watch', 'delete'],
         },
         {
           apiGroups: ['test2.giantswarm.io'],
@@ -111,6 +116,103 @@ describe('AccessControl/utils', () => {
 
       const result = getRolePermissions(role);
       expect(result).toStrictEqual(expectedPermissions);
+    });
+  });
+
+  describe('sortPermissions', () => {
+    it('sorts permissions by the required fields', () => {
+      const permissions: ui.IAccessControlRoleItemPermission[] = [
+        {
+          apiGroups: ['test.giantswarm.io'],
+          resources: ['supertest', 'superboss'],
+          resourceNames: [],
+          verbs: ['get', 'list'],
+        },
+        {
+          apiGroups: ['test2.giantswarm.io'],
+          resources: ['supertest', 'superboss'],
+          resourceNames: [],
+          verbs: ['get', 'list'],
+        },
+        {
+          apiGroups: ['test5.giantswarm.io'],
+          resources: ['some-test'],
+          resourceNames: [],
+          verbs: ['watch'],
+        },
+        {
+          apiGroups: ['test2.giantswarm.io'],
+          resources: ['some-other'],
+          resourceNames: [],
+          verbs: ['delete'],
+        },
+        {
+          apiGroups: ['test3.giantswarm.io'],
+          resources: ['some-resource'],
+          resourceNames: ['some-other-name'],
+          verbs: ['get', 'list'],
+        },
+        {
+          apiGroups: ['test2.giantswarm.io'],
+          resources: ['superboss'],
+          resourceNames: [],
+          verbs: ['watch'],
+        },
+        {
+          apiGroups: ['test3.giantswarm.io'],
+          resources: ['some-resource'],
+          resourceNames: ['some-name'],
+          verbs: ['get', 'list'],
+        },
+      ];
+
+      const expected = [
+        {
+          apiGroups: ['test.giantswarm.io'],
+          resources: ['supertest', 'superboss'],
+          resourceNames: [],
+          verbs: ['get', 'list'],
+        },
+        {
+          apiGroups: ['test2.giantswarm.io'],
+          resources: ['some-other'],
+          resourceNames: [],
+          verbs: ['delete'],
+        },
+        {
+          apiGroups: ['test2.giantswarm.io'],
+          resources: ['superboss'],
+          resourceNames: [],
+          verbs: ['watch'],
+        },
+        {
+          apiGroups: ['test2.giantswarm.io'],
+          resources: ['supertest', 'superboss'],
+          resourceNames: [],
+          verbs: ['get', 'list'],
+        },
+        {
+          apiGroups: ['test3.giantswarm.io'],
+          resources: ['some-resource'],
+          resourceNames: ['some-name'],
+          verbs: ['get', 'list'],
+        },
+        {
+          apiGroups: ['test3.giantswarm.io'],
+          resources: ['some-resource'],
+          resourceNames: ['some-other-name'],
+          verbs: ['get', 'list'],
+        },
+        {
+          apiGroups: ['test5.giantswarm.io'],
+          resources: ['some-test'],
+          resourceNames: [],
+          verbs: ['watch'],
+        },
+      ];
+
+      const result = permissions.sort(sortPermissions);
+      expect(result).toStrictEqual(expected);
     });
   });
 });

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -172,7 +172,36 @@ export function getRolePermissions(
     }
   }
 
-  return Object.values(permissions);
+  const permissionCollection = Object.values(permissions);
+
+  return permissionCollection.sort(sortPermissions);
+}
+
+/**
+ * Sort permissions by:
+ * - apiGroups
+ * - resources
+ * - resourceNames
+ * @param a
+ * @param b
+ */
+export function sortPermissions(
+  a: ui.IAccessControlRoleItemPermission,
+  b: ui.IAccessControlRoleItemPermission
+): number {
+  const sortRules = [
+    () => a.apiGroups.join().localeCompare(b.apiGroups.join()),
+    () => a.resources.join().localeCompare(b.resources.join()),
+    () => a.resourceNames.join().localeCompare(b.resourceNames.join()),
+  ];
+
+  let ruleResult = 0;
+  for (const rule of sortRules) {
+    ruleResult = rule();
+    if (ruleResult !== 0) return ruleResult;
+  }
+
+  return ruleResult;
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/16467

With this PR we aggregate similar permission verbs (if they have the same API Groups, Resources and Resource Names, the verbs will be shown into a single table row).

Also, as a bonus, we now sort permissions by these fields:
* API Groups
* Resources
* Resource Names
(e.g. if 2 permissions have the same API Group, they will be ordered by `Resources`, and so on)