### PR TITLE
apps: persist selected catalogs when navigating between app pages

### DIFF
--- a/src/components/MAPI/apps/AppList/index.tsx
+++ b/src/components/MAPI/apps/AppList/index.tsx
@@ -85,13 +85,18 @@ const AppList: React.FC<{}> = () => {
   const appCatalogListIsLoading =
     typeof appCatalogList === 'undefined' && appCatalogListIsValidating;
 
-  const [searchQuery, setSearchQuery] = useState('');
+  const {
+    selectedCatalogs,
+    selectCatalog,
+    deselectCatalog,
+    searchQuery,
+    setSearchQuery,
+  } = useAppsContext();
+
   const debouncedSearchQuery = useDebounce(
     searchQuery,
     SEARCH_THROTTLE_RATE_MS
   );
-
-  const { selectedCatalogs, selectCatalog, deselectCatalog } = useAppsContext();
 
   useLayoutEffect(() => {
     // Only execute this after the initial catalog load.

--- a/src/components/MAPI/apps/AppList/index.tsx
+++ b/src/components/MAPI/apps/AppList/index.tsx
@@ -7,13 +7,7 @@ import usePrevious from 'lib/hooks/usePrevious';
 import { extractErrorMessage } from 'MAPI/organizations/utils';
 import { GenericResponse } from 'model/clients/GenericResponse';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
-import React, {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { getUserIsAdmin } from 'stores/main/selectors';
 import useSWR from 'swr';
@@ -91,6 +85,8 @@ const AppList: React.FC<{}> = () => {
     deselectCatalog,
     searchQuery,
     setSearchQuery,
+    sortOrder,
+    setSortOrder,
   } = useAppsContext();
 
   const debouncedSearchQuery = useDebounce(
@@ -139,8 +135,6 @@ const AppList: React.FC<{}> = () => {
     appCatalogListIsLoading ||
     (typeof appCatalogIndexAppList === 'undefined' &&
       appCatalogIndexAppListIsValidating);
-
-  const [sortOrder, setSortOrder] = useState('name');
 
   const apps = useMemo(() => {
     if (!appCatalogIndexAppList) return [];

--- a/src/components/MAPI/apps/Apps.tsx
+++ b/src/components/MAPI/apps/Apps.tsx
@@ -6,6 +6,7 @@ import Route from 'Route';
 import { AppsRoutes } from 'shared/constants/routes';
 
 import AppDetail from './AppList/AppDetail';
+import AppsProvider from './AppsProvider';
 
 const Apps: React.FC<{}> = () => {
   return (
@@ -15,10 +16,16 @@ const Apps: React.FC<{}> = () => {
         pathname: AppsRoutes.Home,
       }}
     >
-      <Switch>
-        <Route exact={true} path={AppsRoutes.AppDetail} component={AppDetail} />
-        <Route path={AppsRoutes.Home} component={AppList} />
-      </Switch>
+      <AppsProvider>
+        <Switch>
+          <Route
+            exact={true}
+            path={AppsRoutes.AppDetail}
+            component={AppDetail}
+          />
+          <Route path={AppsRoutes.Home} component={AppList} />
+        </Switch>
+      </AppsProvider>
     </Breadcrumb>
   );
 };

--- a/src/components/MAPI/apps/AppsProvider.tsx
+++ b/src/components/MAPI/apps/AppsProvider.tsx
@@ -14,6 +14,8 @@ export interface IAppsContext {
   selectedCatalogs: SelectedCatalogs;
   selectCatalog: (catalogName: string) => void;
   deselectCatalog: (catalogName: string) => void;
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
 }
 
 const appsContext = createContext<IAppsContext | null>(null);
@@ -28,14 +30,24 @@ interface IDeselectCatalogAction {
   name: string;
 }
 
-type AppsAction = ISelectCatalogAction | IDeselectCatalogAction;
+interface ISetSearchQueryAction {
+  type: 'setSearchQuery';
+  value: string;
+}
+
+type AppsAction =
+  | ISelectCatalogAction
+  | IDeselectCatalogAction
+  | ISetSearchQueryAction;
 
 interface IAppsState {
   selectedCatalogs: SelectedCatalogs;
+  searchQuery: string;
 }
 
 const initialState: IAppsState = {
   selectedCatalogs: {},
+  searchQuery: '',
 };
 
 const reducer: React.Reducer<IAppsState, AppsAction> = produce(
@@ -47,6 +59,10 @@ const reducer: React.Reducer<IAppsState, AppsAction> = produce(
 
       case 'deselectCatalog':
         delete draft.selectedCatalogs[action.name];
+        break;
+
+      case 'setSearchQuery':
+        draft.searchQuery = action.value;
         break;
     }
   },
@@ -74,12 +90,23 @@ const AppsProvider: React.FC<{}> = ({ children }) => {
     });
   }, []);
 
+  const searchQuery = useMemo(() => state.searchQuery, [state.searchQuery]);
+
+  const setSearchQuery = useCallback((value: string) => {
+    dispatch({
+      type: 'setSearchQuery',
+      value,
+    });
+  }, []);
+
   return (
     <appsContext.Provider
       value={{
         selectedCatalogs,
         selectCatalog,
         deselectCatalog,
+        searchQuery,
+        setSearchQuery,
       }}
     >
       {children}

--- a/src/components/MAPI/apps/AppsProvider.tsx
+++ b/src/components/MAPI/apps/AppsProvider.tsx
@@ -1,0 +1,103 @@
+import produce from 'immer';
+import PropTypes from 'prop-types';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useReducer,
+} from 'react';
+
+export type SelectedCatalogs = Record<string, boolean>;
+
+export interface IAppsContext {
+  selectedCatalogs: SelectedCatalogs;
+  selectCatalog: (catalogName: string) => void;
+  deselectCatalog: (catalogName: string) => void;
+}
+
+const appsContext = createContext<IAppsContext | null>(null);
+
+interface ISelectCatalogAction {
+  type: 'selectCatalog';
+  name: string;
+}
+
+interface IDeselectCatalogAction {
+  type: 'deselectCatalog';
+  name: string;
+}
+
+type AppsAction = ISelectCatalogAction | IDeselectCatalogAction;
+
+interface IAppsState {
+  selectedCatalogs: SelectedCatalogs;
+}
+
+const initialState: IAppsState = {
+  selectedCatalogs: {},
+};
+
+const reducer: React.Reducer<IAppsState, AppsAction> = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case 'selectCatalog':
+        draft.selectedCatalogs[action.name] = true;
+        break;
+
+      case 'deselectCatalog':
+        delete draft.selectedCatalogs[action.name];
+        break;
+    }
+  },
+  initialState
+);
+
+const AppsProvider: React.FC<{}> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const selectedCatalogs = useMemo(() => state.selectedCatalogs, [
+    state.selectedCatalogs,
+  ]);
+
+  const selectCatalog = useCallback((name: string) => {
+    dispatch({
+      type: 'selectCatalog',
+      name,
+    });
+  }, []);
+
+  const deselectCatalog = useCallback((name: string) => {
+    dispatch({
+      type: 'deselectCatalog',
+      name,
+    });
+  }, []);
+
+  return (
+    <appsContext.Provider
+      value={{
+        selectedCatalogs,
+        selectCatalog,
+        deselectCatalog,
+      }}
+    >
+      {children}
+    </appsContext.Provider>
+  );
+};
+
+AppsProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export default AppsProvider;
+
+export function useAppsContext(): IAppsContext {
+  const appsProvider = useContext(appsContext);
+  if (!appsProvider) {
+    throw new Error('useAppsContext must be used within an AppsProvider.');
+  }
+
+  return useMemo(() => appsProvider, [appsProvider]);
+}

