### PR TITLE
clusters: add a new cluster detail page with basic functionality

### DIFF
--- a/src/components/Cluster/ClusterDetail/URIBlock.js
+++ b/src/components/Cluster/ClusterDetail/URIBlock.js
@@ -1,3 +1,4 @@
+import { Keyboard } from 'grommet';
 import useCopyToClipboard from 'lib/hooks/useCopyToClipboard';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -22,7 +23,8 @@ const CopyButton = styled.div`
   display: flex;
   align-items: center;
 
-  &:hover {
+  &:hover,
+  &:focus {
     ${StatusIcon} {
       text-shadow: 0px 0px 15px ${(props) => props.theme.colors.shade1};
     }
@@ -35,11 +37,13 @@ const BlockWrapper = styled.div`
   align-items: center;
   max-width: 100%;
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     ${CopyButton} {
       opacity: 0.7;
 
-      &:hover {
+      &:hover,
+      &:focus {
         opacity: 1;
       }
     }
@@ -88,33 +92,39 @@ const URIBlock = ({ children, title, copyContent, ...props }) => {
   };
   const handleMouseLeave = () => setClipboardContent(null);
 
+  const handleOnFocusKeyDown = (e) => {
+    e.preventDefault();
+
+    e.target.click();
+  };
+
   return (
     <BlockWrapper {...props} onMouseLeave={handleMouseLeave}>
       {title && <Title>{title}</Title>}
 
-      <CopyContent>
-        <StyledCode>
-          <CodeWrapper>{children}</CodeWrapper>
-        </StyledCode>
+      <Keyboard onSpace={handleOnFocusKeyDown} onEnter={handleOnFocusKeyDown}>
+        <CopyContent>
+          <StyledCode>
+            <CodeWrapper>{children}</CodeWrapper>
+          </StyledCode>
 
-        {hasContentInClipboard ? (
-          <StatusIcon
-            aria-hidden='true'
-            className='fa fa-done'
-            title='Content copied to clipboard'
-          />
-        ) : (
-          <OverlayTrigger placement='top' overlay={getTooltip(content)}>
-            <CopyButton onClick={copyToClipboard}>
-              <StatusIcon
-                aria-hidden='true'
-                className='fa fa-content-copy'
-                title='Copy content to clipboard'
-              />
-            </CopyButton>
-          </OverlayTrigger>
-        )}
-      </CopyContent>
+          {hasContentInClipboard ? (
+            <StatusIcon
+              className='fa fa-done'
+              title='Content copied to clipboard'
+            />
+          ) : (
+            <OverlayTrigger placement='top' overlay={getTooltip(content)}>
+              <CopyButton onClick={copyToClipboard} role='button' tabIndex={0}>
+                <StatusIcon
+                  className='fa fa-content-copy'
+                  title='Copy content to clipboard'
+                />
+              </CopyButton>
+            </OverlayTrigger>
+          )}
+        </CopyContent>
+      </Keyboard>
     </BlockWrapper>
   );
 };

--- a/src/components/MAPI/clusters/Cluster.tsx
+++ b/src/components/MAPI/clusters/Cluster.tsx
@@ -1,0 +1,28 @@
+import NewClusterWrapper from 'Cluster/NewCluster/NewClusterWrapper';
+import React from 'react';
+import { Redirect, Switch } from 'react-router';
+import Route from 'Route';
+import { OrganizationsRoutes } from 'shared/constants/routes';
+
+import ClusterDetail from './ClusterDetail';
+
+const Cluster: React.FC<{}> = () => {
+  return (
+    <Switch>
+      <Route
+        component={NewClusterWrapper}
+        exact
+        path={OrganizationsRoutes.Clusters.New}
+      />
+      <Route
+        component={ClusterDetail}
+        path={OrganizationsRoutes.Clusters.Detail.Home}
+      />
+      <Redirect to={OrganizationsRoutes.List} />
+    </Switch>
+  );
+};
+
+Cluster.propTypes = {};
+
+export default Cluster;

--- a/src/components/MAPI/clusters/Cluster.tsx
+++ b/src/components/MAPI/clusters/Cluster.tsx
@@ -1,4 +1,5 @@
 import NewClusterWrapper from 'Cluster/NewCluster/NewClusterWrapper';
+import GettingStarted from 'GettingStarted/GettingStarted';
 import React from 'react';
 import { Redirect, Switch } from 'react-router';
 import Route from 'Route';
@@ -13,6 +14,10 @@ const Cluster: React.FC<{}> = () => {
         component={NewClusterWrapper}
         exact
         path={OrganizationsRoutes.Clusters.New}
+      />
+      <Route
+        path={OrganizationsRoutes.Clusters.GettingStarted.Overview}
+        component={GettingStarted}
       />
       <Route
         component={ClusterDetail}

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ClusterDetailOverview: React.FC<{}> = () => {
+  return null;
+};
+
+ClusterDetailOverview.propTypes = {};
+
+export default ClusterDetailOverview;

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -1,6 +1,5 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { push } from 'connected-react-router';
-import { Box } from 'grommet';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import {
@@ -14,7 +13,7 @@ import { useDispatch } from 'react-redux';
 import { useRouteMatch } from 'react-router';
 import { MainRoutes } from 'shared/constants/routes';
 import useSWR, { mutate } from 'swr';
-import ClusterDetailOverviewDelete from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverviewDelete';
+import UIClusterDetailOverview from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview';
 
 import { deleteCluster } from './utils';
 
@@ -78,17 +77,23 @@ const ClusterDetailOverview: React.FC<{}> = () => {
     }
   };
 
+  const description = cluster
+    ? capiv1alpha3.getClusterDescription(cluster)
+    : undefined;
+  const releaseVersion = cluster
+    ? capiv1alpha3.getReleaseVersion(cluster)
+    : undefined;
+
   return (
-    <Box>
-      {cluster && (
-        <ClusterDetailOverviewDelete
-          clusterName={cluster.metadata.name}
-          onDelete={handleDelete}
-          border='top'
-          margin={{ top: 'medium' }}
-        />
-      )}
-    </Box>
+    <UIClusterDetailOverview
+      name={cluster?.metadata.name}
+      namespace={cluster?.metadata.namespace}
+      description={description}
+      creationDate={cluster?.metadata.creationTimestamp}
+      deletionDate={cluster?.metadata.deletionTimestamp ?? null}
+      releaseVersion={releaseVersion}
+      onDelete={handleDelete}
+    />
   );
 };
 

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -1,7 +1,95 @@
-import React from 'react';
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { push } from 'connected-react-router';
+import { Box } from 'grommet';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
+import {
+  extractErrorMessage,
+  getOrgNamespaceFromOrgName,
+} from 'MAPI/organizations/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+import React, { useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { useRouteMatch } from 'react-router';
+import { MainRoutes } from 'shared/constants/routes';
+import useSWR, { mutate } from 'swr';
+import ClusterDetailOverviewDelete from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverviewDelete';
+
+import { deleteCluster } from './utils';
 
 const ClusterDetailOverview: React.FC<{}> = () => {
-  return null;
+  const match = useRouteMatch<{ orgId: string; clusterId: string }>();
+  const { orgId, clusterId } = match.params;
+
+  const clientFactory = useHttpClientFactory();
+  const auth = useAuthProvider();
+
+  const namespace = getOrgNamespaceFromOrgName(orgId);
+
+  const clusterClient = useRef(clientFactory());
+  // The error is handled in the parent component.
+  const { data: cluster, mutate: mutateCluster } = useSWR<
+    capiv1alpha3.ICluster,
+    GenericResponseError
+  >(capiv1alpha3.getClusterKey(namespace, clusterId), () =>
+    capiv1alpha3.getCluster(clusterClient.current, auth, namespace, clusterId)
+  );
+
+  const dispatch = useDispatch();
+
+  const handleDelete = async () => {
+    if (!cluster) return Promise.resolve();
+
+    try {
+      const client = clientFactory();
+
+      const updatedCluster = await deleteCluster(
+        client,
+        auth,
+        cluster.metadata.namespace!,
+        cluster.metadata.name
+      );
+
+      new FlashMessage(
+        `Cluster ${updatedCluster.metadata.name} deleted successfully.`,
+        messageType.SUCCESS,
+        messageTTL.SHORT
+      );
+
+      dispatch(push(MainRoutes.Home));
+
+      mutateCluster(updatedCluster);
+      mutate(
+        capiv1alpha3.getClusterListKey({
+          labelSelector: {
+            matchingLabels: {
+              [capiv1alpha3.labelOrganization]: orgId,
+            },
+          },
+        })
+      );
+
+      return Promise.resolve();
+    } catch (err: unknown) {
+      const errorMessage = extractErrorMessage(err);
+
+      return Promise.reject(new Error(errorMessage));
+    }
+  };
+
+  return (
+    <Box>
+      {cluster && (
+        <ClusterDetailOverviewDelete
+          clusterName={cluster.metadata.name}
+          onDelete={handleDelete}
+          border='top'
+          margin={{ top: 'medium' }}
+        />
+      )}
+    </Box>
+  );
 };
 
 ClusterDetailOverview.propTypes = {};

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -2,16 +2,17 @@ import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { push } from 'connected-react-router';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
+import RoutePath from 'lib/routePath';
 import {
   extractErrorMessage,
   getOrgNamespaceFromOrgName,
 } from 'MAPI/organizations/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useRouteMatch } from 'react-router';
