### PR TITLE
clusters: add support for updating node pool descriptions via the MAPI cluster detail page

### DIFF
--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -1,0 +1,61 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { NodePool } from 'MAPI/types';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
+import { mutate } from 'swr';
+
+export async function updateNodePoolDescription(
+  httpClient: IHttpClient,
+  auth: IOAuth2Provider,
+  nodePool: NodePool,
+  newDescription: string
+) {
+  if (nodePool.kind === capiexpv1alpha3.MachinePool) {
+    let machinePool = await capiexpv1alpha3.getMachinePool(
+      httpClient,
+      auth,
+      nodePool.metadata.namespace!,
+      nodePool.metadata.name
+    );
+    const description = capiexpv1alpha3.getMachinePoolDescription(machinePool);
+    if (description === newDescription) {
+      return machinePool;
+    }
+
+    machinePool.metadata.annotations ??= {};
+    machinePool.metadata.annotations[
+      capiexpv1alpha3.annotationMachinePoolDescription
+    ] = newDescription;
+
+    machinePool = await capiexpv1alpha3.updateMachinePool(
+      httpClient,
+      auth,
+      machinePool
+    );
+
+    mutate(
+      capiexpv1alpha3.getMachinePoolKey(
+        machinePool.metadata.namespace!,
+        machinePool.metadata.name
+      ),
+      machinePool
+    );
+
+    mutate(
+      capiexpv1alpha3.getMachinePoolListKey({
+        labelSelector: {
+          matchingLabels: {
+            [capiv1alpha3.labelCluster]: machinePool.metadata.labels![
+              capiv1alpha3.labelCluster
+            ],
+          },
+        },
+      })
+    );
+
+    return machinePool;
+  }
+
+  return Promise.reject(new Error('Unsupported provider.'));
+}

--- a/src/components/UI/Controls/DropdownMenu.js
+++ b/src/components/UI/Controls/DropdownMenu.js
@@ -34,7 +34,8 @@ export const Link = styled.a`
   font-weight: 400;
   padding: 7px 15px;
   width: 100%;
-  &:hover {
+  &:hover,
+  &:focus {
     background: ${(props) => props.theme.colors.shade9};
   }
 `;

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-kiwQCO jLIoKV"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-bePbjY cbjXBf"
       >
         dogs
       </span>
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-kiwQCO jLIoKV"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-bePbjY cbjXBf"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 dLeNOM"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-bePbjY cbjXBf"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-eDtzrZ ERmKa"
         >
           Some widget
         </span>
@@ -47,7 +47,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 kYALZS"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-bePbjY cbjXBf"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-eDtzrZ ERmKa"
         >
           Some widget
         </span>

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
@@ -1,0 +1,87 @@
+import { Keyboard } from 'grommet';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import DropdownMenu, {
+  DropdownTrigger,
+  Link,
+  List,
+} from 'UI/Controls/DropdownMenu';
+
+const StyledDropdownTrigger = styled(DropdownTrigger)`
+  border-radius: ${({ theme }) => theme.rounding}px;
+`;
+
+interface IWorkerNodesNodePoolActionsProps
+  extends React.ComponentPropsWithoutRef<'div'> {
+  onRenameClick?: () => void;
+}
+
+const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = ({
+  onRenameClick,
+  ...props
+}) => {
+  const handleListKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    (e.target as HTMLElement).click();
+  };
+
+  return (
+    <DropdownMenu
+      {...props}
+      render={({
+        isOpen,
+        onClickHandler,
+        onFocusHandler,
+        onBlurHandler,
+        onKeyDownHandler,
+      }) => (
+        <div onBlur={onBlurHandler} onFocus={onFocusHandler}>
+          <StyledDropdownTrigger
+            aria-expanded={isOpen}
+            aria-haspopup='true'
+            onClick={onClickHandler}
+            onKeyDown={onKeyDownHandler}
+            type='button'
+          >
+            &bull;&bull;&bull;
+          </StyledDropdownTrigger>
+
+          {isOpen && (
+            <Keyboard
+              onEsc={onBlurHandler}
+              onSpace={handleListKeyDown}
+              onEnter={handleListKeyDown}
+            >
+              <List aria-label='Node pool actions' role='menu'>
+                {onRenameClick && (
+                  <li>
+                    <Link
+                      href='#'
+                      onClick={(e) => {
+                        e.preventDefault();
+
+                        onRenameClick();
+                        onBlurHandler();
+                      }}
+                    >
+                      Rename
+                    </Link>
+                  </li>
+                )}
+              </List>
+            </Keyboard>
+          )}
+        </div>
+      )}
+    />
+  );
+};
+
+WorkerNodesNodePoolActions.propTypes = {
+  onRenameClick: PropTypes.func,
+};
+
+export default WorkerNodesNodePoolActions;

