### PR TITLE
Revert copy path for images

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -49,7 +49,6 @@ if (SENTRY_UPLOAD_SOURCEMAPS.toLowerCase() === 'true') {
     new SentryCliPlugin({
       include: './dist',
       authToken: SENTRY_API_KEY,
-      ignoreFile: '.sentrycliignore',
       ignore: ['index.js'],
       org: 'giantswarm',
       project: 'happa',

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -50,6 +50,7 @@ if (SENTRY_UPLOAD_SOURCEMAPS.toLowerCase() === 'true') {
       include: './dist',
       authToken: SENTRY_API_KEY,
       ignoreFile: '.sentrycliignore',
+      ignore: ['index.js'],
       org: 'giantswarm',
       project: 'happa',
       release: SENTRY_RELEASE_VERSION,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -39,7 +39,7 @@ const plugins = [
   new CopyPlugin({
     patterns: [
       { from: 'src/metadata.json', to: 'metadata.json' },
-      { from: 'src/images/**/*.{png,jpg,jpeg,svg,webp}', to: 'images' },
+      { from: 'src/images', to: 'images' },
     ],
   }),
 ];


### PR DESCRIPTION
Fixes a problem with missing images, as they were placed in the wrog path under `/www`.

Also consolidates the Sentry ignore configuration in the webpack config.