### PR TITLE
Replace 'happa' with 'web interface'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,7 @@ jobs:
               "$(cat .docker_image_name)"
             sleep 2
             CURL_OUTPUT=$(ssh remote-docker "curl -s http://localhost:8000")
-            echo "${CURL_OUTPUT}" | grep Happa
+            echo "${CURL_OUTPUT}" | grep "Giant Swarm web interface"
 
   build-fe-docs:
     <<: *defaults

--- a/src/components/Cluster/ClusterDetail/KeypairCreateModal/Utils.ts
+++ b/src/components/Cluster/ClusterDetail/KeypairCreateModal/Utils.ts
@@ -7,7 +7,7 @@ export enum KeypairCreateModalStatus {
 }
 
 export function getDefaultDescription(email: string): string {
-  return `Added by user ${email} using Happa web interface`;
+  return `Added by user ${email} using the Giant Swarm web interface`;
 }
 
 export function getModalTitle(status: KeypairCreateModalStatus): string {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -74,7 +74,7 @@ const Footer: React.FC<IFooterProps> = (props: IFooterProps) => {
 
   return (
     <footer {...props}>
-      <FooterGroup>Happa</FooterGroup>
+      <FooterGroup>Giant Swarm web interface</FooterGroup>
       <FooterGroup>
         <OverlayTrigger
           overlay={<Tooltip id='tooltip'>{tooltipMessage}</Tooltip>}

--- a/src/components/Footer/FooterUtils.ts
+++ b/src/components/Footer/FooterUtils.ts
@@ -89,7 +89,7 @@ export function hasUpdateReady(
 
 export function showUpdateToast(callback?: () => void) {
   new FlashMessage(
-    `There's a new version of happa available!`,
+    `There's a new version of the web interface available.`,
     messageType.INFO,
     messageTTL.FOREVER,
     `Please press the <code>${Constants.METADATA_UPDATE_LABEL}</code> button in the footer of the page to use the latest version (it only takes a couple of seconds).`,

--- a/src/components/Footer/__tests__/Footer.ts
+++ b/src/components/Footer/__tests__/Footer.ts
@@ -87,10 +87,10 @@ describe('Footer', () => {
     jest.runAllTimers();
 
     await findByText(/0.0.1/i);
-    await findAllByText(/update happa now/i);
+    await findAllByText(/update the web interface now/i);
     // Check for the flash message
     expect(
-      getByText(/There's a new version of happa available/i)
+      getByText(/There's a new version of the web interface available/i)
     ).toBeInTheDocument();
 
     const versionWrapper = getByText(/0.0.1/i);
@@ -130,16 +130,16 @@ describe('Footer', () => {
     // Fast-forward until all timers have been executed
     jest.runAllTimers();
 
-    await findAllByText(/update happa now/i);
+    await findAllByText(/update the web interface now/i);
     expect(
-      getByText(/There's a new version of happa available/i)
+      getByText(/There's a new version of the web interface available/i)
     ).toBeInTheDocument();
 
     // Fast-forward until all timers have been executed
     jest.runAllTimers();
 
     expect(
-      getByText(/There's a new version of happa available/i)
+      getByText(/There's a new version of the web interface available/i)
     ).toBeInTheDocument();
   });
 
@@ -166,11 +166,11 @@ describe('Footer', () => {
     // Fast-forward until all timers have been executed
     jest.runAllTimers();
 
-    await findAllByText(/update happa now/i);
+    await findAllByText(/update the web interface now/i);
 
     const updateButton = within(
       document.querySelector('footer') as HTMLElement
-    ).getByText(/update happa now/i);
+    ).getByText(/update the web interface now/i);
     fireEvent.click(updateButton);
 
     expect(getByText(/updating.../i)).toBeInTheDocument();

--- a/src/components/GettingStarted/Steps/ConfigureKubectlAlternative.js
+++ b/src/components/GettingStarted/Steps/ConfigureKubectlAlternative.js
@@ -69,7 +69,7 @@ class ConfigKubeCtl extends React.Component {
 
     this.props.actions
       .clusterCreateKeyPair(this.props.cluster.id, {
-        description: `Added by user ${this.props.user.email} using the Happa web interface.`,
+        description: `Added by user ${this.props.user.email} using the Giant Swarm web interface.`,
         certificate_organizations: 'system:masters',
       })
       .then((keypair) => {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <title>Happa | Giant Swarm</title>
+    <title>Giant Swarm web interface</title>
     <meta name="description" content="" />
     <meta
       name="viewport"

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -19,7 +19,7 @@ export const Constants = {
   DEFAULT_METADATA_CHECK_PERIOD: 10 * 60 * 1000, // 10 minutes
   // eslint-disable-next-line no-magic-numbers
   DEFAULT_METADATA_UPDATE_TIMEOUT: 2 * 1000, // 2 seconds
-  METADATA_UPDATE_LABEL: 'Update happa now',
+  METADATA_UPDATE_LABEL: 'Update the web interface now',
 
   DEFAULT_NODEPOOL_NAME: 'Unnamed node pool',
   DEFAULT_NODEPOOL_DESCRIPTION: 'Please add description',


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16699

This PR removes all user-facing strings "happa" and replaces them with "web interface".