### PR TITLE
Stop displaying inactive versions as upgradable for admins

### DIFF
--- a/src/stores/cluster/__tests__/selectors.ts
+++ b/src/stores/cluster/__tests__/selectors.ts
@@ -125,44 +125,6 @@ describe('cluster::selectors', () => {
       const releaseVersion = selectTargetRelease(initialState, cluster);
       expect(releaseVersion).toBe('2.0.2');
     });
-
-    it('returns the next inactive version, if the user is an admin and there is no newer active version', () => {
-      const initialState = createInitialState(
-        {
-          '1.0.0': createRelease('1.0.0', true),
-          '2.0.0': createRelease('2.0.0', false),
-          '2.0.1': createRelease('2.0.1', false),
-          '2.0.2': createRelease('2.0.2', true),
-          '3.0.0': createRelease('3.0.0', true),
-          '3.0.1': createRelease('3.0.1', false),
-        },
-        true
-      );
-      const cluster = (Object.assign({}, v5ClusterResponse, {
-        release_version: '3.0.0',
-      }) as unknown) as V5.ICluster;
-      const releaseVersion = selectTargetRelease(initialState, cluster);
-      expect(releaseVersion).toBe('3.0.1');
-    });
-
-    it('returns the next pre-release version, if the user is an admin and there is no newer active version', () => {
-      const initialState = createInitialState(
-        {
-          '1.0.0': createRelease('1.0.0', true),
-          '2.0.0': createRelease('2.0.0', false),
-          '2.0.1': createRelease('2.0.1', false),
-          '2.0.2': createRelease('2.0.2', true),
-          '3.0.0': createRelease('3.0.0', true),
-          '3.0.1-alpha': createRelease('3.0.1-alpha', true),
-        },
-        true
-      );
-      const cluster = (Object.assign({}, v5ClusterResponse, {
-        release_version: '3.0.0',
-      }) as unknown) as V5.ICluster;
-      const releaseVersion = selectTargetRelease(initialState, cluster);
-      expect(releaseVersion).toBe('3.0.1-alpha');
-    });
   });
 
   describe('selectIsClusterAwaitingUpgrade', () => {

--- a/src/stores/cluster/selectors.ts
+++ b/src/stores/cluster/selectors.ts
@@ -8,7 +8,6 @@ import {
   isClusterCreating,
   isClusterUpdating,
 } from 'stores/cluster/utils';
-import { getUserIsAdmin } from 'stores/main/selectors';
 import { selectOrganizationByID } from 'stores/organization/selectors';
 import { isPreRelease } from 'stores/releases/utils';
 import { IState } from 'stores/state';
@@ -82,8 +81,6 @@ export function selectTargetRelease(state: IState, cluster?: Cluster | null) {
 
   const releases = Object.assign({}, state.entities.releases.items);
   const clusterReleaseVersion = cluster.release_version ?? '';
-  const isAdmin = getUserIsAdmin(state);
-
   if (!releases[clusterReleaseVersion]) {
     releases[clusterReleaseVersion] = {} as IRelease;
   }
@@ -106,10 +103,6 @@ export function selectTargetRelease(state: IState, cluster?: Cluster | null) {
       nextVersion = availableVersions[i];
 
       break;
-    }
-
-    if (isAdmin && !nextVersion) {
-      nextVersion = availableVersions[i];
     }
   }
 


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C7865GLSY/p1625574670362400

This is a left-over from the days when we had the `Change version` button in the `Upgrade cluster` modal. It was then possible for admins (GS staff) to see the `Upgrade available` warning for inactive/pre-release versions, in order to test upgrades on testing installations, or execute upgrades to pre-release versions on the customers' behalf.

Now, as we have upgrading to beta versions (or inactive versions) available through the `Release details` modal, it is no longer necessary to display the warning (as it might confuse users).

To be clear, this PR removes the ability of admins to see the `Upgrade available` warning when newer versions are inactive or pre-releases.