### PR TITLE
clusters: add the worker nodes tab and the list of node pools

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -12,6 +12,7 @@ import {
   extractErrorMessage,
   getOrgNamespaceFromOrgName,
 } from 'MAPI/organizations/utils';
+import ClusterDetailWorkerNodes from 'MAPI/workernodes/ClusterDetailWorkerNodes';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as metav1 from 'model/services/mapi/metav1';
@@ -52,6 +53,13 @@ function computePaths(orgName: string, clusterName: string) {
     ),
     KeyPairs: RoutePath.createUsablePath(
       OrganizationsRoutes.Clusters.Detail.KeyPairs,
+      {
+        orgId: orgName,
+        clusterId: clusterName,
+      }
+    ),
+    WorkerNodes: RoutePath.createUsablePath(
+      OrganizationsRoutes.Clusters.Detail.WorkerNodes,
       {
         orgId: orgName,
         clusterId: clusterName,
@@ -210,11 +218,16 @@ const ClusterDetail: React.FC<{}> = () => {
         </Heading>
         <Tabs defaultActiveKey={paths.Home} useRoutes={true}>
           <Tab eventKey={paths.Home} title='Overview' />
-          <Tab eventKey={paths.Apps} title='Apps' />
+          <Tab eventKey={paths.WorkerNodes} title='Worker nodes' />
           <Tab eventKey={paths.KeyPairs} title='Key pairs' />
+          <Tab eventKey={paths.Apps} title='Apps' />
           <Tab eventKey={paths.Ingress} title='Ingress' />
         </Tabs>
         <Switch>
+          <Route
+            path={OrganizationsRoutes.Clusters.Detail.WorkerNodes}
+            component={ClusterDetailWorkerNodes}
+          />
           <Route
             path={OrganizationsRoutes.Clusters.Detail.Apps}
             render={() =>

--- a/src/components/MAPI/types.ts
+++ b/src/components/MAPI/types.ts
@@ -1,4 +1,7 @@
+import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
 import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
+import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
 
 export type ControlPlaneNode = capzv1alpha3.IAzureMachine;
 
@@ -7,3 +10,15 @@ export type ControlPlaneNodeList = capzv1alpha3.IAzureMachineList;
 export type ProviderCluster = capzv1alpha3.IAzureCluster;
 
 export type ProviderClusterList = capzv1alpha3.IAzureClusterList;
+
+export type NodePool =
+  | capiv1alpha3.IMachineDeployment
+  | capiexpv1alpha3.IMachinePool;
+
+export type NodePoolList =
+  | capiv1alpha3.IMachineDeploymentList
+  | capiexpv1alpha3.IMachinePoolList;
+
+export type ProviderNodePool = capzexpv1alpha3.IAzureMachinePool;
+
+export type ProviderNodePoolList = capzexpv1alpha3.IAzureMachinePoolList;

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -1,0 +1,309 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { Box, Heading, Text } from 'grommet';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
+import {
+  extractErrorMessage,
+  getOrgNamespaceFromOrgName,
+} from 'MAPI/organizations/utils';
+import { NodePool } from 'MAPI/types';
+import {
+  fetchNodePoolListForCluster,
+  fetchNodePoolListForClusterKey,
+  fetchProviderNodePoolsForNodePools,
+  fetchProviderNodePoolsForNodePoolsKey,
+} from 'MAPI/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+import { useEffect, useMemo, useRef } from 'react';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useParams } from 'react-router';
+import { TransitionGroup } from 'react-transition-group';
+import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
+import { getProvider } from 'stores/main/selectors';
+import styled from 'styled-components';
+import BaseTransition from 'styles/transitions/BaseTransition';
+import useSWR from 'swr';
+import { NodePoolGridRow } from 'UI/Display/MAPI/workernodes/styles';
+
+import { IWorkerNodesAdditionalColumn } from './types';
+import WorkerNodesNodePoolItem from './WorkerNodesNodePoolItem';
+
+const LOADING_COMPONENTS = new Array(4).fill(0);
+
+function getAdditionalColumns(
+  provider: PropertiesOf<typeof Providers>
+): IWorkerNodesAdditionalColumn[] {
+  if (provider === Providers.AZURE) {
+    return [];
+  }
+
+  return [];
+}
+
+function formatMachineTypeColumnTitle(
+  provider: PropertiesOf<typeof Providers>
+) {
+  switch (provider) {
+    case Providers.AWS:
+      return 'Instance type';
+    case Providers.AZURE:
+      return 'VM Size';
+    default:
+      return 'Machine type';
+  }
+}
+
+const Header = styled(Box)<{ additionalColumnsCount?: number }>`
+  ${({ additionalColumnsCount }) => NodePoolGridRow(additionalColumnsCount)}
+
+  text-transform: uppercase;
+  color: #ccc;
+`;
+
+const ColumnInfo = styled(Box)`
+  ${NodePoolGridRow()}
+  padding-bottom: 0;
+  margin-bottom: -5px;
+
+  & {
+    place-items: end normal;
+    grid-template-rows: 20px;
+  }
+`;
+
+const NodesInfo = styled.div`
+  grid-column: 5/9;
+  position: relative;
+  display: flex;
+  justify-content: center;
+
+  ::after {
+    content: '';
+    text-align: center;
+    border: 1px solid;
+    border-color: ${({ theme }) => theme.global.colors['text-weak'].dark};
+    position: absolute;
+    height: 10px;
+    width: 95%;
+    margin: auto;
+    top: calc(50% - 1px);
+    left: 0;
+    right: 0;
+    z-index: 0;
+  }
+
+  ::before {
+    content: '';
+    background: ${({ theme }) => theme.global.colors.background.dark};
+    position: absolute;
+    height: 5px;
+    top: calc(50% - 1px + 5px);
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1;
+  }
+`;
+
+const NodesInfoText = styled(Text)`
+  padding: 0 10px;
+  text-transform: uppercase;
+  background: ${({ theme }) => theme.global.colors.background.dark};
+  z-index: 2;
+`;
+
+const AnimationWrapper = styled.div`
+  .nodepool-list-item-enter {
+    opacity: 0.01;
+    transform: translate3d(-50px, 0, 0);
+  }
+  .nodepool-list-item-enter.nodepool-list-item-enter-active {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+    transition: 0.2s cubic-bezier(1, 0, 0, 1);
+  }
+  .nodepool-list-item-exit {
+    opacity: 1;
+  }
+  .nodepool-list-item-exit.nodepool-list-item-exit-active {
+    opacity: 0.01;
+    transform: translate3d(-50px, 0, 0);
+    transition: 0.2s cubic-bezier(1, 0, 0, 1);
+  }
+`;
+
+interface IClusterDetailWorkerNodesProps {}
+
+const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> = () => {
+  const { clusterId, orgId } = useParams<{
+    clusterId: string;
+    orgId: string;
+  }>();
+
+  const clientFactory = useHttpClientFactory();
+  const auth = useAuthProvider();
+
+  const namespace = getOrgNamespaceFromOrgName(orgId);
+
+  const clusterClient = useRef(clientFactory());
+  const {
+    data: cluster,
+    error: clusterError,
+    isValidating: clusterIsValidating,
+  } = useSWR<capiv1alpha3.ICluster, GenericResponseError>(
+    capiv1alpha3.getClusterKey(namespace, clusterId),
+    () =>
+      capiv1alpha3.getCluster(clusterClient.current, auth, namespace, clusterId)
+  );
+
+  const {
+    data: nodePoolList,
+    error: nodePoolListError,
+    isValidating: nodePoolListIsValidating,
+  } = useSWR(fetchNodePoolListForClusterKey(cluster), () =>
+    fetchNodePoolListForCluster(clientFactory, auth, cluster)
+  );
+
+  const nodePoolListIsLoading =
+    (typeof cluster === 'undefined' &&
+      typeof clusterError === 'undefined' &&
+      clusterIsValidating) ||
+    (typeof nodePoolList === 'undefined' &&
+      typeof nodePoolListError === 'undefined' &&
+      nodePoolListIsValidating);
+
+  useEffect(() => {
+    if (nodePoolListError) {
+      new FlashMessage(
+        'There was a problem loading node pools.',
+        messageType.ERROR,
+        messageTTL.LONG,
+        extractErrorMessage(nodePoolListError)
+      );
+
+      ErrorReporter.getInstance().notify(nodePoolListError);
+    }
+  }, [nodePoolListError]);
+
+  const {
+    data: providerNodePools,
+    error: providerNodePoolsError,
+  } = useSWR(fetchProviderNodePoolsForNodePoolsKey(nodePoolList?.items), () =>
+    fetchProviderNodePoolsForNodePools(clientFactory, auth, nodePoolList!.items)
+  );
+
+  useEffect(() => {
+    if (providerNodePoolsError) {
+      new FlashMessage(
+        'There was a problem loading node pools.',
+        messageType.ERROR,
+        messageTTL.LONG,
+        extractErrorMessage(providerNodePoolsError)
+      );
+
+      ErrorReporter.getInstance().notify(providerNodePoolsError);
+    }
+  }, [providerNodePoolsError]);
+
+  const provider = useSelector(getProvider);
+
+  const additionalColumns = useMemo(() => getAdditionalColumns(provider), [
+    provider,
+  ]);
+
+  return (
+    <Box>
+      <Box>
+        <Heading level={2}>Node pools</Heading>
+        <Text>
+          A node pool is a set of nodes within a Kubernetes cluster that share
+          the same configuration (machine type, CIDR range, etc.). Each node in
+          the pool is labeled by the node pool&apos;s name.
+        </Text>
+      </Box>
+      <ColumnInfo margin={{ top: 'xsmall' }}>
+        <NodesInfo>
+          <NodesInfoText color='text-weak' textAlign='center' size='small'>
+            Nodes
+          </NodesInfoText>
+        </NodesInfo>
+      </ColumnInfo>
+      <Header additionalColumnsCount={additionalColumns.length}>
+        <Box align='center' margin={{ left: '-12px' }}>
+          <Text>Name</Text>
+        </Box>
+        <Box>
+          <Text>Description</Text>
+        </Box>
+        <Box align='center'>
+          <Text>{formatMachineTypeColumnTitle(provider)}</Text>
+        </Box>
+        <Box align='center'>
+          <Text textAlign='center'>Availability zones</Text>
+        </Box>
+        <Box align='center'>
+          <Text>Min</Text>
+        </Box>
+        <Box align='center'>
+          <Text>Max</Text>
+        </Box>
+        <Box align='center'>
+          <Text>Desired</Text>
+        </Box>
+        <Box align='center'>
+          <Text>Current</Text>
+        </Box>
+
+        {additionalColumns.map((column) => (
+          <Box align='center' key={column.title}>
+            <Text textAlign='center'>{column.title}</Text>
+          </Box>
+        ))}
+
+        <Box />
+      </Header>
+      <Box margin={{ bottom: 'small' }}>
+        {nodePoolListIsLoading &&
+          LOADING_COMPONENTS.map((_, idx) => (
+            <WorkerNodesNodePoolItem
+              key={idx}
+              additionalColumns={additionalColumns}
+              margin={{ bottom: 'small' }}
+            />
+          ))}
+
+        <AnimationWrapper>
+          <TransitionGroup>
+            {!nodePoolListIsLoading &&
+              nodePoolList?.items.map((np: NodePool, idx: number) => (
+                <BaseTransition
+                  in={false}
+                  key={np.metadata.name}
+                  appear={false}
+                  exit={true}
+                  timeout={{ enter: 200, exit: 200 }}
+                  delayTimeout={0}
+                  classNames='nodepool-list-item'
+                >
+                  <WorkerNodesNodePoolItem
+                    nodePool={np}
+                    providerNodePool={providerNodePools?.[idx]}
+                    additionalColumns={additionalColumns}
+                    margin={{ bottom: 'small' }}
+                  />
+                </BaseTransition>
+              ))}
+          </TransitionGroup>
+        </AnimationWrapper>
+      </Box>
+    </Box>
+  );
+};
+
+ClusterDetailWorkerNodes.propTypes = {};
+
+export default ClusterDetailWorkerNodes;

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -30,6 +30,7 @@ import useSWR from 'swr';
 import { NodePoolGridRow } from 'UI/Display/MAPI/workernodes/styles';
 
 import { IWorkerNodesAdditionalColumn } from './types';
+import WorkerNodesAzureMachinePoolSpotInstances from './WorkerNodesAzureMachinePoolSpotInstances';
 import WorkerNodesNodePoolItem from './WorkerNodesNodePoolItem';
 
 const LOADING_COMPONENTS = new Array(4).fill(0);
@@ -38,7 +39,18 @@ function getAdditionalColumns(
   provider: PropertiesOf<typeof Providers>
 ): IWorkerNodesAdditionalColumn[] {
   if (provider === Providers.AZURE) {
-    return [];
+    return [
+      {
+        title: 'Spot instances',
+        render: (_, providerNodePool) => {
+          return (
+            <WorkerNodesAzureMachinePoolSpotInstances
+              providerNodePool={providerNodePool}
+            />
+          );
+        },
+      },
+    ];
   }
 
   return [];
@@ -64,8 +76,9 @@ const Header = styled(Box)<{ additionalColumnsCount?: number }>`
   color: #ccc;
 `;
 
-const ColumnInfo = styled(Box)`
-  ${NodePoolGridRow()}
+const ColumnInfo = styled(Box)<{ additionalColumnsCount?: number }>`
+  ${({ additionalColumnsCount }) => NodePoolGridRow(additionalColumnsCount)}
+
   padding-bottom: 0;
   margin-bottom: -5px;
 
@@ -76,7 +89,7 @@ const ColumnInfo = styled(Box)`
 `;
 
 const NodesInfo = styled.div`
-  grid-column: 5/9;
+  grid-column: 5 / span 4;
   position: relative;
   display: flex;
   justify-content: center;
@@ -225,7 +238,10 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> = () =>
           the pool is labeled by the node pool&apos;s name.
         </Text>
       </Box>
-      <ColumnInfo margin={{ top: 'xsmall' }}>
+      <ColumnInfo
+        additionalColumnsCount={additionalColumns.length}
+        margin={{ top: 'xsmall' }}
+      >
         <NodesInfo>
           <NodesInfoText color='text-weak' textAlign='center' size='small'>
             Nodes
@@ -266,7 +282,7 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> = () =>
 
         <Box />
       </Header>
-      <Box margin={{ bottom: 'small' }}>
+      <Box margin={{ top: 'xsmall' }}>
         {nodePoolListIsLoading &&
           LOADING_COMPONENTS.map((_, idx) => (
             <WorkerNodesNodePoolItem

--- a/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
@@ -19,13 +19,13 @@ const WorkerNodesAzureMachinePoolSpotInstances: React.FC<IWorkerNodesAzureMachin
     headline = 'Spot instances enabled';
   }
 
-  let maxPriceRow = '';
+  let maxPriceText = '';
   if (featureEnabled) {
     const maxPrice = providerNodePool?.spec?.template.spotVMOptions?.maxPrice;
     if (maxPrice && maxPrice > 0) {
-      maxPriceRow = `Using maximum price: $${maxPrice}`;
+      maxPriceText = `Using maximum price: $${maxPrice}`;
     } else {
-      maxPriceRow = `Using current on-demand pricing as maximum`;
+      maxPriceText = `Using current on-demand pricing as maximum`;
     }
   }
 
@@ -44,10 +44,10 @@ const WorkerNodesAzureMachinePoolSpotInstances: React.FC<IWorkerNodesAzureMachin
               }-spot-instances-tooltip`}
             >
               <Box width='small'>
-                <Text size='small'>{headline}</Text>
-                {maxPriceRow && (
-                  <Text size='small' margin={{ top: 'xsmall' }}>
-                    {maxPriceRow}
+                <Text size='xsmall'>{headline}</Text>
+                {maxPriceText && (
+                  <Text size='xsmall' margin={{ top: 'xsmall' }}>
+                    {maxPriceText}
                   </Text>
                 )}
               </Box>

--- a/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
@@ -1,0 +1,75 @@
+import { Box, Text } from 'grommet';
+import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import ClusterDetailWidgetOptionalValue from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue';
+
+interface IWorkerNodesAzureMachinePoolSpotInstancesProps {
+  providerNodePool?: capzexpv1alpha3.IAzureMachinePool;
+}
+
+const WorkerNodesAzureMachinePoolSpotInstances: React.FC<IWorkerNodesAzureMachinePoolSpotInstancesProps> = ({
+  providerNodePool,
+}) => {
+  const featureEnabled =
+    typeof providerNodePool?.spec?.template.spotVMOptions !== 'undefined';
+  let headline = 'Spot instances disabled';
+  if (featureEnabled) {
+    headline = 'Spot instances enabled';
+  }
+
+  let maxPriceRow = '';
+  if (featureEnabled) {
+    const maxPrice = providerNodePool?.spec?.template.spotVMOptions?.maxPrice;
+    if (maxPrice && maxPrice > 0) {
+      maxPriceRow = `Using maximum price: $${maxPrice}`;
+    } else {
+      maxPriceRow = `Using current on-demand pricing as maximum`;
+    }
+  }
+
+  return (
+    <ClusterDetailWidgetOptionalValue
+      value={providerNodePool}
+      loaderWidth={30}
+      replaceEmptyValue={false}
+    >
+      {(value) => (
+        <OverlayTrigger
+          overlay={
+            <Tooltip
+              id={`${
+                (value as capzexpv1alpha3.IAzureMachinePool).metadata.name
+              }-spot-instances-tooltip`}
+            >
+              <Box width='small'>
+                <Text size='small'>{headline}</Text>
+                {maxPriceRow && (
+                  <Text size='small' margin={{ top: 'xsmall' }}>
+                    {maxPriceRow}
+                  </Text>
+                )}
+              </Box>
+            </Tooltip>
+          }
+          placement='top'
+        >
+          <Text aria-label='Node pool spot instances status'>
+            <i
+              role='presentation'
+              className={featureEnabled ? 'fa fa-done' : 'fa fa-close'}
+              aria-label={headline}
+            />
+          </Text>
+        </OverlayTrigger>
+      )}
+    </ClusterDetailWidgetOptionalValue>
+  );
+};
+
+WorkerNodesAzureMachinePoolSpotInstances.propTypes = {
+  providerNodePool: PropTypes.object as PropTypes.Requireable<capzexpv1alpha3.IAzureMachinePool>,
+};
+
+export default WorkerNodesAzureMachinePoolSpotInstances;

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -1,0 +1,216 @@
+import { Box, Text } from 'grommet';
+import { NodePool, ProviderNodePool } from 'MAPI/types';
+import {
+  getNodePoolAvailabilityZones,
+  getNodePoolDescription,
+  getNodePoolScaling,
+  getProviderNodePoolMachineType,
+} from 'MAPI/utils';
+import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
+import PropTypes from 'prop-types';
+import React, { useMemo, useState } from 'react';
+import Copyable from 'shared/Copyable';
+import styled from 'styled-components';
+import { Code } from 'styles';
+import AvailabilityZonesLabels from 'UI/Display/Cluster/AvailabilityZones/AvailabilityZonesLabels';
+import ClusterDetailWidgetOptionalValue from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue';
+import { NodePoolGridRow } from 'UI/Display/MAPI/workernodes/styles';
+import ViewAndEditName from 'UI/Inputs/ViewEditName';
+
+import { IWorkerNodesAdditionalColumn } from './types';
+
+function formatMachineTypeLabel(providerNodePool?: ProviderNodePool) {
+  switch (providerNodePool?.kind) {
+    case capzexpv1alpha3.AzureMachinePool:
+      return 'Node pool VM size';
+    default:
+      return undefined;
+  }
+}
+
+const Row = styled(Box)<{ additionalColumnsCount?: number }>`
+  ${({ additionalColumnsCount }) => NodePoolGridRow(additionalColumnsCount)}
+`;
+
+const StyledViewAndEditName = styled(ViewAndEditName)`
+  max-width: ${({ theme }) => theme.global.size.medium};
+
+  input {
+    font-size: 100%;
+    padding: ${({ theme }) => theme.global.edgeSize.xsmall};
+  }
+
+  .btn-group {
+    top: 0;
+    display: flex;
+  }
+`;
+
+interface IWorkerNodesNodePoolItemProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  nodePool?: NodePool;
+  providerNodePool?: ProviderNodePool;
+  additionalColumns?: IWorkerNodesAdditionalColumn[];
+}
+
+const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
+  nodePool,
+  providerNodePool,
+  additionalColumns,
+  ...props
+}) => {
+  const description = nodePool ? getNodePoolDescription(nodePool) : undefined;
+  const availabilityZones = nodePool
+    ? getNodePoolAvailabilityZones(nodePool)
+    : undefined;
+  const machineType = providerNodePool
+    ? getProviderNodePoolMachineType(providerNodePool)
+    : undefined;
+  const scaling = useMemo(() => {
+    if (!nodePool) return undefined;
+
+    return getNodePoolScaling(nodePool);
+  }, [nodePool]);
+
+  const isScalingInProgress = scaling && scaling.desired !== scaling.current;
+
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+
+  return (
+    <Row
+      background='background-front'
+      round='xsmall'
+      additionalColumnsCount={additionalColumns?.length}
+      {...props}
+    >
+      <Box align='center'>
+        <ClusterDetailWidgetOptionalValue
+          value={nodePool?.metadata.name}
+          loaderWidth={70}
+          loaderHeight={26}
+        >
+          {(value) => (
+            <Copyable copyText={value as string}>
+              <Text aria-label='Node pool name'>
+                <Code>{value}</Code>
+              </Text>
+            </Copyable>
+          )}
+        </ClusterDetailWidgetOptionalValue>
+      </Box>
+      <Box>
+        <ClusterDetailWidgetOptionalValue value={description} loaderWidth={150}>
+          {(value) => (
+            <StyledViewAndEditName
+              value={value as string}
+              typeLabel='node pool'
+              onToggleEditingState={setIsEditingDescription}
+              aria-label='Node pool description'
+            />
+          )}
+        </ClusterDetailWidgetOptionalValue>
+      </Box>
+      {!isEditingDescription && (
+        <>
+          <Box align='center'>
+            <ClusterDetailWidgetOptionalValue
+              value={machineType}
+              loaderWidth={130}
+            >
+              {(value) => (
+                <Code aria-label={formatMachineTypeLabel(providerNodePool)}>
+                  {value}
+                </Code>
+              )}
+            </ClusterDetailWidgetOptionalValue>
+          </Box>
+          <Box align='center'>
+            <ClusterDetailWidgetOptionalValue
+              value={availabilityZones}
+              loaderHeight={26}
+            >
+              {(value) => (
+                <AvailabilityZonesLabels zones={value} labelsChecked={[]} />
+              )}
+            </ClusterDetailWidgetOptionalValue>
+          </Box>
+          <Box align='center'>
+            <ClusterDetailWidgetOptionalValue
+              value={scaling?.min}
+              loaderWidth={30}
+            >
+              {(value) => (
+                <Text aria-label='Node pool autoscaler minimum node count'>
+                  {value}
+                </Text>
+              )}
+            </ClusterDetailWidgetOptionalValue>
+          </Box>
+          <Box align='center'>
+            <ClusterDetailWidgetOptionalValue
+              value={scaling?.max}
+              loaderWidth={30}
+            >
+              {(value) => (
+                <Text aria-label='Node pool autoscaler maximum node count'>
+                  {value}
+                </Text>
+              )}
+            </ClusterDetailWidgetOptionalValue>
+          </Box>
+          <Box align='center'>
+            <ClusterDetailWidgetOptionalValue
+              value={scaling?.desired}
+              loaderWidth={30}
+            >
+              {(value) => (
+                <Text aria-label='Node pool autoscaler target node count'>
+                  {value}
+                </Text>
+              )}
+            </ClusterDetailWidgetOptionalValue>
+          </Box>
+          <Box align='center'>
+            <ClusterDetailWidgetOptionalValue
+              value={scaling?.current}
+              loaderWidth={30}
+            >
+              {(value) => (
+                <Box
+                  pad={{ horizontal: 'xsmall', vertical: 'xxsmall' }}
+                  round='xsmall'
+                  background={
+                    isScalingInProgress ? 'status-warning' : undefined
+                  }
+                >
+                  <Text
+                    aria-label='Node pool autoscaler current node count'
+                    color={isScalingInProgress ? 'background' : undefined}
+                  >
+                    {value}
+                  </Text>
+                </Box>
+              )}
+            </ClusterDetailWidgetOptionalValue>
+          </Box>
+
+          {additionalColumns?.map((column) => (
+            <Box key={column.title} align='center'>
+              {column.render(nodePool, providerNodePool)}
+            </Box>
+          ))}
+
+          <Box align='center' />
+        </>
+      )}
+    </Row>
+  );
+};
+
+WorkerNodesNodePoolItem.propTypes = {
+  nodePool: PropTypes.object as PropTypes.Validator<NodePool>,
+  providerNodePool: PropTypes.object as PropTypes.Validator<ProviderNodePool>,
+  additionalColumns: PropTypes.array,
+};
+
+export default WorkerNodesNodePoolItem;

--- a/src/components/MAPI/workernodes/types.ts
+++ b/src/components/MAPI/workernodes/types.ts
@@ -1,0 +1,9 @@
+import { NodePool, ProviderNodePool } from 'MAPI/types';
+
+export interface IWorkerNodesAdditionalColumn {
+  title: string;
+  render: (
+    nodePool?: NodePool,
+    providerNodePool?: ProviderNodePool
+  ) => React.ReactNode;
+}

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-fDMmKd etDSMI"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-kiwQCO jLIoKV"
       >
         dogs
       </span>
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-fDMmKd etDSMI"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-kiwQCO jLIoKV"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 dLeNOM"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-lVUNM hWEZKB"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-bePbjY cbjXBf"
         >
           Some widget
         </span>
@@ -47,7 +47,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 kYALZS"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-lVUNM hWEZKB"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-bePbjY cbjXBf"
         >
           Some widget
         </span>

--- a/src/components/UI/Display/MAPI/workernodes/styles.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/styles.tsx
@@ -1,0 +1,19 @@
+import { css } from 'styled-components';
+
+export const NodePoolGridRow = (extraColumnCount: number = 0) => css`
+  display: grid;
+  grid-gap: 0 ${({ theme }) => theme.global.edgeSize.small};
+  grid-template-columns:
+    minmax(70px, 1fr)
+    minmax(50px, 4fr)
+    4fr
+    3fr
+    repeat(4, 2fr)
+    ${extraColumnCount ? `repeat(${extraColumnCount}, 2fr)` : ''}
+    1fr;
+  grid-template-rows: ${({ theme }) => theme.global.size.xxsmall};
+  justify-content: space-between;
+  place-items: center normal;
+  padding: ${({ theme }) =>
+    `${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.medium}`};
+`;

--- a/src/components/shared/Copyable.tsx
+++ b/src/components/shared/Copyable.tsx
@@ -9,8 +9,10 @@ import styled from 'styled-components';
 const TooltipWrapper = styled.div`
   top: 0px;
   right: 0px;
+  height: 100%;
   position: absolute;
-  display: inline-block;
+  display: flex;
+  align-items: center;
   opacity: 0;
 `;
 

--- a/src/model/services/mapi/capiv1alpha3/exp/index.ts
+++ b/src/model/services/mapi/capiv1alpha3/exp/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
+export * from './key';
 export * from './getMachinePoolList';

--- a/src/model/services/mapi/capiv1alpha3/exp/key.ts
+++ b/src/model/services/mapi/capiv1alpha3/exp/key.ts
@@ -1,0 +1,33 @@
+import { IMachinePool } from './types';
+
+export const annotationMachinePoolDescription =
+  'machine-pool.giantswarm.io/name';
+export const annotationMachinePoolMinSize =
+  'cluster.k8s.io/cluster-api-autoscaler-node-group-min-size';
+export const annotationMachinePoolMaxSize =
+  'cluster.k8s.io/cluster-api-autoscaler-node-group-max-size';
+
+export function getMachinePoolDescription(machinePool: IMachinePool): string {
+  let name =
+    machinePool.metadata.annotations?.[annotationMachinePoolDescription];
+  name ??= 'Unnamed node pool';
+
+  return name;
+}
+
+export function getMachinePoolScaling(
+  machinePool: IMachinePool
+): readonly [number, number] {
+  const annotations = machinePool.metadata.annotations;
+  if (!annotations) return [-1, -1];
+
+  const minScaling = annotations[annotationMachinePoolMinSize];
+  const maxScaling = annotations[annotationMachinePoolMaxSize];
+  if (!minScaling || !maxScaling) return [-1, -1];
+
+  try {
+    return [parseInt(minScaling, 10), parseInt(maxScaling, 10)];
+  } catch {
+    return [-1, -1];
+  }
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/341

This PR adds the `Worker nodes` tab to the new MAPI Cluster detail UI. It behaves mostly like the old one, with an exception: the node pool name can now be copied to clipboard.

There is some stuff missing currently:
- the `Actions` button on the right of each node pool row. This will be added together with node pool renaming.
- a placeholder for when are no node pools. This will be added with node pool creation.

## Preview

<details>
<summary>Some node pools sitting in a tree</summary>

![image](https://user-images.githubusercontent.com/13508038/123247835-8f33c280-d4e7-11eb-8d6b-68f9ed49fe17.png)

</details>