--- a/src/components/MAPI/apps/AppsProvider.tsx
+++ b/src/components/MAPI/apps/AppsProvider.tsx
@@ -16,6 +16,8 @@ export interface IAppsContext {
   deselectCatalog: (catalogName: string) => void;
   searchQuery: string;
   setSearchQuery: (value: string) => void;
+  sortOrder: string;
+  setSortOrder: (orderBy: string) => void;
 }
 
 const appsContext = createContext<IAppsContext | null>(null);
@@ -35,19 +37,27 @@ interface ISetSearchQueryAction {
   value: string;
 }
 
+interface ISetSortOrderAction {
+  type: 'setSortOrder';
+  value: string;
+}
+
 type AppsAction =
   | ISelectCatalogAction
   | IDeselectCatalogAction
-  | ISetSearchQueryAction;
+  | ISetSearchQueryAction
+  | ISetSortOrderAction;
 
 interface IAppsState {
   selectedCatalogs: SelectedCatalogs;
   searchQuery: string;
+  sortOrder: string;
 }
 
 const initialState: IAppsState = {
   selectedCatalogs: {},
   searchQuery: '',
+  sortOrder: 'name',
 };
 
 const reducer: React.Reducer<IAppsState, AppsAction> = produce(
@@ -63,6 +73,10 @@ const reducer: React.Reducer<IAppsState, AppsAction> = produce(
 
       case 'setSearchQuery':
         draft.searchQuery = action.value;
+        break;
+
+      case 'setSortOrder':
+        draft.sortOrder = action.value;
         break;
     }
   },
@@ -99,6 +113,15 @@ const AppsProvider: React.FC<{}> = ({ children }) => {
     });
   }, []);
 
+  const sortOrder = useMemo(() => state.sortOrder, [state.sortOrder]);
+
+  const setSortOrder = useCallback((value: string) => {
+    dispatch({
+      type: 'setSortOrder',
+      value,
+    });
+  }, []);
+
   return (
     <appsContext.Provider
       value={{
@@ -107,6 +130,8 @@ const AppsProvider: React.FC<{}> = ({ children }) => {
         deselectCatalog,
         searchQuery,
         setSearchQuery,
+        sortOrder,
+        setSortOrder,
       }}
     >
       {children}


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/17361

With this PR, the selected catalogs in the sidebar of the `Apps` page will be persisted between route changes (disclaimer: only if we change routes between the app-specific routes - app list and app details, if we navigate outside of that, the selection will be reset).
