### PR TITLE
apps: use the correct catalog name when installing app in workload cluster

### DIFF
--- a/src/components/MAPI/apps/AppList/AppDetail.tsx
+++ b/src/components/MAPI/apps/AppList/AppDetail.tsx
@@ -207,7 +207,7 @@ const AppDetail: React.FC<{}> = () => {
               <AppInstallModal
                 appName={selectedVersion.name}
                 chartName={selectedVersion.name}
-                catalogName={appCatalog!.spec.title}
+                catalogName={appCatalog!.metadata.name}
                 versions={otherVersions}
                 selectedClusterID={selectedClusterID}
               />


### PR DESCRIPTION
As part of the: `can you break happa every day of the week?` challenge