### PR TITLE
auth: fix resuming an existing SSO session

### DIFF
--- a/src/lib/OAuth2/OAuth2.ts
+++ b/src/lib/OAuth2/OAuth2.ts
@@ -142,6 +142,8 @@ class OAuth2 implements IOAuth2Provider {
 
     const newUser = getUserFromOIDCUser(origUser);
 
+    this.userManager.events.load(origUser);
+
     return newUser;
   }
 
@@ -149,6 +151,8 @@ class OAuth2 implements IOAuth2Provider {
     const origUser = await this.userManager.signinSilent();
 
     const newUser = getUserFromOIDCUser(origUser);
+
+    this.userManager.events.load(origUser);
 
     return newUser;
   }


### PR DESCRIPTION
I broke this with https://github.com/giantswarm/happa/pull/2430

Turns out that these events still need to be executed, especially when resuming an existing session