### PR TITLE
footer: add `v` prefix to the version in the release notes URL

### DIFF
--- a/src/components/Footer/FooterUtils.ts
+++ b/src/components/Footer/FooterUtils.ts
@@ -32,7 +32,7 @@ export function getReleaseURL(version: string): string {
       return `https://github.com/giantswarm/happa/commit/${semverVersion.getPreRelease()}`;
     }
 
-    return `https://docs.giantswarm.io/changes/web-ui/happa/${version}/`;
+    return `https://docs.giantswarm.io/changes/web-ui/happa/v${version}/`;
   } catch {
     return 'https://github.com/giantswarm/happa';
   }


### PR DESCRIPTION
Closes https://github.com/giantswarm/happa/issues/2433

Broke this in https://github.com/giantswarm/happa/pull/2393