### PR TITLE
Set nodeJS version to v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/happa
   docker:
-    - image: circleci/node:12-buster
+    - image: circleci/node:14-buster
 
 job_filters: &job_filters
   filters:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Happa is a single page JavaScript application using React+Redux and runs in mode
 
 ## Getting started with development / demoing
 
-Running Happa locally requires [NodeJS 12](https://nodejs.org/) and [Yarn](https://yarnpkg.com/).
+Running Happa locally requires [NodeJS v14](https://nodejs.org/) and [Yarn](https://yarnpkg.com/).
 
 You must have [opsctl](https://github.com/giantswarm/opsctl) installed and configured properly.
 opsctl is our internal tool for managing access to clusters and performing ops related tasks.


### PR DESCRIPTION
To keep up with upstream, this PR sets the NodeJS version used to v14, which is the current LTS (long term support) version of NodeJS. 