### PR TITLE
clusters: add key pairs tab for the MAPI cluster detail page

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -7,6 +7,7 @@ import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import RoutePath from 'lib/routePath';
 import ClusterDetailApps from 'MAPI/apps/ClusterDetailApps';
 import ClusterDetailIngress from 'MAPI/apps/ClusterDetailIngress';
+import ClusterDetailKeyPairs from 'MAPI/keypairs/ClusterDetailKeyPairs';
 import {
   extractErrorMessage,
   getOrgNamespaceFromOrgName,
@@ -44,6 +45,13 @@ function computePaths(orgName: string, clusterName: string) {
     }),
     Ingress: RoutePath.createUsablePath(
       OrganizationsRoutes.Clusters.Detail.Ingress,
+      {
+        orgId: orgName,
+        clusterId: clusterName,
+      }
+    ),
+    KeyPairs: RoutePath.createUsablePath(
+      OrganizationsRoutes.Clusters.Detail.KeyPairs,
       {
         orgId: orgName,
         clusterId: clusterName,
@@ -203,6 +211,7 @@ const ClusterDetail: React.FC<{}> = () => {
         <Tabs defaultActiveKey={paths.Home} useRoutes={true}>
           <Tab eventKey={paths.Home} title='Overview' />
           <Tab eventKey={paths.Apps} title='Apps' />
+          <Tab eventKey={paths.KeyPairs} title='Key pairs' />
           <Tab eventKey={paths.Ingress} title='Ingress' />
         </Tabs>
         <Switch>
@@ -213,6 +222,10 @@ const ClusterDetail: React.FC<{}> = () => {
                 <ClusterDetailApps releaseVersion={clusterReleaseVersion!} />
               )
             }
+          />
+          <Route
+            path={OrganizationsRoutes.Clusters.Detail.KeyPairs}
+            component={ClusterDetailKeyPairs}
           />
           <Route
             path={OrganizationsRoutes.Clusters.Detail.Ingress}

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairDetailsModal.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairDetailsModal.tsx
@@ -1,0 +1,125 @@
+import { Box, Text } from 'grommet';
+import { formatDate, relativeDate } from 'lib/helpers';
+import GenericModal from 'Modals/GenericModal';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Copyable from 'shared/Copyable';
+import styled from 'styled-components';
+import Button from 'UI/Controls/Button';
+import NotAvailable from 'UI/Display/NotAvailable';
+
+const Label = styled(Text).attrs({
+  color: 'text-weak',
+  size: 'small',
+  margin: { bottom: 'xxsmall' },
+})`
+  text-transform: uppercase;
+`;
+
+interface IClusterDetailKeyPairDetailsModalProps {
+  onClose: () => void;
+  id?: string;
+  commonName?: string;
+  organizations?: string;
+  creationDate?: string;
+  expirationDate?: string;
+  isExpiringSoon?: boolean;
+  description?: string;
+  visible?: boolean;
+}
+
+const ClusterDetailKeyPairDetailsModal: React.FC<IClusterDetailKeyPairDetailsModalProps> = ({
+  id,
+  commonName,
+  organizations,
+  creationDate,
+  expirationDate,
+  isExpiringSoon,
+  description,
+  onClose,
+  visible,
+}) => {
+  const title = `Key pair details`;
+
+  return (
+    <GenericModal
+      footer={<Button onClick={onClose}>Close</Button>}
+      onClose={onClose}
+      title={title}
+      aria-label={title}
+      visible={visible}
+    >
+      <Box direction='column' gap='medium'>
+        <Box>
+          <Label>ID</Label>
+          {id ? (
+            <Copyable copyText={id}>
+              <Text>{id}</Text>
+            </Copyable>
+          ) : (
+            <NotAvailable />
+          )}
+        </Box>
+        <Box>
+          <Label>Common Name (CN)</Label>
+          {commonName ? (
+            <Copyable copyText={commonName}>
+              <Text>{commonName}</Text>
+            </Copyable>
+          ) : (
+            <NotAvailable />
+          )}
+        </Box>
+        <Box>
+          <Label>Certificate Organizations (O)</Label>
+          {organizations ? (
+            <Copyable copyText={organizations}>
+              <Text>{organizations}</Text>
+            </Copyable>
+          ) : (
+            <NotAvailable />
+          )}
+        </Box>
+        <Box>
+          <Label>Created</Label>
+          {creationDate ? (
+            <Text>
+              {formatDate(creationDate)} &ndash; {relativeDate(creationDate)}
+            </Text>
+          ) : (
+            <NotAvailable />
+          )}
+        </Box>
+        <Box>
+          <Label>Expiry</Label>
+          {expirationDate ? (
+            <Text color={isExpiringSoon ? 'status-warning' : undefined}>
+              {formatDate(expirationDate)} &ndash;{' '}
+              {relativeDate(expirationDate)}
+            </Text>
+          ) : (
+            <NotAvailable />
+          )}
+        </Box>
+        <Box>
+          <Label>Description</Label>
+          {description ? <Text>{description}</Text> : <NotAvailable />}
+        </Box>
+      </Box>
+    </GenericModal>
+  );
+};
+
+ClusterDetailKeyPairDetailsModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  id: PropTypes.string,
+  commonName: PropTypes.string,
+  organizations: PropTypes.string,
+  creationDate: PropTypes.string,
+  expirationDate: PropTypes.string,
+  isExpiringSoon: PropTypes.bool,
+  description: PropTypes.string,
+  visible: PropTypes.bool,
+};
+
+export default ClusterDetailKeyPairDetailsModal;

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
@@ -105,16 +105,19 @@ const ClusterDetailKeyPairs: React.FC<IClusterDetailKeyPairsProps> = () => {
     );
   }, [keyPairList, selectedKeyPairSerial]);
 