-import { MainRoutes } from 'shared/constants/routes';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import useSWR, { mutate } from 'swr';
 import UIClusterDetailOverview from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview';
 
@@ -83,16 +84,30 @@ const ClusterDetailOverview: React.FC<{}> = () => {
   const releaseVersion = cluster
     ? capiv1alpha3.getReleaseVersion(cluster)
     : undefined;
+  const k8sApiURL = cluster
+    ? capiv1alpha3.getKubernetesAPIEndpointURL(cluster)
+    : undefined;
+
+  const gettingStartedPath = useMemo(
+    () =>
+      RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.GettingStarted.Overview,
+        { orgId, clusterId }
+      ),
+    [orgId, clusterId]
+  );
 
   return (
     <UIClusterDetailOverview
+      onDelete={handleDelete}
+      gettingStartedPath={gettingStartedPath}
       name={cluster?.metadata.name}
       namespace={cluster?.metadata.namespace}
       description={description}
       creationDate={cluster?.metadata.creationTimestamp}
       deletionDate={cluster?.metadata.deletionTimestamp ?? null}
       releaseVersion={releaseVersion}
-      onDelete={handleDelete}
+      k8sApiURL={k8sApiURL}
     />
   );
 };

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -20,8 +20,10 @@ import { Switch, useRouteMatch } from 'react-router';
 import Route from 'Route';
 import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import Tabs from 'shared/Tabs';
+import styled from 'styled-components';
 import useSWR from 'swr';
 import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
+import ClusterDetailWidgetOptionalValue from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue';
 import ViewAndEditName from 'UI/Inputs/ViewEditName';
 
 import ClusterDetailOverview from './ClusterDetailOverview';
@@ -35,6 +37,12 @@ function computePaths(orgName: string, clusterName: string) {
     }),
   };
 }
+
+const StyledViewAndEditName = styled(ViewAndEditName)`
+  input {
+    font-size: 100%;
+  }
+`;
 
 const ClusterDetail: React.FC<{}> = () => {
   const dispatch = useDispatch();
@@ -151,19 +159,25 @@ const ClusterDetail: React.FC<{}> = () => {
       }}
     >
       <Box>
-        <Box margin={{ bottom: 'small' }}>
-          <Heading level={1}>
+        <Heading level={1} margin={{ bottom: 'large' }}>
+          <Box direction='row' align='center'>
             <ClusterIDLabel clusterID={clusterId} copyEnabled={true} />{' '}
-            {clusterDescription && (
-              <ViewAndEditName
-                value={clusterDescription}
-                typeLabel='cluster'
-                onSave={updateDescription}
-                aria-label={clusterDescription}
-              />
-            )}
-          </Heading>
-        </Box>
+            <ClusterDetailWidgetOptionalValue
+              value={clusterDescription}
+              loaderHeight={35}
+              loaderWidth={300}
+            >
+              {(value) => (
+                <StyledViewAndEditName
+                  value={value as string}
+                  typeLabel='cluster'
+                  onSave={updateDescription}
+                  aria-label={value as string}
+                />
+              )}
+            </ClusterDetailWidgetOptionalValue>
+          </Box>
+        </Heading>
         <Tabs defaultActiveKey={paths.Home} useRoutes={true}>
           <Tab eventKey={paths.Home} title='Overview' />
         </Tabs>

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -102,9 +102,7 @@ const ClusterDetail: React.FC<{}> = () => {
         messageTTL.MEDIUM
       );
 
-      if (!cluster) {
-        dispatch(push(MainRoutes.Home));
-      }
+      dispatch(push(MainRoutes.Home));
     }
   }, [cluster, dispatch]);
 

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -152,7 +152,7 @@ const ClusterDetail: React.FC<{}> = () => {
         pathname: match.url,
       }}
     >
-      <>
+      <Box>
         <Box margin={{ bottom: 'small' }}>
           <Heading level={1}>
             <ClusterIDLabel clusterID={clusterId} copyEnabled={true} />{' '}
@@ -175,7 +175,7 @@ const ClusterDetail: React.FC<{}> = () => {
             component={ClusterDetailOverview}
           />
         </Switch>
-      </>
+      </Box>
     </Breadcrumb>
   );
 };

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -84,10 +84,24 @@ const ClusterDetail: React.FC<{}> = () => {
       );
 
       if (!cluster) {
-        dispatch(push(OrganizationsRoutes.Home));
+        dispatch(push(MainRoutes.Home));
       }
     }
   }, [cluster, clusterError, clusterId, dispatch]);
