### PR TITLE
clusters: add support for configuring scaling when creating NPs via the MAPI cluster detail page

### DIFF
--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePool.js
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePool.js
@@ -287,7 +287,7 @@ class AddNodePool extends Component {
       aws,
       azure,
     } = this.state;
-    const { provider } = this.props;
+    const { provider, capabilities } = this.props;
 
     const nodePoolDefinition = {
       availability_zones: {},
@@ -358,11 +358,17 @@ class AddNodePool extends Component {
       }
     }
 
-    // Add scaling setup.
-    nodePoolDefinition.scaling = {
-      min: scaling.min,
-      max: scaling.max,
-    };
+    if (capabilities.supportsNodePoolAutoscaling) {
+      nodePoolDefinition.scaling = {
+        min: scaling.min,
+        max: scaling.max,
+      };
+    } else {
+      nodePoolDefinition.scaling = {
+        min: scaling.min,
+        max: scaling.min,
+      };
+    }
 
     const isValid = this.validate();
 

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -37,12 +37,14 @@ import WorkerNodesCreateNodePoolAvailabilityZones from './WorkerNodesCreateNodeP
 import WorkerNodesCreateNodePoolDescription from './WorkerNodesCreateNodePoolDescription';
 import WorkerNodesCreateNodePoolMachineType from './WorkerNodesCreateNodePoolMachineType';
 import WorkerNodesCreateNodePoolName from './WorkerNodesCreateNodePoolName';
+import WorkerNodesCreateNodePoolScale from './WorkerNodesCreateNodePoolScale';
 
 enum NodePoolPropertyField {
   Name,
   Description,
   MachineType,
   AvailabilityZones,
+  Scale,
 }
 
 interface IApplyPatchAction {
@@ -117,6 +119,7 @@ function makeInitialState(
       [NodePoolPropertyField.Description]: true,
       [NodePoolPropertyField.MachineType]: true,
       [NodePoolPropertyField.AvailabilityZones]: false,
+      [NodePoolPropertyField.Scale]: true,
     },
     isCreating: false,
   };
@@ -295,6 +298,12 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
                 onChange={handleChange(NodePoolPropertyField.AvailabilityZones)}
                 cluster={cluster}
                 margin={{ top: 'small' }}
+              />
+              <WorkerNodesCreateNodePoolScale
+                id={`node-pool-${id}-${NodePoolPropertyField.Scale}`}
+                nodePool={state.nodePool}
+                providerNodePool={state.providerNodePool}
+                onChange={handleChange(NodePoolPropertyField.Scale)}
               />
               <Box direction='row' margin={{ top: 'medium' }}>
                 <Button

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolScale.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolScale.tsx
@@ -1,0 +1,75 @@
+import { NodePool } from 'MAPI/types';
+import { getNodePoolScaling } from 'MAPI/utils';
+import PropTypes from 'prop-types';
+import React, { useRef } from 'react';
+import NodeCountSelector from 'shared/NodeCountSelector';
+import InputGroup from 'UI/Inputs/InputGroup';
+
+import { INodePoolPropertyProps, withNodePoolScaling } from './patches';
+
+interface IWorkerNodesCreateNodePoolScaleProps
+  extends INodePoolPropertyProps,
+    Omit<
+      React.ComponentPropsWithoutRef<typeof InputGroup>,
+      'onChange' | 'id'
+    > {}
+
+const WorkerNodesCreateNodePoolScale: React.FC<IWorkerNodesCreateNodePoolScaleProps> = ({
+  id,
+  nodePool,
+  onChange,
+  readOnly,
+  disabled,
+  ...props
+}) => {
+  const isMinValid = useRef(false);
+  const isMaxValid = useRef(false);
+
+  const handleChange = (newValue: {
+    scaling: {
+      min: number;
+      minValid: boolean;
+      max: number;
+      maxValid: boolean;
+    };
+  }) => {
+    const { min, minValid, max, maxValid } = newValue.scaling;
+
+    isMinValid.current = minValid;
+    isMaxValid.current = maxValid;
+
+    onChange({
+      isValid: minValid && maxValid,
+      patch: withNodePoolScaling(min, max),
+    });
+  };
+
+  const value = getNodePoolScaling(nodePool);
+
+  return (
+    <InputGroup htmlFor={id} label='Scaling range' {...props}>
+      <NodeCountSelector
+        id={id}
+        autoscalingEnabled={true}
+        onChange={handleChange}
+        readOnly={readOnly || disabled}
+        scaling={{
+          min: value.min,
+          minValid: isMinValid.current,
+          max: value.max,
+          maxValid: isMaxValid.current,
+        }}
+      />
+    </InputGroup>
+  );
+};
+
+WorkerNodesCreateNodePoolScale.propTypes = {
+  id: PropTypes.string.isRequired,
+  nodePool: (PropTypes.object as PropTypes.Requireable<NodePool>).isRequired,
+  onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
+};
+
+export default WorkerNodesCreateNodePoolScale;

