### PR TITLE
clusters: add support for setting AZs when creating NPs via the MAPI cluster detail page

### DIFF
--- a/src/components/Cluster/AZSelection/AZSelection.tsx
+++ b/src/components/Cluster/AZSelection/AZSelection.tsx
@@ -24,7 +24,6 @@ const StyledPanel = styled(Panel)`
 `;
 
 const StyledPanelCollapse = styled(PanelCollapse)`
-  font-size: 14px;
   padding: ${({ theme }) => theme.spacingPx * 2}px 0 0
     ${({ theme }) => theme.spacingPx * 7}px;
   opacity: 0;

--- a/src/components/Cluster/AZSelection/AZSelectionAutomatic.tsx
+++ b/src/components/Cluster/AZSelection/AZSelectionAutomatic.tsx
@@ -39,7 +39,7 @@ const AZSelectionAutomatic: React.FC<IAZSelectionAutomaticProps> = ({
   let automaticAZSelectionMessage =
     'Availability zones will be selected randomly.';
   if (numOfZones < 2) {
-    automaticAZSelectionMessage = `Covering one availability zone, the worker nodes of this node pool will be placed in the same availability zone as the cluster's master node.`;
+    automaticAZSelectionMessage = `Covering one availability zone, the worker nodes of this node pool will be placed in the same availability zone as the cluster's control plane node.`;
   }
 
   return (

--- a/src/components/Cluster/AZSelection/AZSelectionAutomatic.tsx
+++ b/src/components/Cluster/AZSelection/AZSelectionAutomatic.tsx
@@ -1,6 +1,8 @@
 import AvailabilityZonesParser from 'Cluster/ClusterDetail/AvailabilityZonesParser';
+import { Box, Text } from 'grommet';
 import PropTypes from 'prop-types';
 import * as React from 'react';
+import styled from 'styled-components';
 
 import {
   AvailabilityZoneSelection,
@@ -8,6 +10,10 @@ import {
   AZSelectionZonesUpdater,
   AZSelectorWrapper,
 } from './AZSelectionUtils';
+
+const StyledAZSelectorWrapper = styled(AZSelectorWrapper)`
+  align-items: baseline;
+`;
 
 interface IAZSelectionAutomaticProps {
   onUpdateZones: AZSelectionZonesUpdater;
@@ -30,9 +36,9 @@ const AZSelectionAutomatic: React.FC<IAZSelectionAutomaticProps> = ({
 }) => {
   if (variant === AZSelectionVariants.Master) {
     return (
-      <p>
+      <Text>
         An Availabilty Zone will be automatically chosen from the existing ones.
-      </p>
+      </Text>
     );
   }
 
@@ -44,8 +50,10 @@ const AZSelectionAutomatic: React.FC<IAZSelectionAutomaticProps> = ({
 
   return (
     <>
-      <AZSelectorWrapper>
-        <p>Number of availability zones to use:</p>
+      <StyledAZSelectorWrapper>
+        <Box>
+          <Text>Number of availability zones to use</Text>
+        </Box>
         <AvailabilityZonesParser
           min={minNumOfZones}
           max={maxNumOfZones}
@@ -56,8 +64,8 @@ const AZSelectionAutomatic: React.FC<IAZSelectionAutomaticProps> = ({
           )}
           isLabels={false}
         />
-      </AZSelectorWrapper>
-      <p>{automaticAZSelectionMessage}</p>
+      </StyledAZSelectorWrapper>
+      <Text>{automaticAZSelectionMessage}</Text>
     </>
   );
 };

--- a/src/components/Cluster/AZSelection/AZSelectionCheckbox.tsx
+++ b/src/components/Cluster/AZSelection/AZSelectionCheckbox.tsx
@@ -1,3 +1,4 @@
+import { Text } from 'grommet';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import RUMActionTarget from 'RUM/RUMActionTarget';
@@ -16,6 +17,7 @@ interface IAZSelectionCheckboxProps
   value?: AvailabilityZoneSelection;
   uniqueIdentifier?: string;
   baseActionName?: string;
+  label?: string;
 }
 
 const AZSelectionCheckbox: React.FC<IAZSelectionCheckboxProps> = ({
@@ -24,6 +26,7 @@ const AZSelectionCheckbox: React.FC<IAZSelectionCheckboxProps> = ({
   value,
   uniqueIdentifier,
   baseActionName,
+  label,
   ...rest
 }) => {
   const typeName = AvailabilityZoneSelection[type as AvailabilityZoneSelection];
@@ -37,6 +40,11 @@ const AZSelectionCheckbox: React.FC<IAZSelectionCheckboxProps> = ({
         checked={value === type}
         onChange={() => onChange(type!)}
         tabIndex={-1}
+        label={
+          <Text weight='normal' color='text'>
+            {label}
+          </Text>
+        }
         {...rest}
       />
     </RUMActionTarget>
@@ -49,6 +57,7 @@ AZSelectionCheckbox.propTypes = {
   type: PropTypes.number,
   uniqueIdentifier: PropTypes.string,
   baseActionName: PropTypes.string,
+  label: PropTypes.string,
 };
 
 AZSelectionCheckbox.defaultProps = {

--- a/src/components/Cluster/AZSelection/AZSelectionCheckbox.tsx
+++ b/src/components/Cluster/AZSelection/AZSelectionCheckbox.tsx
@@ -36,7 +36,7 @@ const AZSelectionCheckbox: React.FC<IAZSelectionCheckboxProps> = ({
         name={id}
         checked={value === type}
         onChange={() => onChange(type!)}
-        tabIndex={0}
+        tabIndex={-1}
         {...rest}
       />
     </RUMActionTarget>

--- a/src/components/Cluster/AZSelection/AZSelectionManual.tsx
+++ b/src/components/Cluster/AZSelection/AZSelectionManual.tsx
@@ -1,4 +1,5 @@
 import AvailabilityZonesParser from 'Cluster/ClusterDetail/AvailabilityZonesParser';
+import { Box, Text } from 'grommet';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import styled from 'styled-components';
@@ -9,12 +10,6 @@ import {
   AZSelectionZonesUpdater,
   AZSelectorWrapper,
 } from './AZSelectionUtils';
-
-const ErrorMessage = styled.p`
-  color: ${({ theme }) => theme.colors.error};
-  font-weight: 400;
-  margin-bottom: 0;
-`;
 
 const ManualAZSelector = styled.div`
   font-size: 16px;
@@ -57,7 +52,9 @@ const AZSelectionManual: React.FC<IAZSelectionManualProps> = ({
 
   return (
     <>
-      <p>{descriptionMessage}</p>
+      <Box margin={{ bottom: 'small' }}>
+        <Text>{descriptionMessage}</Text>
+      </Box>
       <AZSelectorWrapper>
         <ManualAZSelector>
           <AvailabilityZonesParser
@@ -73,7 +70,7 @@ const AZSelectionManual: React.FC<IAZSelectionManualProps> = ({
           />
         </ManualAZSelector>
 
-        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+        {errorMessage && <Text color='status-critical'>{errorMessage}</Text>}
       </AZSelectorWrapper>
     </>
   );

--- a/src/components/Cluster/AZSelection/AZSelectionNotSpecified.tsx
+++ b/src/components/Cluster/AZSelection/AZSelectionNotSpecified.tsx
@@ -1,3 +1,4 @@
+import { Text } from 'grommet';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 
@@ -17,7 +18,7 @@ const AZSelectionNotSpecified: React.FC<IAZSelectionNotSpecifiedProps> = ({
       'By not specifying an availability zone, Azure will select a zone by itself, where the requested virtual machine size has the best availability. This is especially useful for virtual machine sizes with GPU, which are not available in all availability zones.';
   }
 
-  return <p>{descriptionMessage}</p>;
+  return <Text>{descriptionMessage}</Text>;
 };
 
 AZSelectionNotSpecified.propTypes = {

--- a/src/components/MAPI/__tests__/utils.ts
+++ b/src/components/MAPI/__tests__/utils.ts
@@ -1,4 +1,4 @@
-import { generateUID } from 'MAPI/utils';
+import { determineRandomAZs, generateUID } from 'MAPI/utils';
 
 describe('mapi::utils', () => {
   describe('generateUID', () => {
@@ -13,6 +13,72 @@ describe('mapi::utils', () => {
 
         values.add(id);
       }
+    });
+  });
+
+  describe('determineRandomAZs', () => {
+    it('returns a collection of random availability zones', () => {
+      function runTest(tries: number, count: number, fromList: string[]) {
+        const values = new Set<string>();
+        for (let i = 0; i < tries; i++) {
+          const azs = determineRandomAZs(count, fromList).join();
+
+          if (values.has(azs)) return false;
+
+          values.add(azs);
+        }
+
+        return true;
+      }
+
+      const runs = 50;
+      let successRuns = 0;
+      for (let i = 0; i < runs; i++) {
+        const result = runTest(3, 2, ['1', '2', '3', '4', '5']);
+        if (!result) continue;
+
+        successRuns++;
+      }
+
+      // Expect a 50% success rate.
+      // eslint-disable-next-line no-magic-numbers
+      expect(successRuns).toBeGreaterThan(0.05 * runs);
+    });
+
+    it('returns an empty collection for no given availability zones', () => {
+      const azs = determineRandomAZs(3, []);
+      expect(azs).toStrictEqual([]);
+    });
+
+    it('returns an empty collection for 0 desired availability zones', () => {
+      const azs = determineRandomAZs(0, ['1', '2', '3', '4', '5']);
+      expect(azs).toStrictEqual([]);
+    });
+
+    it('includes the existing availability zones and only gets random values for the other required ones', () => {
+      const azs = determineRandomAZs(3, ['1', '2', '3', '4', '5'], ['1', '2']);
+      expect(azs[0]).toEqual('1');
+      expect(azs[1]).toEqual('2');
+    });
+
+    it('includes the existing availability zones and only gets random values for the other required ones', () => {
+      const azs = determineRandomAZs(3, ['1', '2', '3', '4', '5'], ['1', '2']);
+      expect(azs[0]).toEqual('1');
+      expect(azs[1]).toEqual('2');
+      expect(azs[2]).not.toEqual('1');
+      expect(azs[2]).not.toEqual('2');
+      expect(['3', '4', '5'].includes(azs[2])).toBeTruthy();
+    });
+
+    it('does not include the existing availability zones if they are not in the list of supported ones', () => {
+      const azs = determineRandomAZs(2, ['1', '2', '3'], ['4', '5']);
+      expect(azs.includes('4')).toBeFalsy();
+      expect(azs.includes('5')).toBeFalsy();
+    });
+
+    it('returns the maximum number of availability zones possible, even if the available ones are less than we need', () => {
+      const azs = determineRandomAZs(3, ['1', '2']);
+      expect(azs).toStrictEqual(['1', '2']);
     });
   });
 });

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -33,6 +33,7 @@ import {
   createDefaultProviderNodePool,
   createNodePool,
 } from './utils';
+import WorkerNodesCreateNodePoolAvailabilityZones from './WorkerNodesCreateNodePoolAvailabilityZones';
 import WorkerNodesCreateNodePoolDescription from './WorkerNodesCreateNodePoolDescription';
 import WorkerNodesCreateNodePoolMachineType from './WorkerNodesCreateNodePoolMachineType';
 import WorkerNodesCreateNodePoolName from './WorkerNodesCreateNodePoolName';
@@ -41,6 +42,7 @@ enum NodePoolPropertyField {
   Name,
   Description,
   MachineType,
+  AvailabilityZones,
 }
 
 interface IApplyPatchAction {
@@ -114,6 +116,7 @@ function makeInitialState(
       [NodePoolPropertyField.Name]: true,
       [NodePoolPropertyField.Description]: true,
       [NodePoolPropertyField.MachineType]: true,
+      [NodePoolPropertyField.AvailabilityZones]: false,
     },
     isCreating: false,
   };
@@ -284,6 +287,14 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
                 nodePool={state.nodePool}
                 providerNodePool={state.providerNodePool}
                 onChange={handleChange(NodePoolPropertyField.MachineType)}
+              />
+              <WorkerNodesCreateNodePoolAvailabilityZones
+                id={`node-pool-${id}-${NodePoolPropertyField.AvailabilityZones}`}
+                nodePool={state.nodePool}
+                providerNodePool={state.providerNodePool}
+                onChange={handleChange(NodePoolPropertyField.AvailabilityZones)}
+                cluster={cluster}
+                margin={{ top: 'small' }}
               />
               <Box direction='row' margin={{ top: 'medium' }}>
                 <Button

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolAvailabilityZones.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolAvailabilityZones.tsx
@@ -1,0 +1,184 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import AZSelection from 'Cluster/AZSelection/AZSelection';
+import {
+  AvailabilityZoneSelection,
+  AZSelectionVariants,
+  AZSelectionZonesUpdater,
+  IUpdateZoneLabelsPayload,
+  IUpdateZonePickerPayload,
+} from 'Cluster/AZSelection/AZSelectionUtils';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
+import { computeControlPlaneNodesStats } from 'MAPI/clusters/ClusterDetail/utils';
+import { Cluster, ControlPlaneNodeList, NodePool } from 'MAPI/types';
+import {
+  determineRandomAZs,
+  fetchMasterListForCluster,
+  fetchMasterListForClusterKey,
+  getSupportedAvailabilityZones,
+} from 'MAPI/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import PropTypes from 'prop-types';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { RUMActions } from 'shared/constants/realUserMonitoring';
+import { getProvider } from 'stores/main/selectors';
+import useSWR from 'swr';
+import InputGroup from 'UI/Inputs/InputGroup';
+
+import {
+  INodePoolPropertyProps,
+  withNodePoolAvailabilityZones,
+} from './patches';
+
+interface IWorkerNodesCreateNodePoolAvailabilityZonesProps
+  extends INodePoolPropertyProps,
+    Omit<React.ComponentPropsWithoutRef<typeof InputGroup>, 'onChange' | 'id'> {
+  cluster: Cluster;
+}
+
+const WorkerNodesCreateNodePoolAvailabilityZones: React.FC<IWorkerNodesCreateNodePoolAvailabilityZonesProps> = ({
+  id,
+  nodePool,
+  onChange,
+  readOnly,
+  disabled,
+  autoFocus,
+  cluster,
+  ...props
+}) => {
+  const clientFactory = useHttpClientFactory();
+  const auth = useAuthProvider();
+
+  const controlPlaneNodeListKey = cluster
+    ? fetchMasterListForClusterKey(cluster)
+    : null;
+
+  const {
+    data: controlPlaneNodeList,
+    error: controlPlaneNodeListError,
+  } = useSWR<ControlPlaneNodeList, GenericResponseError>(
+    controlPlaneNodeListKey,
+    () => fetchMasterListForCluster(clientFactory, auth, cluster)
+  );
+
+  useEffect(() => {
+    if (controlPlaneNodeListError) {
+      ErrorReporter.getInstance().notify(controlPlaneNodeListError);
+    }
+  }, [controlPlaneNodeListError]);
+
+  const controlPlaneZones = useMemo(() => {
+    if (
+      typeof controlPlaneNodeListError !== 'undefined' ||
+      !controlPlaneNodeList
+    ) {
+      return undefined;
+    }
+
+    return computeControlPlaneNodesStats(controlPlaneNodeList.items)
+      .availabilityZones;
+  }, [controlPlaneNodeList, controlPlaneNodeListError]);
+
+  const provider = useSelector(getProvider);
+  const azStats = useSelector(getSupportedAvailabilityZones);
+
+  const [azSelector, setAzSelector] = useState(
+    AvailabilityZoneSelection.Automatic
+  );
+  const [autoZonesCount, setAutoZonesCount] = useState(1);
+  const [autoZoneIsValid, setAutoZoneIsValid] = useState(true);
+  const [manualZones, setManualZones] = useState<string[]>([]);
+  const [manualZonesIsValid, setManualZonesIsValid] = useState(false);
+
+  const handleChange = (selector: AvailabilityZoneSelection) => {
+    setAzSelector(selector);
+  };
+
+  useEffect(() => {
+    if (!controlPlaneZones) return;
+
+    switch (azSelector) {
+      case AvailabilityZoneSelection.Automatic:
+        onChange({
+          isValid: autoZoneIsValid,
+          patch: withNodePoolAvailabilityZones(
+            determineRandomAZs(autoZonesCount, azStats.all, controlPlaneZones)
+          ),
+        });
+        break;
+
+      case AvailabilityZoneSelection.Manual:
+        onChange({
+          isValid: manualZonesIsValid,
+          patch: withNodePoolAvailabilityZones(manualZones),
+        });
+        break;
+
+      case AvailabilityZoneSelection.NotSpecified:
+        onChange({
+          isValid: true,
+          patch: withNodePoolAvailabilityZones(undefined),
+        });
+        break;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    azSelector,
+    autoZonesCount,
+    autoZoneIsValid,
+    manualZones,
+    manualZonesIsValid,
+    controlPlaneZones,
+  ]);
+
+  const handleZoneChange: AZSelectionZonesUpdater = (azSelection) => (
+    payload
+  ) => {
+    switch (azSelection) {
+      case AvailabilityZoneSelection.Automatic:
+        setAutoZoneIsValid(payload.valid);
+        setAutoZonesCount((payload as IUpdateZonePickerPayload).value);
+        break;
+
+      case AvailabilityZoneSelection.Manual:
+        setManualZonesIsValid(payload.valid);
+        setManualZones((payload as IUpdateZoneLabelsPayload).zonesArray);
+        break;
+    }
+  };
+
+  return (
+    <InputGroup htmlFor={id} label='Availability zones selection' {...props}>
+      {controlPlaneZones && (
+        <AZSelection
+          variant={AZSelectionVariants.NodePool}
+          uniqueIdentifier={id}
+          baseActionName={RUMActions.SelectAZSelection}
+          value={azSelector}
+          provider={provider}
+          onChange={handleChange}
+          minNumOfZones={azStats.minCount}
+          maxNumOfZones={azStats.maxCount}
+          defaultNumOfZones={azStats.defaultCount}
+          allZones={azStats.all}
+          numOfZones={autoZonesCount}
+          selectedZones={manualZones}
+          onUpdateZones={handleZoneChange}
+        />
+      )}
+    </InputGroup>
+  );
+};
+
+WorkerNodesCreateNodePoolAvailabilityZones.propTypes = {
+  id: PropTypes.string.isRequired,
+  nodePool: (PropTypes.object as PropTypes.Requireable<NodePool>).isRequired,
+  cluster: (PropTypes.object as PropTypes.Requireable<Cluster>).isRequired,
+  onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
+};
+
+export default WorkerNodesCreateNodePoolAvailabilityZones;

--- a/src/components/MAPI/workernodes/patches.ts
+++ b/src/components/MAPI/workernodes/patches.ts
@@ -39,3 +39,11 @@ export function withNodePoolMachineType(newMachineType: string): NodePoolPatch {
     }
   };
 }
+
+export function withNodePoolAvailabilityZones(zones?: string[]): NodePoolPatch {
+  return (nodePool: NodePool) => {
+    if (nodePool.kind === capiexpv1alpha3.MachinePool) {
+      nodePool.spec!.failureDomains = zones;
+    }
+  };
+}

--- a/src/components/UI/Display/Cluster/AvailabilityZones/AvailabilityZonesLabel.js
+++ b/src/components/UI/Display/Cluster/AvailabilityZones/AvailabilityZonesLabel.js
@@ -1,3 +1,4 @@
+import { Keyboard } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import RUMActionTarget from 'RUM/RUMActionTarget';
@@ -115,16 +116,25 @@ function AvailabilityZonesLabel({
     }
   };
 
+  const handleSelectKeyDown = (e) => {
+    e.preventDefault();
+
+    toggleChecked();
+  };
+
   return (
     <RUMActionTarget name={RUMActions.ToggleAZ}>
-      <Wrapper
-        className={classNames}
-        title={title}
-        bgColor={color}
-        onClick={toggleChecked}
-      >
-        {label}
-      </Wrapper>
+      <Keyboard onSpace={handleSelectKeyDown} onEnter={handleSelectKeyDown}>
+        <Wrapper
+          className={classNames}
+          title={title}
+          bgColor={color}
+          onClick={toggleChecked}
+          tabIndex={0}
+        >
+          {label}
+        </Wrapper>
+      </Keyboard>
     </RUMActionTarget>
   );
 }

--- a/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
@@ -9,6 +9,7 @@ exports[`RadioInput renders a disabled input 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
+      tabindex="0"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 nMYKY FormField__FormFieldContentBox-m9hood-1"
@@ -24,6 +25,7 @@ exports[`RadioInput renders a disabled input 1`] = `
               class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 kVpJxN"
               disabled=""
               name="some-input"
+              tabindex="-1"
               type="radio"
             />
             <div
@@ -51,6 +53,7 @@ exports[`RadioInput renders a simple input 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
+      tabindex="0"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 nMYKY FormField__FormFieldContentBox-m9hood-1"
@@ -64,6 +67,7 @@ exports[`RadioInput renders a simple input 1`] = `
             <input
               class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 kGVKvV"
               name="some-input"
+              tabindex="-1"
               type="radio"
             />
             <div
@@ -91,6 +95,7 @@ exports[`RadioInput renders an input with a form field label 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
+      tabindex="0"
     >
       <label
         class="StyledText-sc-1sadyjn-0 weZKr"
@@ -112,6 +117,7 @@ exports[`RadioInput renders an input with a form field label 1`] = `
               class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 kGVKvV"
               id="some-input"
               name="some-input"
+              tabindex="-1"
               type="radio"
             />
             <div
@@ -139,6 +145,7 @@ exports[`RadioInput renders an input with a help message 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
+      tabindex="0"
     >
       <span
         class="StyledText-sc-1sadyjn-0 hosPKv"
@@ -157,6 +164,7 @@ exports[`RadioInput renders an input with a help message 1`] = `
             <input
               class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 kGVKvV"
               name="some-input"
+              tabindex="-1"
               type="radio"
             />
             <div
@@ -184,6 +192,7 @@ exports[`RadioInput renders an input with a validation error 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
+      tabindex="0"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 nMYKY FormField__FormFieldContentBox-m9hood-1"
@@ -197,6 +206,7 @@ exports[`RadioInput renders an input with a validation error 1`] = `
             <input
               class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 kGVKvV"
               name="some-input"
+              tabindex="-1"
               type="radio"
             />
             <div
@@ -229,6 +239,7 @@ exports[`RadioInput renders an input with an info message 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
+      tabindex="0"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 nMYKY FormField__FormFieldContentBox-m9hood-1"
@@ -242,6 +253,7 @@ exports[`RadioInput renders an input with an info message 1`] = `
             <input
               class="StyledRadioButton__StyledRadioButtonInput-g1f6ld-1 kGVKvV"
               name="some-input"
+              tabindex="-1"
               type="radio"
             />
             <div

--- a/src/components/UI/Inputs/RadioInput/index.tsx
+++ b/src/components/UI/Inputs/RadioInput/index.tsx
@@ -1,12 +1,14 @@
 import {
   FormField,
   FormFieldProps,
+  Keyboard,
   RadioButton as Input,
   RadioButtonProps,
 } from 'grommet';
 import PropTypes from 'prop-types';
-import * as React from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
+import { setMultipleRefs } from 'utils/componentUtils';
 
 const StyledFormField = styled(FormField)`
   & input {
@@ -83,6 +85,15 @@ const RadioInput = React.forwardRef<HTMLInputElement, IRadioInputProps>(
     },
     ref
   ) => {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    const handleSelectKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+      e.preventDefault();
+
+      if (!inputRef.current) return;
+      inputRef.current.click();
+    };
+
     const patchedContentProps = Object.assign(
       {},
       {
@@ -97,30 +108,34 @@ const RadioInput = React.forwardRef<HTMLInputElement, IRadioInputProps>(
     );
 
     return (
-      <StyledFormField
-        htmlFor={id}
-        contentProps={patchedContentProps}
-        disabled={disabled}
-        required={required}
-        name={name}
-        error={error}
-        info={info}
-        help={help}
-        margin={margin}
-        pad={pad}
-        label={fieldLabel}
-        {...formFieldProps}
-      >
-        <Input
-          {...props}
-          id={id}
-          ref={ref}
+      <Keyboard onSpace={handleSelectKeyDown} onEnter={handleSelectKeyDown}>
+        <StyledFormField
+          htmlFor={id}
+          contentProps={patchedContentProps}
           disabled={disabled}
           required={required}
           name={name}
-          label={label}
-        />
-      </StyledFormField>
+          error={error}
+          info={info}
+          help={help}
+          margin={margin}
+          pad={pad}
+          label={fieldLabel}
+          tabIndex={0}
+          {...formFieldProps}
+        >
+          <Input
+            {...props}
+            id={id}
+            ref={setMultipleRefs(inputRef, ref)}
+            disabled={disabled}
+            required={required}
+            name={name}
+            label={label}
+            tabIndex={-1}
+          />
+        </StyledFormField>
+      </Keyboard>
     );
   }
 );


### PR DESCRIPTION
Towards giantswarm/roadmap#341

This PR adds support for setting availability zones when creating node pools. It uses the same underlying components as the current GS API implementation. However, I've made some improvements in how those components behave (consistent font sizes, improved keyboard navigation).

## Preview

<details>
<summary>Automatic AZ selection</summary>

![image](https://user-images.githubusercontent.com/13508038/124288021-fccb9880-db50-11eb-8225-d62fbdd405fc.png)

</details>

<details>
<summary>Manual AZ selection</summary>

![image](https://user-images.githubusercontent.com/13508038/124288158-25539280-db51-11eb-8765-bd5cb36cd68b.png)

</details>

<details>
<summary>Not specified selection</summary>

![image](https://user-images.githubusercontent.com/13508038/124288087-110f9580-db51-11eb-8b33-14e7ccde2d85.png)

</details>