--- a/src/components/UI/Inputs/ViewEditName.tsx
+++ b/src/components/UI/Inputs/ViewEditName.tsx
@@ -1,12 +1,7 @@
 import { Keyboard } from 'grommet';
 import { hasAppropriateLength } from 'lib/helpers';
 import PropTypes from 'prop-types';
-import React, {
-  Component,
-  FormEvent,
-  GetDerivedStateFromProps,
-  KeyboardEventHandler,
-} from 'react';
+import React, { Component, FormEvent, GetDerivedStateFromProps } from 'react';
 import Overlay from 'react-bootstrap/lib/Overlay';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
@@ -167,7 +162,7 @@ class ViewAndEditName extends Component<
     }
   };
 
-  handleKey: KeyboardEventHandler<HTMLInputElement> = (e) => {
+  handleKey = (e: React.KeyboardEvent<HTMLElement>) => {
     switch (e.key) {
       case 'Escape':
         this.handleCancel();
@@ -208,7 +203,7 @@ class ViewAndEditName extends Component<
               autoComplete='off'
               autoFocus={true}
               onChange={this.handleChange}
-              onKeyUp={this.handleKey}
+              onKeyDown={this.handleKey}
               value={this.state.value}
               formFieldProps={{
                 margin: {

--- a/src/components/UI/__tests__/ViewEditName.js
+++ b/src/components/UI/__tests__/ViewEditName.js
@@ -90,7 +90,7 @@ describe('ViewEditName', () => {
     });
 
     // Press enter
-    fireEvent.keyUp(input, {
+    fireEvent.keyDown(input, {
       key: 'Enter',
     });
 
@@ -113,7 +113,7 @@ describe('ViewEditName', () => {
     });
 
     // Press escape
-    fireEvent.keyUp(input, {
+    fireEvent.keyDown(input, {
       key: 'Escape',
     });
 
@@ -162,7 +162,7 @@ describe('ViewEditName', () => {
     expect(submitButton).toBeDisabled();
 
     // Press enter
-    fireEvent.keyUp(input, {
+    fireEvent.keyDown(input, {
       key: 'Enter',
     });
 

--- a/src/model/services/mapi/capiv1alpha3/exp/getMachinePool.ts
+++ b/src/model/services/mapi/capiv1alpha3/exp/getMachinePool.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { getResource } from '../../generic/getResource';
+import { IMachinePool } from './types';
+
+export function getMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  name: string
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'exp.cluster.x-k8s.io/v1alpha3',
+    kind: 'machinepools',
+    namespace,
+    name,
+  });
+
+  return getResource<IMachinePool>(client, auth, url.toString());
+}
+
+export function getMachinePoolKey(namespace: string, name: string) {
+  return `getMachinePool/${namespace}/${name}`;
+}

--- a/src/model/services/mapi/capiv1alpha3/exp/index.ts
+++ b/src/model/services/mapi/capiv1alpha3/exp/index.ts
@@ -1,3 +1,5 @@
 export * from './types';
 export * from './key';
 export * from './getMachinePoolList';
+export * from './getMachinePool';
+export * from './updateMachinePool';

--- a/src/model/services/mapi/capiv1alpha3/exp/updateMachinePool.ts
+++ b/src/model/services/mapi/capiv1alpha3/exp/updateMachinePool.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { updateResource } from '../../generic/updateResource';
+import { IMachinePool } from './';
+
+export function updateMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  machinePool: IMachinePool
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'exp.cluster.x-k8s.io/v1alpha3',
+    kind: 'machinepools',
+    namespace: machinePool.metadata.namespace!,
+    name: machinePool.metadata.name,
+  } as k8sUrl.IK8sUpdateOptions);
+
+  return updateResource<IMachinePool>(
+    client,
+    auth,
+    url.toString(),
+    machinePool
+  );
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/341

This PR adds support for updating a node pool's description.

## Preview

<details>
<summary>The actions button</summary>

![image](https://user-images.githubusercontent.com/13508038/123408485-5b22d500-d5ad-11eb-8e7d-d2e4b228f007.png)

</details>

<details>
<summary>Updating the description</summary>

![image](https://user-images.githubusercontent.com/13508038/123408583-7097ff00-d5ad-11eb-8d08-fabab3dace5c.png)

</details>