### PR TITLE
Pin underscore version to 1.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@types/serialize-javascript": "^5.0.0",
     "@types/styled-components": "^5.1.9",
     "@types/superagent": "^4.1.10",
-    "@types/underscore": "^1.11.0",
+    "@types/underscore": "^1.11.1",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "4.21.0",
     "@typescript-eslint/parser": "4.22.0",
@@ -242,7 +242,8 @@
     "lodash": "^4.17.21",
     "http-proxy": "^1.18.1",
     "node-fetch": "^2.6.1",
-    "trim": "^0.0.3"
+    "trim": "^0.0.3",
+    "underscore": "1.13.1"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,10 +2956,10 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/underscore@^1.11.0":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.1.tgz#5b773d04c44897137485615dbef56a2919b9fa5a"
-  integrity sha512-mW23Xkp9HYgdMV7gnwuzqnPx6aG0J7xg/b7erQszOcyOizWylwCr9cgYM/BVVJHezUDxwyigG6+wCFQwCvyMBw==
+"@types/underscore@^1.11.1":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.2.tgz#9441e0f6402bbcb72dbee771582fa57c5a1dedd3"
+  integrity sha512-Ls2ylbo7++ITrWk2Yc3G/jijwSq5V3GT0tlgVXEl2kKYXY3ImrtmTCoE2uyTWFRI5owMBriloZFWbE1SXOsE7w==
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
@@ -15921,15 +15921,10 @@ uncontrollable@^7.0.2:
     invariant "^2.2.4"
     react-lifecycles-compat "^3.0.4"
 
-underscore@1.13.1:
+underscore@1.13.1, underscore@1.9.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
   integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
-
-underscore@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Pins underscore to mitigate https://snyk.io/vuln/SNYK-JS-UNDERSCORE-1080984

Tested all BootstrapTable instances, seems fine.