### PR TITLE
clusters: make the azure on-demand pricing checkbox keep its position

### DIFF
--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstancesAzure.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstancesAzure.tsx
@@ -12,7 +12,7 @@ const AzureSpotInstances = styled.div`
 const CheckboxWrapper = styled.div`
   position: absolute;
   left: 170px;
-  bottom: 5px;
+  top: 73px;
 `;
 
 interface IAddNodePoolSpotInstancesAzureProps {


### PR DESCRIPTION
Currently if there's an error in the max pricing input, the `Use current on-demand pricing as max` checkbox will shift its position.

### Before

![image](https://user-images.githubusercontent.com/13508038/119846676-a42e2d80-bf0a-11eb-8d4a-42d30c73ae0b.png)

### After

![image](https://user-images.githubusercontent.com/13508038/119846733-af815900-bf0a-11eb-86ee-2656b3278491.png)
