### PR TITLE
clusters: add support for node pool scaling from the MAPI cluster detail page

### DIFF
--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -268,9 +268,11 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
                 loaderWidth={30}
               >
                 {(value) => (
-                  <Text aria-label='Node pool autoscaler minimum node count'>
-                    {value}
-                  </Text>
+                  <Box pad={{ horizontal: 'xsmall', vertical: 'xxsmall' }}>
+                    <Text aria-label='Node pool autoscaler minimum node count'>
+                      {value}
+                    </Text>
+                  </Box>
                 )}
               </ClusterDetailWidgetOptionalValue>
             </Box>
@@ -280,9 +282,11 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
                 loaderWidth={30}
               >
                 {(value) => (
-                  <Text aria-label='Node pool autoscaler maximum node count'>
-                    {value}
-                  </Text>
+                  <Box pad={{ horizontal: 'xsmall', vertical: 'xxsmall' }}>
+                    <Text aria-label='Node pool autoscaler maximum node count'>
+                      {value}
+                    </Text>
+                  </Box>
                 )}
               </ClusterDetailWidgetOptionalValue>
             </Box>
@@ -292,9 +296,11 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
                 loaderWidth={30}
               >
                 {(value) => (
-                  <Text aria-label='Node pool autoscaler target node count'>
-                    {value}
-                  </Text>
+                  <Box pad={{ horizontal: 'xsmall', vertical: 'xxsmall' }}>
+                    <Text aria-label='Node pool autoscaler target node count'>
+                      {value}
+                    </Text>
+                  </Box>
                 )}
               </ClusterDetailWidgetOptionalValue>
             </Box>

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -27,6 +27,7 @@ import ViewAndEditName from 'UI/Inputs/ViewEditName';
 import { IWorkerNodesAdditionalColumn } from './types';
 import { deleteNodePool, updateNodePoolDescription } from './utils';
 import WorkerNodesNodePoolItemDelete from './WorkerNodesNodePoolItemDelete';
+import WorkerNodesNodePoolItemScale from './WorkerNodesNodePoolItemScale';
 
 function formatMachineTypeLabel(providerNodePool?: ProviderNodePool) {
   switch (providerNodePool?.kind) {
@@ -179,6 +180,16 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
     }
   };
 
