### PR TITLE
apps: remove global app-specific requests when MAPI features are supported

### DIFF
--- a/__tests__/AdminLogin.tsx
+++ b/__tests__/AdminLogin.tsx
@@ -37,7 +37,6 @@ describe('AdminLogin', () => {
     (getInstallationInfo as jest.Mock).mockResolvedValueOnce(AWSInfoResponse);
     (getConfiguration as jest.Mock).mockResolvedValueOnce(metadataResponse);
     getMockCall('/v4/clusters/');
-    getMockCall('/v4/appcatalogs/');
     getMockCall('/v4/releases/', releasesResponse);
 
     const history = createInitialHistory(MainRoutes.AdminLogin);

--- a/__tests__/Login.tsx
+++ b/__tests__/Login.tsx
@@ -191,7 +191,6 @@ describe('Login', () => {
     );
     (getInstallationInfo as jest.Mock).mockResolvedValueOnce(AWSInfoResponse);
     getMockCall('/v4/clusters/');
-    getMockCall('/v4/appcatalogs/');
     getMockCall('/v4/releases/', releasesResponse);
 
     const history = createInitialHistory(MainRoutes.Login);
@@ -288,7 +287,6 @@ describe('Login', () => {
     );
     (getInstallationInfo as jest.Mock).mockResolvedValueOnce(AWSInfoResponse);
     getMockCall('/v4/clusters/');
-    getMockCall('/v4/appcatalogs/');
     getMockCall('/v4/releases/', releasesResponse);
 
     const history = createInitialHistory(MainRoutes.Login);
@@ -332,7 +330,6 @@ describe('Login', () => {
     (getInstallationInfo as jest.Mock).mockResolvedValueOnce(AWSInfoResponse);
 
     getMockCall('/v4/clusters/');
-    getMockCall('/v4/appcatalogs/');
     getMockCall('/v4/releases/', releasesResponse);
 
     const history = createInitialHistory(MainRoutes.Login);

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -14,6 +14,7 @@ import ReactTimeout from 'react-timeout';
 import { bindActionCreators } from 'redux';
 import { Constants, Providers } from 'shared/constants';
 import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import { supportsMapiApps } from 'shared/featureSupport';
 import Tabs from 'shared/Tabs';
 import {
   batchedClusterDetailView,
@@ -33,7 +34,6 @@ import {
 import { selectLoadingFlagByIdAndAction } from 'stores/entityloading/selectors';
 import { selectLoadingFlagByAction } from 'stores/loading/selectors';
 import { getLoggedInUser, getUserIsAdmin } from 'stores/main/selectors';
-import { LoggedInUserTypes } from 'stores/main/types';
 import * as nodePoolActions from 'stores/nodepool/actions';
 import { NODEPOOL_MULTIPLE_LOAD_REQUEST } from 'stores/nodepool/constants';
 import { selectNodePools } from 'stores/nodepool/selectors';
@@ -383,8 +383,7 @@ class ClusterDetailView extends React.Component {
                 </LoadingOverlay>
               </Tab>
               <Tab eventKey={tabsPaths.Apps} title='Apps'>
-                {user?.type === LoggedInUserTypes.MAPI &&
-                provider !== Providers.KVM ? (
+                {supportsMapiApps(user, provider) ? (
                   <ClusterDetailApps
                     clusterId={id}
                     releaseVersion={release_version}
@@ -403,8 +402,7 @@ class ClusterDetailView extends React.Component {
                 )}
               </Tab>
               <Tab eventKey={tabsPaths.Ingress} title='Ingress'>
-                {user?.type === LoggedInUserTypes.MAPI &&
-                provider !== Providers.KVM ? (
+                {supportsMapiApps(user, provider) ? (
                   <ClusterDetailIngress
                     clusterID={cluster.id}
                     provider={provider}

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -303,6 +303,8 @@ class ClusterDetailView extends React.Component {
     const clusterIsUpdating =
       isClusterUpdating(cluster) || clusterIsAwaitingUpgrade;
 
+    const supporsAppsViaMapi = supportsMapiApps(user, provider);
+
     return (
       <DocumentTitle title={`Cluster Details | ${this.clusterName()}`}>
         <LoadingOverlay loading={loading}>
@@ -383,7 +385,7 @@ class ClusterDetailView extends React.Component {
                 </LoadingOverlay>
               </Tab>
               <Tab eventKey={tabsPaths.Apps} title='Apps'>
-                {supportsMapiApps(user, provider) ? (
+                {supporsAppsViaMapi ? (
                   <ClusterDetailApps
                     clusterId={id}
                     releaseVersion={release_version}
@@ -402,7 +404,7 @@ class ClusterDetailView extends React.Component {
                 )}
               </Tab>
               <Tab eventKey={tabsPaths.Ingress} title='Ingress'>
-                {supportsMapiApps(user, provider) ? (
+                {supporsAppsViaMapi ? (
                   <ClusterDetailIngress
                     clusterID={cluster.id}
                     provider={provider}

--- a/src/components/GettingStarted/Steps/InstallIngress.js
+++ b/src/components/GettingStarted/Steps/InstallIngress.js
@@ -9,7 +9,6 @@ import { Link } from 'react-router-dom';
 import { OrganizationsRoutes } from 'shared/constants/routes';
 import { selectClusterById } from 'stores/cluster/selectors';
 import { getLoggedInUser, getProvider } from 'stores/main/selectors';
-import { LoggedInUserTypes } from 'stores/main/types';
 import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
 import GettingStartedBottomNav from 'UI/Display/Documentation/GettingStartedBottomNav';
@@ -73,8 +72,7 @@ const InstallIngress = (props) => {
         </p>
 
         <InstallIngressButtonWrapper>
-          {user?.type === LoggedInUserTypes.MAPI &&
-          provider !== Providers.KVM ? (
+          {supportsMapiApps(user, provider) ? (
             <InstallIngressButtonMAPI clusterID={props.cluster.id} />
           ) : (
             <InstallIngressButton cluster={props.cluster} />

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -18,6 +18,7 @@ import {
   OrganizationsRoutes,
   UsersRoutes,
 } from 'shared/constants/routes';
+import { supportsMapiApps } from 'shared/featureSupport';
 import { batchedLayout, batchedOrganizationSelect } from 'stores/batchActions';
 import {
   getLoggedInUser,
@@ -76,8 +77,7 @@ class Layout extends React.Component {
                   <Switch>
                     <Route component={Home} exact path={MainRoutes.Home} />
 
-                    {user.type === LoggedInUserTypes.MAPI &&
-                    provider !== Providers.KVM ? (
+                    {supportsMapiApps(user, provider) ? (
                       <Route component={AppsMAPI} path={AppsRoutes.Home} />
                     ) : (
                       <Route component={Apps} path={AppsRoutes.Home} />

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -59,6 +59,10 @@ class Layout extends React.Component {
   render() {
     const { user, provider } = this.props;
 
+    const supportsAppsViaMapi = user && supportsMapiApps(user, provider);
+    const showApps =
+      supportsAppsViaMapi || Object.keys(this.props.catalogs.items).length > 0;
+
     return (
       <DocumentTitle>
         <LoadingOverlay loading={!this.props.firstLoadComplete}>
@@ -69,7 +73,7 @@ class Layout extends React.Component {
                 onSelectOrganization={this.selectOrganization}
                 organizations={this.props.organizations}
                 selectedOrganization={this.props.selectedOrganization}
-                showApps={Object.keys(this.props.catalogs.items).length > 0}
+                showApps={showApps}
                 user={user}
               />
               <Breadcrumb data={{ title: 'HOME', pathname: MainRoutes.Home }}>
@@ -77,7 +81,7 @@ class Layout extends React.Component {
                   <Switch>
                     <Route component={Home} exact path={MainRoutes.Home} />
 
-                    {supportsMapiApps(user, provider) ? (
+                    {supportsAppsViaMapi ? (
                       <Route component={AppsMAPI} path={AppsRoutes.Home} />
                     ) : (
                       <Route component={Apps} path={AppsRoutes.Home} />

--- a/src/shared/featureSupport.ts
+++ b/src/shared/featureSupport.ts
@@ -1,0 +1,11 @@
+import { LoggedInUserTypes } from 'stores/main/types';
+
+import { Providers } from './constants';
+import { PropertiesOf } from './types';
+
+export function supportsMapiApps(
+  user: ILoggedInUser,
+  provider: PropertiesOf<typeof Providers>
+): boolean {
+  return user.type === LoggedInUserTypes.MAPI && provider !== Providers.KVM;
+}

--- a/src/stores/batchActions.ts
+++ b/src/stores/batchActions.ts
@@ -6,8 +6,8 @@ import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
 import RoutePath from 'lib/routePath';
 import { AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { Providers } from 'shared/constants';
 import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import { supportsMapiApps } from 'shared/featureSupport';
 import { INodePool } from 'shared/types';
 import {
   enableCatalog,
@@ -95,7 +95,7 @@ export function batchedLayout(
       const user = getLoggedInUser(getState())!;
       const provider = getProvider(getState())!;
 
-      if (user.type !== LoggedInUserTypes.MAPI || provider === Providers.KVM) {
+      if (!supportsMapiApps(user, provider)) {
         const catalogs = await dispatch(listCatalogs());
 
         Object.entries(catalogs)
@@ -256,7 +256,7 @@ export function batchedClusterDetailView(
 
       const user = getLoggedInUser(getState())!;
       const provider = getProvider(getState());
-      if (user.type !== LoggedInUserTypes.MAPI || provider === Providers.KVM) {
+      if (!supportsMapiApps(user, provider)) {
         dispatch(loadClusterApps({ clusterId }));
       }
 
@@ -313,7 +313,7 @@ export function batchedRefreshClusterDetailView(
       const provider = getProvider(getState());
 
       if (
-        (user.type !== LoggedInUserTypes.MAPI || provider === Providers.KVM) &&
+        !supportsMapiApps(user, provider) &&
         Object.keys(cluster).length > 0
       ) {
         dispatch(loadClusterApps({ clusterId }));

--- a/src/stores/batchActions.ts
+++ b/src/stores/batchActions.ts
@@ -6,6 +6,7 @@ import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
 import RoutePath from 'lib/routePath';
 import { AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
+import { Providers } from 'shared/constants';
 import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import { INodePool } from 'shared/types';
 import {
@@ -37,8 +38,7 @@ import {
   refreshUserInfo,
 } from 'stores/main/actions';
 import { getInfo, resumeLogin } from 'stores/main/actions';
-import { getLoggedInUser } from 'stores/main/selectors';
-import { getUserIsAdmin } from 'stores/main/selectors';
+import { getLoggedInUser, getProvider } from 'stores/main/selectors';
 import { LoggedInUserTypes } from 'stores/main/types';
 import { modalHide } from 'stores/modal/actions';
 import {
@@ -92,16 +92,20 @@ export function batchedLayout(
     }
 
     try {
-      const catalogs = await dispatch(listCatalogs());
-      const userIsAdmin = getUserIsAdmin(getState());
+      const user = getLoggedInUser(getState())!;
+      const provider = getProvider(getState())!;
 
-      Object.entries(catalogs)
-        .filter(filterFunc(userIsAdmin))
-        .forEach(([key]) => {
-          if (key !== 'helm-stable') {
-            dispatch(enableCatalog(key));
-          }
-        });
+      if (user.type !== LoggedInUserTypes.MAPI || provider === Providers.KVM) {
+        const catalogs = await dispatch(listCatalogs());
+
+        Object.entries(catalogs)
+          .filter(filterFunc(user.isAdmin))
+          .forEach(([key]) => {
+            if (key !== 'helm-stable') {
+              dispatch(enableCatalog(key));
+            }
+          });
+      }
 
       dispatch(loadReleases());
       await dispatch(
@@ -241,19 +245,23 @@ export function batchedClusterDetailView(
   clusterId: string,
   isV5Cluster: boolean
 ): ThunkAction<Promise<void>, IState, void, AnyAction> {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     try {
       dispatch({
         type: CLUSTER_LOAD_DETAILS_REQUEST,
         id: clusterId,
       });
 
-      // Lets use Promise.all when we have a series of async calls that not depend
-      // on each another. It's faster and it's best from an error handling perspective.
+      dispatch(loadReleases());
+
+      const user = getLoggedInUser(getState())!;
+      const provider = getProvider(getState());
+      if (user.type !== LoggedInUserTypes.MAPI || provider === Providers.KVM) {
+        dispatch(loadClusterApps({ clusterId }));
+      }
+
       await Promise.all([
         dispatch(organizationCredentialsLoad(organizationId)),
-        dispatch(loadReleases()),
-        dispatch(loadClusterApps({ clusterId: clusterId })),
         dispatch(clusterLoadKeyPairs(clusterId)),
       ]);
 
@@ -301,10 +309,14 @@ export function batchedRefreshClusterDetailView(
         );
       }
 
-      // If cluster is an empty object, it means that it has been removed.
-      // We don't want to load apps in this scenario.
-      if (Object.keys(cluster).length > 0) {
-        dispatch(loadClusterApps({ clusterId: clusterId }));
+      const user = getLoggedInUser(getState())!;
+      const provider = getProvider(getState());
+
+      if (
+        (user.type !== LoggedInUserTypes.MAPI || provider === Providers.KVM) &&
+        Object.keys(cluster).length > 0
+      ) {
+        dispatch(loadClusterApps({ clusterId }));
       }
     } catch (err) {
       ErrorReporter.getInstance().notify(err);


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/328

With this PR we no longer execute the global app-specific requests if they are possible via MAPI (if the user is logged in via SSO and it is not a KVM installation).