### PR TITLE
access control: various ux improvements and bug fixes

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
@@ -187,7 +187,7 @@ describe('AccessControl', () => {
     expect(within(cells[2]).getByText('All')).toBeInTheDocument();
     expect(
       within(cells[3]).getByLabelText(
-        'Supported verbs: get, list, watch, patch, update'
+        'Supported verbs: get, watch, list, update, patch'
       )
     ).toBeInTheDocument();
   });

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -142,6 +142,8 @@ export function appendSubjectsToRoleItem(
 export function getRolePermissions(
   role: rbacv1.IClusterRole | rbacv1.IRole
 ): ui.IAccessControlRoleItemPermission[] {
+  if (!role.rules) return [];
+
   const permissions: ui.IAccessControlRoleItemPermission[] = [];
 
   for (const rule of role.rules) {

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
@@ -72,7 +72,7 @@ const AccessControlRoleList: React.FC<IAccessControlRoleListProps> = ({
   return (
     <Sidebar responsive={false} as='aside' aria-label='Role list' {...props}>
       <Content>
-        <Box margin={{ bottom: 'small' }}>
+        <Box margin={{ bottom: 'small' }} pad={{ horizontal: 'small' }}>
           <TextInput
             icon={
               <i

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -37,6 +37,10 @@ const StyledCard = styled(Card)`
   }
 `;
 
+const StyledHeading = styled(Heading)`
+  max-width: 100%;
+`;
+
 interface IAccessControlRoleListItemProps
   extends IAccessControlRoleItem,
     React.ComponentPropsWithoutRef<typeof Card> {
@@ -65,7 +69,7 @@ const AccessControlRoleListItem = React.forwardRef<
       ref={ref}
     >
       <CardHeader>
-        <Heading level={5} margin='none'>
+        <StyledHeading level={5} margin='none'>
           <Box direction='row' align='center'>
             <Text truncate={true}>{name}</Text>
 
@@ -79,7 +83,7 @@ const AccessControlRoleListItem = React.forwardRef<
               </Text>
             )}
           </Box>
-        </Heading>
+        </StyledHeading>
       </CardHeader>
       <CardBody margin={{ top: 'xsmall' }}>
         <Box justify='between' direction='row'>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleVerbs.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleVerbs.tsx
@@ -8,7 +8,7 @@ import {
   IAccessControlRoleItemPermission,
 } from './types';
 
-function formatVerbs(verbs: string[]): string {
+function formatVerbs(verbs: string[], verbMap: IVerbMap): string {
   if (verbs.length < 1) {
     return 'None';
   }
@@ -17,7 +17,22 @@ function formatVerbs(verbs: string[]): string {
     if (verb === '*') return 'All (*)';
   }
 
-  return verbs.join(', ');
+  const verbOrder = Object.keys(verbMap);
+  // Sort verbs in the order they are in the map, and leave unknown ones at the end.
+  const orderedVerbs = verbs.sort((a, b) => {
+    let aIdx = verbOrder.indexOf(a);
+    if (aIdx < 0) {
+      aIdx = verbOrder.length - 1;
+    }
+    let bIdx = verbOrder.indexOf(b);
+    if (bIdx < 0) {
+      bIdx = verbOrder.length - 1;
+    }
+
+    return aIdx - bIdx;
+  });
+
+  return orderedVerbs.join(', ');
 }
 
 interface IVerbSymbol {
@@ -111,7 +126,10 @@ const AccessControlRoleVerbs: React.FC<IAccessControlRoleVerbsProps> = ({
   ...props
 }) => {
   const verbMap = useMemo(() => makeVerbMap(verbs), [verbs]);
-  const formattedVerbs = useMemo(() => formatVerbs(verbs), [verbs]);
+  const formattedVerbs = useMemo(() => formatVerbs(verbs, verbMap), [
+    verbs,
+    verbMap,
+  ]);
 
   return (
     <OverlayTrigger

--- a/src/model/services/mapi/rbacv1/types.ts
+++ b/src/model/services/mapi/rbacv1/types.ts
@@ -33,7 +33,7 @@ export interface IClusterRole {
   apiVersion: 'rbac.authorization.k8s.io/v1';
   kind: typeof ClusterRole;
   metadata: metav1.IObjectMeta;
-  rules: IPolicyRule[];
+  rules: IPolicyRule[] | null;
 }
 
 export const ClusterRoleList = 'ClusterRoleList';
@@ -67,7 +67,7 @@ export interface IRole {
   apiVersion: 'rbac.authorization.k8s.io/v1';
   kind: typeof Role;
   metadata: metav1.IObjectMeta;
-  rules: IPolicyRule[];
+  rules: IPolicyRule[] | null;
 }
 
 export const RoleList = 'RoleList';


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/16463

This PR includes the following:
* Display permission verbs in tooltips in the same order they are displayed in the table
* Fix an error that would be displayed when a `Role`'s `rules` property was `null`.
* Fix a bug that was causing horizontal scroll in the role list when a role had a longer name
* Make the role search input and role items have the same width.