### PR TITLE
apps: use the correct chart name when installing an app

### DIFF
--- a/src/components/MAPI/apps/__tests__/utils.ts
+++ b/src/components/MAPI/apps/__tests__/utils.ts
@@ -30,7 +30,7 @@ describe('utils', () => {
         labels: { 'app-operator.giantswarm.io/version': '1.0.0' },
       },
       spec: {
-        name: 'cool-app',
+        name: 'cool-app-chart',
         namespace: 'cool-app-ns',
         version: '1.2.3',
         catalog: 'cool-apps-123',

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -182,7 +182,7 @@ export async function createApp(
       },
     },
     spec: {
-      name: appConfig.name,
+      name: appConfig.chartName,
       namespace: appConfig.namespace,
       version: appConfig.version,
       catalog: appConfig.catalogName,


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/CRZN9GLJW/p1622460313091900