### PR TITLE
Switch to using const enums, for less runtime code

### DIFF
--- a/src/components/Cluster/AZSelection/AZSelectionUtils.tsx
+++ b/src/components/Cluster/AZSelection/AZSelectionUtils.tsx
@@ -6,7 +6,7 @@ export enum AvailabilityZoneSelection {
   NotSpecified,
 }
 
-export enum AZSelectionVariants {
+export const enum AZSelectionVariants {
   Master,
   NodePool,
 }

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.tsx
@@ -27,7 +27,7 @@ import DeleteConfirmFooter from './DeleteConfirmFooter';
 import EditChartVersionPane from './EditChartVersionPane';
 import InitialPane from './InitialPane';
 
-enum ModalPanes {
+const enum ModalPanes {
   Initial,
   DeleteAppConfig,
   DeleteAppSecret,

--- a/src/components/Cluster/ClusterDetail/Ingress/Instructions.tsx
+++ b/src/components/Cluster/ClusterDetail/Ingress/Instructions.tsx
@@ -35,7 +35,7 @@ const Steps = styled.ol`
   }
 `;
 
-enum IngressPathPrefixes {
+const enum IngressPathPrefixes {
   Pattern = 'YOUR_PREFIX',
   LoadBalancer = 'ingress',
   Example = 'example',

--- a/src/components/Cluster/ClusterDetail/KeypairCreateModal/Utils.ts
+++ b/src/components/Cluster/ClusterDetail/KeypairCreateModal/Utils.ts
@@ -1,7 +1,7 @@
 export const MODAL_CHANGE_TIMEOUT = 200;
 export const VALIDATION_DEBOUNCE_RATE = 1000;
 
-export enum KeypairCreateModalStatus {
+export const enum KeypairCreateModalStatus {
   Adding,
   Success,
 }

--- a/src/components/MAPI/apps/AppDetailsModal/index.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/index.tsx
@@ -32,7 +32,7 @@ import {
 } from '../utils';
 import AppDetailsModalInitialPane from './AppDetailsModalInitialPane';
 
-enum ModalPanes {
+const enum ModalPanes {
   Initial,
   DeleteAppConfig,
   DeleteAppSecret,

--- a/src/components/UI/Display/FlashMessage/index.tsx
+++ b/src/components/UI/Display/FlashMessage/index.tsx
@@ -57,7 +57,8 @@ const FlashMessage: FC<IFlashMessageProps> = ({
 };
 
 FlashMessage.propTypes = {
-  type: PropTypes.oneOf(Object.values(FlashMessageType)).isRequired,
+  type: (PropTypes.string as PropTypes.Requireable<FlashMessageType>)
+    .isRequired,
   children: PropTypes.node,
   className: PropTypes.string,
 };

--- a/src/components/UI/Display/MAPI/AccessControl/types.ts
+++ b/src/components/UI/Display/MAPI/AccessControl/types.ts
@@ -1,4 +1,4 @@
-export enum AccessControlSubjectTypes {
+export const enum AccessControlSubjectTypes {
   Group,
   User,
   ServiceAccount,

--- a/src/lib/MapiAuth/MapiAuth.ts
+++ b/src/lib/MapiAuth/MapiAuth.ts
@@ -2,7 +2,7 @@
 
 import OAuth2 from 'lib/OAuth2/OAuth2';
 
-export enum MapiAuthConnectors {
+export const enum MapiAuthConnectors {
   Customer = 'customer',
   GiantSwarm = 'giantswarm',
 }

--- a/src/lib/OAuth2/OAuth2.ts
+++ b/src/lib/OAuth2/OAuth2.ts
@@ -13,7 +13,7 @@ import {
 
 import { getUserFromOIDCUser, IOAuth2User } from './OAuth2User';
 
-export enum OAuth2Events {
+export const enum OAuth2Events {
   UserLoaded = 'userLoaded',
   TokenExpired = 'tokenExpired',
   TokenExpiring = 'tokenExpiring',

--- a/src/lib/organizationValidation.ts
+++ b/src/lib/organizationValidation.ts
@@ -1,4 +1,4 @@
-export enum OrganizationNameStatusMessage {
+export const enum OrganizationNameStatusMessage {
   TooShort = 'Must be at least 4 characters long',
   StartAndEndWithAlphaNumeric = 'Must start and end with an alphanumeric character (a-z, 0-9)',
   CharacterSet = 'Must contain only a-z, 0-9, and hyphens and underscores',

--- a/src/lib/passwordValidation.ts
+++ b/src/lib/passwordValidation.ts
@@ -1,4 +1,4 @@
-export enum PasswordStatusMessage {
+export const enum PasswordStatusMessage {
   TooShort = 'password_too_short',
   JustNumbers = 'password_not_just_numbers',
   JustLetters = 'password_not_just_letters',

--- a/src/model/clients/HttpClient.ts
+++ b/src/model/clients/HttpClient.ts
@@ -6,7 +6,7 @@ import { GenericResponseError } from './GenericResponseError';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type HttpBody = Record<string, any> | string;
 
-export enum HttpRequestMethods {
+export const enum HttpRequestMethods {
   GET = 'GET',
   POST = 'POST',
   PUT = 'PUT',

--- a/src/model/services/giantSwarm/types.ts
+++ b/src/model/services/giantSwarm/types.ts
@@ -1,3 +1,3 @@
-export enum GiantSwarmPaths {
+export const enum GiantSwarmPaths {
   Info = '/v4/info/',
 }

--- a/src/model/services/mapi/metav1/types.ts
+++ b/src/model/services/mapi/metav1/types.ts
@@ -24,7 +24,7 @@ export interface IList<T> {
   items: T[];
 }
 
-export enum K8sStatusErrorReasons {
+export const enum K8sStatusErrorReasons {
   /**
    * The server has declined to indicate a specific reason.
    */
@@ -134,12 +134,12 @@ export enum K8sStatusErrorReasons {
   ServiceUnavailable = 'ServiceUnavailable',
 }
 
-export enum K8sStatuses {
+export const enum K8sStatuses {
   Success = 'Success',
   Failure = 'Failure',
 }
 
-export enum K8sStatusDetailsCauseTypes {
+export const enum K8sStatusDetailsCauseTypes {
   FieldValueNotFound = 'FieldValueNotFound',
   FieldValueRequired = 'FieldValueRequired',
   FieldValueDuplicate = 'FieldValueDuplicate',

--- a/src/model/services/mapi/rbacv1/types.ts
+++ b/src/model/services/mapi/rbacv1/types.ts
@@ -14,7 +14,7 @@ export interface IRoleRef {
   name: string;
 }
 
-export enum SubjectKinds {
+export const enum SubjectKinds {
   User = 'User',
   Group = 'Group',
   ServiceAccount = 'ServiceAccount',

--- a/src/model/services/metadata/types.ts
+++ b/src/model/services/metadata/types.ts
@@ -1,4 +1,4 @@
-export enum MetadataPaths {
+export const enum MetadataPaths {
   Configuration = '/metadata.json',
 }
 

--- a/src/shared/constants/cssBreakpoints.ts
+++ b/src/shared/constants/cssBreakpoints.ts
@@ -1,4 +1,4 @@
-export enum CSSBreakpoints {
+export const enum CSSBreakpoints {
   Small = 'small',
   Medium = 'medium',
   Large = 'large',

--- a/src/shared/constants/realUserMonitoring.ts
+++ b/src/shared/constants/realUserMonitoring.ts
@@ -1,4 +1,4 @@
-export enum RUMActions {
+export const enum RUMActions {
   WindowResize = 'WINDOW_RESIZE',
   WindowLoad = 'WINDOW_LOAD',
   WebVitals = 'WEB_VITALS',

--- a/src/stores/main/types.ts
+++ b/src/stores/main/types.ts
@@ -21,7 +21,7 @@ import {
   VERIFY_PASSWORD_RECOVERY_TOKEN,
 } from 'stores/main/constants';
 
-export enum LoggedInUserTypes {
+export const enum LoggedInUserTypes {
   GS,
   MAPI,
 }

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import theme from './theme';
 
-export enum FlashMessageType {
+export const enum FlashMessageType {
   Danger = 'danger',
   Success = 'success',
   Warning = 'warning',


### PR DESCRIPTION
This PR switches to using `const` enums for almost all enums (except for `AvailabilityZoneSelection`, because we need its keys [here](https://github.com/giantswarm/happa/blob/8c4aebefc21a884d0e2f5b88cb54552bdfc86b44/src/components/Cluster/AZSelection/AZSelectionCheckbox.tsx#L29))

The difference between regular enums and `const` enums is that for each regular enum, a new object gets created. For example, for the `AZSelectionVariants` enum, which looks like this:
```typescript
export enum AZSelectionVariants {
	Master,
	NodePool
}
```

The compiled code for it looks similar to this:
```typescript
const AZSelectionVariants = {
	Master: 0,
	NodePool: 1,
	0: "Master",
	1: "NodePool"
}
```

When it's used, it looks like this:
```typescript
const azVariant = AZSelectionVariants.Master;
```

In the compiled code, its usage looks the same.


However, if we use `const` enums, the value of the key in the enum will be used in place:

```typescript
export const enum AZSelectionVariants {
	Master,
	NodePool
}
```

There is no compiled code for it.

When it's used, it looks like this:
```typescript
const azVariant = AZSelectionVariants.Master;
```

But when it's compiled, its usage will look like this:
```typescript
const azVariant = 0;
```

Using this, we can output less code, and have less property accesses, so MORE SPEED ⚡ .