### PR TITLE
Remove error notification for expired credentials

### DIFF
--- a/src/stores/batchActions.ts
+++ b/src/stores/batchActions.ts
@@ -85,7 +85,6 @@ export function batchedLayout(
         messageType.WARNING,
         messageTTL.MEDIUM
       );
-      ErrorReporter.getInstance().notify(err);
 
       return;
     }


### PR DESCRIPTION
This removes an error notification for the case that the user is no longer authenticated, which happens frequently when credentials expire.