+  const [isScaleConfirmOpen, setIsScaleConfirmOpen] = useState(false);
+
+  const onScale = () => {
+    setIsScaleConfirmOpen(true);
+  };
+
+  const onCancelScale = () => {
+    setIsScaleConfirmOpen(false);
+  };
+
   return (
     <Box {...props}>
       <Row
@@ -321,6 +332,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
               <WorkerNodesNodePoolActions
                 onRenameClick={onStartEditingDescription}
                 onDeleteClick={onDelete}
+                onScaleClick={onScale}
               />
             </Box>
           </>
@@ -335,6 +347,17 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
             onCancel={onCancelDelete}
             open={isDeleteConfirmOpen}
             isLoading={isDeleteLoading}
+          />
+        </Box>
+      )}
+
+      {nodePool && (
+        <Box margin={{ top: isScaleConfirmOpen ? 'small' : undefined }}>
+          <WorkerNodesNodePoolItemScale
+            nodePool={nodePool}
+            onConfirm={onCancelScale}
+            onCancel={onCancelScale}
+            open={isScaleConfirmOpen}
           />
         </Box>
       )}

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemScale.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemScale.tsx
@@ -1,0 +1,265 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { Box, Text } from 'grommet';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
+import { extractErrorMessage } from 'MAPI/organizations/utils';
+import { NodePool } from 'MAPI/types';
+import { getNodePoolScaling } from 'MAPI/utils';
+import PropTypes from 'prop-types';
+import React, { useMemo, useState } from 'react';
+import NodeCountSelector from 'shared/NodeCountSelector';
+import Button from 'UI/Controls/Button';
+import ConfirmationPrompt from 'UI/Controls/ConfirmationPrompt';
+
+import { updateNodePoolScaling } from './utils';
+
+function formatNodesLabel(nodesCount: number): string {
+  if (nodesCount === 1) {
+    return 'node';
+  }
+
+  return 'nodes';
+}
+
+function getWorkerNodesDifference(min: number, max: number, desired: number) {
+  if (min > desired) {
+    return min - desired;
+  } else if (max < desired) {
+    return max - desired;
+  }
+
+  return 0;
+}
+
+function getSubmitButtonAttributes(fromValue: {
+  min: number;
+  minValid: boolean;
+  max: number;
+  maxValid: boolean;
+  initialScaling: ReturnType<typeof getNodePoolScaling>;
+}): { disabled: boolean; style?: 'primary' | 'danger'; label?: string } {
+  const { min, minValid, max, maxValid, initialScaling } = fromValue;
+
+  const nodesDifference = getWorkerNodesDifference(
+    min,
+    max,
+    initialScaling.desired
+  );
+
+  const isValid = minValid && maxValid;
+
+  if (nodesDifference > 0 && initialScaling.desired > 0) {
+    return {
+      label: `Increase minimum number of nodes by ${nodesDifference}`,
+      style: 'primary',
+      disabled: !isValid,
+    };
+  } else if (nodesDifference < 0 && initialScaling.desired > 0) {
+    const nodesLabel = formatNodesLabel(Math.abs(nodesDifference));
+
+    return {
+      label: `Remove ${Math.abs(nodesDifference)} ${nodesLabel}`,
+      style: 'danger',
+      disabled: !isValid,
+    };
+  }
+
+  if (min !== initialScaling.min || max !== initialScaling.max) {
+    return {
+      label: 'Apply',
+      style: 'primary',
+      disabled: !isValid,
+    };
+  }
+
+  return {
+    style: 'primary',
+    disabled: true,
+  };
+}
+
+interface IWorkerNodesNodePoolItemScaleProps
+  extends React.ComponentPropsWithoutRef<typeof ConfirmationPrompt> {
+  nodePool: NodePool;
+}
+
+const WorkerNodesNodePoolItemScale: React.FC<IWorkerNodesNodePoolItemScaleProps> = ({
+  nodePool,
+  onConfirm,
+  onCancel,
+  open,
+  ...props
+}) => {
+  const initialScaling = useMemo(() => getNodePoolScaling(nodePool), [
+    nodePool,
+  ]);
+
+  const [scalingMin, setScalingMin] = useState(initialScaling.min);
+  const [scalingMinValid, setScalingMinValid] = useState(true);
+  const [scalingMax, setScalingMax] = useState(initialScaling.max);
+  const [scalingMaxValid, setScalingMaxValid] = useState(true);
+
+  const handleScaleChange = (newValue: {
+    scaling: {
+      min: number;
+      minValid: boolean;
+      max: number;
+      maxValid: boolean;
+    };
+  }) => {
+    /**
+     * When the confirmation prompt is closed, and we reset the values,
+     * the `min` and the `max` limits of the 2 inputs would change,
+     * which would make the underlying `NumberPicker` components call this
+     * callback, with partial values, therefore preventing the full reset
+     * from happening.
+     */
+    if (!open) return;
+
+    const { min, minValid, max, maxValid } = newValue.scaling;
+
+    setScalingMin(min);
+    setScalingMinValid(minValid);
+    setScalingMax(max);
+    setScalingMaxValid(maxValid);
+  };
+
+  const handleCancel = () => {
+    onCancel?.();
+
+    setScalingMin(initialScaling.min);
+    setScalingMinValid(true);
+    setScalingMax(initialScaling.max);
+    setScalingMaxValid(true);
+  };
+
+  const clientFactory = useHttpClientFactory();
+  const auth = useAuthProvider();
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleScale = async () => {
+    setIsLoading(true);
+
+    try {
+      await updateNodePoolScaling(
+        clientFactory(),
+        auth,
+        nodePool,
+        scalingMin,
+        scalingMax
+      );
+
+      onConfirm?.();
+      setTimeout(() => {
+        setIsLoading(false);
+        // eslint-disable-next-line no-magic-numbers
+      }, 200);
+
+      new FlashMessage(
+        `Node pool <code>${nodePool.metadata.name}</code> updated successfully`,
+        messageType.SUCCESS,
+        messageTTL.SHORT
+      );
+    } catch (err) {
+      setIsLoading(false);
+
+      const errorMessage = extractErrorMessage(err);
+
+      new FlashMessage(
+        `Could not update node pool <code>${nodePool.metadata.name}</code>`,
+        messageType.ERROR,
+        messageTTL.FOREVER,
+        errorMessage
+      );
+
+      ErrorReporter.getInstance().notify(err);
+    }
+  };
+
+  const submitButtonAttributes = useMemo(
+    () =>
+      getSubmitButtonAttributes({
+        min: scalingMin,
+        minValid: scalingMinValid,
+        max: scalingMax,
+        maxValid: scalingMaxValid,
+        initialScaling,
+      }),
+    [scalingMin, scalingMinValid, scalingMax, scalingMaxValid, initialScaling]
+  );
+
+  const nodesDifference = getWorkerNodesDifference(
+    scalingMin,
+    scalingMax,
+    initialScaling.desired
+  );
+
+  return (
+    <ConfirmationPrompt
+      onConfirm={submitButtonAttributes.label ? handleScale : undefined}
+      confirmButton={
+        <Button
+          bsStyle={submitButtonAttributes.style}
+          onClick={handleScale}
+          loading={isLoading}
+          disabled={submitButtonAttributes.disabled}
+        >
+          {submitButtonAttributes.label}
+        </Button>
+      }
+      onCancel={!isLoading ? handleCancel : undefined}
+      title={`Edit scaling settings for ${nodePool.metadata.name}`}
+      open={open}
+      {...props}
+    >
+      <Box>
+        <Text>
+          Set the scaling range and let the autoscaler set the effective number
+          of worker nodes based on the usage.
+        </Text>
+      </Box>
+      <Box width={{ max: 'large' }} margin={{ top: 'small' }}>
+        <NodeCountSelector
+          autoscalingEnabled={true}
+          readOnly={isLoading}
+          onChange={handleScaleChange}
+          scaling={{
+            min: scalingMin,
+            minValid: scalingMinValid,
+            max: scalingMax,
+            maxValid: scalingMaxValid,
+          }}
+        />
+      </Box>
+
+      {nodesDifference < 0 && (
+        <Box margin={{ top: 'small' }}>
+          <Text color='status-warning'>
+            <i
+              className='fa fa-warning'
+              role='presentation'
+              aria-hidden={true}
+            />{' '}
+            The node pool currently has {initialScaling.desired} worker{' '}
+            {formatNodesLabel(initialScaling.desired)} running. By setting the
+            maximum lower than that, you enforce the removal of{' '}
+            {Math.abs(nodesDifference)}{' '}
+            {formatNodesLabel(Math.abs(nodesDifference))}. This could result in
+            unscheduled workloads.
+          </Text>
+        </Box>
+      )}
+    </ConfirmationPrompt>
+  );
+};
+
+WorkerNodesNodePoolItemScale.propTypes = {
+  nodePool: (PropTypes.object as PropTypes.Requireable<NodePool>).isRequired,
+  onConfirm: PropTypes.func,
+  onCancel: PropTypes.func,
+  open: PropTypes.bool,
+};
+
+export default WorkerNodesNodePoolItemScale;

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemScale.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemScale.tsx
@@ -38,7 +38,7 @@ function getSubmitButtonAttributes(fromValue: {
   max: number;
   maxValid: boolean;
   initialScaling: ReturnType<typeof getNodePoolScaling>;
-}): { disabled: boolean; style?: 'primary' | 'danger'; label?: string } {
+}): { disabled: boolean; label: string; style?: 'primary' | 'danger' } {
   const { min, minValid, max, maxValid, initialScaling } = fromValue;
 
   const nodesDifference = getWorkerNodesDifference(
@@ -47,7 +47,10 @@ function getSubmitButtonAttributes(fromValue: {
     initialScaling.desired
   );
 
-  const isValid = minValid && maxValid;
+  const isValid =
+    minValid &&
+    maxValid &&
+    (min !== initialScaling.min || max !== initialScaling.max);
 
   if (nodesDifference > 0 && initialScaling.desired > 0) {
     return {
@@ -65,17 +68,10 @@ function getSubmitButtonAttributes(fromValue: {
     };
   }
 
-  if (min !== initialScaling.min || max !== initialScaling.max) {
-    return {
-      label: 'Apply',
-      style: 'primary',
-      disabled: !isValid,
-    };
-  }
-
   return {
+    label: 'Apply',
     style: 'primary',
-    disabled: true,
+    disabled: !isValid,
   };
 }
 
@@ -198,7 +194,7 @@ const WorkerNodesNodePoolItemScale: React.FC<IWorkerNodesNodePoolItemScaleProps>
 
   return (
     <ConfirmationPrompt
-      onConfirm={submitButtonAttributes.label ? handleScale : undefined}
+      onConfirm={handleScale}
       confirmButton={
         <Button
           bsStyle={submitButtonAttributes.style}
@@ -210,7 +206,7 @@ const WorkerNodesNodePoolItemScale: React.FC<IWorkerNodesNodePoolItemScaleProps>
         </Button>
       }
       onCancel={!isLoading ? handleCancel : undefined}
-      title={`Edit scaling settings for ${nodePool.metadata.name}`}
+      title='Edit scaling limits'
       open={open}
       {...props}
     >
@@ -235,7 +231,7 @@ const WorkerNodesNodePoolItemScale: React.FC<IWorkerNodesNodePoolItemScaleProps>
       </Box>
 
       {nodesDifference < 0 && (
-        <Box margin={{ top: 'small' }}>
+        <Box margin={{ top: 'small' }} width={{ max: 'large' }}>
           <Text color='status-warning'>
             <i
               className='fa fa-warning'

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -119,3 +119,82 @@ export async function deleteNodePool(
 
   return Promise.reject(new Error('Unsupported provider.'));
 }
+
+export async function updateNodePoolScaling(
+  httpClient: IHttpClient,
+  auth: IOAuth2Provider,
+  nodePool: NodePool,
+  min: number,
+  max: number
+) {
+  if (nodePool.kind === capiexpv1alpha3.MachinePool) {
+    let machinePool = await capiexpv1alpha3.getMachinePool(
+      httpClient,
+      auth,
+      nodePool.metadata.namespace!,
+      nodePool.metadata.name
+    );
+
+    if (
+      nodePool.metadata.annotations?.[
+        capiexpv1alpha3.annotationMachinePoolMinSize
+      ] === min.toString() &&
+      nodePool.metadata.annotations?.[
+        capiexpv1alpha3.annotationMachinePoolMaxSize
+      ] === max.toString()
+    ) {
+      return machinePool;
+    }
+
+    machinePool.metadata.annotations ??= {};
+    machinePool.metadata.annotations[
+      capiexpv1alpha3.annotationMachinePoolMinSize
+    ] = min.toString();
+    machinePool.metadata.annotations[
+      capiexpv1alpha3.annotationMachinePoolMaxSize
+    ] = max.toString();
+
+    machinePool = await capiexpv1alpha3.updateMachinePool(
+      httpClient,
+      auth,
+      machinePool
+    );
+
+    mutate(
+      capiexpv1alpha3.getMachinePoolKey(
+        machinePool.metadata.namespace!,
+        machinePool.metadata.name
+      ),
+      machinePool
+    );
+
+    // Update the deleted machine pool in place.
+    mutate(
+      capiexpv1alpha3.getMachinePoolListKey({
+        labelSelector: {
+          matchingLabels: {
+            [capiv1alpha3.labelCluster]: machinePool.metadata.labels![
+              capiv1alpha3.labelCluster
+            ],
+          },
+        },
+      }),
+      produce((draft: capiexpv1alpha3.IMachinePoolList) => {
+        for (let i = 0; i < draft.items.length; i++) {
+          if (draft.items[i].metadata.name === machinePool.metadata.name) {
+            draft.items[i] = machinePool;
+          }
+        }
+
+        draft.items = draft.items.sort(compareNodePools);
+
+        return draft;
+      }),
+      false
+    );
+
+    return machinePool;
+  }
+
+  return Promise.reject(new Error('Unsupported provider.'));
+}

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
@@ -16,11 +16,13 @@ interface IWorkerNodesNodePoolActionsProps
   extends React.ComponentPropsWithoutRef<'div'> {
   onRenameClick?: () => void;
   onDeleteClick?: () => void;
+  onScaleClick?: () => void;
 }
 
 const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = ({
   onRenameClick,
   onDeleteClick,
+  onScaleClick,
   ...props
 }) => {
   const handleListKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
@@ -73,6 +75,21 @@ const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = (
                     </Link>
                   </li>
                 )}
+                {onScaleClick && (
+                  <li>
+                    <Link
+                      href='#'
+                      onClick={(e) => {
+                        e.preventDefault();
+
+                        onScaleClick();
+                        onBlurHandler();
+                      }}
+                    >
+                      <Text>Edit scaling limits</Text>
+                    </Link>
+                  </li>
+                )}
                 {onDeleteClick && (
                   <li>
                     <Link
@@ -100,6 +117,7 @@ const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = (
 WorkerNodesNodePoolActions.propTypes = {
   onRenameClick: PropTypes.func,
   onDeleteClick: PropTypes.func,
+  onScaleClick: PropTypes.func,
 };
 
 export default WorkerNodesNodePoolActions;

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
@@ -69,7 +69,7 @@ const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = (
                         onBlurHandler();
                       }}
                     >
-                      Rename
+                      <Text>Rename</Text>
                     </Link>
                   </li>
                 )}

--- a/src/components/shared/NodeCountSelector.js
+++ b/src/components/shared/NodeCountSelector.js
@@ -1,3 +1,4 @@
+import { Text } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import NumberPicker from 'UI/Inputs/NumberPicker';
@@ -89,11 +90,11 @@ class NodeCountSelector extends React.Component {
               />
             </InnerTwoInputArea>
           </TwoInputArea>
-          <p data-testid='node-count-selector-autoscaling-label'>
+          <Text data-testid='node-count-selector-autoscaling-label'>
             {scaling.min === scaling.max
               ? 'To enable autoscaling, set minimum and maximum to different values.'
               : 'To disable autoscaling, set both numbers to the same value.'}
-          </p>
+          </Text>
         </form>
       );
     }


### PR DESCRIPTION
Towards giantswarm/roadmap#341

This PR adds support for scaling node pools in the MAPI cluster detail page. The implementation is slightly different compared to deletion, as the logic for scaling is not included in the `WorkerNodesNodePoolItem` component. I will update the deletion component, for consistency, in a separate PR.

## Preview

<details>
<summary>no value changed</summary>

![image](https://user-images.githubusercontent.com/13508038/123965321-9d388600-d9b4-11eb-9788-30e570890623.png)

</details>

<details>
<summary>increased min by 2</summary>

![image](https://user-images.githubusercontent.com/13508038/123965146-72e6c880-d9b4-11eb-9b3f-17ae2cb656dc.png)

</details>

<details>
<summary>made max lower than current number of nodes</summary>

![image](https://user-images.githubusercontent.com/13508038/123965063-5fd3f880-d9b4-11eb-8042-94cef1ccda9a.png)

</details>