-  const [selectedKeyPairExpirationDate, isSelectedKeyPairExpiringSoon] =
-    useMemo(() => {
-      if (!selectedKeyPair) return [undefined, false];
+  const [
+    selectedKeyPairExpirationDate,
+    isSelectedKeyPairExpiringSoon,
+  ] = useMemo(() => {
+    if (!selectedKeyPair) return [undefined, false];
 
-      const expirationDate =
-        getKeyPairExpirationDate(selectedKeyPair).toISOString();
-      const isExpiringSoon = isKeyPairExpiringSoon(selectedKeyPair);
+    const expirationDate = getKeyPairExpirationDate(
+      selectedKeyPair
+    ).toISOString();
+    const isExpiringSoon = isKeyPairExpiringSoon(selectedKeyPair);
 
-      return [expirationDate, isExpiringSoon];
-    }, [selectedKeyPair]);
+    return [expirationDate, isExpiringSoon];
+  }, [selectedKeyPair]);
 
   const handleOpenDetails = (serial: string) => () => {
     setSelectedKeyPairSerial(serial);

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
@@ -1,0 +1,173 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import CertificateOrgsLabel from 'Cluster/ClusterDetail/CertificateOrgsLabel';
+import { Box, Text } from 'grommet';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { relativeDate } from 'lib/helpers';
+import { useHttpClient } from 'lib/hooks/useHttpClient';
+import { extractErrorMessage } from 'MAPI/organizations/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import * as legacyKeyPairs from 'model/services/mapi/legacy/keypairs';
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router';
+import Copyable from 'shared/Copyable';
+import useSWR from 'swr';
+import Button from 'UI/Controls/Button';
+import ClusterDetailWidgetLoadingPlaceholder from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetLoadingPlaceholder';
+import NotAvailable from 'UI/Display/NotAvailable';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from 'UI/Display/Table';
+import Truncated from 'UI/Util/Truncated';
+
+import { getKeyPairExpirationDate, isKeyPairExpiringSoon } from './utils';
+
+const LOADING_COMPONENTS = new Array(4).fill(0);
+
+function formatCommonName(value: string) {
+  return (
+    <Copyable copyText={value}>
+      <Truncated numStart={20} numEnd={40}>
+        {value}
+      </Truncated>
+    </Copyable>
+  );
+}
+
+function formatOrganization(value: string) {
+  if (!value) return <NotAvailable />;
+
+  return (
+    <Copyable copyText={value}>
+      <CertificateOrgsLabel value={value} />
+    </Copyable>
+  );
+}
+
+const formatExpirationDate = (keyPair: legacyKeyPairs.IKeyPair) => {
+  const expirationDate = getKeyPairExpirationDate(keyPair);
+  const isExpiringSoon = isKeyPairExpiringSoon(keyPair);
+
+  return (
+    <Text color={isExpiringSoon ? 'status-warning' : undefined}>
+      {relativeDate(expirationDate)}
+    </Text>
+  );
+};
+
+interface IClusterDetailKeyPairsProps {}
+
+const ClusterDetailKeyPairs: React.FC<IClusterDetailKeyPairsProps> = () => {
+  const { clusterId } = useParams<{ clusterId: string; orgId: string }>();
+
+  const keyPairListClient = useHttpClient();
+  const auth = useAuthProvider();
+
+  const {
+    data: keyPairList,
+    error: keyPairListError,
+    isValidating: keyPairListIsValidating,
+  } = useSWR<legacyKeyPairs.IKeyPairList, GenericResponseError>(
+    legacyKeyPairs.getKeyPairListKey(clusterId),
+    () => legacyKeyPairs.getKeyPairList(keyPairListClient, auth, clusterId)
+  );
+
+  const keyPairListIsLoading =
+    typeof keyPairList === 'undefined' &&
+    typeof keyPairListError === 'undefined' &&
+    keyPairListIsValidating;
+
+  useEffect(() => {
+    if (keyPairListError) {
+      new FlashMessage(
+        'There was a problem loading key pairs.',
+        messageType.ERROR,
+        messageTTL.LONG,
+        extractErrorMessage(keyPairListError)
+      );
+
+      ErrorReporter.getInstance().notify(keyPairListError);
+    }
+  }, [keyPairListError]);
+
+  return (
+    <Box>
+      <Box>
+        <Text>
+          Key pairs consist of an RSA private key and certificate, signed by the
+          certificate authority (CA) belonging to this cluster. They are used
+          for access to the cluster via the Kubernetes API.
+        </Text>
+      </Box>
+      <Table width='100%' margin={{ top: 'medium' }}>
+        <TableHeader>
+          <TableRow>
+            <TableCell>Common Name (CN)</TableCell>
+            <TableCell>Organization (O)</TableCell>
+            <TableCell>Created</TableCell>
+            <TableCell>Expiry</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {keyPairListIsLoading &&
+            LOADING_COMPONENTS.map((_, i) => (
+              <TableRow key={i}>
+                <TableCell size='large'>
+                  <ClusterDetailWidgetLoadingPlaceholder width={400} />
+                </TableCell>
+                <TableCell size='small'>
+                  <ClusterDetailWidgetLoadingPlaceholder />
+                </TableCell>
+                <TableCell size='small'>
+                  <ClusterDetailWidgetLoadingPlaceholder />
+                </TableCell>
+                <TableCell size='small'>
+                  <ClusterDetailWidgetLoadingPlaceholder />
+                </TableCell>
+              </TableRow>
+            ))}
+
+          {!keyPairListIsLoading &&
+            keyPairList!.items.map((keyPair) => (
+              <TableRow key={keyPair.serial_number}>
+                <TableCell size='large'>
+                  {formatCommonName(keyPair.common_name)}
+                </TableCell>
+                <TableCell size='small'>
+                  {formatOrganization(keyPair.certificate_organizations)}
+                </TableCell>
+                <TableCell size='small'>
+                  {relativeDate(keyPair.create_date)}
+                </TableCell>
+                <TableCell size='small'>
+                  {formatExpirationDate(keyPair)}
+                </TableCell>
+                <TableCell size='xsmall'>
+                  <Button bsSize='sm'>Details</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+
+          {!keyPairListIsLoading && keyPairList!.items.length === 0 && (
+            <TableRow>
+              <TableCell>
+                <Text color='text-weak'>
+                  There are no key pairs to display.
+                </Text>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};
+
+ClusterDetailKeyPairs.propTypes = {};
+
+export default ClusterDetailKeyPairs;

--- a/src/components/MAPI/keypairs/utils.ts
+++ b/src/components/MAPI/keypairs/utils.ts
@@ -1,15 +1,29 @@
 import add from 'date-fns/fp/add';
 import compareAsc from 'date-fns/fp/compareAsc';
+import differenceInHours from 'date-fns/fp/differenceInHours';
 import toDate from 'date-fns-tz/toDate';
 import * as keypairs from 'model/services/mapi/legacy/keypairs';
 
-export function isKeyPairActive(keyPair: keypairs.IKeyPair) {
+export function getKeyPairExpirationDate(keyPair: keypairs.IKeyPair) {
   const creationDate = toDate(keyPair.create_date, { timeZone: 'UTC' });
   const expirationDate = add({
     hours: keyPair.ttl,
   })(creationDate);
 
+  return expirationDate;
+}
+
+export function isKeyPairActive(keyPair: keypairs.IKeyPair) {
+  const expirationDate = getKeyPairExpirationDate(keyPair);
   const now = toDate(new Date(), { timeZone: 'UTC' });
 
   return compareAsc(expirationDate)(now) < 0;
+}
+
+export function isKeyPairExpiringSoon(keyPair: keypairs.IKeyPair) {
+  const expirationDate = getKeyPairExpirationDate(keyPair);
+  const now = toDate(new Date(), { timeZone: 'UTC' });
+
+  // eslint-disable-next-line no-magic-numbers
+  return differenceInHours(now)(expirationDate) < 24;
 }

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         class="StyledBox-sc-13pk1d4-0 eITwkI"
       >
         <div
-          class="sc-bXTfsO iBZYDH sc-cOLXIz fyvzqI"
+          class="sc-bXTfsO iBZYDH sc-iMrple ksYbfI"
         >
           <span
             aria-label="35 dogs"
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-iMrple jAtTaO"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-fDMmKd etDSMI"
       >
         dogs
       </span>
@@ -48,7 +48,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         class="StyledBox-sc-13pk1d4-0 eITwkI"
       >
         <div
-          class="sc-bXTfsO iBZYDH sc-cOLXIz fyvzqI"
+          class="sc-bXTfsO iBZYDH sc-iMrple ksYbfI"
         >
           <span
             aria-label="1 dog"
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-iMrple jAtTaO"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-fDMmKd etDSMI"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 dLeNOM"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-fDMmKd etDSMI"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-lVUNM hWEZKB"
         >
           Some widget
         </span>
@@ -47,7 +47,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 kYALZS"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-fDMmKd etDSMI"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-lVUNM hWEZKB"
         >
           Some widget
         </span>

--- a/src/components/shared/Copyable.tsx
+++ b/src/components/shared/Copyable.tsx
@@ -1,3 +1,4 @@
+import { Keyboard } from 'grommet';
 import useCopyToClipboard from 'lib/hooks/useCopyToClipboard';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -14,17 +15,16 @@ const TooltipWrapper = styled.div`
 `;
 
 const Wrapper = styled.div`
-  .copyable {
-    padding-right: 20px;
-    position: relative;
-    overflow: inherit;
-    text-overflow: inherit;
-    display: inherit;
+  padding-right: 20px;
+  position: relative;
+  overflow: inherit;
+  text-overflow: inherit;
+  display: inherit;
 
-    &:hover {
-      ${TooltipWrapper} {
-        opacity: 0.7;
-      }
+  &:hover,
+  &:focus-visible {
+    ${TooltipWrapper} {
+      opacity: 0.7;
     }
   }
 `;
@@ -51,32 +51,41 @@ const Copyable: React.FC<ICopyableProps> = ({ children, copyText }) => {
     setClipboardContent(null);
   };
 
-  return (
-    <Wrapper
-      onClick={handleCopyToClipboard}
-      onMouseLeave={handleDisplayCopyingDone}
-      style={{ cursor: 'pointer' }}
-      title='Copy content to clipboard'
-    >
-      <Content>{children}</Content>
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.preventDefault();
 
-      <TooltipWrapper>
-        {hasContentInClipboard ? (
-          <i
-            aria-hidden='true'
-            className='fa fa-done'
-            title='Content copied to clipboard'
-          />
-        ) : (
-          <OverlayTrigger
-            overlay={<Tooltip id='tooltip'>Copy to clipboard.</Tooltip>}
-            placement='top'
-          >
-            <i aria-hidden='true' className='fa fa-content-copy' />
-          </OverlayTrigger>
-        )}
-      </TooltipWrapper>
-    </Wrapper>
+    handleCopyToClipboard();
+  };
+
+  return (
+    <Keyboard onSpace={handleKeyDown} onEnter={handleKeyDown}>
+      <Wrapper
+        onClick={handleCopyToClipboard}
+        onMouseLeave={handleDisplayCopyingDone}
+        style={{ cursor: 'pointer' }}
+        title='Copy content to clipboard'
+        tabIndex={0}
+      >
+        <Content>{children}</Content>
+
+        <TooltipWrapper>
+          {hasContentInClipboard ? (
+            <i
+              aria-hidden='true'
+              className='fa fa-done'
+              title='Content copied to clipboard'
+            />
+          ) : (
+            <OverlayTrigger
+              overlay={<Tooltip id='tooltip'>Copy to clipboard.</Tooltip>}
+              placement='top'
+            >
+              <i aria-hidden='true' className='fa fa-content-copy' />
+            </OverlayTrigger>
+          )}
+        </TooltipWrapper>
+      </Wrapper>
+    </Keyboard>
   );
 };
 

--- a/src/lib/helpers.tsx
+++ b/src/lib/helpers.tsx
@@ -204,7 +204,7 @@ export function compareDates(
  * @param date
  */
 // TODO(axbarsan): Refactor a part of this into a UI component.
-export function relativeDate(date?: string): ReactElement {
+export function relativeDate(date?: string | number | Date): ReactElement {
   if (!date) {
     return <NotAvailable />;
   }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/341

This PR adds a read-only GUI for key pairs. It behaves pretty much like the old one, but you can't create key pairs.

The PR also includes a fix for the `Copyable` component, as well as some keyboard navigation improvements for it.

## Preview

<details>
<summary>Random keypair list</summary>

<img width="1309" alt="image" src="https://user-images.githubusercontent.com/13508038/122728435-6eb20100-d278-11eb-9f74-3abd439f2f44.png">

</details>

<details>
<summary>Some details</summary>

<img width="646" alt="image" src="https://user-images.githubusercontent.com/13508038/122728518-838e9480-d278-11eb-8f94-b9a07b82c14d.png">

</details>

<details>
<summary>Nothing to display</summary>

<img width="1243" alt="image" src="https://user-images.githubusercontent.com/13508038/122728642-a15bf980-d278-11eb-8d0a-b8712af2405a.png">

</details>