### PR TITLE
clusters: add support for upgrading clusters using the MAPI cluster detail page

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/utils.ts
+++ b/src/components/MAPI/clusters/ClusterDetail/utils.ts
@@ -136,3 +136,27 @@ export function computeControlPlaneNodesStats(
 
   return stats;
 }
+
+export async function updateClusterReleaseVersion(
+  httpClient: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  name: string,
+  newVersion: string
+) {
+  const cluster = await capiv1alpha3.getCluster(
+    httpClient,
+    auth,
+    namespace,
+    name
+  );
+  const releaseVersion = capiv1alpha3.getReleaseVersion(cluster);
+  if (releaseVersion === newVersion) {
+    return cluster;
+  }
+
+  cluster.metadata.labels ??= {};
+  cluster.metadata.labels[capiv1alpha3.labelReleaseVersion] = newVersion;
+
+  return capiv1alpha3.updateCluster(httpClient, auth, cluster);
+}

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -1,5 +1,5 @@
 import ErrorReporter from 'lib/errors/ErrorReporter';
-import { IRelease, ReleaseHelper } from 'lib/ReleaseHelper';
+import * as releasesUtils from 'MAPI/releases/utils';
 import { IMachineType } from 'MAPI/utils';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
@@ -117,28 +117,12 @@ export function isClusterUpgradable(
   if (!releaseVersion) return false;
 
   try {
-    const mappedReleases = releases.reduce(
-      (acc: Record<string, IRelease>, r: releasev1alpha1.IRelease) => {
-        // Remove the `v` prefix.
-        const normalizedVersion = r.metadata.name.slice(1);
-
-        acc[normalizedVersion] = {
-          version: normalizedVersion,
-          active: r.spec.state === 'active',
-        };
-
-        return acc;
-      },
-      {}
-    );
-
-    const releaseHelper = new ReleaseHelper({
-      availableReleases: mappedReleases,
+    const releaseHelper = releasesUtils.getReleaseHelper(
+      releaseVersion,
       provider,
-      currentReleaseVersion: releaseVersion,
       isAdmin,
-      ignorePreReleases: true,
-    });
+      releases
+    );
 
     return releaseHelper.getNextVersion() !== null;
   } catch (err) {

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -147,3 +147,15 @@ export function isClusterUpgrading(cluster: capiv1alpha3.ICluster): boolean {
     )
   );
 }
+
+export function isClusterCreating(cluster: capiv1alpha3.ICluster): boolean {
+  return (
+    capiv1alpha3.isConditionTrue(cluster, capiv1alpha3.conditionTypeCreating) &&
+    capiv1alpha3.isConditionFalse(
+      cluster,
+      capiv1alpha3.conditionTypeCreating,
+      capiv1alpha3.withReasonCreationCompleted(),
+      capiv1alpha3.withReasonExistingObject()
+    )
+  );
+}

--- a/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
@@ -7,12 +7,14 @@ import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
 import ReleaseComponentLabel from 'UI/Display/Cluster/ReleaseComponentLabel';
+import ClusterDetailReleaseDetailsUpgradeOptions from 'UI/Display/MAPI/releases/ClusterDetailReleaseDetailsUpgradeOptions';
+import * as ui from 'UI/Display/MAPI/releases/types';
 
 const StyledReleaseDetailsModalSection = styled(ReleaseDetailsModalSection)`
   margin-top: 0;
 `;
 
-export interface IClusterDetailReleaseDetailsModalComponent {
+interface IClusterDetailReleaseDetailsModalComponent {
   name: string;
   version: string;
 }
@@ -20,19 +22,23 @@ export interface IClusterDetailReleaseDetailsModalComponent {
 interface IClusterDetailReleaseDetailsModalProps {
   version: string;
   onClose: () => void;
+  onUpgradeVersionSelect: (version: string) => void;
   visible?: boolean;
   creationDate?: string;
   components?: IClusterDetailReleaseDetailsModalComponent[];
   releaseNotesURL?: string;
+  supportedUpgradeVersions?: ui.IReleaseVersion[];
 }
 
 const ClusterDetailReleaseDetailsModal: React.FC<IClusterDetailReleaseDetailsModalProps> = ({
   version,
   onClose,
+  onUpgradeVersionSelect,
   visible,
   creationDate,
   components,
   releaseNotesURL,
+  supportedUpgradeVersions,
 }) => {
   const title = `Details for release v${version}`;
 
@@ -82,6 +88,15 @@ const ClusterDetailReleaseDetailsModal: React.FC<IClusterDetailReleaseDetailsMod
             </Text>
           </StyledReleaseDetailsModalSection>
         )}
+
+        {supportedUpgradeVersions && supportedUpgradeVersions.length > 0 && (
+          <StyledReleaseDetailsModalSection title='Upgrade options'>
+            <ClusterDetailReleaseDetailsUpgradeOptions
+              supportedVersions={supportedUpgradeVersions}
+              onVersionClick={onUpgradeVersionSelect}
+            />
+          </StyledReleaseDetailsModalSection>
+        )}
       </Box>
     </GenericModal>
   );
@@ -90,10 +105,12 @@ const ClusterDetailReleaseDetailsModal: React.FC<IClusterDetailReleaseDetailsMod
 ClusterDetailReleaseDetailsModal.propTypes = {
   version: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  onUpgradeVersionSelect: PropTypes.func.isRequired,
   visible: PropTypes.bool,
   components: PropTypes.array,
   creationDate: PropTypes.string,
   releaseNotesURL: PropTypes.string,
+  supportedUpgradeVersions: PropTypes.array,
 };
 
 export default ClusterDetailReleaseDetailsModal;

--- a/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
@@ -71,9 +71,15 @@ const ClusterDetailReleaseDetailsModal: React.FC<IClusterDetailReleaseDetailsMod
 
         {releaseNotesURL && (
           <StyledReleaseDetailsModalSection title='Release notes'>
-            <a href={releaseNotesURL} rel='noopener noreferrer' target='_blank'>
-              {releaseNotesURL}
-            </a>
+            <Text>
+              <a
+                href={releaseNotesURL}
+                rel='noopener noreferrer'
+                target='_blank'
+              >
+                {releaseNotesURL}
+              </a>
+            </Text>
           </StyledReleaseDetailsModalSection>
         )}
       </Box>

