### PR TITLE
Update architect-orb to 2.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@2.7.0
+  architect: giantswarm/architect@2.8.0
 
 defaults: &defaults
   working_directory: ~/happa


### PR DESCRIPTION
New orb version required to generate App CR without status in app-collection