### PR TITLE
Create swc plugin that removes prop types in production builds

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -7,5 +7,5 @@
       "__tests__/*": ["./__tests__/*"]
     }
   },
-  "include": ["src", "testUtils", "__tests__"]
+  "include": ["src", "testUtils", "__tests__", "scripts"]
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "noty": "^3.1.4",
     "oidc-client": "^1.11.5",
     "platform": "1.3.6",
-    "prop-types": "15.7.2",
     "react": "17.0.2",
     "react-bootstrap": "0.33.1",
     "react-bootstrap-table-next": "4.0.3",
@@ -118,6 +117,7 @@
     "web-vitals": "^1.1.1"
   },
   "devDependencies": {
+    "prop-types": "15.7.2",
     "@babel/core": "7.14.3",
     "@babel/preset-env": "7.14.2",
     "@babel/preset-react": "7.13.13",

--- a/scripts/swc/PropTypesStripper.ts
+++ b/scripts/swc/PropTypesStripper.ts
@@ -1,0 +1,107 @@
+import {
+  AssignmentExpression,
+  ClassDeclaration,
+  Declaration,
+  Expression,
+  ExpressionStatement,
+  ImportDeclaration,
+  Module,
+  Program,
+} from '@swc/core';
+
+class PropTypesStripper {
+  public visitProgram(n: Program): Program {
+    switch (n.type) {
+      case 'Module':
+        return this.visitModule(n);
+      default:
+        return n;
+    }
+  }
+
+  public visitModule(n: Module): Module {
+    n.body = n.body.map((member) => {
+      switch (member.type) {
+        case 'ClassDeclaration':
+          return this.visitClassDeclaration(member);
+        case 'ImportDeclaration':
+          return this.visitImportDeclaration(member);
+        case 'ExpressionStatement':
+          return this.visitExpressionStatement(member);
+        default:
+          return member;
+      }
+    });
+
+    return n;
+  }
+
+  public visitAssignmentExpression(n: AssignmentExpression): Expression {
+    if (
+      n.operator === '=' &&
+      n.left.type === 'MemberExpression' &&
+      n.left.object.type === 'Identifier' &&
+      n.left.property.type === 'Identifier' &&
+      n.left.property.value === 'propTypes'
+    ) {
+      return {
+        type: 'UnaryExpression',
+        span: n.span,
+        operator: 'void',
+        argument: {
+          type: 'NumericLiteral',
+          span: n.span,
+          value: 0,
+        },
+      };
+    }
+
+    return n;
+  }
+
+  public visitClassDeclaration(n: ClassDeclaration): Declaration {
+    n.body = n.body.filter((member) => {
+      if (
+        member.type === 'ClassProperty' &&
+        // @ts-expect-error
+        member.isStatic &&
+        member.key.type === 'Identifier' &&
+        member.key.value === 'propTypes'
+      ) {
+        return false;
+      }
+
+      return true;
+    });
+
+    return n;
+  }
+
+  public visitImportDeclaration(n: ImportDeclaration): ImportDeclaration {
+    if (n.source.value === 'prop-types') {
+      return ({
+        type: 'EmptyStatement',
+        span: n.span,
+      } as unknown) as ImportDeclaration;
+    }
+
+    return n;
+  }
+
+  public visitExpressionStatement(n: ExpressionStatement): ExpressionStatement {
+    n.expression = this.visitExpression(n.expression);
+
+    return n;
+  }
+
+  public visitExpression(n: Expression): Expression {
+    switch (n.type) {
+      case 'AssignmentExpression':
+        return this.visitAssignmentExpression(n);
+      default:
+        return n;
+    }
+  }
+}
+
+export default PropTypesStripper;

--- a/scripts/swc/__tests__/PropTypesStripper.ts
+++ b/scripts/swc/__tests__/PropTypesStripper.ts
@@ -1,0 +1,55 @@
+import { parse, parseSync, transformSync } from '@swc/core';
+import PropTypesStripper from '../PropTypesStripper';
+
+describe('PropTypesStripper', () => {
+  it('removes empty prop types if assigned as a property', () => {
+    expect(transformCode(`TestComponent.propTypes = {};`)).toEqual(`void 0;`);
+  });
+
+  it('removes prop types if assigned as a property', () => {
+    expect(
+      transformCode(`TestComponent.propTypes = {
+      value: PropTypes.string,
+      otherStuff: PropTypes.oneOf('test1', 'test2'),
+    };`)
+    ).toEqual(`void 0;`);
+  });
+
+  it('removes prop types if assigned as a static class property', () => {
+    expect(
+      transformCode(`class Test {
+      static propTypes = {
+        value: PropTypes.string,
+        otherStuff: PropTypes.oneOf('test1', 'test2'),
+      };
+      doSomething() {}
+    }`)
+    ).toEqual(`class Test {
+    doSomething() {
+    }
+}`);
+  });
+
+  it('removes "prop-types" import', () => {
+    expect(transformCode(`import PropTypes from 'prop-types';`)).toEqual(``);
+  });
+});
+
+function transformCode(code: string): string {
+  const instance = new PropTypesStripper();
+
+  const parsed = parseSync(code);
+  const out = transformSync(parsed, {
+    jsc: {
+      target: 'es2020',
+      parser: {
+        syntax: 'typescript',
+        tsx: true,
+      },
+    },
+    plugin: (m) => instance.visitProgram(m),
+  });
+
+  // Strip end newline.
+  return out.code.slice(0, -1);
+}

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -446,10 +446,6 @@ class ClusterDetailView extends React.Component {
   }
 }
 
