### PR TITLE
clusters: display release details when clicking on release version

### DIFF
--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -147,3 +147,19 @@ export function isClusterUpgradable(
     return false;
   }
 }
+
+export function isClusterUpgrading(cluster: capiv1alpha3.ICluster): boolean {
+  return (
+    capiv1alpha3.isConditionTrue(
+      cluster,
+      capiv1alpha3.conditionTypeUpgrading,
+      capiv1alpha3.withReasonUpgradePending()
+    ) &&
+    capiv1alpha3.isConditionFalse(
+      cluster,
+      capiv1alpha3.conditionTypeUpgrading,
+      capiv1alpha3.withReasonUpgradeNotStarted(),
+      capiv1alpha3.withReasonUpgradeCompleted()
+    )
+  );
+}

--- a/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
@@ -1,0 +1,93 @@
+import { Box, Text } from 'grommet';
+import { relativeDate } from 'lib/helpers';
+import GenericModal from 'Modals/GenericModal';
+import ReleaseDetailsModalSection from 'Modals/ReleaseDetailsModal/ReleaseDetailsModalSection';
+import PropTypes from 'prop-types';
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+import Button from 'UI/Controls/Button';
+import ReleaseComponentLabel from 'UI/Display/Cluster/ReleaseComponentLabel';
+
+const StyledReleaseDetailsModalSection = styled(ReleaseDetailsModalSection)`
+  margin-top: 0;
+`;
+
+export interface IClusterDetailReleaseDetailsModalComponent {
+  name: string;
+  version: string;
+}
+
+interface IClusterDetailReleaseDetailsModalProps {
+  version: string;
+  onClose: () => void;
+  visible?: boolean;
+  creationDate?: string;
+  components?: IClusterDetailReleaseDetailsModalComponent[];
+  releaseNotesURL?: string;
+}
+
+const ClusterDetailReleaseDetailsModal: React.FC<IClusterDetailReleaseDetailsModalProps> = ({
+  version,
+  onClose,
+  visible,
+  creationDate,
+  components,
+  releaseNotesURL,
+}) => {
+  const title = `Details for release v${version}`;
+
+  const sortedComponents = useMemo(() => {
+    if (!components) return [];
+
+    return components.sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    });
+  }, [components]);
+
+  return (
+    <GenericModal
+      footer={<Button onClick={onClose}>Close</Button>}
+      onClose={onClose}
+      title={title}
+      aria-label={title}
+      visible={visible}
+    >
+      <Box direction='column' gap='medium'>
+        <Box>
+          <Text>Released {relativeDate(creationDate)}</Text>
+        </Box>
+
+        {components && (
+          <Box wrap={true} direction='row' gap='xxsmall'>
+            {sortedComponents.map((component) => (
+              <ReleaseComponentLabel
+                key={component.name}
+                name={component.name}
+                version={component.version}
+              />
+            ))}
+          </Box>
+        )}
+
+        {releaseNotesURL && (
+          <StyledReleaseDetailsModalSection title='Release notes'>
+            <a href={releaseNotesURL} rel='noopener noreferrer' target='_blank'>
+              {releaseNotesURL}
+            </a>
+          </StyledReleaseDetailsModalSection>
+        )}
+      </Box>
+    </GenericModal>
+  );
+};
+
+ClusterDetailReleaseDetailsModal.propTypes = {
+  version: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  visible: PropTypes.bool,
+  components: PropTypes.array,
+  creationDate: PropTypes.string,
+  releaseNotesURL: PropTypes.string,
+};
+
+export default ClusterDetailReleaseDetailsModal;

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -1,12 +1,12 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
-import { Text } from 'grommet';
+import { Keyboard, Text } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { useHttpClient } from 'lib/hooks/useHttpClient';
 import { isClusterUpgradable, isClusterUpgrading } from 'MAPI/clusters/utils';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import PropTypes from 'prop-types';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { getProvider, getUserIsAdmin } from 'stores/main/selectors';
 import styled from 'styled-components';
