### PR TITLE
Submit each URI visited to RUM

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -126,6 +126,17 @@ window.addEventListener('load', () => {
   });
 });
 
+// Log each URI visited
+let lastURI = '';
+history.listen((evt) => {
+  if (lastURI !== evt.pathname) {
+    lastURI = evt.pathname;
+    submitCustomRUM(RUMActions.URIChange, 1, {
+      pathname: evt.pathname,
+    });
+  }
+});
+
 // Log core web vitals.
 const recorded: Record<string, boolean> = {};
 

--- a/src/shared/constants/realUserMonitoring.ts
+++ b/src/shared/constants/realUserMonitoring.ts
@@ -2,6 +2,7 @@ export enum RUMActions {
   WindowResize = 'WINDOW_RESIZE',
   WindowLoad = 'WINDOW_LOAD',
   WebVitals = 'WEB_VITALS',
+  URIChange = 'URI_CHANGE',
 
   ClickMainNavLogo = 'CLICK_MAINNAV_LOGO',
 


### PR DESCRIPTION
With this change, every URI visited in the app will be logged to RUM. So far, only URIs with other RUM events happening were logged.

This gives us more complete information regarding which parts of happa are used.

## Preview

![image](https://user-images.githubusercontent.com/273727/122248934-baeff080-cec8-11eb-92cd-f7292d20e9f2.png)
