### PR TITLE
clusters: add support for node pool deletion from the MAPI cluster detail page

### DIFF
--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -1,9 +1,9 @@
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import * as releasesUtils from 'MAPI/releases/utils';
+import { NodePool, ProviderNodePool } from 'MAPI/types';
 import { IMachineType } from 'MAPI/utils';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
-import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import { Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
@@ -24,10 +24,8 @@ export function getWorkerNodesCount(
 }
 
 export function getWorkerNodesCPU(
-  nodePools?:
-    | capiv1alpha3.IMachineDeployment[]
-    | capiexpv1alpha3.IMachinePool[],
-  providerNodePools?: capzexpv1alpha3.IAzureMachinePool[],
+  nodePools?: NodePool[],
+  providerNodePools?: ProviderNodePool[],
   machineTypes?: Record<string, IMachineType>
 ) {
   if (!nodePools || !providerNodePools || !machineTypes) return undefined;
@@ -35,7 +33,7 @@ export function getWorkerNodesCPU(
   let count = 0;
 
   for (let i = 0; i < providerNodePools.length; i++) {
-    const vmSize = providerNodePools[i].spec?.template.vmSize;
+    const vmSize = providerNodePools[i]?.spec?.template.vmSize;
     const readyReplicas = nodePools[i].status?.readyReplicas;
 
     if (typeof vmSize !== 'undefined' && typeof readyReplicas !== 'undefined') {
@@ -52,10 +50,8 @@ export function getWorkerNodesCPU(
 }
 
 export function getWorkerNodesMemory(
-  nodePools?:
-    | capiv1alpha3.IMachineDeployment[]
-    | capiexpv1alpha3.IMachinePool[],
-  providerNodePools?: capzexpv1alpha3.IAzureMachinePool[],
+  nodePools?: NodePool[],
+  providerNodePools?: ProviderNodePool[],
   machineTypes?: Record<string, IMachineType>
 ) {
   if (!nodePools || !providerNodePools || !machineTypes) return undefined;
@@ -63,7 +59,7 @@ export function getWorkerNodesMemory(
   let count = 0;
 
   for (let i = 0; i < providerNodePools.length; i++) {
-    const vmSize = providerNodePools[i].spec?.template.vmSize;
+    const vmSize = providerNodePools[i]?.spec?.template.vmSize;
     const readyReplicas = nodePools[i].status?.readyReplicas;
 
     if (typeof vmSize !== 'undefined' && typeof readyReplicas !== 'undefined') {

--- a/src/components/MAPI/organizations/OrganizationDetailGeneral/utils.ts
+++ b/src/components/MAPI/organizations/OrganizationDetailGeneral/utils.ts
@@ -2,6 +2,7 @@ import ErrorReporter from 'lib/errors/ErrorReporter';
 import { HttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
 import { compare } from 'lib/semver';
+import { NodePool, ProviderNodePool } from 'MAPI/types';
 import {
   fetchMasterListForCluster,
   fetchNodePoolListForCluster,
@@ -11,9 +12,7 @@ import {
 } from 'MAPI/utils';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
-import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
 import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
-import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import * as ui from 'UI/Display/Organizations/types';
 
@@ -128,7 +127,7 @@ function appendMasterStats(
 }
 
 function appendNodePoolsStats(
-  nodePools: capiv1alpha3.IMachineDeployment[] | capiexpv1alpha3.IMachinePool[],
+  nodePools: NodePool[],
   summary: ui.IOrganizationDetailClustersSummary
 ) {
   for (const nodePool of nodePools) {
@@ -140,13 +139,13 @@ function appendNodePoolsStats(
 }
 
 function appendProviderNodePoolsStats(
-  nodePools: capiv1alpha3.IMachineDeployment[] | capiexpv1alpha3.IMachinePool[],
-  providerNodePools: capzexpv1alpha3.IAzureMachinePool[],
+  nodePools: NodePool[],
+  providerNodePools: ProviderNodePool[],
   machineTypes: Record<string, IMachineType>,
   summary: ui.IOrganizationDetailClustersSummary
 ) {
   for (let i = 0; i < providerNodePools.length; i++) {
-    const vmSize = providerNodePools[i].spec?.template.vmSize;
+    const vmSize = providerNodePools[i]?.spec?.template.vmSize;
     const readyReplicas = nodePools[i].status?.readyReplicas;
 
     if (typeof vmSize !== 'undefined' && typeof readyReplicas !== 'undefined') {

--- a/src/components/MAPI/types.ts
+++ b/src/components/MAPI/types.ts
@@ -19,6 +19,6 @@ export type NodePoolList =
   | capiv1alpha3.IMachineDeploymentList
   | capiexpv1alpha3.IMachinePoolList;
 
-export type ProviderNodePool = capzexpv1alpha3.IAzureMachinePool;
+export type ProviderNodePool = capzexpv1alpha3.IAzureMachinePool | undefined;
 
 export type ProviderNodePoolList = capzexpv1alpha3.IAzureMachinePoolList;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -50,6 +50,34 @@ export function getMachineTypes(): Record<string, IMachineType> {
   return machineTypes;
 }
 
+export function compareNodePools(a: NodePool, b: NodePool) {
+  // Move node pools that are currently deleting to the end of the list.
+  const aIsDeleting = typeof a.metadata.deletionTimestamp !== 'undefined';
+  const bIsDeleting = typeof b.metadata.deletionTimestamp !== 'undefined';
+
+  if (aIsDeleting && !bIsDeleting) {
+    return 1;
+  } else if (!aIsDeleting && bIsDeleting) {
+    return -1;
+  }
+
+  if (
+    a.kind === capiexpv1alpha3.MachinePool &&
+    b.kind === capiexpv1alpha3.MachinePool
+  ) {
+    // Sort by description.
+    const descriptionComparison = capiexpv1alpha3
+      .getMachinePoolDescription(a)
+      .localeCompare(capiexpv1alpha3.getMachinePoolDescription(b));
+    if (descriptionComparison !== 0) {
+      return descriptionComparison;
+    }
+  }
+
+  // If descriptions are the same, sort by resource name.
+  return a.metadata.name.localeCompare(b.metadata.name);
+}
+
 export async function fetchNodePoolListForCluster(
   httpClientFactory: HttpClientFactory,
   auth: IOAuth2Provider,
@@ -62,30 +90,48 @@ export async function fetchNodePoolListForCluster(
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let list: NodePoolList;
+
   switch (infrastructureRef.kind) {
-    case capzv1alpha3.AzureCluster: {
-      return capiexpv1alpha3.getMachinePoolList(httpClientFactory(), auth, {
-        labelSelector: {
-          matchingLabels: {
-            [capiv1alpha3.labelCluster]: cluster!.metadata.name,
+    case capzv1alpha3.AzureCluster:
+      list = await capiexpv1alpha3.getMachinePoolList(
+        httpClientFactory(),
+        auth,
+        {
+          labelSelector: {
+            matchingLabels: {
+              [capiv1alpha3.labelCluster]: cluster!.metadata.name,
+            },
           },
-        },
-      });
-    }
+        }
+      );
+
+      break;
 
     // TODO(axbarsan): Use CAPA type once available.
     case 'AWSCluster':
-      return capiv1alpha3.getMachineDeploymentList(httpClientFactory(), auth, {
-        labelSelector: {
-          matchingLabels: {
-            [capiv1alpha3.labelCluster]: cluster!.metadata.name,
+      list = await capiv1alpha3.getMachineDeploymentList(
+        httpClientFactory(),
+        auth,
+        {
+          labelSelector: {
+            matchingLabels: {
+              [capiv1alpha3.labelCluster]: cluster!.metadata.name,
+            },
           },
-        },
-      });
+        }
+      );
+
+      break;
 
     default:
       return Promise.reject(new Error('Unsupported provider.'));
   }
+
+  list.items = list.items.sort(compareNodePools);
+
+  return list;
 }
 
 export function fetchNodePoolListForClusterKey(

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemDelete.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemDelete.tsx
@@ -1,0 +1,57 @@
+import { Text } from 'grommet';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Button from 'UI/Controls/Button';
+import ConfirmationPrompt from 'UI/Controls/ConfirmationPrompt';
+
+interface IWorkerNodesNodePoolItemDeleteProps
+  extends React.ComponentPropsWithoutRef<typeof ConfirmationPrompt> {
+  nodePoolName: string;
+  isLoading?: boolean;
+}
+
+const WorkerNodesNodePoolItemDelete: React.FC<IWorkerNodesNodePoolItemDeleteProps> = ({
+  nodePoolName,
+  onConfirm,
+  isLoading,
+  onCancel,
+  ...props
+}) => {
+  return (
+    <ConfirmationPrompt
+      onConfirm={onConfirm}
+      confirmButton={
+        <Button bsStyle='danger' onClick={onConfirm} loading={isLoading}>
+          <i
+            className='fa fa-delete'
+            role='presentation'
+            aria-hidden={true}
+            aria-label='Delete'
+          />{' '}
+          Delete {nodePoolName}
+        </Button>
+      }
+      onCancel={!isLoading ? onCancel : undefined}
+      title={`Do you really want to delete node pool ${nodePoolName}?`}
+      {...props}
+    >
+      <Text>
+        Nodes will be drained and workloads re-scheduled, if possible, to nodes
+        from other pools.
+      </Text>
+      <Text>
+        <Text weight='bold'>Note</Text>: Make sure your scheduling rules are
+        tolerant enough so that workloads can be re-assigned.
+      </Text>
+    </ConfirmationPrompt>
+  );
+};
+
+WorkerNodesNodePoolItemDelete.propTypes = {
+  nodePoolName: PropTypes.string.isRequired,
+  onConfirm: PropTypes.func,
+  onCancel: PropTypes.func,
+  isLoading: PropTypes.bool,
+};
+
+export default WorkerNodesNodePoolItemDelete;

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -1,3 +1,4 @@
+import produce from 'immer';
 import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
 import { NodePool } from 'MAPI/types';
 import { IHttpClient } from 'model/clients/HttpClient';
@@ -52,6 +53,62 @@ export async function updateNodePoolDescription(
           },
         },
       })
+    );
+
+    return machinePool;
+  }
+
+  return Promise.reject(new Error('Unsupported provider.'));
+}
+
+export async function deleteNodePool(
+  httpClient: IHttpClient,
+  auth: IOAuth2Provider,
+  nodePool: NodePool
+) {
+  if (nodePool.kind === capiexpv1alpha3.MachinePool) {
+    let machinePool = await capiexpv1alpha3.getMachinePool(
+      httpClient,
+      auth,
+      nodePool.metadata.namespace!,
+      nodePool.metadata.name
+    );
+
+    machinePool = await capiexpv1alpha3.deleteMachinePool(
+      httpClient,
+      auth,
+      machinePool
+    );
+
+    mutate(
+      capiexpv1alpha3.getMachinePoolKey(
+        machinePool.metadata.namespace!,
+        machinePool.metadata.name
+      ),
+      machinePool
+    );
+
+    // Update the deleted machine pool in place.
+    mutate(
+      capiexpv1alpha3.getMachinePoolListKey({
+        labelSelector: {
+          matchingLabels: {
+            [capiv1alpha3.labelCluster]: machinePool.metadata.labels![
+              capiv1alpha3.labelCluster
+            ],
+          },
+        },
+      }),
+      produce((draft: capiexpv1alpha3.IMachinePoolList) => {
+        for (let i = 0; i < draft.items.length; i++) {
+          if (draft.items[i].metadata.name === machinePool.metadata.name) {
+            draft.items[i] = machinePool;
+          }
+        }
+
+        return draft;
+      }),
+      false
     );
 
     return machinePool;

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -1,6 +1,7 @@
 import produce from 'immer';
 import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
 import { NodePool } from 'MAPI/types';
+import { compareNodePools } from 'MAPI/utils';
 import { IHttpClient } from 'model/clients/HttpClient';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
@@ -105,6 +106,8 @@ export async function deleteNodePool(
             draft.items[i] = machinePool;
           }
         }
+
+        draft.items = draft.items.sort(compareNodePools);
 
         return draft;
       }),

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-bePbjY cbjXBf"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-eDtzrZ ERmKa"
       >
         dogs
       </span>
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-bePbjY cbjXBf"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-eDtzrZ ERmKa"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 dLeNOM"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-eDtzrZ ERmKa"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-bcCSnW eHbbkh"
         >
           Some widget
         </span>
@@ -47,7 +47,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 kYALZS"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-eDtzrZ ERmKa"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-bcCSnW eHbbkh"
         >
           Some widget
         </span>

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
@@ -1,4 +1,4 @@
-import { Keyboard } from 'grommet';
+import { Keyboard, Text } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
@@ -15,10 +15,12 @@ const StyledDropdownTrigger = styled(DropdownTrigger)`
 interface IWorkerNodesNodePoolActionsProps
   extends React.ComponentPropsWithoutRef<'div'> {
   onRenameClick?: () => void;
+  onDeleteClick?: () => void;
 }
 
 const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = ({
   onRenameClick,
+  onDeleteClick,
   ...props
 }) => {
   const handleListKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
@@ -71,6 +73,21 @@ const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = (
                     </Link>
                   </li>
                 )}
+                {onDeleteClick && (
+                  <li>
+                    <Link
+                      href='#'
+                      onClick={(e) => {
+                        e.preventDefault();
+
+                        onDeleteClick();
+                        onBlurHandler();
+                      }}
+                    >
+                      <Text color='status-critical'>Delete</Text>
+                    </Link>
+                  </li>
+                )}
               </List>
             </Keyboard>
           )}
@@ -82,6 +99,7 @@ const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = (
 
 WorkerNodesNodePoolActions.propTypes = {
   onRenameClick: PropTypes.func,
+  onDeleteClick: PropTypes.func,
 };
 
 export default WorkerNodesNodePoolActions;

--- a/src/model/services/mapi/capiv1alpha3/exp/deleteMachinePool.ts
+++ b/src/model/services/mapi/capiv1alpha3/exp/deleteMachinePool.ts
@@ -1,0 +1,22 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { deleteResource } from '../../generic/deleteResource';
+import { IMachinePool } from './types';
+
+export function deleteMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  cluster: IMachinePool
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'exp.cluster.x-k8s.io/v1alpha3',
+    kind: 'machinepools',
+    namespace: cluster.metadata.namespace,
+    name: cluster.metadata.name,
+  } as k8sUrl.IK8sDeleteOptions);
+
+  return deleteResource<IMachinePool>(client, auth, url.toString());
+}

--- a/src/model/services/mapi/capiv1alpha3/exp/index.ts
+++ b/src/model/services/mapi/capiv1alpha3/exp/index.ts
@@ -3,3 +3,4 @@ export * from './key';
 export * from './getMachinePoolList';
 export * from './getMachinePool';
 export * from './updateMachinePool';
+export * from './deleteMachinePool';


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/341

This PR includes the node pool deletion functionality in the MAPI `Cluster detail` page. It also includes a slight change that lets us display deleting node pools in the UI.

Same as with clusters, deleted node pools appear at the bottom.

## Preview

<details>
<summary>Delete confirmation</summary>

![image](https://user-images.githubusercontent.com/13508038/123433018-4c4b1b00-d5cb-11eb-9f57-2535c6d80ed8.png)

</details>

<details>
<summary>Node pool has been deleted</summary>

![image](https://user-images.githubusercontent.com/13508038/123436384-de085780-d5ce-11eb-8a76-9489ed447e4c.png)

</details>