--- a/src/components/MAPI/workernodes/patches.ts
+++ b/src/components/MAPI/workernodes/patches.ts
@@ -47,3 +47,19 @@ export function withNodePoolAvailabilityZones(zones?: string[]): NodePoolPatch {
     }
   };
 }
+
+export function withNodePoolScaling(min: number, max: number): NodePoolPatch {
+  return (nodePool: NodePool) => {
+    if (nodePool.kind === capiexpv1alpha3.MachinePool) {
+      nodePool.spec!.replicas = min;
+
+      nodePool.metadata.annotations ??= {};
+      nodePool.metadata.annotations[
+        capiexpv1alpha3.annotationMachinePoolMinSize
+      ] = min.toString();
+      nodePool.metadata.annotations[
+        capiexpv1alpha3.annotationMachinePoolMaxSize
+      ] = max.toString();
+    }
+  };
+}

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -331,10 +331,13 @@ function createDefaultMachinePool(config: {
       annotations: {
         [capiexpv1alpha3.annotationMachinePoolDescription]:
           Constants.DEFAULT_NODEPOOL_DESCRIPTION,
+        [capiexpv1alpha3.annotationMachinePoolMinSize]: Constants.NP_DEFAULT_MIN_SCALING.toString(),
+        [capiexpv1alpha3.annotationMachinePoolMaxSize]: Constants.NP_DEFAULT_MAX_SCALING.toString(),
       },
     },
     spec: {
       clusterName,
+      replicas: Constants.NP_DEFAULT_MIN_SCALING,
       template: {
         metadata: {} as metav1.IObjectMeta,
         spec: {

--- a/src/components/UI/Inputs/NumberPicker/index.tsx
+++ b/src/components/UI/Inputs/NumberPicker/index.tsx
@@ -187,7 +187,7 @@ const NumberPicker = React.forwardRef<HTMLInputElement, INumberPickerProps>(
     };
 
     useEffect(() => {
-      if (prevMax !== max || prevMin !== min) {
+      if ((prevMax && prevMax !== max) || (prevMin && prevMin !== min)) {
         const error = validateInput(currValue, min, max);
         updateValue(currValue, error);
       }

--- a/src/components/shared/NodeCountSelector.js
+++ b/src/components/shared/NodeCountSelector.js
@@ -16,10 +16,6 @@ const DEFAULT_VALUE_CONSTRAINTS = {
  * max values for scaling limits.
  */
 class NodeCountSelector extends React.Component {
-  handleFormSubmit = (e) => {
-    e.preventDefault();
-  };
-
   updateValue(valuesToAdd) {
     const nextScalingValue = Object.assign({}, this.props.scaling, valuesToAdd);
 
@@ -57,7 +53,7 @@ class NodeCountSelector extends React.Component {
 
     if (this.props.autoscalingEnabled === true) {
       return (
-        <form onSubmit={this.handleFormSubmit}>
+        <div>
           <TwoInputArea>
             <InnerTwoInputArea>
               <NumberPicker
@@ -95,12 +91,12 @@ class NodeCountSelector extends React.Component {
               ? 'To enable autoscaling, set minimum and maximum to different values.'
               : 'To disable autoscaling, set both numbers to the same value.'}
           </Text>
-        </form>
+        </div>
       );
     }
 
     return (
-      <form onSubmit={this.handleFormSubmit}>
+      <div>
         <NumberPicker
           min={minValue}
           max={maxValue}
@@ -114,7 +110,7 @@ class NodeCountSelector extends React.Component {
             width: 'small',
           }}
         />
-      </form>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Towards giantswarm/roadmap#341

No fancy stuff here, this allows us to set node pool scaling when creating node pools via the MAPI cluster details page.

## Preview

<details>
<summary>The form with the new option</summary>

![image](https://user-images.githubusercontent.com/13508038/124439615-ea807300-dd79-11eb-9973-1c68acd9becb.png)

</details>