@@ -18,8 +18,28 @@ import ClusterDetailWidget from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterD
 import ClusterDetailWidgetOptionalValue from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue';
 import NotAvailable from 'UI/Display/NotAvailable';
 
+import ClusterDetailReleaseDetailsModal from './ClusterDetailReleaseDetailsModal';
+
 const StyledDot = styled(Dot)`
   padding: 0;
+`;
+
+const VersionLabel = styled(Text)``;
+
+const StyledLink = styled.a`
+  :hover {
+    text-decoration: none;
+
+    ${VersionLabel} {
+      border-bottom: ${({ theme }) =>
+        `${theme.global.borderSize.xsmall} solid ${theme.global.colors['text-strong'].dark}`};
+    }
+  }
+
+  ${VersionLabel} {
+    border-bottom: ${({ theme }) =>
+      `${theme.global.borderSize.xsmall} solid ${theme.global.colors['text-xweak'].dark}`};
+  }
 `;
 
 interface IClusterDetailWidgetReleaseProps
@@ -54,7 +74,7 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
     ? capiv1alpha3.getReleaseVersion(cluster)
     : undefined;
 
-  const k8sVersion = useMemo(() => {
+  const currentRelease = useMemo(() => {
     const formattedReleaseVersion = `v${releaseVersion}`;
 
     const release = releaseList?.items.find(
@@ -62,11 +82,18 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
     );
     if (!release) return undefined;
 
-    const version = releasev1alpha1.getK8sVersion(release);
-    if (typeof version === 'undefined') return '';
+    return release;
+  }, [releaseList?.items, releaseVersion]);
+
+  const k8sVersion = useMemo(() => {
+    if (!releaseList) return undefined;
+    if (!currentRelease) return '';
+
+    const version = releasev1alpha1.getK8sVersion(currentRelease);
+    if (!version) return '';
 
     return version;
-  }, [releaseList?.items, releaseVersion]);
+  }, [releaseList, currentRelease]);
 
   const provider = useSelector(getProvider);
   const isAdmin = useSelector(getUserIsAdmin);
@@ -79,6 +106,33 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
 
     return isClusterUpgradable(cluster, provider, isAdmin, releaseList.items);
   }, [cluster, provider, isAdmin, releaseList]);
+
+  const [versionModalVisible, setVersionModalVisible] = useState(false);
+
+  const handleVersionClick = (
+    e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
+  ) => {
+    e.preventDefault();
+
+    setVersionModalVisible(true);
+  };
+
+  const handleVersionModalClose = () => {
+    setVersionModalVisible(false);
+  };
+
+  const releaseComponents = useMemo(() => {
+    if (!currentRelease) return undefined;
+
+    return [
+      ...currentRelease.spec.components,
+      ...(currentRelease.spec.apps ?? []),
+    ];
+  }, [currentRelease]);
+
+  const releaseNotesURL = currentRelease
+    ? releasev1alpha1.getReleaseNotesURL(currentRelease)
+    : undefined;
 
   return (
     <ClusterDetailWidget
@@ -97,14 +151,22 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
         replaceEmptyValue={false}
       >
         {(value) => (
-          <Text aria-label={`Cluster release version ${value}`}>
-            <i
-              className='fa fa-version-tag'
-              role='presentation'
-              aria-hidden='true'
-            />{' '}
-            {value || <NotAvailable />}
-          </Text>
+          <Keyboard onSpace={handleVersionClick}>
+            <StyledLink
+              href='#'
+              aria-label={`Cluster release version ${value}`}
+              onClick={handleVersionClick}
+            >
+              <Text>
+                <i
+                  className='fa fa-version-tag'
+                  role='presentation'
+                  aria-hidden='true'
+                />
+              </Text>{' '}
+              <VersionLabel>{value || <NotAvailable />}</VersionLabel>
+            </StyledLink>
+          </Keyboard>
         )}
       </ClusterDetailWidgetOptionalValue>
       <StyledDot />
@@ -126,6 +188,17 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
           isUpgrading={isUpgrading}
           isUpgradable={isUpgradable}
           margin={{ left: 'small' }}
+        />
+      )}
+
+      {releaseVersion && (
+        <ClusterDetailReleaseDetailsModal
+          version={releaseVersion}
+          onClose={handleVersionModalClose}
+          visible={versionModalVisible}
+          creationDate={currentRelease?.metadata.creationTimestamp}
+          components={releaseComponents}
+          releaseNotesURL={releaseNotesURL}
         />
       )}
     </ClusterDetailWidget>