-ClusterDetailView.contextTypes = {
-  router: PropTypes.object,
-};
-
 ClusterDetailView.propTypes = {
   cluster: PropTypes.object,
   user: PropTypes.object,

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -49,8 +49,13 @@ interface ISignUpState {
   advancable: boolean;
 }
 
-export class SignUp extends React.Component<ISignUpProps, ISignUpState> {
-  public static propTypes = {};
+class SignUp extends React.Component<ISignUpProps, ISignUpState> {
+  public static propTypes = {
+    match: PropTypes.object,
+    dispatch: PropTypes.func,
+    actions: PropTypes.object,
+  };
+
   private password: HTMLInputElement | null = null;
   private passwordConfirmation: HTMLInputElement | null = null;
 
@@ -432,12 +437,6 @@ export class SignUp extends React.Component<ISignUpProps, ISignUpState> {
   }
 }
 
-SignUp.propTypes = {
-  match: PropTypes.object,
-  dispatch: PropTypes.func,
-  actions: PropTypes.object,
-};
-
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
     actions: bindActionCreators(mainActions, dispatch),
@@ -445,4 +444,5 @@ function mapDispatchToProps(dispatch: Dispatch) {
   };
 }
 
+// @ts-expect-error
 export default connect(null, mapDispatchToProps)(SignUp);

--- a/src/components/Users/DeleteUserModal.js
+++ b/src/components/Users/DeleteUserModal.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import UsersModal, { UsersModalPropTypes } from './UsersModal';
+import UsersModal from './UsersModal';
 
 const DeleteUserModal = ({ forUser, isLoading, ...props }) => {
   const confirmButtonText = isLoading ? 'Deleting User' : 'Delete User';
@@ -25,7 +25,16 @@ DeleteUserModal.defaultProps = {
 };
 
 DeleteUserModal.propTypes = {
-  ...UsersModalPropTypes,
+  show: PropTypes.bool,
+  title: PropTypes.string,
+  onClose: PropTypes.func,
+  onConfirm: PropTypes.func,
+  isLoading: PropTypes.bool,
+  children: PropTypes.node,
+  confirmText: PropTypes.string,
+  confirmDisabled: PropTypes.bool,
+  confirmHidden: PropTypes.bool,
+  cancelText: PropTypes.string,
   forUser: PropTypes.string,
 };
 

--- a/src/components/Users/InviteUserModal/index.js
+++ b/src/components/Users/InviteUserModal/index.js
@@ -2,7 +2,7 @@ import usePrevious from 'lib/hooks/usePrevious';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 
-import UsersModal, { UsersModalPropTypes } from '../UsersModal';
+import UsersModal from '../UsersModal';
 import InviteUserForm from './InviteUserForm';
 import InviteUserSuccess from './InviteUserSuccess';
 
@@ -143,7 +143,16 @@ InviteUserModal.defaultProps = {
 };
 
 InviteUserModal.propTypes = {
-  ...UsersModalPropTypes,
+  show: PropTypes.bool,
+  title: PropTypes.string,
+  onClose: PropTypes.func,
+  onConfirm: PropTypes.func,
+  isLoading: PropTypes.bool,
+  children: PropTypes.node,
+  confirmText: PropTypes.string,
+  confirmDisabled: PropTypes.bool,
+  confirmHidden: PropTypes.bool,
+  cancelText: PropTypes.string,
   organizations: PropTypes.object,
   initiallySelectedOrganizations: PropTypes.arrayOf(PropTypes.string),
   invitationResult: PropTypes.object,

--- a/src/components/Users/UnexpireUserModal.js
+++ b/src/components/Users/UnexpireUserModal.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import UsersModal, { UsersModalPropTypes } from './UsersModal';
+import UsersModal from './UsersModal';
 
 const UnexpireUserModal = ({ forUser, isLoading, ...props }) => {
   const confirmButtonText = isLoading
@@ -28,7 +28,16 @@ UnexpireUserModal.defaultProps = {
 };
 
 UnexpireUserModal.propTypes = {
-  ...UsersModalPropTypes,
+  show: PropTypes.bool,
+  title: PropTypes.string,
+  onClose: PropTypes.func,
+  onConfirm: PropTypes.func,
+  isLoading: PropTypes.bool,
+  children: PropTypes.node,
+  confirmText: PropTypes.string,
+  confirmDisabled: PropTypes.bool,
+  confirmHidden: PropTypes.bool,
+  cancelText: PropTypes.string,
   forUser: PropTypes.string,
 };
 

--- a/src/components/Users/UsersModal.js
+++ b/src/components/Users/UsersModal.js
@@ -65,7 +65,7 @@ UsersModal.defaultProps = {
   cancelText: 'Cancel',
 };
 
-export const UsersModalPropTypes = {
+UsersModal.propTypes = {
   show: PropTypes.bool,
   title: PropTypes.string,
   onClose: PropTypes.func,
@@ -77,7 +77,5 @@ export const UsersModalPropTypes = {
   confirmHidden: PropTypes.bool,
   cancelText: PropTypes.string,
 };
-
-UsersModal.propTypes = UsersModalPropTypes;
 
 export default UsersModal;

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -12,7 +12,7 @@ interface IErrorBoundaryState {
   hasError: boolean;
 }
 
-export default class ErrorBoundary extends Component<
+class ErrorBoundary extends Component<
   IErrorBoundaryProps,
   IErrorBoundaryState
 > {
@@ -48,3 +48,5 @@ export default class ErrorBoundary extends Component<
     return this.props.children;
   }
 }
+
+export default ErrorBoundary;

--- a/src/styles/transitions/BaseTransition.tsx
+++ b/src/styles/transitions/BaseTransition.tsx
@@ -3,19 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 
-export const BaseTransitionPropTypes = {
-  in: PropTypes.bool,
-  children: PropTypes.node.isRequired,
-  timeout: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.shape({
-      appear: PropTypes.number,
-      enter: PropTypes.number,
-      exit: PropTypes.number,
-    }),
-  ]),
-};
-
 interface IBaseTransitionProps
   extends React.ComponentPropsWithoutRef<typeof CSSTransition> {
   classNames: string;
@@ -50,7 +37,16 @@ BaseTransition.defaultProps = {
 };
 
 BaseTransition.propTypes = {
-  ...BaseTransitionPropTypes,
+  in: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  timeout: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
+  ]),
   classNames: PropTypes.string.isRequired,
   delayTimeout: PropTypes.number,
 };

--- a/src/styles/transitions/SlideTransition.js
+++ b/src/styles/transitions/SlideTransition.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import BaseTransition, { BaseTransitionPropTypes } from './BaseTransition';
+import BaseTransition from './BaseTransition';
 
 const SlideTransition = ({ direction, children, ...props }) => {
   return (
@@ -16,7 +16,16 @@ SlideTransition.defaultProps = {
 };
 
 SlideTransition.propTypes = {
-  ...BaseTransitionPropTypes,
+  in: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  timeout: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
+  ]),
   direction: PropTypes.oneOf(['up', 'down', 'right', 'left']),
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,5 @@
       "module": "CommonJS"
     }
   },
-  "include": ["./*.**", "src", "testUtils", "__tests__"]
+  "include": ["./*.**", "src", "testUtils", "__tests__", "scripts"]
 }

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-magic-numbers, no-console */
 