+
+  useEffect(() => {
+    if (typeof cluster?.metadata.deletionTimestamp !== 'undefined') {
+      new FlashMessage(
+        `Cluster <code>${cluster.metadata.name}</code> is currently being deleted`,
+        messageType.INFO,
+        messageTTL.MEDIUM
+      );
+
+      if (!cluster) {
+        dispatch(push(MainRoutes.Home));
+      }
+    }
+  }, [cluster, dispatch]);
 
   return (
     <Breadcrumb

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface IClusterDetailProps {}
+
+const ClusterDetail: React.FC<IClusterDetailProps> = () => {
+  return null;
+};
+
+ClusterDetail.propTypes = {};
+
+export default ClusterDetail;

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -1,9 +1,114 @@
-import React from 'react';
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { push } from 'connected-react-router';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { useHttpClient } from 'lib/hooks/useHttpClient';
+import RoutePath from 'lib/routePath';
+import {
+  extractErrorMessage,
+  getOrgNamespaceFromOrgName,
+} from 'MAPI/organizations/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+import * as metav1 from 'model/services/mapi/metav1';
+import React, { useEffect, useMemo } from 'react';
+import { Tab } from 'react-bootstrap';
+import { Breadcrumb } from 'react-breadcrumbs';
+import { useDispatch } from 'react-redux';
+import { Switch, useRouteMatch } from 'react-router';
+import Route from 'Route';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import Tabs from 'shared/Tabs';
+import useSWR from 'swr';
 
-interface IClusterDetailProps {}
+import ClusterDetailOverview from './ClusterDetailOverview';
 
-const ClusterDetail: React.FC<IClusterDetailProps> = () => {
-  return null;
+function computePaths(orgName: string, clusterName: string) {
+  return {
+    Home: RoutePath.createUsablePath(OrganizationsRoutes.Clusters.Detail.Home, {
+      orgId: orgName,
+      clusterId: clusterName,
+    }),
+  };
+}
+
+const ClusterDetail: React.FC<{}> = () => {
+  const dispatch = useDispatch();
+
+  const match = useRouteMatch<{ orgId: string; clusterId: string }>();
+  const { orgId, clusterId } = match.params;
+
+  const paths = useMemo(() => computePaths(orgId, clusterId), [
+    orgId,
+    clusterId,
+  ]);
+
+  const client = useHttpClient();
+  const auth = useAuthProvider();
+
+  const namespace = getOrgNamespaceFromOrgName(orgId);
+
+  const { data: cluster, error: clusterError } = useSWR<
+    capiv1alpha3.ICluster,
+    GenericResponseError
+  >(capiv1alpha3.getClusterKey(namespace, clusterId), () =>
+    capiv1alpha3.getCluster(client, auth, namespace, clusterId)
+  );
+
+  useEffect(() => {
+    if (clusterError) {
+      ErrorReporter.getInstance().notify(clusterError);
+    }
+
+    if (
+      metav1.isStatusError(
+        clusterError?.data,
+        metav1.K8sStatusErrorReasons.NotFound
+      )
+    ) {
+      new FlashMessage(
+        `Cluster <code>${clusterId}</code> not found`,
+        messageType.ERROR,
+        messageTTL.FOREVER,
+        'Please make sure the Cluster ID is correct and that you have access to it.'
+      );
+
+      dispatch(push(MainRoutes.Home));
+    } else if (clusterError) {
+      const errorMessage = extractErrorMessage(clusterError);
+      new FlashMessage(
+        `There was a problem loading cluster <code>${clusterId}</code>`,
+        messageType.ERROR,
+        messageTTL.FOREVER,
+        errorMessage
+      );
+
+      if (!cluster) {
+        dispatch(push(OrganizationsRoutes.Home));
+      }
+    }
+  }, [cluster, clusterError, clusterId, dispatch]);
+
+  return (
+    <Breadcrumb
+      data={{
+        title: clusterId,
+        pathname: match.url,
+      }}
+    >
+      <>
+        <Tabs defaultActiveKey={paths.Home} useRoutes={true}>
+          <Tab eventKey={paths.Home} title='Overview' />
+        </Tabs>
+        <Switch>
+          <Route
+            path={OrganizationsRoutes.Clusters.Detail.Home}
+            component={ClusterDetailOverview}
+          />
+        </Switch>
+      </>
+    </Breadcrumb>
+  );
 };
 
 ClusterDetail.propTypes = {};

--- a/src/components/MAPI/clusters/ClusterDetail/utils.ts
+++ b/src/components/MAPI/clusters/ClusterDetail/utils.ts
@@ -1,0 +1,29 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+
+export async function updateClusterDescription(
+  httpClient: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  name: string,
+  newDescription: string
+) {
+  const cluster = await capiv1alpha3.getCluster(
+    httpClient,
+    auth,
+    namespace,
+    name
+  );
+  const description = capiv1alpha3.getClusterDescription(cluster);
+  if (description === newDescription) {
+    return cluster;
+  }
+
+  cluster.metadata.annotations ??= {};
+  cluster.metadata.annotations[
+    capiv1alpha3.annotationClusterDescription
+  ] = newDescription;
+
+  return capiv1alpha3.updateCluster(httpClient, auth, cluster);
+}

--- a/src/components/MAPI/clusters/ClusterDetail/utils.ts
+++ b/src/components/MAPI/clusters/ClusterDetail/utils.ts
@@ -27,3 +27,19 @@ export async function updateClusterDescription(
 
   return capiv1alpha3.updateCluster(httpClient, auth, cluster);
 }
+
+export async function deleteCluster(
+  httpClient: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  name: string
+) {
+  const cluster = await capiv1alpha3.getCluster(
+    httpClient,
+    auth,
+    namespace,
+    name
+  );
+
+  return capiv1alpha3.deleteCluster(httpClient, auth, cluster);
+}

--- a/src/components/MAPI/organizations/Organization.tsx
+++ b/src/components/MAPI/organizations/Organization.tsx
@@ -1,9 +1,13 @@
 import Cluster from 'Cluster/Cluster';
+import ClusterMapi from 'MAPI/clusters/Cluster';
 import React from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
+import { useSelector } from 'react-redux';
 import { Redirect, Switch, useParams, useRouteMatch } from 'react-router';
 import Route from 'Route';
 import { OrganizationsRoutes } from 'shared/constants/routes';
+import { supportsMapiClusters } from 'shared/featureSupport';
+import { getLoggedInUser, getProvider } from 'stores/main/selectors';
 
 import OrganizationDetail from './OrganizationDetail';
 
@@ -13,6 +17,9 @@ const Organization: React.FC<IOrganizationProps> = () => {
   const { orgId } = useParams<{ orgId: string }>();
   const match = useRouteMatch();
 
+  const user = useSelector(getLoggedInUser)!;
+  const provider = useSelector(getProvider);
+
   return (
     <Breadcrumb
       data={{
@@ -21,7 +28,15 @@ const Organization: React.FC<IOrganizationProps> = () => {
       }}
     >
       <Switch>
-        <Route component={Cluster} path={OrganizationsRoutes.Clusters.Home} />
+        {supportsMapiClusters(user, provider) ? (
+          <Route
+            component={ClusterMapi}
+            path={OrganizationsRoutes.Clusters.Home}
+          />
+        ) : (
+          <Route component={Cluster} path={OrganizationsRoutes.Clusters.Home} />
+        )}
+
         <Route
           path={OrganizationsRoutes.Detail}
           component={OrganizationDetail}

--- a/src/components/UI/Display/Cluster/ClusterIDLabel/index.js
+++ b/src/components/UI/Display/Cluster/ClusterIDLabel/index.js
@@ -1,3 +1,4 @@
+import { Keyboard } from 'grommet';
 import useCopyToClipboard from 'lib/hooks/useCopyToClipboard';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -71,33 +72,40 @@ const ClusterIDLabel = ({ clusterID, copyEnabled }) => {
     </Label>
   );
 
-  return (
-    <Wrapper onMouseLeave={() => setClipboardContent(null)}>
-      {labelComponent}
+  const handleOnFocusKeyDown = (e) => {
+    e.preventDefault();
 
-      {copyEnabled &&
-        (hasContentInClipboard ? (
-          <i
-            key='cluster-id-copy-button'
-            aria-hidden='true'
-            className='fa fa-done'
-          />
-        ) : (
-          <OverlayTrigger
-            overlay={<Tooltip id='tooltip'>Copy ID to clipboard</Tooltip>}
-            placement='top'
-          >
+    e.target.click();
+  };
+
+  return (
+    <Keyboard onSpace={handleOnFocusKeyDown} onEnter={handleOnFocusKeyDown}>
+      <Wrapper onMouseLeave={() => setClipboardContent(null)}>
+        {labelComponent}
+
+        {copyEnabled &&
+          (hasContentInClipboard ? (
             <i
               key='cluster-id-copy-button'
               aria-hidden='true'
-              className='fa fa-content-copy'
-              onClick={copyToClipboard}
-              role='button'
-              tabIndex={0}
+              className='fa fa-done'
             />
-          </OverlayTrigger>
-        ))}
-    </Wrapper>
+          ) : (
+            <OverlayTrigger
+              overlay={<Tooltip id='tooltip'>Copy ID to clipboard</Tooltip>}
+              placement='top'
+            >
+              <i
+                key='cluster-id-copy-button'
+                className='fa fa-content-copy'
+                onClick={copyToClipboard}
+                role='button'
+                tabIndex={0}
+              />
+            </OverlayTrigger>
+          ))}
+      </Wrapper>
+    </Keyboard>
   );
 };
 

--- a/src/components/UI/Display/Cluster/ClusterIDLabel/index.js
+++ b/src/components/UI/Display/Cluster/ClusterIDLabel/index.js
@@ -9,7 +9,8 @@ import CachingColorHash from 'utils/cachingColorHash';
 const colorHash = new CachingColorHash();
 
 const Wrapper = styled.span`
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
 
   &:hover,
   &:focus-within {

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -5,20 +5,28 @@ import React from 'react';
 import { IClusterItem } from '../types';
 import ClusterDetailOverviewDelete from './ClusterDetailOverviewDelete';
 import ClusterDetailWidgetCreated from './ClusterDetailWidgetCreated';
+import ClusterDetailWidgetKubernetesAPI from './ClusterDetailWidgetKubernetesAPI';
 
 interface IClusterDetailOverviewProps extends IClusterItem {
   onDelete: () => Promise<void>;
+  gettingStartedPath: string;
 }
 
 const ClusterDetailOverview: React.FC<IClusterDetailOverviewProps> = ({
   onDelete,
+  gettingStartedPath,
   name,
   creationDate,
+  k8sApiURL,
 }) => {
   const isLoading = typeof name === 'undefined';
 
   return (
-    <Box>
+    <Box direction='column' gap='small'>
+      <ClusterDetailWidgetKubernetesAPI
+        gettingStartedPath={gettingStartedPath}
+        k8sApiURL={k8sApiURL}
+      />
       <ClusterDetailWidgetCreated creationDate={creationDate} />
       {!isLoading && (
         <ClusterDetailOverviewDelete
@@ -34,8 +42,10 @@ const ClusterDetailOverview: React.FC<IClusterDetailOverviewProps> = ({
 
 ClusterDetailOverview.propTypes = {
   onDelete: PropTypes.func.isRequired,
+  gettingStartedPath: PropTypes.string.isRequired,
   name: PropTypes.string,
   creationDate: PropTypes.string,
+  k8sApiURL: PropTypes.string,
 };
 
 export default ClusterDetailOverview;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from 'grommet';
+import { formatDate, relativeDate } from 'lib/helpers';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import { Dot } from 'styles';
+
+import { IClusterItem } from '../types';
+import ClusterDetailOverviewDelete from './ClusterDetailOverviewDelete';
+import ClusterDetailWidget from './ClusterDetailWidget';
+
+const StyledDot = styled(Dot)`
+  padding: 0;
+`;
+
+interface IClusterDetailOverviewProps extends IClusterItem {
+  onDelete: () => Promise<void>;
+}
+
+const ClusterDetailOverview: React.FC<IClusterDetailOverviewProps> = ({
+  onDelete,
+  name,
+  creationDate,
+}) => {
+  if (!name || !creationDate) return null;
+
+  return (
+    <Box>
+      <ClusterDetailWidget title='Created' inline={true}>
+        <Text>{relativeDate(creationDate)}</Text>
+        <StyledDot />
+        <Text>{formatDate(creationDate)}</Text>
+      </ClusterDetailWidget>
+      <ClusterDetailOverviewDelete
+        clusterName={name}
+        onDelete={onDelete}
+        border='top'
+        margin={{ top: 'medium' }}
+      />
+    </Box>
+  );
+};
+
+ClusterDetailOverview.propTypes = {
+  onDelete: PropTypes.func.isRequired,
+  name: PropTypes.string,
+  creationDate: PropTypes.string,
+};
+
+export default ClusterDetailOverview;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -1,17 +1,10 @@
-import { Box, Text } from 'grommet';
-import { formatDate, relativeDate } from 'lib/helpers';
+import { Box } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'styled-components';
-import { Dot } from 'styles';
 
 import { IClusterItem } from '../types';
 import ClusterDetailOverviewDelete from './ClusterDetailOverviewDelete';
-import ClusterDetailWidget from './ClusterDetailWidget';
-
-const StyledDot = styled(Dot)`
-  padding: 0;
-`;
+import ClusterDetailWidgetCreated from './ClusterDetailWidgetCreated';
 
 interface IClusterDetailOverviewProps extends IClusterItem {
   onDelete: () => Promise<void>;
@@ -22,29 +15,19 @@ const ClusterDetailOverview: React.FC<IClusterDetailOverviewProps> = ({
   name,
   creationDate,
 }) => {
-  if (!name || !creationDate) return null;
+  const isLoading = typeof name === 'undefined';
 
   return (
     <Box>
-      <ClusterDetailWidget
-        title='Created'
-        inline={true}
-        contentProps={{
-          direction: 'row',
-          gap: 'xsmall',
-          wrap: true,
-        }}
-      >
-        <Text>{relativeDate(creationDate)}</Text>
-        <StyledDot />
-        <Text>{formatDate(creationDate)}</Text>
-      </ClusterDetailWidget>
-      <ClusterDetailOverviewDelete
-        clusterName={name}
-        onDelete={onDelete}
-        border='top'
-        margin={{ top: 'medium' }}
-      />
+      <ClusterDetailWidgetCreated creationDate={creationDate} />
+      {!isLoading && (
+        <ClusterDetailOverviewDelete
+          clusterName={name!}
+          onDelete={onDelete}
+          border='top'
+          margin={{ top: 'medium' }}
+        />
+      )}
     </Box>
   );
 };

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -26,7 +26,15 @@ const ClusterDetailOverview: React.FC<IClusterDetailOverviewProps> = ({
 
   return (
     <Box>
-      <ClusterDetailWidget title='Created' inline={true}>
+      <ClusterDetailWidget
+        title='Created'
+        inline={true}
+        contentProps={{
+          direction: 'row',
+          gap: 'xsmall',
+          wrap: true,
+        }}
+      >
         <Text>{relativeDate(creationDate)}</Text>
         <StyledDot />
         <Text>{formatDate(creationDate)}</Text>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverviewDelete.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailOverviewDelete.tsx
@@ -1,0 +1,120 @@
+import { Box, Text } from 'grommet';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import Button from 'UI/Controls/Button';
+import ConfirmationPrompt from 'UI/Controls/ConfirmationPrompt';
+
+interface IClusterDetailOverviewDeleteProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  clusterName: string;
+  onDelete: () => Promise<void>;
+}
+
+const ClusterDetailOverviewDelete: React.FC<IClusterDetailOverviewDeleteProps> = ({
+  clusterName,
+  onDelete,
+  ...props
+}) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [confirmationVisible, setConfirmationVisible] = useState(false);
+
+  const showConfirmation = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+
+    setConfirmationVisible(true);
+  };
+
+  const hideConfirmation = () => {
+    window.setTimeout(() => {
+      setConfirmationVisible(false);
+    });
+  };
+
+  const handleDelete = async () => {
+    setIsLoading(true);
+    setConfirmationVisible(false);
+
+    try {
+      await onDelete();
+    } catch (err: unknown) {
+      const message = (err as Error).message;
+
+      setIsLoading(false);
+
+      new FlashMessage(
+        `Could not delete cluster ${clusterName}:`,
+        messageType.ERROR,
+        messageTTL.LONG,
+        message
+      );
+
+      ErrorReporter.getInstance().notify(err as never);
+    }
+  };
+
+  return (
+    <Box direction='column' gap='medium' pad={{ top: 'medium' }} {...props}>
+      <Text weight='bold' size='large' margin='none'>
+        Delete this cluster
+      </Text>
+      <Box width='large'>
+        <Text>
+          All workloads on this cluster will be terminated. Data stored on the
+          worker nodes will be lost. There is no way to undo this action.
+        </Text>
+      </Box>
+      <Box>
+        <ConfirmationPrompt
+          open={confirmationVisible}
+          onConfirm={handleDelete}
+          onCancel={hideConfirmation}
+          confirmButton={
+            <Button bsStyle='danger' onClick={handleDelete}>
+              <i
+                className='fa fa-delete'
+                role='presentation'
+                aria-hidden={true}
+                aria-label='Delete'
+              />{' '}
+              Delete {clusterName}
+            </Button>
+          }
+          title={`Do you really want to delete cluster ${clusterName}?`}
+        >
+          <Text>
+            As you might have read in the text above, this means that there is
+            no way back.
+          </Text>
+        </ConfirmationPrompt>
+
+        {!confirmationVisible && (
+          <Box animation={{ type: 'fadeIn', duration: 300 }}>
+            <Button
+              bsStyle='danger'
+              onClick={showConfirmation}
+              loading={isLoading}
+            >
+              <i
+                className='fa fa-delete'
+                role='presentation'
+                aria-hidden={true}
+                aria-label='Delete'
+              />{' '}
+              Delete cluster
+            </Button>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+ClusterDetailOverviewDelete.propTypes = {
+  clusterName: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+export default ClusterDetailOverviewDelete;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClusterDetailWidget renders a inline widget 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 hSiATR"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 bLmXgB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 cPuPbk"
+    >
+      <header
+        class="StyledBox-sc-13pk1d4-0 dLeNOM"
+      >
+        <span
+          class="StyledText-sc-1sadyjn-0 iFfteu ClusterDetailWidget__Title-sc-15uj98x-0 iPyTFw"
+        >
+          Some widget
+        </span>
+      </header>
+      <div
+        class="StyledBox-sc-13pk1d4-0 jjUbKU"
+      >
+        <span
+          class="StyledText-sc-1sadyjn-0 cORcyl"
+        >
+          Some content
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ClusterDetailWidget renders a simple widget 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 hSiATR"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-1qc9t9l-0 bLmXgB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 cPuPbk"
+    >
+      <header
+        class="StyledBox-sc-13pk1d4-0 kYALZS"
+      >
+        <span
+          class="StyledText-sc-1sadyjn-0 iFfteu ClusterDetailWidget__Title-sc-15uj98x-0 iPyTFw"
+        >
+          Some widget
+        </span>
+      </header>
+      <div
+        class="StyledBox-sc-13pk1d4-0 jjUbKU"
+      >
+        <span
+          class="StyledText-sc-1sadyjn-0 cORcyl"
+        >
+          Some content
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/index.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/index.tsx
@@ -1,0 +1,24 @@
+import { Text } from 'grommet';
+import * as React from 'react';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import ClusterDetailWidget from '..';
+
+describe('ClusterDetailWidget', () => {
+  it('renders a simple widget', () => {
+    const { container } = renderWithTheme(ClusterDetailWidget, {
+      title: 'Some widget',
+      children: <Text>Some content</Text>,
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a inline widget', () => {
+    const { container } = renderWithTheme(ClusterDetailWidget, {
+      title: 'Some widget',
+      inline: true,
+      children: <Text>Some content</Text>,
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/index.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/index.tsx
@@ -35,7 +35,7 @@ const ClusterDetailWidget: React.FC<IClusterDetailOverviewProps> = ({
         flex={{ grow: 0, shrink: 1 }}
         margin='small'
       >
-        <Title>{title}</Title>
+        <Title color='text-weak'>{title}</Title>
       </CardHeader>
       <CardBody
         direction='row'

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/index.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/index.tsx
@@ -1,0 +1,64 @@
+import { Card, CardBody, CardHeader, Text } from 'grommet';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+const Title = styled(Text)`
+  text-transform: uppercase;
+`;
+
+interface IClusterDetailOverviewProps
+  extends React.ComponentPropsWithoutRef<typeof Card> {
+  title: string;
+  inline?: boolean;
+}
+
+const ClusterDetailWidget: React.FC<IClusterDetailOverviewProps> = ({
+  title,
+  children,
+  inline,
+  ...props
+}) => {
+  return (
+    <Card
+      direction='row'
+      elevation='none'
+      overflow='visible'
+      background='background-front'
+      round='xsmall'
+      pad='xsmall'
+      wrap={true}
+      {...props}
+    >
+      <CardHeader
+        basis={inline ? '200px' : '100%'}
+        flex={{ grow: 0, shrink: 1 }}
+        margin='small'
+      >
+        <Title>{title}</Title>
+      </CardHeader>
+      <CardBody
+        direction='row'
+        gap='xsmall'
+        wrap={true}
+        basis='200px'
+        flex={{ grow: 1, shrink: 0 }}
+        margin='small'
+      >
+        {children}
+      </CardBody>
+    </Card>
+  );
+};
+
+ClusterDetailWidget.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  inline: PropTypes.bool,
+};
+
+ClusterDetailWidget.defaultProps = {
+  inline: false,
+};
+
+export default ClusterDetailWidget;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/index.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/index.tsx
@@ -11,12 +11,14 @@ interface IClusterDetailOverviewProps
   extends React.ComponentPropsWithoutRef<typeof Card> {
   title: string;
   inline?: boolean;
+  contentProps?: React.ComponentPropsWithoutRef<typeof CardBody>;
 }
 
 const ClusterDetailWidget: React.FC<IClusterDetailOverviewProps> = ({
   title,
   children,
   inline,
+  contentProps,
   ...props
 }) => {
   return (
@@ -38,12 +40,10 @@ const ClusterDetailWidget: React.FC<IClusterDetailOverviewProps> = ({
         <Title color='text-weak'>{title}</Title>
       </CardHeader>
       <CardBody
-        direction='row'
-        gap='xsmall'
-        wrap={true}
         basis='200px'
         flex={{ grow: 1, shrink: 0 }}
         margin='small'
+        {...contentProps}
       >
         {children}
       </CardBody>
@@ -55,6 +55,9 @@ ClusterDetailWidget.propTypes = {
   title: PropTypes.string.isRequired,
   children: PropTypes.node,
   inline: PropTypes.bool,
+  contentProps: PropTypes.object as PropTypes.Requireable<
+    IClusterDetailOverviewProps['contentProps']
+  >,
 };
 
 ClusterDetailWidget.defaultProps = {

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/stories/ClusterDetailWidget.stories.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/stories/ClusterDetailWidget.stories.tsx
@@ -1,0 +1,11 @@
+import { Meta } from '@storybook/react/types-6-0';
+
+import ClusterDetailWidget from '..';
+
+export { Simple } from './Simple';
+export { Inline } from './Inline';
+
+export default {
+  title: 'Display/Clusters/ClusterDetailWidget',
+  component: ClusterDetailWidget,
+} as Meta;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/stories/Inline.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/stories/Inline.tsx
@@ -1,0 +1,33 @@
+import { Story } from '@storybook/react';
+import { Text } from 'grommet';
+import React, { ComponentPropsWithoutRef } from 'react';
+
+import ClusterDetailWidget from '..';
+
+export const Inline: Story<
+  ComponentPropsWithoutRef<typeof ClusterDetailWidget>
+> = (args) => {
+  return (
+    <ClusterDetailWidget
+      {...args}
+      contentProps={{
+        direction: 'row',
+        gap: 'xsmall',
+        wrap: true,
+      }}
+    >
+      <Text>Something</Text>
+      <Text>Something else</Text>
+    </ClusterDetailWidget>
+  );
+};
+
+Inline.args = {
+  title: 'Some widget',
+  inline: true,
+};
+
+Inline.argTypes = {
+  title: { control: { type: 'text' } },
+  inline: { control: { type: 'boolean' } },
+};

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/stories/Simple.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/stories/Simple.tsx
@@ -1,0 +1,43 @@
+import { Story } from '@storybook/react';
+import { Box, Heading, Text } from 'grommet';
+import React, { ComponentPropsWithoutRef } from 'react';
+
+import ClusterDetailWidget from '..';
+
+export const Simple: Story<
+  ComponentPropsWithoutRef<typeof ClusterDetailWidget>
+> = (args) => {
+  return (
+    <ClusterDetailWidget {...args}>
+      <Text>Hi everyone. This is a widget that you can customize</Text>
+      <Box direction='row' pad='small' gap='small' margin={{ top: 'medium' }}>
+        <Box align='center'>
+          <Heading level={3} margin='none'>
+            50
+          </Heading>
+          <Text>shades of happa</Text>
+        </Box>
+        <Box align='center'>
+          <Heading level={3} margin='none'>
+            50
+          </Heading>
+          <Text>shades of happa</Text>
+        </Box>
+        <Box align='center'>
+          <Heading level={3} margin='none'>
+            50
+          </Heading>
+          <Text>shades of happa</Text>
+        </Box>
+      </Box>
+    </ClusterDetailWidget>
+  );
+};
+
+Simple.args = {
+  title: 'Some widget',
+};
+
+Simple.argTypes = {
+  title: { control: { type: 'text' } },
+};

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetCreated.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetCreated.tsx
@@ -40,7 +40,7 @@ const ClusterDetailWidgetCreated: React.FC<IClusterDetailWidgetCreatedProps> = (
         {(value) => <Text>{relativeDate(value as string)}</Text>}
       </ClusterDetailWidgetOptionalValue>
       <StyledDot />
-      <ClusterDetailWidgetOptionalValue value={creationDate}>
+      <ClusterDetailWidgetOptionalValue value={creationDate} loaderWidth={150}>
         {(value) => <Text>{formatDate(value as string)}</Text>}
       </ClusterDetailWidgetOptionalValue>
     </ClusterDetailWidget>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetCreated.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetCreated.tsx
@@ -1,0 +1,54 @@
+import { Text } from 'grommet';
+import { formatDate, relativeDate } from 'lib/helpers';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import { Dot } from 'styles';
+
+import { IClusterItem } from '../types';
+import ClusterDetailWidget from './ClusterDetailWidget';
+import ClusterDetailWidgetOptionalValue from './ClusterDetailWidgetOptionalValue';
+
+const StyledDot = styled(Dot)`
+  padding: 0;
+`;
+
+interface IClusterDetailWidgetCreatedProps
+  extends Omit<
+      React.ComponentPropsWithoutRef<typeof ClusterDetailWidget>,
+      'title'
+    >,
+    Pick<IClusterItem, 'creationDate'> {}
+
+const ClusterDetailWidgetCreated: React.FC<IClusterDetailWidgetCreatedProps> = ({
+  creationDate,
+  ...props
+}) => {
+  return (
+    <ClusterDetailWidget
+      title='Created'
+      inline={true}
+      contentProps={{
+        direction: 'row',
+        gap: 'xsmall',
+        wrap: true,
+        align: 'center',
+      }}
+      {...props}
+    >
+      <ClusterDetailWidgetOptionalValue value={creationDate}>
+        {(value) => <Text>{relativeDate(value as string)}</Text>}
+      </ClusterDetailWidgetOptionalValue>
+      <StyledDot />
+      <ClusterDetailWidgetOptionalValue value={creationDate}>
+        {(value) => <Text>{formatDate(value as string)}</Text>}
+      </ClusterDetailWidgetOptionalValue>
+    </ClusterDetailWidget>
+  );
+};
+
+ClusterDetailWidgetCreated.propTypes = {
+  creationDate: PropTypes.string,
+};
+
+export default ClusterDetailWidgetCreated;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
@@ -46,12 +46,12 @@ const ClusterDetailWidgetKubernetesAPI: React.FC<IClusterDetailWidgetKubernetesA
         loaderHeight={24}
       >
         {/* @ts-expect-error */}
-        {(value) => <URIBlock copyContent={true}>{value}</URIBlock>}
+        {(value) => <URIBlock>{value}</URIBlock>}
       </ClusterDetailWidgetOptionalValue>
 
       {typeof k8sApiURL !== 'undefined' && (
         <Link to={gettingStartedPath}>
-          <GetStartedButton>
+          <GetStartedButton tabIndex={-1}>
             <i className='fa fa-start' aria-hidden={true} role='presentation' />
             Get Started
           </GetStartedButton>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
@@ -1,0 +1,69 @@
+import URIBlock from 'Cluster/ClusterDetail/URIBlock';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import Button from 'UI/Controls/Button';
+
+import { IClusterItem } from '../types';
+import ClusterDetailWidget from './ClusterDetailWidget';
+import ClusterDetailWidgetOptionalValue from './ClusterDetailWidgetOptionalValue';
+
+const GetStartedButton = styled(Button)`
+  text-transform: uppercase;
+`;
+
+interface IClusterDetailWidgetKubernetesAPIProps
+  extends Omit<
+      React.ComponentPropsWithoutRef<typeof ClusterDetailWidget>,
+      'title'
+    >,
+    Pick<IClusterItem, 'k8sApiURL'> {
+  gettingStartedPath: string;
+}
+
+const ClusterDetailWidgetKubernetesAPI: React.FC<IClusterDetailWidgetKubernetesAPIProps> = ({
+  k8sApiURL,
+  gettingStartedPath,
+  ...props
+}) => {
+  return (
+    <ClusterDetailWidget
+      title='Kubernetes API'
+      inline={true}
+      contentProps={{
+        direction: 'row',
+        gap: 'xsmall',
+        wrap: true,
+        align: 'center',
+        justify: 'between',
+      }}
+      {...props}
+    >
+      <ClusterDetailWidgetOptionalValue
+        value={k8sApiURL}
+        loaderWidth={400}
+        loaderHeight={24}
+      >
+        {/* @ts-expect-error */}
+        {(value) => <URIBlock copyContent={true}>{value}</URIBlock>}
+      </ClusterDetailWidgetOptionalValue>
+
+      {typeof k8sApiURL !== 'undefined' && (
+        <Link to={gettingStartedPath}>
+          <GetStartedButton>
+            <i className='fa fa-start' aria-hidden={true} role='presentation' />
+            Get Started
+          </GetStartedButton>
+        </Link>
+      )}
+    </ClusterDetailWidget>
+  );
+};
+
+ClusterDetailWidgetKubernetesAPI.propTypes = {
+  gettingStartedPath: PropTypes.string.isRequired,
+  k8sApiURL: PropTypes.string,
+};
+
+export default ClusterDetailWidgetKubernetesAPI;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetLoadingPlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetLoadingPlaceholder.tsx
@@ -1,0 +1,32 @@
+import { Box } from 'grommet';
+import * as React from 'react';
+import ContentLoader from 'react-content-loader';
+import { useTheme } from 'styled-components';
+
+interface IClusterDetailWidgetLoadingPlaceholderProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {}
+
+const ClusterDetailWidgetLoadingPlaceholder: React.FC<IClusterDetailWidgetLoadingPlaceholderProps> = (
+  props
+) => {
+  const theme = useTheme();
+
+  return (
+    <Box {...props}>
+      <ContentLoader
+        viewBox='0 0 100 15'
+        speed={2}
+        height={15}
+        width='100'
+        backgroundColor={theme.global.colors['text-xweak'].dark}
+        foregroundColor={theme.global.colors['text-weak'].dark}
+      >
+        <rect x='0' y='0' rx='4' ry='4' width='100' height='15' />
+      </ContentLoader>
+    </Box>
+  );
+};
+
+ClusterDetailWidgetLoadingPlaceholder.propTypes = {};
+
+export default React.memo(ClusterDetailWidgetLoadingPlaceholder);

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetLoadingPlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetLoadingPlaceholder.tsx
@@ -1,32 +1,51 @@
 import { Box } from 'grommet';
+import PropTypes from 'prop-types';
 import * as React from 'react';
 import ContentLoader from 'react-content-loader';
 import { useTheme } from 'styled-components';
 
 interface IClusterDetailWidgetLoadingPlaceholderProps
-  extends React.ComponentPropsWithoutRef<typeof Box> {}
+  extends Omit<React.ComponentPropsWithoutRef<typeof Box>, 'height' | 'width'> {
+  height?: number;
+  width?: number;
+}
 
-const ClusterDetailWidgetLoadingPlaceholder: React.FC<IClusterDetailWidgetLoadingPlaceholderProps> = (
-  props
-) => {
+const ClusterDetailWidgetLoadingPlaceholder: React.FC<IClusterDetailWidgetLoadingPlaceholderProps> = ({
+  height,
+  width,
+  ...props
+}) => {
   const theme = useTheme();
 
   return (
-    <Box {...props}>
+    <Box
+      width={{ max: `${width}px` }}
+      overflow='hidden'
+      round='xsmall'
+      {...props}
+    >
       <ContentLoader
-        viewBox='0 0 100 15'
+        viewBox={`0 0 ${width} ${height}`}
         speed={2}
-        height={15}
-        width='100'
+        height={height}
+        width={width}
         backgroundColor={theme.global.colors['text-xweak'].dark}
         foregroundColor={theme.global.colors['text-weak'].dark}
       >
-        <rect x='0' y='0' rx='4' ry='4' width='100' height='15' />
+        <rect x='0' y='0' rx='0' ry='0' width={width} height={height} />
       </ContentLoader>
     </Box>
   );
 };
 
-ClusterDetailWidgetLoadingPlaceholder.propTypes = {};
+ClusterDetailWidgetLoadingPlaceholder.propTypes = {
+  height: PropTypes.number,
+  width: PropTypes.number,
+};
+
+ClusterDetailWidgetLoadingPlaceholder.defaultProps = {
+  height: 15,
+  width: 100,
+};
 
 export default React.memo(ClusterDetailWidgetLoadingPlaceholder);

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue.tsx
@@ -15,16 +15,24 @@ interface IClusterDetailWidgetOptionalValueProps {
   children: (value: string | number) => React.ReactElement;
   value?: string | number;
   replaceEmptyValue?: boolean;
+  loaderHeight?: number;
+  loaderWidth?: number;
 }
 
 const ClusterDetailWidgetOptionalValue: React.FC<IClusterDetailWidgetOptionalValueProps> = ({
   value,
   children,
   replaceEmptyValue,
+  loaderHeight,
+  loaderWidth,
 }) => {
   if (typeof value === 'undefined') {
     return (
-      <ClusterDetailWidgetLoadingPlaceholder margin={{ vertical: 'xsmall' }} />
+      <ClusterDetailWidgetLoadingPlaceholder
+        margin={{ vertical: 'xsmall' }}
+        height={loaderHeight}
+        width={loaderWidth}
+      />
     );
   }
 
@@ -44,6 +52,8 @@ ClusterDetailWidgetOptionalValue.propTypes = {
   children: PropTypes.func.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   replaceEmptyValue: PropTypes.bool,
+  loaderHeight: PropTypes.number,
+  loaderWidth: PropTypes.number,
 };
 
 ClusterDetailWidgetOptionalValue.defaultProps = {

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue.tsx
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import styled from 'styled-components';
+import NotAvailable from 'UI/Display/NotAvailable';
+import RefreshableLabel from 'UI/Display/RefreshableLabel';
+
+import ClusterDetailWidgetLoadingPlaceholder from './ClusterDetailWidgetLoadingPlaceholder';
+
+const StyledRefreshableLabel = styled(RefreshableLabel)`
+  padding: 0;
+  margin: 0;
+`;
+
+interface IClusterDetailWidgetOptionalValueProps {
+  children: (value: string | number) => React.ReactElement;
+  value?: string | number;
+  replaceEmptyValue?: boolean;
+}
+
+const ClusterDetailWidgetOptionalValue: React.FC<IClusterDetailWidgetOptionalValueProps> = ({
+  value,
+  children,
+  replaceEmptyValue,
+}) => {
+  if (typeof value === 'undefined') {
+    return (
+      <ClusterDetailWidgetLoadingPlaceholder margin={{ vertical: 'xsmall' }} />
+    );
+  }
+
+  if (replaceEmptyValue && (value === '' || value === -1)) {
+    return <NotAvailable />;
+  }
+
+  return (
+    // @ts-expect-error
+    <StyledRefreshableLabel value={value}>
+      {children(value)}
+    </StyledRefreshableLabel>
+  );
+};
+
+ClusterDetailWidgetOptionalValue.propTypes = {
+  children: PropTypes.func.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  replaceEmptyValue: PropTypes.bool,
+};
+
+ClusterDetailWidgetOptionalValue.defaultProps = {
+  replaceEmptyValue: true,
+};
+
+export default ClusterDetailWidgetOptionalValue;

--- a/src/components/UI/Display/MAPI/clusters/types.ts
+++ b/src/components/UI/Display/MAPI/clusters/types.ts
@@ -10,4 +10,5 @@ export interface IClusterItem {
   workerNodesCount?: number;
   workerNodesCPU?: number;
   workerNodesMemory?: number; // In gigabytes.
+  k8sApiURL?: string;
 }

--- a/src/components/UI/Inputs/ViewEditName.tsx
+++ b/src/components/UI/Inputs/ViewEditName.tsx
@@ -1,3 +1,4 @@
+import { Keyboard } from 'grommet';
 import { hasAppropriateLength } from 'lib/helpers';
 import PropTypes from 'prop-types';
 import React, {
@@ -180,6 +181,12 @@ class ViewAndEditName extends Component<
     }
   };
 
+  handleFocusKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.preventDefault();
+
+    ((e.target as HTMLElement).firstChild as HTMLElement)?.click();
+  };
+
   render() {
     const {
       typeLabel,
@@ -233,18 +240,23 @@ class ViewAndEditName extends Component<
 
     // View mode
     return (
-      <span {...rest}>
-        <OverlayTrigger
-          overlay={
-            <Tooltip id='tooltip'>Click to edit {typeLabel} name</Tooltip>
-          }
-          placement='top'
-        >
-          <NameLabel onClick={this.activateEditMode}>
-            {this.state.value}
-          </NameLabel>
-        </OverlayTrigger>
-      </span>
+      <Keyboard
+        onSpace={this.handleFocusKeyDown}
+        onEnter={this.handleFocusKeyDown}
+      >
+        <span tabIndex={0} {...rest}>
+          <OverlayTrigger
+            overlay={
+              <Tooltip id='tooltip'>Click to edit {typeLabel} name</Tooltip>
+            }
+            placement='top'
+          >
+            <NameLabel onClick={this.activateEditMode}>
+              {this.state.value}
+            </NameLabel>
+          </OverlayTrigger>
+        </span>
+      </Keyboard>
     );
   }
 }

--- a/src/model/services/mapi/capiv1alpha3/deleteCluster.ts
+++ b/src/model/services/mapi/capiv1alpha3/deleteCluster.ts
@@ -1,0 +1,22 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { deleteResource } from '../generic/deleteResource';
+import { ICluster } from './types';
+
+export function deleteCluster(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  cluster: ICluster
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha3',
+    kind: 'clusters',
+    namespace: cluster.metadata.namespace,
+    name: cluster.metadata.name,
+  } as k8sUrl.IK8sDeleteOptions);
+
+  return deleteResource<ICluster>(client, auth, url.toString());
+}

--- a/src/model/services/mapi/capiv1alpha3/getCluster.ts
+++ b/src/model/services/mapi/capiv1alpha3/getCluster.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { getResource } from '../generic/getResource';
+import { ICluster } from './';
+
+export function getCluster(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  name: string
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha3',
+    kind: 'clusters',
+    namespace,
+    name,
+  });
+
+  return getResource<ICluster>(client, auth, url.toString());
+}
+
+export function getClusterKey(namespace: string, name: string) {
+  return `getClusterKey/${namespace}/${name}`;
+}

--- a/src/model/services/mapi/capiv1alpha3/index.ts
+++ b/src/model/services/mapi/capiv1alpha3/index.ts
@@ -3,5 +3,6 @@ export * from './getClusterInfraRef';
 export * from './getClusterList';
 export * from './getCluster';
 export * from './updateCluster';
+export * from './deleteCluster';
 export * from './getMachineDeploymentList';
 export * from './key';

--- a/src/model/services/mapi/capiv1alpha3/index.ts
+++ b/src/model/services/mapi/capiv1alpha3/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './getClusterInfraRef';
 export * from './getClusterList';
+export * from './getCluster';
 export * from './getMachineDeploymentList';
 export * from './key';

--- a/src/model/services/mapi/capiv1alpha3/index.ts
+++ b/src/model/services/mapi/capiv1alpha3/index.ts
@@ -2,5 +2,6 @@ export * from './types';
 export * from './getClusterInfraRef';
 export * from './getClusterList';
 export * from './getCluster';
+export * from './updateCluster';
 export * from './getMachineDeploymentList';
 export * from './key';

--- a/src/model/services/mapi/capiv1alpha3/key.ts
+++ b/src/model/services/mapi/capiv1alpha3/key.ts
@@ -32,6 +32,15 @@ export function getClusterOrganization(cluster: ICluster): string | undefined {
   return cluster.metadata.labels?.[labelOrganization];
 }
 
+export function getKubernetesAPIEndpointURL(
+  cluster: ICluster
+): string | undefined {
+  const hostname = cluster.spec?.controlPlaneEndpoint?.host;
+  if (!hostname) return undefined;
+
+  return `https://${hostname}`;
+}
+
 export function getCondition(
   cluster: ICluster,
   type: string

--- a/src/model/services/mapi/capiv1alpha3/key.ts
+++ b/src/model/services/mapi/capiv1alpha3/key.ts
@@ -6,6 +6,8 @@ export const labelOrganization = 'giantswarm.io/organization';
 export const labelCluster = 'giantswarm.io/cluster';
 export const labelReleaseVersion = 'release.giantswarm.io/version';
 
+export const annotationClusterDescription = 'cluster.giantswarm.io/description';
+
 export const conditionTypeCreating = 'Creating';
 export const conditionTypeUpgrading = 'Upgrading';
 
@@ -16,8 +18,7 @@ export const conditionReasonUpgradeNotStarted = 'UpgradeNotStarted';
 export const conditionReasonUpgradePending = 'UpgradePending';
 
 export function getClusterDescription(cluster: ICluster): string {
-  let name =
-    cluster.metadata.annotations?.['cluster.giantswarm.io/description'];
+  let name = cluster.metadata.annotations?.[annotationClusterDescription];
   name ??= 'Unnamed cluster';
 
   return name;

--- a/src/model/services/mapi/capiv1alpha3/updateCluster.ts
+++ b/src/model/services/mapi/capiv1alpha3/updateCluster.ts
@@ -1,0 +1,22 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { updateResource } from '../generic/updateResource';
+import { ICluster } from './';
+
+export function updateCluster(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  cluster: ICluster
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha3',
+    kind: 'clusters',
+    namespace: cluster.metadata.namespace!,
+    name: cluster.metadata.name,
+  } as k8sUrl.IK8sUpdateOptions);
+
+  return updateResource<ICluster>(client, auth, url.toString(), cluster);
+}

--- a/src/shared/featureFlags.ts
+++ b/src/shared/featureFlags.ts
@@ -31,7 +31,7 @@ export const flags: Record<Feature, IFeatureFlag> = {
   NextGenClusters: {
     enabled: false,
     init: () => window.featureFlags.FEATURE_MAPI_CLUSTERS,
-    experimentName: 'Use Management API for the list of clusters',
+    experimentName: 'Use Management API for cluster management',
     persist: true,
   },
 };


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9077

This PR adds some basic features for the new `Cluster detail` page layout, which uses the Management API for fetching information.

What's in this PR:
- Cluster description renaming
- Cluster deletion (behaves the same as organization deletion)
- Info about clusters (name, description, kubernetes API URL, creation date)
- Cluster details widget (will be used for all the different panes on the page)

The rest will be implemented in next PRs

### Preview

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/13508038/120997768-c5531180-c787-11eb-85ef-957d458384a3.png)

</details>

<details>
<summary>Deletion confirmation</summary>

![image](https://user-images.githubusercontent.com/13508038/120998015-f6cbdd00-c787-11eb-81e4-a3a6d80b3980.png)

</details>

<details>
<summary>Loading animations</summary>

![image](https://user-images.githubusercontent.com/13508038/121013498-2fc07d80-c799-11eb-9d49-5a18d4e0f2fe.png)

</details>