### PR TITLE
clusters: add the Apps and Ingress tabs to the MAPI cluster detail page

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -386,10 +386,7 @@ class ClusterDetailView extends React.Component {
               </Tab>
               <Tab eventKey={tabsPaths.Apps} title='Apps'>
                 {supporsAppsViaMapi ? (
-                  <ClusterDetailApps
-                    clusterId={id}
-                    releaseVersion={release_version}
-                  />
+                  <ClusterDetailApps releaseVersion={release_version} />
                 ) : (
                   <ClusterApps
                     clusterId={id}

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -403,7 +403,6 @@ class ClusterDetailView extends React.Component {
               <Tab eventKey={tabsPaths.Ingress} title='Ingress'>
                 {supporsAppsViaMapi ? (
                   <ClusterDetailIngress
-                    clusterID={cluster.id}
                     provider={provider}
                     k8sEndpoint={cluster.api_endpoint}
                     kvmTCPHTTPPort={Constants.KVM_INGRESS_TCP_HTTP_PORT}

--- a/src/components/MAPI/apps/ClusterDetailApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailApps.tsx
@@ -19,6 +19,7 @@ import React, {
   useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router';
 import { AppConstants } from 'shared/constants';
 import { AppsRoutes } from 'shared/constants/routes';
 import { supportsOptionalIngress } from 'stores/cluster/utils';
@@ -86,15 +87,16 @@ const PreinstalledApps = styled.div`
   }
 `;
 
+// FIXME(axbarsan): Fetch cluster by ID in URL params once AWS has namespaced clusters.
 interface IClusterDetailApps {
-  clusterId: string;
   releaseVersion: string;
 }
 
 const ClusterDetailApps: React.FC<IClusterDetailApps> = ({
-  clusterId,
   releaseVersion,
 }) => {
+  const { clusterId } = useParams<{ clusterId: string }>();
+
   const clientFactory = useHttpClientFactory();
   const auth = useAuthProvider();
 
@@ -328,7 +330,6 @@ const ClusterDetailApps: React.FC<IClusterDetailApps> = ({
 };
 
 ClusterDetailApps.propTypes = {
-  clusterId: PropTypes.string.isRequired,
   releaseVersion: PropTypes.string.isRequired,
 };
 

--- a/src/components/MAPI/apps/ClusterDetailIngress.tsx
+++ b/src/components/MAPI/apps/ClusterDetailIngress.tsx
@@ -9,6 +9,7 @@ import { GenericResponse } from 'model/clients/GenericResponse';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
 import PropTypes from 'prop-types';
 import React, { useEffect, useMemo } from 'react';
+import { useParams } from 'react-router';
 import { Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
 import styled from 'styled-components';
@@ -31,9 +32,9 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
   }
 `;
 
+// FIXME(axbarsan): Fetch cluster by ID in URL params once AWS has namespaced clusters.
 interface IClusterDetailIngressProps
   extends React.ComponentPropsWithoutRef<'div'> {
-  clusterID: string;
   provider?: PropertiesOf<typeof Providers>;
   k8sEndpoint?: string;
   kvmTCPHTTPPort?: number;
@@ -41,17 +42,18 @@ interface IClusterDetailIngressProps
 }
 
 const ClusterDetailIngress: React.FC<IClusterDetailIngressProps> = ({
-  clusterID,
   provider,
   k8sEndpoint,
   kvmTCPHTTPPort,
   kvmTCPHTTPSPort,
   ...rest
 }) => {
+  const { clusterId } = useParams<{ clusterId: string }>();
+
   const auth = useAuthProvider();
 
   const appListClient = useHttpClient();
-  const appListGetOptions = { namespace: clusterID };
+  const appListGetOptions = { namespace: clusterId };
   const {
     data: appList,
     error: appListError,
@@ -112,7 +114,7 @@ const ClusterDetailIngress: React.FC<IClusterDetailIngressProps> = ({
       )}
 
       {!hasIngress && !appListIsLoading && !appListError && (
-        <InstallIngressButton clusterID={clusterID} />
+        <InstallIngressButton clusterID={clusterId} />
       )}
 
       {appListError && (
@@ -130,7 +132,6 @@ const ClusterDetailIngress: React.FC<IClusterDetailIngressProps> = ({
 };
 
 ClusterDetailIngress.propTypes = {
-  clusterID: PropTypes.string.isRequired,
   provider: PropTypes.oneOf(Object.values(Providers)),
   k8sEndpoint: PropTypes.string,
   kvmTCPHTTPPort: PropTypes.number,

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -5,6 +5,7 @@ import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import RoutePath from 'lib/routePath';
+import ClusterDetailApps from 'MAPI/apps/ClusterDetailApps';
 import {
   extractErrorMessage,
   getOrgNamespaceFromOrgName,
@@ -32,6 +33,10 @@ import { updateClusterDescription } from './utils';
 function computePaths(orgName: string, clusterName: string) {
   return {
     Home: RoutePath.createUsablePath(OrganizationsRoutes.Clusters.Detail.Home, {
+      orgId: orgName,
+      clusterId: clusterName,
+    }),
+    Apps: RoutePath.createUsablePath(OrganizationsRoutes.Clusters.Detail.Apps, {
       orgId: orgName,
       clusterId: clusterName,
     }),
@@ -117,6 +122,9 @@ const ClusterDetail: React.FC<{}> = () => {
   const clusterDescription = cluster
     ? capiv1alpha3.getClusterDescription(cluster)
     : undefined;
+  const clusterReleaseVersion = cluster
+    ? capiv1alpha3.getReleaseVersion(cluster)
+    : undefined;
 
   const updateDescription = async (newValue: string) => {
     if (!cluster) return;
@@ -180,8 +188,17 @@ const ClusterDetail: React.FC<{}> = () => {
         </Heading>
         <Tabs defaultActiveKey={paths.Home} useRoutes={true}>
           <Tab eventKey={paths.Home} title='Overview' />
+          <Tab eventKey={paths.Apps} title='Apps' />
         </Tabs>
         <Switch>
+          <Route
+            path={OrganizationsRoutes.Clusters.Detail.Apps}
+            render={() =>
+              cluster && (
+                <ClusterDetailApps releaseVersion={clusterReleaseVersion!} />
+              )
+            }
+          />
           <Route
             path={OrganizationsRoutes.Clusters.Detail.Home}
             component={ClusterDetailOverview}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/341

This PR adds the `Apps` and `Ingress` tabs to the MAPI cluster detail page. Luckily, these have already been refactored to use the MAPI, so it's just a matter of a few small tweaks