### PR TITLE
Avoid error notification for invalid app values file

### DIFF
--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -206,8 +206,6 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
         setValuesYAMLError('');
       } catch (err) {
         setValuesYAMLError('Unable to parse valid YAML from this file.');
-
-        ErrorReporter.getInstance().notify(err);
       }
     };
 

--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -230,8 +230,6 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
         setSecretsYAMLError('');
       } catch (err) {
         setSecretsYAMLError('Unable to parse valid YAML from this file.');
-
-        ErrorReporter.getInstance().notify(err);
       }
     };
 

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload.tsx
@@ -1,5 +1,4 @@
 import yaml from 'js-yaml';
-import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import PropTypes from 'prop-types';
 import React, { useRef, useState } from 'react';
@@ -45,8 +44,6 @@ const YAMLFileUpload: React.FC<IYAMLFileUploadProps> = ({
         );
 
         setFileUploading(false);
-
-        ErrorReporter.getInstance().notify(err);
       }
     };
 

--- a/src/components/MAPI/apps/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/AppInstallModal.tsx
@@ -188,8 +188,6 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
         setValuesYAMLError('');
       } catch (err) {
         setValuesYAMLError('Unable to parse valid YAML from this file.');
-
-        ErrorReporter.getInstance().notify(err);
       }
     };
 

--- a/src/components/MAPI/apps/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/AppInstallModal.tsx
@@ -212,8 +212,6 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
         setSecretsYAMLError('');
       } catch (err) {
         setSecretsYAMLError('Unable to parse valid YAML from this file.');
-
-        ErrorReporter.getInstance().notify(err);
       }
     };
 


### PR DESCRIPTION
With this PR we turn off the error notification (submission to Sentry) for errors happening if a user tries uploading an invalid values.yaml file.