--- a/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
@@ -1,0 +1,105 @@
+import GenericModal from 'Modals/GenericModal';
+import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import Button from 'UI/Controls/Button';
+import ClusterDetailUpgradeModalDisclaimer from 'UI/Display/MAPI/releases/ClusterDetailUpgradeModalDisclaimer';
+
+enum ClusterDetailUpgradeModalPane {
+  Disclaimer,
+  Changelog,
+}
+
+function formatReleaseVersion(release: releasev1alpha1.IRelease) {
+  // Remove leading `v`.
+  return release.metadata.name.slice(1);
+}
+
+function formatModalTitle(
+  pane: ClusterDetailUpgradeModalPane,
+  fromRelease: releasev1alpha1.IRelease,
+  toRelease: releasev1alpha1.IRelease
+) {
+  switch (pane) {
+    case ClusterDetailUpgradeModalPane.Disclaimer:
+      return `Upgrade to ${formatReleaseVersion(toRelease)}`;
+    case ClusterDetailUpgradeModalPane.Changelog:
+      return `Changes from ${formatReleaseVersion(
+        fromRelease
+      )} to ${formatReleaseVersion(toRelease)}`;
+    default:
+      return '';
+  }
+}
+
+function formatPrimaryButtonText(pane: ClusterDetailUpgradeModalPane) {
+  switch (pane) {
+    case ClusterDetailUpgradeModalPane.Disclaimer:
+      return 'Inspect changes';
+    case ClusterDetailUpgradeModalPane.Changelog:
+      return 'Start upgrade';
+    default:
+      return '';
+  }
+}
+
+interface IClusterDetailUpgradeModalProps {
+  fromRelease: releasev1alpha1.IRelease;
+  toRelease: releasev1alpha1.IRelease;
+  onClose?: () => void;
+  visible?: boolean;
+}
+
+const ClusterDetailUpgradeModal: React.FC<IClusterDetailUpgradeModalProps> = ({
+  fromRelease,
+  toRelease,
+  visible,
+  onClose,
+}) => {
+  const [currentPane, setCurrentPane] = useState(
+    ClusterDetailUpgradeModalPane.Disclaimer
+  );
+
+  const title = formatModalTitle(currentPane, fromRelease, toRelease);
+  const primaryButtonText = formatPrimaryButtonText(currentPane);
+
+  const handlePrimaryButtonClick = () => {
+    if (currentPane === ClusterDetailUpgradeModalPane.Disclaimer) {
+      setCurrentPane(currentPane + 1);
+    }
+  };
+
+  return (
+    <GenericModal
+      footer={
+        <>
+          {primaryButtonText && (
+            <Button bsStyle='primary' onClick={handlePrimaryButtonClick}>
+              {primaryButtonText}
+            </Button>
+          )}
+          <Button onClick={onClose}>Cancel</Button>
+        </>
+      }
+      onClose={onClose}
+      title={title}
+      aria-label={title}
+      visible={visible}
+    >
+      {currentPane === ClusterDetailUpgradeModalPane.Disclaimer && (
+        <ClusterDetailUpgradeModalDisclaimer />
+      )}
+    </GenericModal>
+  );
+};
+
+ClusterDetailUpgradeModal.propTypes = {
+  fromRelease: (PropTypes.object as PropTypes.Requireable<releasev1alpha1.IRelease>)
+    .isRequired,
+  toRelease: (PropTypes.object as PropTypes.Requireable<releasev1alpha1.IRelease>)
+    .isRequired,
+  onClose: PropTypes.func,
+  visible: PropTypes.bool,
+};
+
+export default ClusterDetailUpgradeModal;

--- a/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
@@ -1,9 +1,12 @@
 import GenericModal from 'Modals/GenericModal';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import Button from 'UI/Controls/Button';
+import ClusterDetailUpgradeModalChangelog from 'UI/Display/MAPI/releases/ClusterDetailUpgradeModalChangelog';
 import ClusterDetailUpgradeModalDisclaimer from 'UI/Display/MAPI/releases/ClusterDetailUpgradeModalDisclaimer';
+
+import { getReleaseComponentsDiff } from './utils';
 
 enum ClusterDetailUpgradeModalPane {
   Disclaimer,
@@ -43,6 +46,28 @@ function formatPrimaryButtonText(pane: ClusterDetailUpgradeModalPane) {
   }
 }
 
