### PR TITLE
clusters: add support for configuring spot instances on NP creation via the MAPI page

### DIFF
--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePool.js
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePool.js
@@ -399,7 +399,7 @@ class AddNodePool extends Component {
       ? 'Scaling range'
       : 'Node count';
 
-    let spotInstancesLabel = 'Spot instances';
+    let spotInstancesLabel = 'Spot virtual machines';
     if (provider === Providers.AWS) {
       spotInstancesLabel = 'Instance distribution';
     }

--- a/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstancesAzure.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstancesAzure.tsx
@@ -40,10 +40,10 @@ const AddNodePoolSpotInstancesAzure: React.FC<IAddNodePoolSpotInstancesAzureProp
         min={0}
         max={Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_MAX}
         precision={Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_PRECISION}
-        label='Maximum price per hour'
+        label='Price limit'
         error={maxPriceValidationError}
         disabled={useOnDemandPricing}
-        help='The maximum price per hour that a single node pool VM instance can reach before it is deallocated.'
+        help='The highest amount per hour (in USD) you are willing to pay, per virtual machine.'
         contentProps={{
           width: 'small',
         }}
@@ -52,7 +52,7 @@ const AddNodePoolSpotInstancesAzure: React.FC<IAddNodePoolSpotInstancesAzureProp
         <CheckBoxInput
           checked={useOnDemandPricing}
           onChange={(e) => setUseOnDemandPricing(e.target.checked)}
-          label='Use current on-demand pricing as max'
+          label='Use the on-demand price as limit'
         />
       </CheckboxWrapper>
     </AzureSpotInstances>

--- a/src/components/Cluster/ClusterDetail/AddNodePool/__tests__/AddNodePool.tsx
+++ b/src/components/Cluster/ClusterDetail/AddNodePool/__tests__/AddNodePool.tsx
@@ -44,7 +44,9 @@ describe('AddNodePool', () => {
           defaultState
         );
 
-        expect(screen.queryByText(/spot instances/i)).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(/spot virtual machines/i)
+        ).not.toBeInTheDocument();
       });
 
       it('when spot instances are turned on, the default behaviour is using on-demand max pricing', () => {
@@ -68,13 +70,13 @@ describe('AddNodePool', () => {
           defaultState
         );
 
-        expect(screen.getByText('Spot instances')).toBeInTheDocument();
+        expect(screen.getByText('Spot virtual machines')).toBeInTheDocument();
 
         const toggleLabelElement = screen.getByText('Enabled');
         expect(toggleLabelElement).toBeInTheDocument();
         fireEvent.click(toggleLabelElement);
 
-        expect(screen.getByLabelText('Maximum price per hour')).toHaveValue(0);
+        expect(screen.getByLabelText('Price limit')).toHaveValue(0);
 
         const expectedNodePool = ({
           availability_zones: {
@@ -126,7 +128,7 @@ describe('AddNodePool', () => {
           defaultState
         );
 
-        expect(screen.getByText('Spot instances')).toBeInTheDocument();
+        expect(screen.getByText('Spot virtual machines')).toBeInTheDocument();
 
         const toggleLabelElement = screen.getByText('Enabled');
         expect(toggleLabelElement).toBeInTheDocument();
@@ -134,13 +136,11 @@ describe('AddNodePool', () => {
 
         // Deactivate current on-demand max pricing.
         const onDemandToggleElement = screen.getByText(
-          'Use current on-demand pricing as max'
+          'Use the on-demand price as limit'
         );
         fireEvent.click(onDemandToggleElement);
 
-        const maxPriceInputElement = screen.getByLabelText(
-          'Maximum price per hour'
-        );
+        const maxPriceInputElement = screen.getByLabelText('Price limit');
         fireEvent.change(maxPriceInputElement, {
           target: {
             value: '0.00035',

--- a/src/components/Cluster/ClusterDetail/NodePoolScalingSpotInstancesDetails.tsx
+++ b/src/components/Cluster/ClusterDetail/NodePoolScalingSpotInstancesDetails.tsx
@@ -43,9 +43,9 @@ const NodePoolScalingSpotInstancesDetails: React.FC<INodePoolScalingSpotInstance
   } else if (provider === Providers.AZURE) {
     const spotInstancesEnabled =
       nodePool.node_spec?.azure?.spot_instances?.enabled ?? false;
-    let headline = 'Spot instances disabled';
+    let headline = 'Spot virtual machines disabled';
     if (spotInstancesEnabled) {
-      headline = 'Spot instances enabled';
+      headline = 'Spot virtual machines enabled';
     }
 
     let maxPriceRow = '';

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTableSpotInstancesTab.tsx
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTableSpotInstancesTab.tsx
@@ -46,7 +46,7 @@ function getExplanation(provider: PropertiesOf<typeof Providers>) {
 function getTabLabel(provider: PropertiesOf<typeof Providers>) {
   switch (provider) {
     case Providers.AZURE:
-      return 'Spot instances';
+      return 'Spot VMs';
     case Providers.AWS:
       return 'Spot count';
     default:

--- a/src/components/Cluster/ClusterDetail/__tests__/NodePoolScaling.tsx
+++ b/src/components/Cluster/ClusterDetail/__tests__/NodePoolScaling.tsx
@@ -78,7 +78,9 @@ describe('NodePoolScaling', () => {
 
       // Hover over the column.
       fireEvent.mouseEnter(spotInstancesTab);
-      expect(screen.getByText('Spot instances disabled')).toBeInTheDocument();
+      expect(
+        screen.getByText('Spot virtual machines disabled')
+      ).toBeInTheDocument();
       fireEvent.mouseLeave(spotInstancesTab);
     });
 
@@ -120,7 +122,9 @@ describe('NodePoolScaling', () => {
 
       // Hover over the column.
       fireEvent.mouseEnter(spotInstancesTab);
-      expect(screen.getByText(/spot instances enabled/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/spot virtual machines enabled/i)
+      ).toBeInTheDocument();
       expect(
         screen.getByText(/using current on-demand pricing as maximum/i)
       ).toBeInTheDocument();
@@ -165,7 +169,9 @@ describe('NodePoolScaling', () => {
 
       // Hover over the column.
       fireEvent.mouseEnter(spotInstancesTab);
-      expect(screen.getByText(/spot instances enabled/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/spot virtual machines enabled/i)
+      ).toBeInTheDocument();
       expect(
         screen.getByText(/using maximum price: \$0.00035/i)
       ).toBeInTheDocument();

--- a/src/components/Cluster/ClusterDetail/__tests__/V5ClusterDetailTableNodePoolScaling.tsx
+++ b/src/components/Cluster/ClusterDetail/__tests__/V5ClusterDetailTableNodePoolScaling.tsx
@@ -16,7 +16,9 @@ describe('V5ClusterDetailTableNodePoolScaling', () => {
         supportsSpotInstances: false,
       });
 
-      expect(screen.queryByText(/spot instances/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/spot virtual machines/i)
+      ).not.toBeInTheDocument();
     });
 
     it('renders the spot instances column if the feature is supported', async () => {
@@ -25,12 +27,12 @@ describe('V5ClusterDetailTableNodePoolScaling', () => {
         supportsSpotInstances: true,
       });
 
-      const labelElement = screen.getByText('Spot instances');
+      const labelElement = screen.getByText('Spot VMs');
       expect(labelElement).toBeInTheDocument();
 
       // Hover over element to see explanation.
       fireEvent.mouseEnter(labelElement);
-      const explanationText = 'Whether Spot instances are used or not.';
+      const explanationText = 'Whether Spot virtual machines are used or not.';
       const explanationElement = screen.getByText(explanationText);
       expect(explanationElement).toBeInTheDocument();
       fireEvent.mouseLeave(labelElement);

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -46,7 +46,7 @@ function getAdditionalColumns(
   if (provider === Providers.AZURE) {
     return [
       {
-        title: 'Spot instances',
+        title: 'Spot VMs',
         render: (_, providerNodePool) => {
           return (
             <WorkerNodesAzureMachinePoolSpotInstances

--- a/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
@@ -18,9 +18,9 @@ const WorkerNodesAzureMachinePoolSpotInstances: React.FC<IWorkerNodesAzureMachin
 }) => {
   const featureEnabled =
     typeof providerNodePool?.spec?.template.spotVMOptions !== 'undefined';
-  let headline = 'Spot instances disabled';
+  let headline = 'Spot virtual machines disabled';
   if (featureEnabled) {
-    headline = 'Spot instances enabled';
+    headline = 'Spot virtual machines enabled';
   }
 
   let maxPriceText = '';
@@ -61,7 +61,7 @@ const WorkerNodesAzureMachinePoolSpotInstances: React.FC<IWorkerNodesAzureMachin
           }
           placement='top'
         >
-          <Text aria-label='Node pool spot instances status'>
+          <Text aria-label='Node pool spot virtual machines status'>
             <i
               role='presentation'
               className={featureEnabled ? 'fa fa-done' : 'fa fa-close'}

--- a/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
@@ -1,4 +1,8 @@
 import { Box, Text } from 'grommet';
+import {
+  getProviderNodePoolSpotInstances,
+  INodePoolSpotInstancesAzure,
+} from 'MAPI/utils';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -21,7 +25,9 @@ const WorkerNodesAzureMachinePoolSpotInstances: React.FC<IWorkerNodesAzureMachin
 
   let maxPriceText = '';
   if (featureEnabled) {
-    const maxPrice = providerNodePool?.spec?.template.spotVMOptions?.maxPrice;
+    const maxPrice = (getProviderNodePoolSpotInstances(
+      providerNodePool
+    ) as INodePoolSpotInstancesAzure).maxPrice;
     if (maxPrice && maxPrice > 0) {
       maxPriceText = `Using maximum price: $${maxPrice}`;
     } else {

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -14,6 +14,7 @@ import {
 } from 'MAPI/types';
 import {
   generateUID,
+  getClusterReleaseVersion,
   getProviderClusterLocation,
   getProviderNodePoolLocation,
 } from 'MAPI/utils';
@@ -24,6 +25,7 @@ import { useSelector } from 'react-redux';
 import { Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
 import { getProvider } from 'stores/main/selectors';
+import { supportsNodePoolSpotInstances } from 'stores/nodepool/utils';
 import Button from 'UI/Controls/Button';
 
 import { INodePoolPropertyValue, NodePoolPatch } from './patches';
@@ -38,6 +40,7 @@ import WorkerNodesCreateNodePoolDescription from './WorkerNodesCreateNodePoolDes
 import WorkerNodesCreateNodePoolMachineType from './WorkerNodesCreateNodePoolMachineType';
 import WorkerNodesCreateNodePoolName from './WorkerNodesCreateNodePoolName';
 import WorkerNodesCreateNodePoolScale from './WorkerNodesCreateNodePoolScale';
+import WorkerNodesCreateNodePoolSpotInstances from './WorkerNodesCreateNodePoolSpotInstances';
 
 enum NodePoolPropertyField {
   Name,
@@ -45,6 +48,7 @@ enum NodePoolPropertyField {
   MachineType,
   AvailabilityZones,
   Scale,
+  SpotInstances,
 }
 
 interface IApplyPatchAction {
@@ -120,6 +124,7 @@ function makeInitialState(
       [NodePoolPropertyField.MachineType]: true,
       [NodePoolPropertyField.AvailabilityZones]: false,
       [NodePoolPropertyField.Scale]: true,
+      [NodePoolPropertyField.SpotInstances]: true,
     },
     isCreating: false,
   };
@@ -248,6 +253,11 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
     }
   };
 
+  const clusterReleaseVersion = getClusterReleaseVersion(cluster);
+  const supportsSpotInstances = clusterReleaseVersion
+    ? supportsNodePoolSpotInstances(provider, clusterReleaseVersion)
+    : false;
+
   return (
     <Collapsible {...props}>
       <Keyboard onEsc={handleCancel}>
@@ -299,6 +309,16 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
                 cluster={cluster}
                 margin={{ top: 'small' }}
               />
+
+              {supportsSpotInstances && (
+                <WorkerNodesCreateNodePoolSpotInstances
+                  id={`node-pool-${id}-${NodePoolPropertyField.SpotInstances}`}
+                  nodePool={state.nodePool}
+                  providerNodePool={state.providerNodePool}
+                  onChange={handleChange(NodePoolPropertyField.SpotInstances)}
+                />
+              )}
+
               <WorkerNodesCreateNodePoolScale
                 id={`node-pool-${id}-${NodePoolPropertyField.Scale}`}
                 nodePool={state.nodePool}

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
@@ -1,0 +1,154 @@
+import AddNodePoolMachineType from 'Cluster/ClusterDetail/AddNodePool/AddNodePoolMachineType';
+import AddNodePoolSpotInstances from 'Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstances';
+import { ProviderNodePool } from 'MAPI/types';
+import {
+  getProviderNodePoolSpotInstances,
+  INodePoolSpotInstancesAzure,
+} from 'MAPI/utils';
+import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
+import PropTypes from 'prop-types';
+import React, { useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Constants } from 'shared/constants';
+import { getProvider } from 'stores/main/selectors';
+import CheckBoxInput from 'UI/Inputs/CheckBoxInput';
+import InputGroup from 'UI/Inputs/InputGroup';
+
+import {
+  INodePoolPropertyProps,
+  INodePoolSpotInstancesConfigAzure,
+  NodePoolSpotInstancesConfig,
+  withNodePoolSpotInstances,
+} from './patches';
+
+function getLabel(providerNodePool: ProviderNodePool): string {
+  switch (providerNodePool?.kind) {
+    case capzexpv1alpha3.AzureMachinePool:
+      return 'Spot instances';
+    default:
+      return '';
+  }
+}
+
+function getToggleLabel(providerNodePool: ProviderNodePool): string {
+  switch (providerNodePool?.kind) {
+    case capzexpv1alpha3.AzureMachinePool:
+      return 'Enabled';
+    default:
+      return '';
+  }
+}
+
+function validateMaxPrice(maxPrice: number): string {
+  if (maxPrice < Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_MIN) {
+    return `The value should be between ${Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_MIN} and ${Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_MAX}.`;
+  }
+
+  return '';
+}
+
+const notImplementedCallback = () => {};
+
+interface IWorkerNodesCreateNodePoolSpotInstancesProps
+  extends INodePoolPropertyProps,
+    Omit<
+      React.ComponentPropsWithoutRef<typeof AddNodePoolMachineType>,
+      'onChange' | 'id'
+    > {}
+
+const WorkerNodesCreateNodePoolSpotInstances: React.FC<IWorkerNodesCreateNodePoolSpotInstancesProps> = ({
+  id,
+  providerNodePool,
+  onChange,
+  readOnly,
+  disabled,
+  ...props
+}) => {
+  const value = getProviderNodePoolSpotInstances(providerNodePool);
+  const useOnDemandPricing =
+    typeof (value as INodePoolSpotInstancesAzure).maxPrice === 'number' &&
+    (value as INodePoolSpotInstancesAzure).maxPrice < 0;
+
+  const patchConfig = useRef<NodePoolSpotInstancesConfig>({
+    enabled: value.enabled,
+  });
+
+  const [validationError, setValidationError] = useState('');
+
+  const appendChanges = (
+    config: NodePoolSpotInstancesConfig,
+    errorMessage = ''
+  ) => {
+    onChange({
+      isValid: errorMessage.length < 1,
+      patch: withNodePoolSpotInstances(config),
+    });
+  };
+
+  const handleToggleFeature = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValidationError('');
+
+    patchConfig.current.enabled = e.target.checked;
+
+    appendChanges(patchConfig.current);
+  };
+
+  const handleSetMaxPrice = (newPrice: number) => {
+    const validationResult = validateMaxPrice(newPrice);
+    setValidationError(validationResult);
+
+    (patchConfig.current as INodePoolSpotInstancesConfigAzure).maxPrice = newPrice;
+
+    appendChanges(patchConfig.current, validationResult);
+  };
+
+  const toggleOnDemandPricing = (enabled: boolean) => {
+    setValidationError('');
+
+    const nextPrice = enabled
+      ? -1
+      : Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_MIN;
+
+    (patchConfig.current as INodePoolSpotInstancesConfigAzure).maxPrice = nextPrice;
+
+    appendChanges(patchConfig.current);
+  };
+
+  const provider = useSelector(getProvider);
+
+  return (
+    <InputGroup htmlFor={id} label={getLabel(providerNodePool)} {...props}>
+      <CheckBoxInput
+        id={id}
+        checked={value.enabled}
+        onChange={handleToggleFeature}
+        label={getToggleLabel(providerNodePool)}
+      />
+      {value.enabled && (
+        <AddNodePoolSpotInstances
+          provider={provider}
+          spotPercentage={-1}
+          setSpotPercentage={notImplementedCallback}
+          onDemandBaseCapacity={-1}
+          setOnDemandBaseCapacity={notImplementedCallback}
+          maxPrice={(value as INodePoolSpotInstancesAzure).maxPrice}
+          setMaxPrice={handleSetMaxPrice}
+          maxPriceValidationError={validationError}
+          useOnDemandPricing={useOnDemandPricing}
+          setUseOnDemandPricing={toggleOnDemandPricing}
+        />
+      )}
+    </InputGroup>
+  );
+};
+
+WorkerNodesCreateNodePoolSpotInstances.propTypes = {
+  id: PropTypes.string.isRequired,
+  providerNodePool: (PropTypes.object as PropTypes.Requireable<ProviderNodePool>)
+    .isRequired,
+  onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
+};
+
+export default WorkerNodesCreateNodePoolSpotInstances;

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
@@ -48,6 +48,12 @@ function validateMaxPrice(maxPrice: number): string {
   return '';
 }
 
+function formatMaxPrice(maxPrice: number, useOnDemandPricing: boolean): number {
+  if (useOnDemandPricing && maxPrice < 0) return 0;
+
+  return maxPrice;
+}
+
 const notImplementedCallback = () => {};
 
 interface IWorkerNodesCreateNodePoolSpotInstancesProps
@@ -117,6 +123,11 @@ const WorkerNodesCreateNodePoolSpotInstances: React.FC<IWorkerNodesCreateNodePoo
 
   const provider = useSelector(getProvider);
 
+  const formattedMaxPrice = formatMaxPrice(
+    (value as INodePoolSpotInstancesAzure).maxPrice,
+    useOnDemandPricing
+  );
+
   return (
     <InputGroup htmlFor={id} label={getLabel(providerNodePool)} {...props}>
       <CheckBoxInput
@@ -136,7 +147,7 @@ const WorkerNodesCreateNodePoolSpotInstances: React.FC<IWorkerNodesCreateNodePoo
           setSpotPercentage={notImplementedCallback}
           onDemandBaseCapacity={-1}
           setOnDemandBaseCapacity={notImplementedCallback}
-          maxPrice={(value as INodePoolSpotInstancesAzure).maxPrice}
+          maxPrice={formattedMaxPrice}
           setMaxPrice={handleSetMaxPrice}
           maxPriceValidationError={validationError}
           useOnDemandPricing={useOnDemandPricing}

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
@@ -1,5 +1,6 @@
 import AddNodePoolMachineType from 'Cluster/ClusterDetail/AddNodePool/AddNodePoolMachineType';
 import AddNodePoolSpotInstances from 'Cluster/ClusterDetail/AddNodePool/AddNodePoolSpotInstances';
+import { Text } from 'grommet';
 import { ProviderNodePool } from 'MAPI/types';
 import {
   getProviderNodePoolSpotInstances,
@@ -122,7 +123,11 @@ const WorkerNodesCreateNodePoolSpotInstances: React.FC<IWorkerNodesCreateNodePoo
         id={id}
         checked={value.enabled}
         onChange={handleToggleFeature}
-        label={getToggleLabel(providerNodePool)}
+        label={
+          <Text weight='normal' color='text'>
+            {getToggleLabel(providerNodePool)}
+          </Text>
+        }
       />
       {value.enabled && (
         <AddNodePoolSpotInstances

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
@@ -97,7 +97,7 @@ const WorkerNodesCreateNodePoolSpotInstances: React.FC<IWorkerNodesCreateNodePoo
     const validationResult = validateMaxPrice(newPrice);
     setValidationError(validationResult);
 
-    (patchConfig.current as INodePoolSpotInstancesConfigAzure).maxPrice = newPrice;
+    (patchConfig.current as INodePoolSpotInstancesConfigAzure).maxPrice = newPrice.toString();
 
     appendChanges(patchConfig.current, validationResult);
   };
@@ -109,7 +109,7 @@ const WorkerNodesCreateNodePoolSpotInstances: React.FC<IWorkerNodesCreateNodePoo
       ? -1
       : Constants.AZURE_SPOT_INSTANCES_MAX_PRICE_MIN;
 
-    (patchConfig.current as INodePoolSpotInstancesConfigAzure).maxPrice = nextPrice;
+    (patchConfig.current as INodePoolSpotInstancesConfigAzure).maxPrice = nextPrice.toString();
 
     appendChanges(patchConfig.current);
   };

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
@@ -25,7 +25,7 @@ import {
 function getLabel(providerNodePool: ProviderNodePool): string {
   switch (providerNodePool?.kind) {
     case capzexpv1alpha3.AzureMachinePool:
-      return 'Spot instances';
+      return 'Spot virtual machines';
     default:
       return '';
   }

--- a/src/components/MAPI/workernodes/patches.ts
+++ b/src/components/MAPI/workernodes/patches.ts
@@ -66,7 +66,7 @@ export function withNodePoolScaling(min: number, max: number): NodePoolPatch {
 
 export interface INodePoolSpotInstancesConfigAzure {
   enabled: boolean;
-  maxPrice: number;
+  maxPrice: string;
 }
 
 export interface INodePoolSpotInstancesConfigAWS {
@@ -90,7 +90,7 @@ export function withNodePoolSpotInstances(
 
       providerNodePool.spec!.template.spotVMOptions ??= {};
       providerNodePool.spec!.template.spotVMOptions.maxPrice = (config as INodePoolSpotInstancesConfigAzure).maxPrice;
-      providerNodePool.spec!.template.spotVMOptions.maxPrice ??= -1;
+      providerNodePool.spec!.template.spotVMOptions.maxPrice ??= '-1';
     }
   };
 }

--- a/src/components/MAPI/workernodes/patches.ts
+++ b/src/components/MAPI/workernodes/patches.ts
@@ -63,3 +63,34 @@ export function withNodePoolScaling(min: number, max: number): NodePoolPatch {
     }
   };
 }
+
+export interface INodePoolSpotInstancesConfigAzure {
+  enabled: boolean;
+  maxPrice: number;
+}
+
+export interface INodePoolSpotInstancesConfigAWS {
+  enabled: boolean;
+}
+
+export type NodePoolSpotInstancesConfig =
+  | INodePoolSpotInstancesConfigAzure
+  | INodePoolSpotInstancesConfigAWS;
+
+export function withNodePoolSpotInstances(
+  config: NodePoolSpotInstancesConfig
+): NodePoolPatch {
+  return (_, providerNodePool: ProviderNodePool) => {
+    if (providerNodePool?.kind === capzexpv1alpha3.AzureMachinePool) {
+      if (!config.enabled) {
+        providerNodePool.spec!.template.spotVMOptions = undefined;
+
+        return;
+      }
+
+      providerNodePool.spec!.template.spotVMOptions ??= {};
+      providerNodePool.spec!.template.spotVMOptions.maxPrice = (config as INodePoolSpotInstancesConfigAzure).maxPrice;
+      providerNodePool.spec!.template.spotVMOptions.maxPrice ??= -1;
+    }
+  };
+}

--- a/src/components/UI/Inputs/CheckBoxInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/CheckBoxInput/__tests__/__snapshots__/index.tsx.snap
@@ -9,6 +9,7 @@ exports[`CheckBoxInput renders a disabled input 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-kfPtPH cAAOBn"
+      tabindex="0"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 nMYKY FormField__FormFieldContentBox-m9hood-1"
@@ -24,6 +25,7 @@ exports[`CheckBoxInput renders a disabled input 1`] = `
             <input
               class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 TEVFi"
               disabled=""
+              tabindex="-1"
               type="checkbox"
               value="Hi people"
             />
@@ -51,6 +53,7 @@ exports[`CheckBoxInput renders a simple input 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-kfPtPH cAAOBn"
+      tabindex="0"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 nMYKY FormField__FormFieldContentBox-m9hood-1"
@@ -63,6 +66,7 @@ exports[`CheckBoxInput renders a simple input 1`] = `
           >
             <input
               class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 xGwgC"
+              tabindex="-1"
               type="checkbox"
               value="Hi people"
             />
@@ -89,6 +93,7 @@ exports[`CheckBoxInput renders a toggle input 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-kfPtPH cAAOBn"
+      tabindex="0"
     >
       <label
         class="StyledText-sc-1sadyjn-0 weZKr"
@@ -111,6 +116,7 @@ exports[`CheckBoxInput renders a toggle input 1`] = `
           >
             <input
               class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 xGwgC"
+              tabindex="-1"
               type="checkbox"
             />
             <span
@@ -145,6 +151,7 @@ exports[`CheckBoxInput renders an input with a form field label 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-kfPtPH cAAOBn"
+      tabindex="0"
     >
       <label
         class="StyledText-sc-1sadyjn-0 weZKr"
@@ -162,6 +169,7 @@ exports[`CheckBoxInput renders an input with a form field label 1`] = `
           >
             <input
               class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 xGwgC"
+              tabindex="-1"
               type="checkbox"
               value="Hi people"
             />
@@ -188,6 +196,7 @@ exports[`CheckBoxInput renders an input with a help message 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-kfPtPH cAAOBn"
+      tabindex="0"
     >
       <span
         class="StyledText-sc-1sadyjn-0 hosPKv"
@@ -205,6 +214,7 @@ exports[`CheckBoxInput renders an input with a help message 1`] = `
           >
             <input
               class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 xGwgC"
+              tabindex="-1"
               type="checkbox"
               value="Hi people"
             />
@@ -231,6 +241,7 @@ exports[`CheckBoxInput renders an input with a validation error 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-kfPtPH cAAOBn"
+      tabindex="0"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 nMYKY FormField__FormFieldContentBox-m9hood-1"
@@ -243,6 +254,7 @@ exports[`CheckBoxInput renders an input with a validation error 1`] = `
           >
             <input
               class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 xGwgC"
+              tabindex="-1"
               type="checkbox"
               value="Hi people"
             />
@@ -274,6 +286,7 @@ exports[`CheckBoxInput renders an input with an info message 1`] = `
   >
     <div
       class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-kfPtPH cAAOBn"
+      tabindex="0"
     >
       <div
         class="StyledBox-sc-13pk1d4-0 nMYKY FormField__FormFieldContentBox-m9hood-1"
@@ -286,6 +299,7 @@ exports[`CheckBoxInput renders an input with an info message 1`] = `
           >
             <input
               class="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 xGwgC"
+              tabindex="-1"
               type="checkbox"
               value="Hi people"
             />

--- a/src/components/UI/Inputs/CheckBoxInput/index.tsx
+++ b/src/components/UI/Inputs/CheckBoxInput/index.tsx
@@ -3,10 +3,12 @@ import {
   CheckBoxProps,
   FormField,
   FormFieldProps,
+  Keyboard,
 } from 'grommet';
 import PropTypes from 'prop-types';
-import * as React from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
+import { setMultipleRefs } from 'utils/componentUtils';
 
 const StyledFormField = styled(FormField)`
   & input {
@@ -83,6 +85,15 @@ const CheckBoxInput = React.forwardRef<HTMLInputElement, ICheckBoxInputProps>(
     },
     ref
   ) => {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    const handleSelectKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+      e.preventDefault();
+
+      if (!inputRef.current) return;
+      inputRef.current.click();
+    };
+
     const patchedContentProps = Object.assign(
       {},
       {
@@ -97,30 +108,34 @@ const CheckBoxInput = React.forwardRef<HTMLInputElement, ICheckBoxInputProps>(
     );
 
     return (
-      <StyledFormField
-        htmlFor={id}
-        contentProps={patchedContentProps}
-        disabled={disabled}
-        required={required}
-        name={name}
-        error={error}
-        info={info}
-        help={help}
-        margin={margin}
-        pad={pad}
-        label={fieldLabel}
-        {...formFieldProps}
-      >
-        <Input
-          {...props}
-          id={id}
-          ref={ref}
+      <Keyboard onSpace={handleSelectKeyDown} onEnter={handleSelectKeyDown}>
+        <StyledFormField
+          htmlFor={id}
+          contentProps={patchedContentProps}
           disabled={disabled}
           required={required}
           name={name}
-          label={label}
-        />
-      </StyledFormField>
+          error={error}
+          info={info}
+          help={help}
+          margin={margin}
+          pad={pad}
+          label={fieldLabel}
+          tabIndex={0}
+          {...formFieldProps}
+        >
+          <Input
+            {...props}
+            id={id}
+            ref={setMultipleRefs(inputRef, ref)}
+            disabled={disabled}
+            required={required}
+            name={name}
+            label={label}
+            tabIndex={-1}
+          />
+        </StyledFormField>
+      </Keyboard>
     );
   }
 );

--- a/src/model/services/mapi/capzv1alpha3/types.ts
+++ b/src/model/services/mapi/capzv1alpha3/types.ts
@@ -154,7 +154,7 @@ export interface IUserAssignedIdentity {
 }
 
 export interface ISpotVMOptions {
-  maxPrice?: number | string;
+  maxPrice?: metav1.Quantity;
 }
 
 export interface ISecurityProfile {

--- a/src/model/services/mapi/metav1/key.ts
+++ b/src/model/services/mapi/metav1/key.ts
@@ -1,4 +1,5 @@
 import { IK8sStatus, IK8sStatusError, K8sStatusErrorReasons } from './';
+import { Quantity } from './types';
 
 /**
  * Determine if an object is a K8s status response.
@@ -21,4 +22,99 @@ export function isStatusError<
   if (!isStatus(obj)) return false;
 
   return obj.reason === reason;
+}
+
+/**
+ * Quantity helper functions copied from the official kubernetes client.
+ * {@link https://github.com/kubernetes-client/javascript/blob/ad6e451ce01f698ab18ceb03fb712e014bc93a5b/src/util.ts}
+ *
+ * All suffixes can be found here.
+ * {@link https://github.com/kubernetes/apimachinery/blob/8303750571678b1e7ccef2b8b597b5286aab7eb7/pkg/api/resource/suffix.go#L108}
+ */
+const floatingPointRegexp = /[\.0-9]/;
+export function getQuantitySuffix(quantity: Quantity): string {
+  let ix = quantity.length - 1;
+  while (ix >= 0 && !floatingPointRegexp.test(quantity.charAt(ix))) {
+    ix--;
+  }
+
+  return ix === -1 ? '' : quantity.substring(ix + 1);
+}
+
+export function quantityToScalar(quantity: Quantity): number | BigInt {
+  if (!quantity) {
+    return 0;
+  }
+
+  const suffix = getQuantitySuffix(quantity);
+  switch (suffix) {
+    case 'n':
+      return (
+        // eslint-disable-next-line no-magic-numbers
+        Number(quantity.substr(0, quantity.length - 1)).valueOf() / 1000000000.0
+      );
+    case 'u':
+      return (
+        // eslint-disable-next-line no-magic-numbers
+        Number(quantity.substr(0, quantity.length - 1)).valueOf() / 1000000.0
+      );
+    case 'm':
+      return (
+        // eslint-disable-next-line no-magic-numbers
+        Number(quantity.substr(0, quantity.length - 1)).valueOf() / 1000.0
+      );
+    case '': {
+      const num = Number(quantity).valueOf();
+      if (isNaN(num)) {
+        throw new Error(`Unknown quantity ${quantity}`);
+      }
+
+      return num;
+    }
+    case 'k':
+      return (
+        // eslint-disable-next-line no-magic-numbers
+        Number(quantity.substr(0, quantity.length - 1)).valueOf() * 1000.0
+      );
+    case 'Ki':
+      // eslint-disable-next-line no-magic-numbers
+      return BigInt(quantity.substr(0, quantity.length - 2)) * BigInt(1024);
+    case 'Mi':
+      return (
+        // eslint-disable-next-line no-magic-numbers
+        BigInt(quantity.substr(0, quantity.length - 2)) * BigInt(1024 ** 2)
+      );
+    case 'Gi':
+      return (
+        BigInt(quantity.substr(0, quantity.length - 2)) *
+        // eslint-disable-next-line no-magic-numbers
+        BigInt(1024 ** 3)
+      );
+    case 'Ti':
+      return (
+        BigInt(quantity.substr(0, quantity.length - 2)) *
+        // eslint-disable-next-line no-magic-numbers
+        BigInt(1024 ** 3) *
+        // eslint-disable-next-line no-magic-numbers
+        BigInt(1024)
+      );
+    case 'Pi':
+      return (
+        BigInt(quantity.substr(0, quantity.length - 2)) *
+        // eslint-disable-next-line no-magic-numbers
+        BigInt(1024 ** 3) *
+        // eslint-disable-next-line no-magic-numbers
+        BigInt(1024 ** 2)
+      );
+    case 'Ei':
+      return (
+        BigInt(quantity.substr(0, quantity.length - 2)) *
+        // eslint-disable-next-line no-magic-numbers
+        BigInt(1024 ** 3) *
+        // eslint-disable-next-line no-magic-numbers
+        BigInt(1024 ** 3)
+      );
+    default:
+      throw new Error(`Unknown suffix: ${suffix}`);
+  }
 }

--- a/src/model/services/mapi/metav1/types.ts
+++ b/src/model/services/mapi/metav1/types.ts
@@ -220,3 +220,5 @@ export interface IK8sStatusErrorCodeMapping {
   [K8sStatusErrorReasons.ServiceUnavailable]: 503;
 }
 /* eslint-enable no-magic-numbers */
+
+export type Quantity = string;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -49,7 +49,8 @@ export const Constants = {
     'Upper end of the scaling range for the cluster autoscaler',
   SPOT_COLUMN_EXPLANATION_AWS:
     'Current number of spot instances in this node pool',
-  SPOT_COLUMN_EXPLANATION_AZURE: 'Whether Spot instances are used or not.',
+  SPOT_COLUMN_EXPLANATION_AZURE:
+    'Whether Spot virtual machines are used or not.',
 
   KEYPAIR_DEFAULT_TTL: 24, // A day, In hours
   // eslint-disable-next-line no-magic-numbers


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/341

This PR adds support for configuring Azure spot instances when creating node pools from the MAPI cluster detail page. It uses the same UI components as the current GS API implementation, so nothing too crazy on that part.

The PR also includes a small change in the way we display the maximum spot instance pricing in node pools that have already been created. Because the max price is a `Quantity` type, and not a regular string or number, it represents a serialized value of a number, with certain suffixes that represent the number that the prefix should be multiplied by to get the actual value.

> For example, `"10u"` represents `0.00001`.

The utility for parsing these types of data structures has been copied from the official Kubernetes JS client, with a few added suffixes.

## Preview

<details>
<summary>Spot instances disabled</summary>

![image](https://user-images.githubusercontent.com/13508038/124503207-59cf8480-ddc5-11eb-9b26-33c02bcc4f50.png)

</details>

<details>
<summary>Using current on-demand pricing as the max price</summary>

![image](https://user-images.githubusercontent.com/13508038/124503227-6227bf80-ddc5-11eb-8410-8144be241e6e.png)

</details>

<details>
<summary>With some max value</summary>

![image](https://user-images.githubusercontent.com/13508038/124503246-6eac1800-ddc5-11eb-90c6-d00b7128d48c.png)

</details>