### PR TITLE
apps: update app configuration via MAPI

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterApps.js
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.js
@@ -2,6 +2,7 @@ import { push } from 'connected-react-router';
 import { ingressControllerInstallationURL } from 'lib/docs';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { compare } from 'lib/semver';
+import AppDetailsModalMAPI from 'MAPI/apps/AppDetailsModal';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -15,6 +16,8 @@ import {
 import { isClusterCreating, isClusterUpdating } from 'stores/cluster/utils';
 import { selectErrorByIdAndAction } from 'stores/entityerror/selectors';
 import { selectCluster } from 'stores/main/actions';
+import { getLoggedInUser } from 'stores/main/selectors';
+import { LoggedInUserTypes } from 'stores/main/types';
 import { getKubernetesReleaseEOLStatus } from 'stores/releases/utils';
 import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
@@ -184,7 +187,7 @@ class ClusterApps extends React.Component {
         return {
           appDetailsModal: {
             visible: false,
-            app: null,
+            appName: '',
           },
         };
       }
@@ -221,7 +224,7 @@ class ClusterApps extends React.Component {
   state = {
     appDetailsModal: {
       visible: false,
-      app: null,
+      appName: '',
     },
   };
 
@@ -336,7 +339,7 @@ class ClusterApps extends React.Component {
     if (this.isComponentMounted) {
       this.setState({
         appDetailsModal: {
-          appName: null,
+          appName: '',
           visible: false,
         },
       });
@@ -494,7 +497,14 @@ class ClusterApps extends React.Component {
           )}
         </div>
 
-        {selectedApp && (
+        {selectedApp && this.props.user.type === LoggedInUserTypes.MAPI ? (
+          <AppDetailsModalMAPI
+            app={selectedApp}
+            clusterId={this.props.clusterId}
+            onClose={this.hideAppModal}
+            visible={this.state.appDetailsModal.visible}
+          />
+        ) : (
           <AppDetailsModal
             // Instead of just assigning the selected app to the state of this component,
             // this ensures any updates to the apps continue to flow down into the modal.
@@ -520,6 +530,7 @@ ClusterApps.propTypes = {
   clusterIsUpdating: PropTypes.bool,
   clusterIsAwaitingUpgrade: PropTypes.bool,
   clusterIsCreating: PropTypes.bool,
+  user: PropTypes.object,
 };
 
 function mapStateToProps(state, props) {
@@ -537,6 +548,7 @@ function mapStateToProps(state, props) {
       state
     ),
     clusterIsCreating: cluster ? isClusterCreating(cluster) : false,
+    user: getLoggedInUser(state),
   };
 }
 

--- a/src/components/Cluster/ClusterDetail/ClusterApps.js
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.js
@@ -497,23 +497,25 @@ class ClusterApps extends React.Component {
           )}
         </div>
 
-        {selectedApp && this.props.user.type === LoggedInUserTypes.MAPI ? (
-          <AppDetailsModalMAPI
-            app={selectedApp}
-            clusterId={this.props.clusterId}
-            onClose={this.hideAppModal}
-            visible={this.state.appDetailsModal.visible}
-          />
-        ) : (
-          <AppDetailsModal
-            // Instead of just assigning the selected app to the state of this component,
-            // this ensures any updates to the apps continue to flow down into the modal.
-            app={selectedApp}
-            clusterId={this.props.clusterId}
-            onClose={this.hideAppModal}
-            visible={this.state.appDetailsModal.visible}
-          />
-        )}
+        {selectedApp &&
+          (this.props.user.type === LoggedInUserTypes.MAPI ? (
+            <AppDetailsModalMAPI
+              appName={selectedApp.metadata.name}
+              catalog={selectedApp.spec.catalog}
+              clusterId={this.props.clusterId}
+              onClose={this.hideAppModal}
+              visible={this.state.appDetailsModal.visible}
+            />
+          ) : (
+            <AppDetailsModal
+              // Instead of just assigning the selected app to the state of this component,
+              // this ensures any updates to the apps continue to flow down into the modal.
+              app={selectedApp}
+              clusterId={this.props.clusterId}
+              onClose={this.hideAppModal}
+              visible={this.state.appDetailsModal.visible}
+            />
+          ))}
       </>
     );
   }

--- a/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
@@ -1,0 +1,196 @@
+import YAMLFileUpload from 'Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload';
+import { spinner } from 'images';
+import PropTypes from 'prop-types';
+import React from 'react';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+import styled from 'styled-components';
+import Button from 'UI/Controls/Button';
+import VersionPicker from 'UI/Controls/VersionPicker/VersionPicker';
+import DetailItem from 'UI/Layout/DetailList';
+import Truncated from 'UI/Util/Truncated';
+
+const Upper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 25px;
+
+  > div {
+    width: 50%;
+  }
+`;
+
+type ConfigChangeHandler = (values: string, done: () => void) => void;
+
+interface IAppDetailsModalInitialPaneProps {
+  app: IInstalledApp;
+  appVersions: IAppCatalogAppVersion[];
+  dispatchCreateAppConfig: ConfigChangeHandler;
+  dispatchCreateAppSecret: ConfigChangeHandler;
+  dispatchUpdateAppConfig: ConfigChangeHandler;
+  dispatchUpdateAppSecret: ConfigChangeHandler;
+  showDeleteAppConfigPane: () => void;
+  showDeleteAppPane: () => void;
+  showDeleteAppSecretPane: () => void;
+  showEditChartVersionPane: (version?: string) => void;
+  catalogNotFound?: boolean;
+}
+
+const AppDetailsModalInitialPane: React.FC<IAppDetailsModalInitialPaneProps> = (
+  props
+) => {
+  return (
+    <div>
+      <Upper>
+        <DetailItem title='CATALOG' className='code'>
+          <span>{props.app.spec.catalog}</span>
+        </DetailItem>
+
+        <DetailItem title='CHART VERSION'>
+          {/* If we have a catalog, but we're still loading the appVersions
+              then show a loading spinner.
+           */}
+          {!props.catalogNotFound && !props.appVersions && (
+            <img className='loader' width='25px' src={spinner} />
+          )}
+
+          {/* If we don't have a catalog, don't show a version picker because
+              we wil never know what versions are available.
+           */}
+          {props.catalogNotFound && (
+            <OverlayTrigger
+              overlay={
+                <Tooltip id='tooltip'>
+                  Unable to fetch versions for this app. Could not find the
+                  corresponding catalog. Changing versions is disabled.
+                </Tooltip>
+              }
+              placement='top'
+            >
+              <span>
+                {props.app.spec.version} <i className='fa fa-warning' />
+              </span>
+            </OverlayTrigger>
+          )}
+
+          {/* If we have app versions loaded, show the VersionPicker */}
+          {props.appVersions && (
+            <VersionPicker
+              selectedVersion={props.app.spec.version}
+              versions={props.appVersions.map((v) => ({
+                chartVersion: v.version,
+                created: v.created,
+                includesVersion: v.appVersion,
+                test: false,
+              }))}
+              onChange={props.showEditChartVersionPane}
+            />
+          )}
+        </DetailItem>
+
+        <DetailItem title='NAMESPACE' className='code'>
+          <span>{props.app.spec.namespace}</span>
+        </DetailItem>
+
+        <DetailItem title='APP VERSION' className='code'>
+          {props.app.status.app_version === '' ? (
+            <span>Information pending...</span>
+          ) : (
+            <Truncated as='span'>{props.app.status.app_version}</Truncated>
+          )}
+        </DetailItem>
+
+        <DetailItem title='RELEASE STATUS' className='code'>
+          {props.app.status?.release?.status ? (
+            <span>{props.app.status.release.status}</span>
+          ) : (
+            <span>Information pending...</span>
+          )}
+        </DetailItem>
+      </Upper>
+
+      <DetailItem title='user level config values' className='well'>
+        {props.app.spec.user_config.configmap.name !== '' ? (
+          <>
+            <span>User level config values have been set</span>
+
+            <div className='actions'>
+              <YAMLFileUpload
+                buttonText='Replace values'
+                onInputChange={props.dispatchUpdateAppConfig}
+              />
+
+              <Button bsStyle='danger' onClick={props.showDeleteAppConfigPane}>
+                <i className='fa fa-delete' /> Delete
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <span>No user level config values</span>
+
+            <div className='actions'>
+              <YAMLFileUpload
+                buttonText='Upload user level config values'
+                onInputChange={props.dispatchCreateAppConfig}
+              />
+            </div>
+          </>
+        )}
+      </DetailItem>
+
+      <DetailItem title='user level secret values' className='well'>
+        {props.app.spec.user_config.secret.name !== '' ? (
+          <>
+            <span>User level secret values have been set</span>
+
+            <div className='actions'>
+              <YAMLFileUpload
+                buttonText='Replace user level secret values'
+                onInputChange={props.dispatchUpdateAppSecret}
+              />
+
+              <Button bsStyle='danger' onClick={props.showDeleteAppSecretPane}>
+                <i className='fa fa-delete' /> Delete
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <span>No user level secret values</span>
+
+            <div className='actions'>
+              <YAMLFileUpload
+                buttonText='Upload user level secret values'
+                onInputChange={props.dispatchCreateAppSecret}
+              />
+            </div>
+          </>
+        )}
+      </DetailItem>
+
+      <DetailItem title='Delete This App'>
+        <Button bsStyle='danger' onClick={props.showDeleteAppPane}>
+          <i className='fa fa-delete' />
+          Delete App
+        </Button>
+      </DetailItem>
+    </div>
+  );
+};
+
+AppDetailsModalInitialPane.propTypes = {
+  app: (PropTypes.object as PropTypes.Requireable<IInstalledApp>).isRequired,
+  appVersions: PropTypes.array.isRequired,
+  dispatchCreateAppConfig: PropTypes.func.isRequired,
+  dispatchCreateAppSecret: PropTypes.func.isRequired,
+  dispatchUpdateAppConfig: PropTypes.func.isRequired,
+  dispatchUpdateAppSecret: PropTypes.func.isRequired,
+  showDeleteAppConfigPane: PropTypes.func.isRequired,
+  showDeleteAppPane: PropTypes.func.isRequired,
+  showDeleteAppSecretPane: PropTypes.func.isRequired,
+  showEditChartVersionPane: PropTypes.func.isRequired,
+  catalogNotFound: PropTypes.bool,
+};
+
+export default AppDetailsModalInitialPane;

--- a/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
@@ -71,7 +71,8 @@ const AppDetailsModalInitialPane: React.FC<IAppDetailsModalInitialPaneProps> = (
                 placement='top'
               >
                 <span>
-                  {props.app.spec.version} <i className='fa fa-warning' />
+                  <Truncated as='span'>{props.app.spec.version}</Truncated>{' '}
+                  <i className='fa fa-warning' />
                 </span>
               </OverlayTrigger>
             )}

--- a/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
@@ -112,7 +112,7 @@ const AppDetailsModalInitialPane: React.FC<IAppDetailsModalInitialPaneProps> = (
       </Upper>
 
       <DetailItem title='user level config values' className='well'>
-        {props.app.spec.userConfig?.configMap?.name !== '' ? (
+        {props.app.spec.userConfig?.configMap?.name ? (
           <>
             <span>User level config values have been set</span>
 

--- a/src/components/MAPI/apps/AppDetailsModal/index.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/index.tsx
@@ -22,6 +22,7 @@ import Button from 'UI/Controls/Button';
 import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
 
 import {
+  deleteAppWithName,
   deleteConfigMapForApp,
   deleteSecretForApp,
   ensureConfigMapForApp,
@@ -227,12 +228,28 @@ const AppDetailsModal: React.FC<IAppDetailsModalProps> = ({
     }
   }
 
-  function deleteApp() {
-    // await dispatch(deleteAppAction({ appName, clusterId }));
-    // await dispatch(loadClusterApps({ clusterId: clusterId }));
-    setAppUpdateIsLoading(true);
-    setAppUpdateIsLoading(false);
-    handleClose();
+  async function deleteApp() {
+    try {
+      await deleteAppWithName(clientFactory(), auth, clusterId, appName);
+
+      // TODO(axbarsan): Mutate apps list, once that request exists.
+      handleClose();
+
+      new FlashMessage(
+        `App <code>${appName}</code> was scheduled for deletion on <code>${clusterId}</code>. This may take a couple of minutes.`,
+        messageType.SUCCESS,
+        messageTTL.LONG
+      );
+    } catch (err) {
+      const errorMessage = extractErrorMessage(err);
+
+      new FlashMessage(
+        `Something went wrong while trying to delete your app.`,
+        messageType.ERROR,
+        messageTTL.LONG,
+        errorMessage
+      );
+    }
   }
 
   async function createAppConfig(values: string, done: () => void) {

--- a/src/components/MAPI/apps/AppDetailsModal/index.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/index.tsx
@@ -1,0 +1,319 @@
+import DeleteConfirmFooter from 'Cluster/ClusterDetail/AppDetailsModal/DeleteConfirmFooter';
+import EditChartVersionPane from 'Cluster/ClusterDetail/AppDetailsModal/EditChartVersionPane';
+import GenericModal from 'components/Modals/GenericModal';
+import useError from 'lib/hooks/useError';
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  catalogLoadIndex,
+  createAppConfig as createAppConfigAction,
+  createAppSecret as createAppSecretAction,
+  deleteAppConfig as deleteAppConfigAction,
+  deleteAppSecret as deleteAppSecretAction,
+  deleteClusterApp as deleteAppAction,
+  loadClusterApps,
+  updateAppConfig as updateAppConfigAction,
+  updateAppSecret as updateAppSecretAction,
+  updateClusterApp as updateAppAction,
+  updateClusterApp,
+} from 'stores/appcatalog/actions';
+import { IAsynchronousDispatch } from 'stores/asynchronousAction';
+import { selectLoadingFlagByAction } from 'stores/loading/selectors';
+import { IState } from 'stores/state';
+import Button from 'UI/Controls/Button';
+import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
+
+import AppDetailsModalInitialPane from './AppDetailsModalInitialPane';
+
+enum ModalPanes {
+  Initial,
+  DeleteAppConfig,
+  DeleteAppSecret,
+  DeleteApp,
+  EditChartVersion,
+}
+
+interface IAppDetailsModalProps {
+  app: IInstalledApp;
+  clusterId: string;
+  onClose: () => void;
+  visible?: boolean;
+}
+
+const AppDetailsModal: React.FC<IAppDetailsModalProps> = ({
+  app,
+  clusterId,
+  onClose,
+  visible,
+}) => {
+  const dispatch = useDispatch<IAsynchronousDispatch<IState>>();
+
+  const catalog = useSelector<IState, IAppCatalog | undefined>(
+    (state) => state.entities.catalogs.items[app.spec.catalog]
+  );
+  const isLoading = useSelector((state: IState) =>
+    selectLoadingFlagByAction(state, updateAppAction().types.request)
+  );
+  const { errorMessage } = useError(updateClusterApp().types.error);
+
+  const appName = app.metadata.name;
+  const appVersions = catalog?.apps?.[app.spec.name] ?? [];
+
+  const [pane, setPane] = useState(ModalPanes.Initial);
+  const [desiredVersion, setDesiredVersion] = useState(app.spec.version);
+  const { clear: clearUpdateAppError } = useError(
+    updateAppAction().types.error
+  );
+
+  useEffect(() => {
+    if (catalog && !catalog.apps) {
+      dispatch(catalogLoadIndex(catalog.metadata.name));
+    }
+  }, [catalog, app, dispatch]);
+
+  function showPane(paneToShow: ModalPanes) {
+    return () => {
+      clearUpdateAppError();
+      setPane(paneToShow);
+    };
+  }
+
+  function showEditChartVersionPane(version?: string) {
+    if (typeof version === 'undefined') return;
+
+    setDesiredVersion(version);
+    setPane(ModalPanes.EditChartVersion);
+  }
+
+  function handleClose() {
+    showPane(ModalPanes.Initial)();
+    onClose();
+  }
+
+  async function editChartVersion() {
+    const { error } = await dispatch(
+      updateAppAction({ appName, clusterId, version: desiredVersion })
+    );
+
+    if (error) {
+      return;
+    }
+
+    await dispatch(loadClusterApps({ clusterId: clusterId }));
+    handleClose();
+  }
+
+  async function deleteAppConfig() {
+    await dispatch(deleteAppConfigAction(appName, clusterId));
+    await dispatch(loadClusterApps({ clusterId: clusterId }));
+    handleClose();
+  }
+
+  async function deleteAppSecret() {
+    await dispatch(deleteAppSecretAction(appName, clusterId));
+    await dispatch(loadClusterApps({ clusterId: clusterId }));
+    handleClose();
+  }
+
+  async function deleteApp() {
+    await dispatch(deleteAppAction({ appName, clusterId }));
+    await dispatch(loadClusterApps({ clusterId: clusterId }));
+    handleClose();
+  }
+
+  async function createAppConfig(values: string, done: () => void) {
+    await dispatch(createAppConfigAction(appName, clusterId, values));
+    await dispatch(loadClusterApps({ clusterId: clusterId }));
+    done();
+    handleClose();
+  }
+
+  async function updateAppConfig(values: string, done: () => void) {
+    await dispatch(updateAppConfigAction(appName, clusterId, values));
+    await dispatch(loadClusterApps({ clusterId: clusterId }));
+    done();
+    handleClose();
+  }
+
+  async function createAppSecret(values: string, done: () => void) {
+    await dispatch(createAppSecretAction(appName, clusterId, values));
+    await dispatch(loadClusterApps({ clusterId: clusterId }));
+    done();
+    handleClose();
+  }
+
+  async function updateAppSecret(values: string, done: () => void) {
+    await dispatch(updateAppSecretAction(appName, clusterId, values));
+    await dispatch(loadClusterApps({ clusterId: clusterId }));
+    done();
+    handleClose();
+  }
+
+  switch (pane) {
+    case ModalPanes.Initial:
+      return (
+        <GenericModal
+          aria-label='App details'
+          title={appName}
+          onClose={handleClose}
+          visible={visible}
+        >
+          <AppDetailsModalInitialPane
+            app={app}
+            catalogNotFound={!catalog}
+            appVersions={appVersions}
+            dispatchCreateAppConfig={createAppConfig}
+            dispatchCreateAppSecret={createAppSecret}
+            dispatchUpdateAppConfig={updateAppConfig}
+            dispatchUpdateAppSecret={updateAppSecret}
+            showDeleteAppConfigPane={showPane(ModalPanes.DeleteAppConfig)}
+            showDeleteAppPane={showPane(ModalPanes.DeleteApp)}
+            showDeleteAppSecretPane={showPane(ModalPanes.DeleteAppSecret)}
+            showEditChartVersionPane={showEditChartVersionPane}
+          />
+        </GenericModal>
+      );
+
+    case ModalPanes.EditChartVersion:
+      return (
+        <GenericModal
+          aria-label='App details - Edit chart version'
+          title={
+            <>
+              Change Chart Version for {appName} on{' '}
+              <ClusterIDLabel clusterID={clusterId} />
+            </>
+          }
+          footer={
+            <>
+              <Button
+                bsStyle='primary'
+                onClick={editChartVersion}
+                loading={isLoading}
+              >
+                Update Chart Version
+              </Button>
+              <Button bsStyle='link' onClick={showPane(ModalPanes.Initial)}>
+                Cancel
+              </Button>
+            </>
+          }
+          onClose={handleClose}
+          visible={visible}
+        >
+          <EditChartVersionPane
+            currentVersion={app.spec.version}
+            desiredVersion={desiredVersion}
+            errorMessage={errorMessage}
+          />
+        </GenericModal>
+      );
+
+    case ModalPanes.DeleteAppConfig:
+      return (
+        <GenericModal
+          aria-label='App details - Delete app config'
+          title={
+            <>
+              Delete user level config values for {appName} on{' '}
+              <ClusterIDLabel clusterID={clusterId} />
+            </>
+          }
+          footer={
+            <DeleteConfirmFooter
+              cta='Delete user level config values'
+              onConfirm={deleteAppConfig}
+              onCancel={showPane(ModalPanes.Initial)}
+            />
+          }
+          onClose={handleClose}
+          visible={visible}
+        >
+          <>
+            Are you sure you want to delete user level config values for{' '}
+            {appName} on <ClusterIDLabel clusterID={clusterId} />?
+            <br />
+            <br />
+            There is no undo.
+          </>
+        </GenericModal>
+      );
+
+    case ModalPanes.DeleteAppSecret:
+      return (
+        <GenericModal
+          aria-label='App details - Delete app secret'
+          title={
+            <>
+              Delete user level secret values for {appName} on{' '}
+              <ClusterIDLabel clusterID={clusterId} />
+            </>
+          }
+          footer={
+            <DeleteConfirmFooter
+              cta='Delete user level secret values'
+              onConfirm={deleteAppSecret}
+              onCancel={showPane(ModalPanes.Initial)}
+            />
+          }
+          onClose={handleClose}
+          visible={visible}
+        >
+          <>
+            Are you sure you want to delete user level secret values for{' '}
+            {appName} on <ClusterIDLabel clusterID={clusterId} />?
+            <br />
+            <br />
+            There is no undo.
+          </>
+        </GenericModal>
+      );
+
+    case ModalPanes.DeleteApp:
+      return (
+        <GenericModal
+          aria-label='App details - Delete app'
+          title={
+            <>
+              Delete {appName} on
+              <ClusterIDLabel clusterID={clusterId} />
+            </>
+          }
+          footer={
+            <DeleteConfirmFooter
+              cta='Delete App'
+              onConfirm={deleteApp}
+              onCancel={showPane(ModalPanes.Initial)}
+            />
+          }
+          onClose={handleClose}
+          visible={visible}
+        >
+          <>
+            Are you sure you want to delete {appName}&nbsp; on{' '}
+            <ClusterIDLabel clusterID={clusterId} />?
+            <br />
+            <br />
+            There is no undo.
+          </>
+        </GenericModal>
+      );
+
+    default:
+      return null;
+  }
+};
+
+AppDetailsModal.propTypes = {
+  app: (PropTypes.object as PropTypes.Requireable<IInstalledApp>).isRequired,
+  clusterId: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  visible: PropTypes.bool,
+};
+
+AppDetailsModal.defaultProps = {
+  visible: false,
+};
+
+export default AppDetailsModal;

--- a/src/components/MAPI/apps/AppDetailsModal/index.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/index.tsx
@@ -27,6 +27,7 @@ import {
   deleteSecretForApp,
   ensureConfigMapForApp,
   ensureSecretForApp,
+  updateAppVersion,
 } from '../utils';
 import AppDetailsModalInitialPane from './AppDetailsModalInitialPane';
 
@@ -153,19 +154,35 @@ const AppDetailsModal: React.FC<IAppDetailsModalProps> = ({
     onClose();
   }
 
-  function editChartVersion() {
-    // const { error } = await dispatch(
-    //   updateAppAction({ appName, clusterId, version: desiredVersion })
-    // );
+  async function editChartVersion() {
+    try {
+      setAppUpdateIsLoading(true);
 
-    // if (error) {
-    //   return;
-    // }
+      const updatedApp = await updateAppVersion(
+        clientFactory(),
+        auth,
+        clusterId,
+        appName,
+        desiredVersion
+      );
 
-    // await dispatch(loadClusterApps({ clusterId: clusterId }));
-    setAppUpdateIsLoading(true);
-    setAppUpdateIsLoading(false);
-    handleClose();
+      mutateApp(updatedApp);
+      // TODO(axbarsan): Mutate apps list, once that request exists.
+
+      setAppUpdateIsLoading(false);
+      handleClose();
+
+      new FlashMessage(
+        `App <code>${appName}</code> on <code>${clusterId}</code> has been updated. Changes might take some time to take effect.`,
+        messageType.SUCCESS,
+        messageTTL.LONG
+      );
+    } catch (err) {
+      setAppUpdateIsLoading(false);
+
+      const errorMessage = extractErrorMessage(err);
+      setAppUpdateError(errorMessage);
+    }
   }
 
   async function deleteAppConfig() {

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -268,3 +268,163 @@ export function filterClusters(
     }
   });
 }
+
+export async function ensureConfigMapForApp(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  appName: string,
+  contents: string
+) {
+  const userConfigMapName = getUserConfigMapName(appName);
+  const configMap = await ensureAppUserConfigMap(
+    client,
+    auth,
+    namespace,
+    userConfigMapName,
+    contents
+  );
+
+  if (!configMap) return null;
+
+  const app = await applicationv1alpha1.getApp(
+    client,
+    auth,
+    namespace,
+    appName
+  );
+  app.spec.userConfig = {
+    ...app.spec.userConfig,
+    configMap: {
+      name: configMap.metadata.name,
+      namespace: configMap.metadata.namespace!,
+    },
+  };
+
+  return applicationv1alpha1.updateApp(client, auth, app);
+}
+
+export async function ensureSecretForApp(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  appName: string,
+  contents: string
+) {
+  const userSecretName = getUserSecretName(appName);
+  const secret = await ensureAppUserSecret(
+    client,
+    auth,
+    namespace,
+    userSecretName,
+    contents
+  );
+
+  if (!secret) return null;
+
+  const app = await applicationv1alpha1.getApp(
+    client,
+    auth,
+    namespace,
+    appName
+  );
+  app.spec.userConfig = {
+    ...app.spec.userConfig,
+    secret: {
+      name: secret.metadata.name,
+      namespace: secret.metadata.namespace!,
+    },
+  };
+
+  return applicationv1alpha1.updateApp(client, auth, app);
+}
+
+export async function deleteConfigMapForApp(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  appName: string
+) {
+  const app = await applicationv1alpha1.getApp(
+    client,
+    auth,
+    namespace,
+    appName
+  );
+  app.spec.userConfig = {
+    ...app.spec.userConfig,
+    configMap: {
+      name: '',
+      namespace: '',
+    },
+  };
+
+  await applicationv1alpha1.updateApp(client, auth, app);
+
+  try {
+    const userConfigMapName = getUserConfigMapName(appName);
+    const configMap = await corev1.getConfigMap(
+      client,
+      auth,
+      userConfigMapName,
+      namespace
+    );
+    await corev1.deleteConfigMap(client, auth, configMap);
+  } catch (err) {
+    if (
+      !metav1.isStatusError(
+        (err as GenericResponse).data,
+        metav1.K8sStatusErrorReasons.NotFound
+      )
+    ) {
+      return Promise.reject(err);
+    }
+  }
+
+  return app;
+}
+
+export async function deleteSecretForApp(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  appName: string
+) {
+  const app = await applicationv1alpha1.getApp(
+    client,
+    auth,
+    namespace,
+    appName
+  );
+  app.spec.userConfig = {
+    ...app.spec.userConfig,
+    secret: {
+      name: '',
+      namespace: '',
+    },
+  };
+
+  await applicationv1alpha1.updateApp(client, auth, app);
+
+  try {
+    const userSecretName = getUserSecretName(appName);
+    const secret = await corev1.getSecret(
+      client,
+      auth,
+      userSecretName,
+      namespace
+    );
+    await corev1.deleteSecret(client, auth, secret);
+  } catch (err) {
+    if (
+      !metav1.isStatusError(
+        (err as GenericResponse).data,
+        metav1.K8sStatusErrorReasons.NotFound
+      )
+    ) {
+      return Promise.reject(err);
+    }
+  }
+
+  return app;
+}

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -428,3 +428,31 @@ export async function deleteSecretForApp(
 
   return app;
 }
+
+export async function deleteAppWithName(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  appName: string
+) {
+  try {
+    const app = await applicationv1alpha1.getApp(
+      client,
+      auth,
+      namespace,
+      appName
+    );
+    await applicationv1alpha1.deleteApp(client, auth, app);
+  } catch (err) {
+    if (
+      !metav1.isStatusError(
+        (err as GenericResponse).data,
+        metav1.K8sStatusErrorReasons.NotFound
+      )
+    ) {
+      return Promise.reject(err);
+    }
+  }
+
+  return Promise.resolve();
+}

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -456,3 +456,21 @@ export async function deleteAppWithName(
 
   return Promise.resolve();
 }
+
+export async function updateAppVersion(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  appName: string,
+  version: string
+) {
+  const app = await applicationv1alpha1.getApp(
+    client,
+    auth,
+    namespace,
+    appName
+  );
+  app.spec.version = version;
+
+  return applicationv1alpha1.updateApp(client, auth, app);
+}

--- a/src/model/services/mapi/applicationv1alpha1/deleteApp.ts
+++ b/src/model/services/mapi/applicationv1alpha1/deleteApp.ts
@@ -1,0 +1,22 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { deleteResource } from '../generic/deleteResource';
+import { IApp } from './types';
+
+export function deleteApp(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  app: IApp
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'apps',
+    name: app.metadata.name,
+    namespace: app.metadata.namespace!,
+  });
+
+  return deleteResource<IApp>(client, auth, url.toString());
+}

--- a/src/model/services/mapi/applicationv1alpha1/getApp.ts
+++ b/src/model/services/mapi/applicationv1alpha1/getApp.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { getResource } from '../generic/getResource';
+import { IApp } from './types';
+
+export function getApp(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  name: string
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'apps',
+    name,
+    namespace,
+  });
+
+  return getResource<IApp>(client, auth, url.toString());
+}
+
+export function getAppKey(namespace: string, name: string) {
+  return `getApp/${namespace}/${name}`;
+}

--- a/src/model/services/mapi/applicationv1alpha1/getAppCatalogEntryList.ts
+++ b/src/model/services/mapi/applicationv1alpha1/getAppCatalogEntryList.ts
@@ -1,0 +1,39 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { getResource } from '../generic/getResource';
+import { IAppCatalogEntryList } from './types';
+
+export interface IGetAppCatalogEntryListOptions {
+  namespace?: string;
+  labelSelector?: k8sUrl.IK8sLabelSelector;
+}
+
+export function getAppCatalogEntryList(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  options?: IGetAppCatalogEntryListOptions
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'appcatalogentries',
+    ...options,
+  });
+
+  return getResource<IAppCatalogEntryList>(client, auth, url.toString());
+}
+
+export function getAppCatalogEntryListKey(
+  options?: IGetAppCatalogEntryListOptions
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'appcatalogentries',
+    ...options,
+  });
+
+  return url.toString();
+}

--- a/src/model/services/mapi/applicationv1alpha1/index.ts
+++ b/src/model/services/mapi/applicationv1alpha1/index.ts
@@ -3,4 +3,5 @@ export * from './key';
 export * from './getAppList';
 export * from './createApp';
 export * from './getApp';
+export * from './updateApp';
 export * from './getAppCatalogEntryList';

--- a/src/model/services/mapi/applicationv1alpha1/index.ts
+++ b/src/model/services/mapi/applicationv1alpha1/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
 export * from './key';
 export * from './getAppList';
+export * from './getAppCatalogEntryList';
 export * from './createApp';

--- a/src/model/services/mapi/applicationv1alpha1/index.ts
+++ b/src/model/services/mapi/applicationv1alpha1/index.ts
@@ -4,4 +4,5 @@ export * from './getAppList';
 export * from './createApp';
 export * from './getApp';
 export * from './updateApp';
+export * from './deleteApp';
 export * from './getAppCatalogEntryList';

--- a/src/model/services/mapi/applicationv1alpha1/index.ts
+++ b/src/model/services/mapi/applicationv1alpha1/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './key';
 export * from './getAppList';
-export * from './getAppCatalogEntryList';
 export * from './createApp';
+export * from './getApp';
+export * from './getAppCatalogEntryList';

--- a/src/model/services/mapi/applicationv1alpha1/key.ts
+++ b/src/model/services/mapi/applicationv1alpha1/key.ts
@@ -1,1 +1,4 @@
 export const labelAppOperator = 'app-operator.giantswarm.io/version';
+export const labelAppName = 'app.kubernetes.io/name';
+export const labelAppVersion = 'app.kubernetes.io/version';
+export const labelAppCatalog = 'application.giantswarm.io/catalog';

--- a/src/model/services/mapi/applicationv1alpha1/types.ts
+++ b/src/model/services/mapi/applicationv1alpha1/types.ts
@@ -94,3 +94,95 @@ export interface IAppList extends metav1.IList<IApp> {
   apiVersion: 'application.giantswarm.io/v1alpha1';
   kind: typeof AppList;
 }
+
+export interface IAppCatalogSpecStorage {
+  type: string;
+  URL: string;
+}
+
+export interface IAppCatalogSpecConfigSecret {
+  name: string;
+  namespace: string;
+}
+
+export interface IAppCatalogSpecConfigConfigMap {
+  name: string;
+  namespace: string;
+}
+
+export interface IAppCatalogSpecConfig {
+  configMap?: IAppCatalogSpecConfigConfigMap;
+  secret?: IAppCatalogSpecConfigSecret;
+}
+
+export interface IAppCatalogSpec {
+  title: string;
+  description: string;
+  logoURL: string;
+  storage: IAppCatalogSpecStorage;
+  config?: IAppCatalogSpecConfig;
+}
+
+export const AppCatalog = 'AppCatalog';
+
+export interface IAppCatalog {
+  apiVersion: 'application.giantswarm.io/v1alpha1';
+  kind: typeof AppCatalog;
+  metadata: metav1.IObjectMeta;
+  spec: IAppCatalogSpec;
+}
+
+export const AppCatalogList = 'AppCatalogList';
+
+export interface IAppCatalogList extends metav1.IList<IAppCatalog> {
+  apiVersion: 'application.giantswarm.io/v1alpha1';
+  kind: typeof AppCatalogList;
+}
+
+export type Provider = 'aws' | 'azure' | 'kvm';
+
+export interface IAppCatalogEntrySpecRestrictions {
+  clusterSingleton?: boolean;
+  fixedNamespace?: string;
+  gpuInstance?: string;
+  compatibleProviders?: Provider[];
+  namespaceSingleton?: boolean;
+}
+
+export interface IAppCatalogEntrySpecChart {
+  apiVersion: string;
+  home?: string;
+  icon?: string;
+}
+
+export interface IAppCatalogEntrySpecCatalog {
+  name: string;
+  namespace?: string;
+}
+
+export interface IAppCatalogEntrySpec {
+  appName: string;
+  appVersion: string;
+  version: string;
+  catalog: IAppCatalogEntrySpecCatalog;
+  chart: IAppCatalogEntrySpecChart;
+  dateCreated: string | null;
+  dateUpdated: string | null;
+  restrictions?: IAppCatalogEntrySpecRestrictions;
+}
+
+export const AppCatalogEntry = 'AppCatalogEntry';
+
+export interface IAppCatalogEntry {
+  apiVersion: 'application.giantswarm.io/v1alpha1';
+  kind: typeof AppCatalogEntry;
+  metadata: metav1.IObjectMeta;
+  spec: IAppCatalogEntrySpec;
+}
+
+export const AppCatalogEntryList = 'AppCatalogEntryList';
+
+export interface IAppCatalogEntryList extends metav1.IList<IAppCatalogEntry> {
+  apiVersion: 'application.giantswarm.io/v1alpha1';
+  kind: typeof AppCatalogEntryList;
+}

--- a/src/model/services/mapi/applicationv1alpha1/updateApp.ts
+++ b/src/model/services/mapi/applicationv1alpha1/updateApp.ts
@@ -1,0 +1,22 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { updateResource } from '../generic/updateResource';
+import { IApp } from './types';
+
+export function updateApp(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  app: IApp
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'apps',
+    name: app.metadata.name,
+    namespace: app.metadata.namespace!,
+  } as k8sUrl.IK8sUpdateOptions);
+
+  return updateResource<IApp>(client, auth, url.toString(), app);
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/328

As with the previous PR with app installation, this one duplicates the existing necessary components, and replaces the REST API logic with the MAPI one.