+function formatVisiblePane(
+  pane: ClusterDetailUpgradeModalPane,
+  fromRelease: releasev1alpha1.IRelease,
+  toRelease: releasev1alpha1.IRelease
+) {
+  switch (pane) {
+    case ClusterDetailUpgradeModalPane.Disclaimer:
+      return <ClusterDetailUpgradeModalDisclaimer />;
+
+    case ClusterDetailUpgradeModalPane.Changelog:
+      return (
+        <ClusterDetailUpgradeModalChangelog
+          releaseNotesURL={releasev1alpha1.getReleaseNotesURL(toRelease)}
+          componentsDiff={getReleaseComponentsDiff(fromRelease, toRelease)}
+        />
+      );
+
+    default:
+      return null;
+  }
+}
+
 interface IClusterDetailUpgradeModalProps {
   fromRelease: releasev1alpha1.IRelease;
   toRelease: releasev1alpha1.IRelease;
@@ -60,8 +85,15 @@ const ClusterDetailUpgradeModal: React.FC<IClusterDetailUpgradeModalProps> = ({
     ClusterDetailUpgradeModalPane.Disclaimer
   );
 
-  const title = formatModalTitle(currentPane, fromRelease, toRelease);
+  const title = useMemo(
+    () => formatModalTitle(currentPane, fromRelease, toRelease),
+    [currentPane, fromRelease, toRelease]
+  );
   const primaryButtonText = formatPrimaryButtonText(currentPane);
+  const visiblePane = useMemo(
+    () => formatVisiblePane(currentPane, fromRelease, toRelease),
+    [currentPane, fromRelease, toRelease]
+  );
 
   const handlePrimaryButtonClick = () => {
     if (currentPane === ClusterDetailUpgradeModalPane.Disclaimer) {
@@ -86,9 +118,7 @@ const ClusterDetailUpgradeModal: React.FC<IClusterDetailUpgradeModalProps> = ({
       aria-label={title}
       visible={visible}
     >
-      {currentPane === ClusterDetailUpgradeModalPane.Disclaimer && (
-        <ClusterDetailUpgradeModalDisclaimer />
-      )}
+      {visiblePane}
     </GenericModal>
   );
 };

--- a/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
@@ -71,6 +71,7 @@ function formatVisiblePane(
 interface IClusterDetailUpgradeModalProps {
   fromRelease: releasev1alpha1.IRelease;
   toRelease: releasev1alpha1.IRelease;
+  onUpgrade: () => Promise<void>;
   onClose?: () => void;
   visible?: boolean;
 }
@@ -78,6 +79,7 @@ interface IClusterDetailUpgradeModalProps {
 const ClusterDetailUpgradeModal: React.FC<IClusterDetailUpgradeModalProps> = ({
   fromRelease,
   toRelease,
+  onUpgrade,
   visible,
   onClose,
 }) => {
@@ -96,8 +98,13 @@ const ClusterDetailUpgradeModal: React.FC<IClusterDetailUpgradeModalProps> = ({
   );
 
   const handlePrimaryButtonClick = () => {
-    if (currentPane === ClusterDetailUpgradeModalPane.Disclaimer) {
-      setCurrentPane(currentPane + 1);
+    switch (currentPane) {
+      case ClusterDetailUpgradeModalPane.Disclaimer:
+        setCurrentPane(currentPane + 1);
+        break;
+      case ClusterDetailUpgradeModalPane.Changelog:
+        onUpgrade();
+        break;
     }
   };
 
@@ -128,6 +135,7 @@ ClusterDetailUpgradeModal.propTypes = {
     .isRequired,
   toRelease: (PropTypes.object as PropTypes.Requireable<releasev1alpha1.IRelease>)
     .isRequired,
+  onUpgrade: PropTypes.func.isRequired,
   onClose: PropTypes.func,
   visible: PropTypes.bool,
 };

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -190,6 +190,14 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
     setUpgradeModalVisible(true);
   };
 
+  const handleUpgradeVersionSelect = (version: string) => {
+    if (!currentRelease) return;
+
+    handleVersionModalClose();
+    setTargetVersion(version);
+    setUpgradeModalVisible(true);
+  };
+
   const upgradeCluster = async () => {
     if (!cluster) return;
 
@@ -305,6 +313,10 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
           creationDate={currentRelease?.metadata.creationTimestamp}
           components={releaseComponents}
           releaseNotesURL={releaseNotesURL}
+          supportedUpgradeVersions={
+            !isCreating ? supportedUpgradeVersions : undefined
+          }
+          onUpgradeVersionSelect={handleUpgradeVersionSelect}
         />
       )}
 

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -1,8 +1,9 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
-import { Keyboard, Text } from 'grommet';
+import { Box, Keyboard, Text } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { useHttpClient } from 'lib/hooks/useHttpClient';
-import { isClusterUpgradable, isClusterUpgrading } from 'MAPI/clusters/utils';
+import { isClusterCreating, isClusterUpgrading } from 'MAPI/clusters/utils';
+import * as releasesUtils from 'MAPI/releases/utils';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import PropTypes from 'prop-types';
@@ -12,13 +13,16 @@ import { getProvider, getUserIsAdmin } from 'stores/main/selectors';
 import styled from 'styled-components';
 import { Dot } from 'styles';
 import useSWR from 'swr';
+import Button from 'UI/Controls/Button';
 import KubernetesVersionLabel from 'UI/Display/Cluster/KubernetesVersionLabel';
 import ClusterDetailStatus from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailStatus';
 import ClusterDetailWidget from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget';
 import ClusterDetailWidgetOptionalValue from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue';
+import * as ui from 'UI/Display/MAPI/releases/types';
 import NotAvailable from 'UI/Display/NotAvailable';
 
 import ClusterDetailReleaseDetailsModal from './ClusterDetailReleaseDetailsModal';
+import ClusterDetailUpgradeModal from './ClusterDetailUpgradeModal';
 
 const StyledDot = styled(Dot)`
   padding: 0;
@@ -98,14 +102,28 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
   const provider = useSelector(getProvider);
   const isAdmin = useSelector(getUserIsAdmin);
 
+  const supportedUpgradeVersions: ui.IReleaseVersion[] = useMemo(() => {
+    if (!releaseList || !releaseVersion) return [];
+
+    return releasesUtils.getSupportedUpgradeVersions(
+      releaseVersion,
+      provider,
+      isAdmin,
+      releaseList.items
+    );
+  }, [isAdmin, provider, releaseList, releaseVersion]);
+
+  const nextVersion = useMemo(() => {
+    return supportedUpgradeVersions.find(
+      (r) => r.status !== ui.ReleaseVersionStatus.PreRelease
+    )?.version;
+  }, [supportedUpgradeVersions]);
+
   const isDeleting =
     cluster && typeof cluster.metadata.deletionTimestamp !== 'undefined';
   const isUpgrading = cluster && isClusterUpgrading(cluster);
-  const isUpgradable = useMemo(() => {
-    if (!releaseList || !cluster) return false;
-
-    return isClusterUpgradable(cluster, provider, isAdmin, releaseList.items);
-  }, [cluster, provider, isAdmin, releaseList]);
+  const isUpgradable = typeof nextVersion !== 'undefined';
+  const isCreating = cluster && isClusterCreating(cluster);
 
   const [versionModalVisible, setVersionModalVisible] = useState(false);
 
@@ -134,61 +152,90 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
     ? releasev1alpha1.getReleaseNotesURL(currentRelease)
     : undefined;
 
+  const [targetVersion, setTargetVersion] = useState('');
+  const targetRelease = useMemo(() => {
+    if (!releaseList) return undefined;
+
+    return releaseList.items.find(
+      (v) => v.metadata.name.slice(1) === targetVersion
+    );
+  }, [releaseList, targetVersion]);
+
+  const [upgradeModalVisible, setUpgradeModalVisible] = useState(false);
+
+  const handleUpgradeModalClose = () => {
+    setUpgradeModalVisible(false);
+
+    /**
+     * Reset target version only after modal closes,
+     * to prevent flashes in the modal's content
+     */
+    setTimeout(() => {
+      setTargetVersion('');
+      // eslint-disable-next-line no-magic-numbers
+    }, 200);
+  };
+
+  const handleUpgradeButtonClick = () => {
+    if (!currentRelease || !nextVersion) return;
+
+    setTargetVersion(nextVersion);
+    setUpgradeModalVisible(true);
+  };
+
   return (
-    <ClusterDetailWidget
-      title='Release'
-      inline={true}
-      contentProps={{
-        direction: 'row',
-        gap: 'xsmall',
-        wrap: true,
-        align: 'center',
-      }}
-      {...props}
-    >
-      <ClusterDetailWidgetOptionalValue
-        value={releaseVersion}
-        replaceEmptyValue={false}
-      >
-        {(value) => (
-          <Keyboard onSpace={handleVersionClick}>
-            <StyledLink
-              href='#'
-              aria-label={`Cluster release version ${value}`}
-              onClick={handleVersionClick}
-            >
-              <Text>
-                <i
-                  className='fa fa-version-tag'
-                  role='presentation'
-                  aria-hidden='true'
-                />
-              </Text>{' '}
-              <VersionLabel>{value || <NotAvailable />}</VersionLabel>
-            </StyledLink>
-          </Keyboard>
-        )}
-      </ClusterDetailWidgetOptionalValue>
-      <StyledDot />
-      <ClusterDetailWidgetOptionalValue
-        value={k8sVersion}
-        replaceEmptyValue={false}
-      >
-        {(value) => (
-          <KubernetesVersionLabel
-            hidePatchVersion={false}
-            version={value as string}
+    <ClusterDetailWidget title='Release' inline={true} {...props}>
+      <Box direction='row' gap='xsmall' wrap={true} align='center'>
+        <ClusterDetailWidgetOptionalValue
+          value={releaseVersion}
+          replaceEmptyValue={false}
+        >
+          {(value) => (
+            <Keyboard onSpace={handleVersionClick}>
+              <StyledLink
+                href='#'
+                aria-label={`Cluster release version ${value}`}
+                onClick={handleVersionClick}
+              >
+                <Text>
+                  <i
+                    className='fa fa-version-tag'
+                    role='presentation'
+                    aria-hidden='true'
+                  />
+                </Text>{' '}
+                <VersionLabel>{value || <NotAvailable />}</VersionLabel>
+              </StyledLink>
+            </Keyboard>
+          )}
+        </ClusterDetailWidgetOptionalValue>
+        <StyledDot />
+        <ClusterDetailWidgetOptionalValue
+          value={k8sVersion}
+          replaceEmptyValue={false}
+        >
+          {(value) => (
+            <KubernetesVersionLabel
+              hidePatchVersion={false}
+              version={value as string}
+            />
+          )}
+        </ClusterDetailWidgetOptionalValue>
+
+        {cluster && (
+          <ClusterDetailStatus
+            isDeleting={isDeleting}
+            isUpgrading={isUpgrading}
+            isUpgradable={isUpgradable}
+            margin={{ left: 'small' }}
           />
         )}
-      </ClusterDetailWidgetOptionalValue>
+      </Box>
 
-      {cluster && (
-        <ClusterDetailStatus
-          isDeleting={isDeleting}
-          isUpgrading={isUpgrading}
-          isUpgradable={isUpgradable}
-          margin={{ left: 'small' }}
-        />
+      {!isCreating && isUpgradable && (
+        <Box margin={{ top: 'small' }}>
+          <Button onClick={handleUpgradeButtonClick}>Upgrade cluster…</Button>
+        </Box>
       )}
 
       {releaseVersion && (
@@ -199,6 +246,15 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
           creationDate={currentRelease?.metadata.creationTimestamp}
           components={releaseComponents}
           releaseNotesURL={releaseNotesURL}
+        />
+      )}
+
+      {currentRelease && targetRelease && (
+        <ClusterDetailUpgradeModal
+          visible={upgradeModalVisible}
+          onClose={handleUpgradeModalClose}
+          fromRelease={currentRelease}
+          toRelease={targetRelease}
         />
       )}
     </ClusterDetailWidget>

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -132,6 +132,8 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
   const isUpgradable = typeof nextVersion !== 'undefined';
   const isCreating = cluster && isClusterCreating(cluster);
 
+  const canUpgrade = !isUpgrading && !isCreating && isUpgradable;
+
   const [versionModalVisible, setVersionModalVisible] = useState(false);
 
   const handleVersionClick = (
@@ -299,7 +301,7 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
         )}
       </Box>
 
-      {!isCreating && isUpgradable && (
+      {canUpgrade && (
         <Box margin={{ top: 'small' }}>
           <Button onClick={handleUpgradeButtonClick}>Upgrade cluster…</Button>
         </Box>
@@ -314,7 +316,7 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
           components={releaseComponents}
           releaseNotesURL={releaseNotesURL}
           supportedUpgradeVersions={
-            !isCreating ? supportedUpgradeVersions : undefined
+            canUpgrade ? supportedUpgradeVersions : undefined
           }
           onUpgradeVersionSelect={handleUpgradeVersionSelect}
         />

--- a/src/components/MAPI/releases/__tests__/utils.ts
+++ b/src/components/MAPI/releases/__tests__/utils.ts
@@ -1,0 +1,276 @@
+import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
+import * as releasev1alpha1Mocks from 'testUtils/mockHttpCalls/releasev1alpha1';
+import * as ui from 'UI/Display/MAPI/releases/types';
+
+import { getReleaseComponentsDiff } from '../utils';
+
+describe('releases::utils', () => {
+  describe('getReleaseComponentsDiff', () => {
+    it('gets an empty diff for 2 empty releases', () => {
+      const a: releasev1alpha1.IRelease = {
+        ...releasev1alpha1Mocks.v13_1_0,
+        spec: {
+          ...releasev1alpha1Mocks.v13_1_0.spec,
+          components: [],
+          apps: [],
+        },
+      };
+
+      const diff = getReleaseComponentsDiff(a, a);
+      expect(diff).toStrictEqual({
+        changes: [],
+      });
+    });
+
+    it('finds changed versions between releases', () => {
+      const a: releasev1alpha1.IRelease = {
+        ...releasev1alpha1Mocks.v13_1_0,
+        spec: {
+          ...releasev1alpha1Mocks.v13_1_0.spec,
+          components: [
+            {
+              catalog: 'control-plane-catalog',
+              name: 'containerlinux',
+              version: '2765.2.2',
+            },
+            {
+              catalog: 'control-plane-catalog',
+              name: 'etcd',
+              version: '3.4.14',
+            },
+          ],
+          apps: [],
+        },
+      };
+
+      const b: releasev1alpha1.IRelease = {
+        ...releasev1alpha1Mocks.v13_1_0,
+        spec: {
+          ...releasev1alpha1Mocks.v13_1_0.spec,
+          components: [
+            {
+              catalog: 'control-plane-catalog',
+              name: 'containerlinux',
+              version: '2766.0.0',
+            },
+            {
+              catalog: 'control-plane-catalog',
+              name: 'etcd',
+              version: '3.4.14',
+            },
+          ],
+          apps: [],
+        },
+      };
+
+      const diff = getReleaseComponentsDiff(a, b);
+      expect(diff).toStrictEqual({
+        changes: [
+          {
+            changeType: ui.ReleaseComponentsDiffChangeType.Update,
+            component: 'containerlinux',
+            oldVersion: '2765.2.2',
+            newVersion: '2766.0.0',
+          },
+        ],
+      } as ui.IReleaseComponentsDiff);
+    });
+
+    it('finds removed components', () => {
+      const a: releasev1alpha1.IRelease = {
+        ...releasev1alpha1Mocks.v13_1_0,
+        spec: {
+          ...releasev1alpha1Mocks.v13_1_0.spec,
+          components: [
+            {
+              catalog: 'control-plane-catalog',
+              name: 'containerlinux',
+              version: '2765.2.2',
+            },
+            {
+              catalog: 'control-plane-catalog',
+              name: 'etcd',
+              version: '3.4.14',
+            },
+          ],
+          apps: [],
+        },
+      };
+
+      const b: releasev1alpha1.IRelease = {
+        ...releasev1alpha1Mocks.v13_1_0,
+        spec: {
+          ...releasev1alpha1Mocks.v13_1_0.spec,
+          components: [
+            {
+              catalog: 'control-plane-catalog',
+              name: 'containerlinux',
+              version: '2765.2.2',
+            },
+          ],
+          apps: [],
+        },
+      };
+
+      const diff = getReleaseComponentsDiff(a, b);
+      expect(diff).toStrictEqual({
+        changes: [
+          {
+            changeType: ui.ReleaseComponentsDiffChangeType.Delete,
+            component: 'etcd',
+            oldVersion: '3.4.14',
+          },
+        ],
+      } as ui.IReleaseComponentsDiff);
+    });
+  });
+
+  it('finds added components', () => {
+    const a: releasev1alpha1.IRelease = {
+      ...releasev1alpha1Mocks.v13_1_0,
+      spec: {
+        ...releasev1alpha1Mocks.v13_1_0.spec,
+        components: [
+          {
+            catalog: 'control-plane-catalog',
+            name: 'containerlinux',
+            version: '2765.2.2',
+          },
+        ],
+        apps: [],
+      },
+    };
+
+    const b: releasev1alpha1.IRelease = {
+      ...releasev1alpha1Mocks.v13_1_0,
+      spec: {
+        ...releasev1alpha1Mocks.v13_1_0.spec,
+        components: [
+          {
+            catalog: 'control-plane-catalog',
+            name: 'containerlinux',
+            version: '2765.2.2',
+          },
+          {
+            catalog: 'control-plane-catalog',
+            name: 'etcd',
+            version: '3.4.14',
+          },
+        ],
+        apps: [],
+      },
+    };
+
+    const diff = getReleaseComponentsDiff(a, b);
+    expect(diff).toStrictEqual({
+      changes: [
+        {
+          changeType: ui.ReleaseComponentsDiffChangeType.Add,
+          component: 'etcd',
+          newVersion: '3.4.14',
+        },
+      ],
+    } as ui.IReleaseComponentsDiff);
+  });
+
+  it('gets a full blown diff between 2 releases', () => {
+    const diff = getReleaseComponentsDiff(
+      releasev1alpha1Mocks.v14_0_1,
+      releasev1alpha1Mocks.v15_0_0
+    );
+    expect(diff).toStrictEqual({
+      changes: [
+        {
+          changeType: 1,
+          component: 'app-operator',
+          newVersion: '4.4.0',
+          oldVersion: '3.2.1',
+        },
+        {
+          changeType: 1,
+          component: 'azure-operator',
+          newVersion: '5.7.0',
+          oldVersion: '5.5.3',
+        },
+        {
+          changeType: 1,
+          component: 'cert-exporter',
+          newVersion: '1.6.1',
+          oldVersion: '1.6.0',
+        },
+        {
+          changeType: 1,
+          component: 'cert-operator',
+          newVersion: '1.0.1',
+          oldVersion: '0.1.0',
+        },
+        {
+          changeType: 1,
+          component: 'chart-operator',
+          newVersion: '2.14.0',
+          oldVersion: '2.12.0',
+        },
+        {
+          changeType: 1,
+          component: 'cluster-autoscaler',
+          newVersion: '1.20.2',
+          oldVersion: '1.19.1',
+        },
+        {
+          changeType: 1,
+          component: 'cluster-operator',
+          newVersion: '0.27.1',
+          oldVersion: '0.23.22',
+        },
+        {
+          changeType: 1,
+          component: 'containerlinux',
+          newVersion: '2605.12.0',
+          oldVersion: '2765.2.2',
+        },
+        {
+          changeType: 1,
+          component: 'coredns',
+          newVersion: '1.4.1',
+          oldVersion: '1.2.0',
+        },
+        {
+          changeType: 1,
+          component: 'external-dns',
+          newVersion: '2.3.1',
+          oldVersion: '2.3.0',
+        },
+        {
+          changeType: 1,
+          component: 'kube-state-metrics',
+          newVersion: '1.3.1',
+          oldVersion: '1.3.0',
+        },
+        {
+          changeType: 1,
+          component: 'kubernetes',
+          newVersion: '1.20.6',
+          oldVersion: '1.18.0',
+        },
+        {
+          changeType: 1,
+          component: 'metrics-server',
+          newVersion: '1.3.0',
+          oldVersion: '1.2.1',
+        },
+        {
+          changeType: 1,
+          component: 'net-exporter',
+          newVersion: '1.10.1',
+          oldVersion: '1.9.2',
+        },
+        {
+          changeType: 1,
+          component: 'node-exporter',
+          newVersion: '1.7.2',
+          oldVersion: '1.7.1',
+        },
+      ],
+    } as ui.IReleaseComponentsDiff);
+  });
+});

--- a/src/components/MAPI/releases/__tests__/utils.ts
+++ b/src/components/MAPI/releases/__tests__/utils.ts
@@ -123,154 +123,154 @@ describe('releases::utils', () => {
         ],
       } as ui.IReleaseComponentsDiff);
     });
-  });
 
-  it('finds added components', () => {
-    const a: releasev1alpha1.IRelease = {
-      ...releasev1alpha1Mocks.v13_1_0,
-      spec: {
-        ...releasev1alpha1Mocks.v13_1_0.spec,
-        components: [
+    it('finds added components', () => {
+      const a: releasev1alpha1.IRelease = {
+        ...releasev1alpha1Mocks.v13_1_0,
+        spec: {
+          ...releasev1alpha1Mocks.v13_1_0.spec,
+          components: [
+            {
+              catalog: 'control-plane-catalog',
+              name: 'containerlinux',
+              version: '2765.2.2',
+            },
+          ],
+          apps: [],
+        },
+      };
+
+      const b: releasev1alpha1.IRelease = {
+        ...releasev1alpha1Mocks.v13_1_0,
+        spec: {
+          ...releasev1alpha1Mocks.v13_1_0.spec,
+          components: [
+            {
+              catalog: 'control-plane-catalog',
+              name: 'containerlinux',
+              version: '2765.2.2',
+            },
+            {
+              catalog: 'control-plane-catalog',
+              name: 'etcd',
+              version: '3.4.14',
+            },
+          ],
+          apps: [],
+        },
+      };
+
+      const diff = getReleaseComponentsDiff(a, b);
+      expect(diff).toStrictEqual({
+        changes: [
           {
-            catalog: 'control-plane-catalog',
-            name: 'containerlinux',
-            version: '2765.2.2',
+            changeType: ui.ReleaseComponentsDiffChangeType.Add,
+            component: 'etcd',
+            newVersion: '3.4.14',
           },
         ],
-        apps: [],
-      },
-    };
+      } as ui.IReleaseComponentsDiff);
+    });
 
-    const b: releasev1alpha1.IRelease = {
-      ...releasev1alpha1Mocks.v13_1_0,
-      spec: {
-        ...releasev1alpha1Mocks.v13_1_0.spec,
-        components: [
+    it('gets a full blown diff between 2 releases', () => {
+      const diff = getReleaseComponentsDiff(
+        releasev1alpha1Mocks.v14_0_1,
+        releasev1alpha1Mocks.v15_0_0
+      );
+      expect(diff).toStrictEqual({
+        changes: [
           {
-            catalog: 'control-plane-catalog',
-            name: 'containerlinux',
-            version: '2765.2.2',
+            changeType: 1,
+            component: 'app-operator',
+            newVersion: '4.4.0',
+            oldVersion: '3.2.1',
           },
           {
-            catalog: 'control-plane-catalog',
-            name: 'etcd',
-            version: '3.4.14',
+            changeType: 1,
+            component: 'azure-operator',
+            newVersion: '5.7.0',
+            oldVersion: '5.5.3',
+          },
+          {
+            changeType: 1,
+            component: 'cert-exporter',
+            newVersion: '1.6.1',
+            oldVersion: '1.6.0',
+          },
+          {
+            changeType: 1,
+            component: 'cert-operator',
+            newVersion: '1.0.1',
+            oldVersion: '0.1.0',
+          },
+          {
+            changeType: 1,
+            component: 'chart-operator',
+            newVersion: '2.14.0',
+            oldVersion: '2.12.0',
+          },
+          {
+            changeType: 1,
+            component: 'cluster-autoscaler',
+            newVersion: '1.20.2',
+            oldVersion: '1.19.1',
+          },
+          {
+            changeType: 1,
+            component: 'cluster-operator',
+            newVersion: '0.27.1',
+            oldVersion: '0.23.22',
+          },
+          {
+            changeType: 1,
+            component: 'containerlinux',
+            newVersion: '2605.12.0',
+            oldVersion: '2765.2.2',
+          },
+          {
+            changeType: 1,
+            component: 'coredns',
+            newVersion: '1.4.1',
+            oldVersion: '1.2.0',
+          },
+          {
+            changeType: 1,
+            component: 'external-dns',
+            newVersion: '2.3.1',
+            oldVersion: '2.3.0',
+          },
+          {
+            changeType: 1,
+            component: 'kube-state-metrics',
+            newVersion: '1.3.1',
+            oldVersion: '1.3.0',
+          },
+          {
+            changeType: 1,
+            component: 'kubernetes',
+            newVersion: '1.20.6',
+            oldVersion: '1.18.0',
+          },
+          {
+            changeType: 1,
+            component: 'metrics-server',
+            newVersion: '1.3.0',
+            oldVersion: '1.2.1',
+          },
+          {
+            changeType: 1,
+            component: 'net-exporter',
+            newVersion: '1.10.1',
+            oldVersion: '1.9.2',
+          },
+          {
+            changeType: 1,
+            component: 'node-exporter',
+            newVersion: '1.7.2',
+            oldVersion: '1.7.1',
           },
         ],
-        apps: [],
-      },
-    };
-
-    const diff = getReleaseComponentsDiff(a, b);
-    expect(diff).toStrictEqual({
-      changes: [
-        {
-          changeType: ui.ReleaseComponentsDiffChangeType.Add,
-          component: 'etcd',
-          newVersion: '3.4.14',
-        },
-      ],
-    } as ui.IReleaseComponentsDiff);
-  });
-
-  it('gets a full blown diff between 2 releases', () => {
-    const diff = getReleaseComponentsDiff(
-      releasev1alpha1Mocks.v14_0_1,
-      releasev1alpha1Mocks.v15_0_0
-    );
-    expect(diff).toStrictEqual({
-      changes: [
-        {
-          changeType: 1,
-          component: 'app-operator',
-          newVersion: '4.4.0',
-          oldVersion: '3.2.1',
-        },
-        {
-          changeType: 1,
-          component: 'azure-operator',
-          newVersion: '5.7.0',
-          oldVersion: '5.5.3',
-        },
-        {
-          changeType: 1,
-          component: 'cert-exporter',
-          newVersion: '1.6.1',
-          oldVersion: '1.6.0',
-        },
-        {
-          changeType: 1,
-          component: 'cert-operator',
-          newVersion: '1.0.1',
-          oldVersion: '0.1.0',
-        },
-        {
-          changeType: 1,
-          component: 'chart-operator',
-          newVersion: '2.14.0',
-          oldVersion: '2.12.0',
-        },
-        {
-          changeType: 1,
-          component: 'cluster-autoscaler',
-          newVersion: '1.20.2',
-          oldVersion: '1.19.1',
-        },
-        {
-          changeType: 1,
-          component: 'cluster-operator',
-          newVersion: '0.27.1',
-          oldVersion: '0.23.22',
-        },
-        {
-          changeType: 1,
-          component: 'containerlinux',
-          newVersion: '2605.12.0',
-          oldVersion: '2765.2.2',
-        },
-        {
-          changeType: 1,
-          component: 'coredns',
-          newVersion: '1.4.1',
-          oldVersion: '1.2.0',
-        },
-        {
-          changeType: 1,
-          component: 'external-dns',
-          newVersion: '2.3.1',
-          oldVersion: '2.3.0',
-        },
-        {
-          changeType: 1,
-          component: 'kube-state-metrics',
-          newVersion: '1.3.1',
-          oldVersion: '1.3.0',
-        },
-        {
-          changeType: 1,
-          component: 'kubernetes',
-          newVersion: '1.20.6',
-          oldVersion: '1.18.0',
-        },
-        {
-          changeType: 1,
-          component: 'metrics-server',
-          newVersion: '1.3.0',
-          oldVersion: '1.2.1',
-        },
-        {
-          changeType: 1,
-          component: 'net-exporter',
-          newVersion: '1.10.1',
-          oldVersion: '1.9.2',
-        },
-        {
-          changeType: 1,
-          component: 'node-exporter',
-          newVersion: '1.7.2',
-          oldVersion: '1.7.1',
-        },
-      ],
-    } as ui.IReleaseComponentsDiff);
+      } as ui.IReleaseComponentsDiff);
+    });
   });
 });

--- a/src/components/MAPI/releases/utils.ts
+++ b/src/components/MAPI/releases/utils.ts
@@ -1,6 +1,5 @@
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { IRelease, ReleaseHelper } from 'lib/ReleaseHelper';
-import { compare } from 'lib/semver';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import { Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
@@ -128,7 +127,7 @@ export function getReleaseComponentsDiff(
       continue;
     }
 
-    if (compare(oldVersion, newVersion) !== 0) {
+    if (oldVersion !== newVersion) {
       // A component's version has changed.
       diff.changes.push({
         component: component.name,

--- a/src/components/MAPI/releases/utils.ts
+++ b/src/components/MAPI/releases/utils.ts
@@ -1,0 +1,37 @@
+import { IRelease, ReleaseHelper } from 'lib/ReleaseHelper';
+import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
+import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
+
+export function getReleaseHelper(
+  currVersion: string,
+  provider: PropertiesOf<typeof Providers>,
+  isAdmin: boolean,
+  releases: releasev1alpha1.IRelease[],
+  ignorePreReleases = true
+) {
+  const mappedReleases = releases.reduce(
+    (acc: Record<string, IRelease>, r: releasev1alpha1.IRelease) => {
+      // Remove the `v` prefix.
+      const normalizedVersion = r.metadata.name.slice(1);
+
+      acc[normalizedVersion] = {
+        version: normalizedVersion,
+        active: r.spec.state === 'active',
+      };
+
+      return acc;
+    },
+    {}
+  );
+
+  const releaseHelper = new ReleaseHelper({
+    availableReleases: mappedReleases,
+    provider,
+    currentReleaseVersion: currVersion,
+    isAdmin,
+    ignorePreReleases,
+  });
+
+  return releaseHelper;
+}

--- a/src/components/MAPI/releases/utils.ts
+++ b/src/components/MAPI/releases/utils.ts
@@ -1,7 +1,9 @@
+import ErrorReporter from 'lib/errors/ErrorReporter';
 import { IRelease, ReleaseHelper } from 'lib/ReleaseHelper';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import { Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
+import * as ui from 'UI/Display/MAPI/releases/types';
 
 export function getReleaseHelper(
   currVersion: string,
@@ -34,4 +36,38 @@ export function getReleaseHelper(
   });
 
   return releaseHelper;
+}
+
+export function getSupportedUpgradeVersions(
+  currVersion: string,
+  provider: PropertiesOf<typeof Providers>,
+  isAdmin: boolean,
+  releases: releasev1alpha1.IRelease[]
+): ui.IReleaseVersion[] {
+  try {
+    const releaseHelper = getReleaseHelper(
+      currVersion,
+      provider,
+      isAdmin,
+      releases
+    );
+
+    const availableReleases = releaseHelper.getSupportedUpgradeVersions();
+
+    return availableReleases.map((r) => {
+      const status =
+        r.getPreRelease().length > 0
+          ? ui.ReleaseVersionStatus.PreRelease
+          : ui.ReleaseVersionStatus.Stable;
+
+      return {
+        version: r.toString(),
+        status,
+      };
+    });
+  } catch (err) {
+    ErrorReporter.getInstance().notify(err);
+
+    return [];
+  }
 }

--- a/src/components/UI/Display/MAPI/releases/ClusterDetailReleaseDetailsUpgradeOptions.tsx
+++ b/src/components/UI/Display/MAPI/releases/ClusterDetailReleaseDetailsUpgradeOptions.tsx
@@ -1,4 +1,4 @@
-import { Box, Paragraph } from 'grommet';
+import { Box, Keyboard, Paragraph } from 'grommet';
 import ReleaseDetailsModalUpgradeOptionsBetaDisclaimer from 'Modals/ReleaseDetailsModal/ReleaseDetailsModalUpgradeOptionsBetaDisclaimer';
 import ReleaseDetailsModalUpgradeOptionsVersion from 'Modals/ReleaseDetailsModal/ReleaseDetailsModalUpgradeOptionsVersion';
 import PropTypes from 'prop-types';
@@ -23,21 +23,36 @@ const ClusterDetailReleaseDetailsUpgradeOptions: React.FC<IClusterDetailReleaseD
     onVersionClick(version);
   };
 
+  const handleKeyDown = (version: string) => (
+    e: React.KeyboardEvent<HTMLElement>
+  ) => {
+    e.preventDefault();
+
+    handleVersionClick(version)();
+  };
+
   const containsBetaReleases = useMemo(() => {
     return supportedVersions.some(isReleaseBeta);
   }, [supportedVersions]);
 
   if (supportedVersions.length === 1) {
+    const release = supportedVersions[0];
+
     return (
       <>
         <Paragraph fill={true}>
           This cluster can be upgraded to{' '}
-          <ReleaseDetailsModalUpgradeOptionsVersion
-            version={supportedVersions[0].version}
-            isBeta={isReleaseBeta(supportedVersions[0])}
-            onClick={handleVersionClick(supportedVersions[0].version)}
-            tabIndex={0}
-          />
+          <Keyboard
+            onSpace={handleKeyDown(release.version)}
+            onEnter={handleKeyDown(release.version)}
+          >
+            <ReleaseDetailsModalUpgradeOptionsVersion
+              version={release.version}
+              isBeta={isReleaseBeta(release)}
+              onClick={handleVersionClick(release.version)}
+              tabIndex={0}
+            />
+          </Keyboard>
           .
         </Paragraph>
         {containsBetaReleases && (
@@ -56,12 +71,17 @@ const ClusterDetailReleaseDetailsUpgradeOptions: React.FC<IClusterDetailReleaseD
       </Paragraph>
       {supportedVersions.map((release) => (
         <Box key={release.version}>
-          <ReleaseDetailsModalUpgradeOptionsVersion
-            version={release.version}
-            isBeta={isReleaseBeta(release)}
-            onClick={handleVersionClick(release.version)}
-            tabIndex={0}
-          />
+          <Keyboard
+            onSpace={handleKeyDown(release.version)}
+            onEnter={handleKeyDown(release.version)}
+          >
+            <ReleaseDetailsModalUpgradeOptionsVersion
+              version={release.version}
+              isBeta={isReleaseBeta(release)}
+              onClick={handleVersionClick(release.version)}
+              tabIndex={0}
+            />
+          </Keyboard>
         </Box>
       ))}
       {containsBetaReleases && (

--- a/src/components/UI/Display/MAPI/releases/ClusterDetailReleaseDetailsUpgradeOptions.tsx
+++ b/src/components/UI/Display/MAPI/releases/ClusterDetailReleaseDetailsUpgradeOptions.tsx
@@ -1,0 +1,81 @@
+import { Box, Paragraph } from 'grommet';
+import ReleaseDetailsModalUpgradeOptionsBetaDisclaimer from 'Modals/ReleaseDetailsModal/ReleaseDetailsModalUpgradeOptionsBetaDisclaimer';
+import ReleaseDetailsModalUpgradeOptionsVersion from 'Modals/ReleaseDetailsModal/ReleaseDetailsModalUpgradeOptionsVersion';
+import PropTypes from 'prop-types';
+import React, { useMemo } from 'react';
+
+import { IReleaseVersion, ReleaseVersionStatus } from './types';
+
+function isReleaseBeta(release: IReleaseVersion) {
+  return release.status === ReleaseVersionStatus.PreRelease;
+}
+
+interface IClusterDetailReleaseDetailsUpgradeOptionsProps {
+  supportedVersions: IReleaseVersion[];
+  onVersionClick: (version: string) => void;
+}
+
+const ClusterDetailReleaseDetailsUpgradeOptions: React.FC<IClusterDetailReleaseDetailsUpgradeOptionsProps> = ({
+  supportedVersions,
+  onVersionClick,
+}) => {
+  const handleVersionClick = (version: string) => () => {
+    onVersionClick(version);
+  };
+
+  const containsBetaReleases = useMemo(() => {
+    return supportedVersions.some(isReleaseBeta);
+  }, [supportedVersions]);
+
+  if (supportedVersions.length === 1) {
+    return (
+      <>
+        <Paragraph fill={true}>
+          This cluster can be upgraded to{' '}
+          <ReleaseDetailsModalUpgradeOptionsVersion
+            version={supportedVersions[0].version}
+            isBeta={isReleaseBeta(supportedVersions[0])}
+            onClick={handleVersionClick(supportedVersions[0].version)}
+            tabIndex={0}
+          />
+          .
+        </Paragraph>
+        {containsBetaReleases && (
+          <Box margin={{ top: 'medium' }}>
+            <ReleaseDetailsModalUpgradeOptionsBetaDisclaimer />
+          </Box>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Paragraph fill={true}>
+        This cluster can be upgraded to these releases:
+      </Paragraph>
+      {supportedVersions.map((release) => (
+        <Box key={release.version}>
+          <ReleaseDetailsModalUpgradeOptionsVersion
+            version={release.version}
+            isBeta={isReleaseBeta(release)}
+            onClick={handleVersionClick(release.version)}
+            tabIndex={0}
+          />
+        </Box>
+      ))}
+      {containsBetaReleases && (
+        <Box margin={{ top: 'medium' }}>
+          <ReleaseDetailsModalUpgradeOptionsBetaDisclaimer />
+        </Box>
+      )}
+    </>
+  );
+};
+
+ClusterDetailReleaseDetailsUpgradeOptions.propTypes = {
+  supportedVersions: PropTypes.array.isRequired,
+  onVersionClick: PropTypes.func.isRequired,
+};
+
+export default ClusterDetailReleaseDetailsUpgradeOptions;

--- a/src/components/UI/Display/MAPI/releases/ClusterDetailUpgradeModalChangelog.tsx
+++ b/src/components/UI/Display/MAPI/releases/ClusterDetailUpgradeModalChangelog.tsx
@@ -1,0 +1,98 @@
+import { Box, Text } from 'grommet';
+import ReleaseDetailsModalSection from 'Modals/ReleaseDetailsModal/ReleaseDetailsModalSection';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import ReleaseComponentLabel from 'UI/Display/Cluster/ReleaseComponentLabel';
+
+import {
+  IReleaseComponentsDiff,
+  ReleaseComponentsDiffChangeType,
+} from './types';
+
+function formatReleaseComponentLabel(
+  change: IReleaseComponentsDiff['changes'][0]
+) {
+  switch (change.changeType) {
+    case ReleaseComponentsDiffChangeType.Add:
+      return (
+        <ReleaseComponentLabel
+          name={change.component}
+          key={change.component}
+          version={change.newVersion}
+          isAdded={true}
+        />
+      );
+
+    case ReleaseComponentsDiffChangeType.Delete:
+      return (
+        <ReleaseComponentLabel
+          name={change.component}
+          key={change.component}
+          version={change.oldVersion}
+          isRemoved={true}
+        />
+      );
+
+    case ReleaseComponentsDiffChangeType.Update:
+      return (
+        <ReleaseComponentLabel
+          name={change.component}
+          key={change.component}
+          oldVersion={change.oldVersion}
+          version={change.newVersion}
+        />
+      );
+
+    default:
+      return null;
+  }
+}
+
+const StyledReleaseDetailsModalSection = styled(ReleaseDetailsModalSection)`
+  margin-top: 0;
+`;
+
+interface IClusterDetailUpgradeModalChangelogProps {
+  releaseNotesURL?: string;
+  componentsDiff?: IReleaseComponentsDiff;
+}
+
+const ClusterDetailUpgradeModalChangelog: React.FC<IClusterDetailUpgradeModalChangelogProps> = ({
+  releaseNotesURL,
+  componentsDiff,
+}) => {
+  return (
+    <Box direction='column' gap='medium'>
+      {componentsDiff && (
+        <StyledReleaseDetailsModalSection title='Component changes'>
+          <Box
+            wrap={true}
+            direction='row'
+            gap='xxsmall'
+            margin={{ top: 'medium' }}
+          >
+            {componentsDiff.changes.map(formatReleaseComponentLabel)}
+          </Box>
+        </StyledReleaseDetailsModalSection>
+      )}
+
+      {releaseNotesURL && (
+        <StyledReleaseDetailsModalSection title='Release notes'>
+          <Text>
+            <a href={releaseNotesURL} rel='noopener noreferrer' target='_blank'>
+              {releaseNotesURL}
+            </a>
+          </Text>
+        </StyledReleaseDetailsModalSection>
+      )}
+    </Box>
+  );
+};
+
+ClusterDetailUpgradeModalChangelog.propTypes = {
+  releaseNotesURL: PropTypes.string,
+  componentsDiff: PropTypes.object as PropTypes.Requireable<IReleaseComponentsDiff>,
+};
+
+export default ClusterDetailUpgradeModalChangelog;

--- a/src/components/UI/Display/MAPI/releases/ClusterDetailUpgradeModalDisclaimer.tsx
+++ b/src/components/UI/Display/MAPI/releases/ClusterDetailUpgradeModalDisclaimer.tsx
@@ -1,0 +1,40 @@
+import { Box, Paragraph, Text } from 'grommet';
+import * as docs from 'lib/docs';
+import React from 'react';
+
+interface IClusterDetailUpgradeModalDisclaimerProps {}
+
+const ClusterDetailUpgradeModalDisclaimer: React.FC<IClusterDetailUpgradeModalDisclaimerProps> = () => {
+  return (
+    <Box direction='column'>
+      <Paragraph fill={true}>
+        Please read our{' '}
+        <a
+          href={docs.clusterUpgradeChecklistURL}
+          rel='noopener noreferrer'
+          target='_blank'
+        >
+          checklist for cluster upgrades{' '}
+          <i
+            className='fa fa-open-in-new'
+            role='presentation'
+            aria-hidden='true'
+          />
+        </a>{' '}
+        to ensure the cluster and workloads are{' '}
+        <Text weight='bold'>prepared for an upgrade</Text>.
+      </Paragraph>
+      <Paragraph fill={true}>
+        As this cluster has one master node, the{' '}
+        <Text weight='bold'>
+          Kubernetes API will be unavailable for a few minutes
+        </Text>{' '}
+        during the upgrade.
+      </Paragraph>
+    </Box>
+  );
+};
+
+ClusterDetailUpgradeModalDisclaimer.propTypes = {};
+
+export default ClusterDetailUpgradeModalDisclaimer;

--- a/src/components/UI/Display/MAPI/releases/types.ts
+++ b/src/components/UI/Display/MAPI/releases/types.ts
@@ -1,0 +1,32 @@
+export enum ReleaseComponentsDiffChangeType {
+  Add,
+  Update,
+  Delete,
+}
+
+export interface IReleaseComponentsDiffChangeAdd {
+  component: string;
+  changeType: ReleaseComponentsDiffChangeType.Add;
+  newVersion: string;
+}
+
+export interface IReleaseComponentsDiffChangeUpdate {
+  component: string;
+  changeType: ReleaseComponentsDiffChangeType.Update;
+  newVersion: string;
+  oldVersion: string;
+}
+
+export interface IReleaseComponentsDiffChangeDelete {
+  component: string;
+  changeType: ReleaseComponentsDiffChangeType.Delete;
+  oldVersion: string;
+}
+
+export interface IReleaseComponentsDiff {
+  changes: (
+    | IReleaseComponentsDiffChangeAdd
+    | IReleaseComponentsDiffChangeUpdate
+    | IReleaseComponentsDiffChangeDelete
+  )[];
+}

--- a/src/components/UI/Display/MAPI/releases/types.ts
+++ b/src/components/UI/Display/MAPI/releases/types.ts
@@ -30,3 +30,13 @@ export interface IReleaseComponentsDiff {
     | IReleaseComponentsDiffChangeDelete
   )[];
 }
+
+export enum ReleaseVersionStatus {
+  Stable,
+  PreRelease,
+}
+
+export interface IReleaseVersion {
+  version: string;
+  status: ReleaseVersionStatus;
+}

--- a/testUtils/mockHttpCalls/releasev1alpha1/releases.ts
+++ b/testUtils/mockHttpCalls/releasev1alpha1/releases.ts
@@ -407,3 +407,137 @@ export const v13_1_0: releasev1alpha1.IRelease = {
     ready: true,
   },
 };
+
+export const v15_0_0: releasev1alpha1.IRelease = {
+  apiVersion: 'release.giantswarm.io/v1alpha1',
+  kind: 'Release',
+  metadata: {
+    annotations: {
+      'giantswarm.io/docs':
+        'https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/',
+      'giantswarm.io/release-notes':
+        'https://github.com/giantswarm/releases/tree/master/azure/v15.0.0',
+      'meta.helm.sh/release-name': 'releases-azure',
+      'meta.helm.sh/release-namespace': 'giantswarm',
+    },
+    creationTimestamp: '2021-06-15T07:33:33Z',
+    finalizers: ['operatorkit.giantswarm.io/release-operator-release'],
+    generation: 1,
+    labels: {
+      'app.kubernetes.io/managed-by': 'Helm',
+    },
+    name: 'v15.0.0',
+    resourceVersion: '326011895',
+    selfLink: '/apis/release.giantswarm.io/v1alpha1/releases/v15.0.0',
+    uid: 'e610a7dc-2fee-45f5-bc42-c4920a8875a6',
+  },
+  spec: {
+    apps: [
+      {
+        catalog: 'default',
+        name: 'cert-exporter',
+        version: '1.6.1',
+      },
+      {
+        catalog: 'default',
+        name: 'chart-operator',
+        version: '2.14.0',
+      },
+      {
+        catalog: 'default',
+        componentVersion: '1.8.0',
+        name: 'coredns',
+        version: '1.4.1',
+      },
+      {
+        catalog: 'default',
+        componentVersion: '0.7.6',
+        name: 'external-dns',
+        version: '2.3.1',
+      },
+      {
+        catalog: 'default',
+        componentVersion: '1.9.7',
+        name: 'kube-state-metrics',
+        version: '1.3.1',
+      },
+      {
+        catalog: 'default',
+        name: 'metrics-server',
+        version: '1.3.0',
+      },
+      {
+        catalog: 'default',
+        name: 'net-exporter',
+        version: '1.10.1',
+      },
+      {
+        catalog: 'default',
+        componentVersion: '1.0.1',
+        name: 'node-exporter',
+        version: '1.7.2',
+      },
+      {
+        catalog: 'default',
+        name: 'cluster-autoscaler',
+        version: '1.20.2',
+      },
+      {
+        catalog: 'default',
+        name: 'azure-scheduled-events',
+        version: '0.4.0',
+      },
+    ],
+    components: [
+      {
+        catalog: 'control-plane-catalog',
+        name: 'app-operator',
+        version: '4.4.0',
+      },
+      {
+        catalog: 'control-plane-catalog',
+        name: 'azure-operator',
+        releaseOperatorDeploy: true,
+        version: '5.7.0',
+      },
+      {
+        catalog: 'control-plane-catalog',
+        name: 'cert-operator',
+        releaseOperatorDeploy: true,
+        version: '1.0.1',
+      },
+      {
+        catalog: 'control-plane-catalog',
+        name: 'cluster-operator',
+        releaseOperatorDeploy: true,
+        version: '0.27.1',
+      },
+      {
+        catalog: 'control-plane-catalog',
+        name: 'kubernetes',
+        version: '1.20.6',
+      },
+      {
+        catalog: 'control-plane-catalog',
+        name: 'containerlinux',
+        version: '2605.12.0',
+      },
+      {
+        catalog: 'control-plane-catalog',
+        name: 'calico',
+        version: '3.15.3',
+      },
+      {
+        catalog: 'control-plane-catalog',
+        name: 'etcd',
+        version: '3.4.14',
+      },
+    ],
+    date: '2021-06-14T11:40:38Z',
+    state: 'active',
+  },
+  status: {
+    inUse: true,
+    ready: true,
+  },
+};


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/9077

This PR adds all the upgrade logic necessary for the MAPI cluster details page. This means:
- The upgrade button (visible when the cluster is done creating, or when it's not already upgrading)
- The upgrade modal
	- Disclaimer pane (saying that an upgrade can break your loved cluster)
	- Changelog pane (what changed between the current version and the version you're trying to upgrade to)
- The supported releases section in the release details modal

The look and feel should be 95% the same as the current GS API implementation, with a few improvements.

Also, please take a look at the PR comments to find out more about the implementation details.

## Preview

<details>
<summary>Upgrade button</summary>

<img width="600" alt="image" src="https://user-images.githubusercontent.com/13508038/122924249-dbef9000-d365-11eb-81f8-fd1e91c96db7.png">

</details>

<details>
<summary>Disclaimer pane</summary>

<img width="600" alt="image" src="https://user-images.githubusercontent.com/13508038/122924299-e742bb80-d365-11eb-873f-2c7b2d0d4a65.png">

</details>

<details>
<summary>Changelog pane</summary>

<img width="600" alt="image" src="https://user-images.githubusercontent.com/13508038/122924373-f9bcf500-d365-11eb-8fbe-36b2fa75dbd5.png">

</details>

<details>
<summary>Upgrade options</summary>

<img width="600" alt="image" src="https://user-images.githubusercontent.com/13508038/122924439-0e00f200-d366-11eb-839c-5bbfd4daf6cf.png">

</details>