+import { Config, ReactConfig } from '@swc/core';
 import chalk from 'chalk';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import dotenv from 'dotenv';
@@ -120,6 +121,29 @@ const makeFeatureFlags = () => {
   return flags;
 };
 
+export const compilerConfig: Config = {
+  jsc: {
+    target: 'es2015',
+    parser: {
+      syntax: 'typescript',
+      tsx: true,
+      decorators: true,
+      dynamicImport: true,
+    },
+    transform: {
+      legacyDecorator: true,
+      decoratorMetadata: true,
+      react: {
+        runtime: 'automatic',
+      } as ReactConfig,
+    },
+    externalHelpers: true,
+  },
+  env: {
+    targets: '> 0.25%, not dead',
+  },
+};
+
 const config: webpack.Configuration = {
   amd: false,
   entry: ['./src/components/index.tsx'],
@@ -132,35 +156,6 @@ const config: webpack.Configuration = {
   },
   module: {
     rules: [
-      {
-        test: /\.(js|ts)(x?)$/,
-        exclude: /node_modules/,
-        use: {
-          loader: 'swc-loader',
-          options: {
-            jsc: {
-              target: 'es2015',
-              parser: {
-                syntax: 'typescript',
-                tsx: true,
-                decorators: true,
-                dynamicImport: true,
-              },
-              transform: {
-                legacyDecorator: true,
-                decoratorMetadata: true,
-                react: {
-                  runtime: 'automatic',
-                },
-              },
-              externalHelpers: true,
-            },
-            env: {
-              targets: '> 0.25%, not dead',
-            },
-          },
-        },
-      },
       {
         test: /\.m?js/,
         resolve: {

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -17,7 +17,7 @@ import webpack from 'webpack';
 import merge from 'webpack-merge';
 
 import ProxyPlugin from './scripts/webpack/proxyPlugin';
-import common from './webpack.common';
+import common, { compilerConfig } from './webpack.common';
 
 const config: webpack.Configuration = merge(common, {
   mode: 'development',
@@ -75,6 +75,14 @@ const config: webpack.Configuration = merge(common, {
   ],
   module: {
     rules: [
+      {
+        test: /\.(js|ts)(x?)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: require.resolve('swc-loader'),
+          options: compilerConfig,
+        },
+      },
       {
         test: /\.css$/,
         use: ['style-loader', 'css-loader'],


### PR DESCRIPTION
This PR adds a plugin for the `swc` compiler, which strips react component `propTypes` and removes the `prop-types` import when building the production app. We don't need them because they don't run in production anyway, so they just take up extra code.

The savings are not noticeable (~40 KB), but it was an occasion for me to have some fun with `swc`.

Not all possible scenarios are handled (you can see what's handled in the `PropTypesStripper` test), but all the patterns that we use right now work.
In order to make my job easier, I've changed the code that was not following our current pattern, to have everything working smoothly. 👍🏻 