### PR TITLE
Use relative command paths in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
 # .husky/pre-commit (v5)
 
-yarn typecheck && yarn precommit
+# typecheck and lint
+./node_modules/.bin/tsc && \
+   ./node_modules/.bin/lint-staged


### PR DESCRIPTION
This PR solves the problem that when `yarn` is not available in a global path, the pre-commit wasn't working. (seen in Github Desktop)

## Background

Due to problems with homebrew upgrading node JS automatically and the system (macOS) providing node v16 (which is too new for happa and node-sass) I switched to `nvm` for managing node versions.

As this seems to be the way things work with `nvm`, `npm install -g yarn` results in yarn being installed in

    /Users/marian/.local/share/nvm/v14.16.1/bin/yarn

which is not in my PATH. I could add it to my PATH, but that's not really how nvm is supposed to work. With nvm I should be able to have several version of yarn in folders like `/Users/marian/.local/share/nvm/<node-version>/bin`.

In the terminal, once `nvm use v14.16.1` has been issued, I can use the `yarn` command just fine.

When creating a commit from Github Desktop however, the `yarn` command is not found. Resulting in this error:

![image](https://user-images.githubusercontent.com/273727/117791787-fa347d00-b24a-11eb-90a0-086959b5a7e1.png)

All this PR does is

- replace `yarn typecheck` with the command it resolves to (`./node_modules/.bin/tsc`)
- replace `yarn precommit`with `./node_modules/.bin/lint-staged`

which should work for everyone with or without `yarn` in the path.