--- a/src/components/Modals/ReleaseDetailsModal/ReleaseDetailsModalSection.tsx
+++ b/src/components/Modals/ReleaseDetailsModal/ReleaseDetailsModalSection.tsx
@@ -14,9 +14,10 @@ interface IReleaseDetailsModalSectionProps
 const ReleaseDetailsModalSection: React.FC<IReleaseDetailsModalSectionProps> = ({
   title,
   children,
+  ...props
 }) => {
   return (
-    <Wrapper>
+    <Wrapper {...props}>
       {title && (
         <h5>
           <strong>{title}</strong>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailStatus.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailStatus.tsx
@@ -1,0 +1,62 @@
+import { Box, Text } from 'grommet';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+interface IClusterDetailStatusProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  isDeleting?: boolean;
+  isUpgrading?: boolean;
+  isUpgradable?: boolean;
+}
+
+const ClusterDetailStatus: React.FC<IClusterDetailStatusProps> = ({
+  isDeleting,
+  isUpgrading,
+  isUpgradable,
+  ...props
+}) => {
+  let iconClassName = '';
+  let message = '';
+  let tooltip = '';
+
+  switch (true) {
+    case isDeleting:
+      return null;
+
+    case isUpgrading:
+      iconClassName = 'fa fa-version-upgrade';
+      message = 'Upgrade in progress…';
+      tooltip =
+        'The cluster is currently upgrading. This step usually takes about 30 minutes.';
+      break;
+
+    case isUpgradable:
+      iconClassName = 'fa fa-warning';
+      message = 'Upgrade available';
+      tooltip = `There's a new release version available. Upgrade now to get the latest features.`;
+      break;
+  }
+
+  return (
+    <OverlayTrigger
+      overlay={<Tooltip id='tooltip'>{tooltip}</Tooltip>}
+      placement='top'
+    >
+      <Box aria-label='Cluster status' {...props}>
+        <Text color='status-warning'>
+          <i className={iconClassName} role='presentation' aria-hidden='true' />{' '}
+          {message}
+        </Text>
+      </Box>
+    </OverlayTrigger>
+  );
+};
+
+ClusterDetailStatus.propTypes = {
+  isDeleting: PropTypes.bool,
+  isUpgrading: PropTypes.bool,
+  isUpgradable: PropTypes.bool,
+};
+
+export default ClusterDetailStatus;

--- a/src/model/services/mapi/releasev1alpha1/key.ts
+++ b/src/model/services/mapi/releasev1alpha1/key.ts
@@ -1,5 +1,11 @@
 import { IRelease } from './';
 
+export const annotationReleaseNotesURL = 'giantswarm.io/release-notes';
+
 export function getK8sVersion(cr: IRelease): string | undefined {
   return cr.spec.components.find((c) => c.name === 'kubernetes')?.version;
+}
+
+export function getReleaseNotesURL(cr: IRelease): string | undefined {
+  return cr.metadata.annotations?.[annotationReleaseNotesURL];
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9077

This PR adds:
* modal that displays the release details when clicking on the release version
* upgrading/upgradable status label/icon

Actually upgrading the cluster (and the upgrade options at the bottom of the release details modal) will be coming in the next PR

## Preview

<details>
<summary>Upgrade available</summary>

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/13508038/122551450-48505380-d035-11eb-9308-efe152247a08.png">

</details>

<details>
<summary>Release details</summary>

<img width="663" alt="image" src="https://user-images.githubusercontent.com/13508038/122551515-5f8f4100-d035-11eb-987f-dcfbac7d14c7.png">

</details>