### PR TITLE
Prevent throwing an error if the app metadata is not loaded yet and the footer version is invalid

### DIFF
--- a/src/components/Footer/FooterUtils.ts
+++ b/src/components/Footer/FooterUtils.ts
@@ -4,6 +4,8 @@ import { VersionImpl } from 'lib/Version';
 import { Constants } from 'shared/constants';
 
 export function formatVersion(version: string): string {
+  if (version.length < 1) return 'VERSION';
+
   try {
     const semverVersion = new VersionImpl(version);
 
@@ -18,13 +20,11 @@ export function formatVersion(version: string): string {
         semverVersion.getPreRelease().slice(0, 5),
       ].join('');
     }
-
-    return version;
   } catch (err) {
     ErrorReporter.getInstance().notify(err);
-
-    return 'development';
   }
+
+  return version;
 }
 
 export function getReleaseURL(version: string): string {

--- a/src/stores/metadata/reducer.ts
+++ b/src/stores/metadata/reducer.ts
@@ -10,7 +10,7 @@ import { IMetadataState, MetadataAction } from 'stores/metadata/types';
 
 const initialState: IMetadataState = {
   version: {
-    current: 'VERSION',
+    current: '',
     new: null,
     lastCheck: 0,
     timer: 0,

--- a/testUtils/mockHttpCalls/metadata.ts
+++ b/testUtils/mockHttpCalls/metadata.ts
@@ -1,5 +1,5 @@
 import { mockAPIResponse } from 'testUtils/mockHttpCalls/constantsAndHelpers';
 
 export const metadataResponse = mockAPIResponse({
-  version: 'VERSION',
+  version: '',
 });

--- a/testUtils/preloginState.js
+++ b/testUtils/preloginState.js
@@ -40,7 +40,7 @@ export default {
   errors: {},
   metadata: {
     version: {
-      current: 'VERSION',
+      current: '',
       new: null,
       lastCheck: 0,
       timer: 0,


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/17418

While the app is loading `/metadata.json`, this version will be invalid