### PR TITLE
clusters: add getting started guide specific for MAPI clusters

### DIFF
--- a/src/components/MAPI/clusters/Cluster.tsx
+++ b/src/components/MAPI/clusters/Cluster.tsx
@@ -1,11 +1,11 @@
 import NewClusterWrapper from 'Cluster/NewCluster/NewClusterWrapper';
-import GettingStarted from 'GettingStarted/GettingStarted';
 import React from 'react';
 import { Redirect, Switch } from 'react-router';
 import Route from 'Route';
 import { OrganizationsRoutes } from 'shared/constants/routes';
 
 import ClusterDetail from './ClusterDetail';
+import GettingStarted from './GettingStarted';
 
 const Cluster: React.FC<{}> = () => {
   return (

--- a/src/components/MAPI/clusters/GettingStarted/GettingStartedPlatformTabs.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/GettingStartedPlatformTabs.tsx
@@ -1,0 +1,68 @@
+import { Box } from 'grommet';
+import {
+  GettingStartedPlatform,
+  useGettingStartedContext,
+} from 'MAPI/clusters/GettingStarted/GettingStartedProvider';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Tab } from 'react-bootstrap';
+import Tabs from 'shared/Tabs';
+import styled from 'styled-components';
+
+const StyledTab = styled(Tab)`
+  padding: ${({ theme }) => theme.global.edgeSize.medium};
+  background: ${({ theme }) => theme.global.colors['background-front'].dark};
+  border-radius: ${({ theme }) => theme.rounding}px;
+`;
+
+interface IGettingStartedPlatformTabsProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  linuxContent?: React.ReactNode;
+  macOSContent?: React.ReactNode;
+  windowsContent?: React.ReactNode;
+}
+
+const GettingStartedPlatformTabs: React.FC<IGettingStartedPlatformTabsProps> = ({
+  linuxContent,
+  macOSContent,
+  windowsContent,
+  ...props
+}) => {
+  const { selectedPlatform, setSelectedPlatform } = useGettingStartedContext();
+
+  return (
+    <Box {...props}>
+      <Tabs
+        defaultActiveKey={selectedPlatform as never}
+        activeKey={selectedPlatform}
+        onSelect={setSelectedPlatform as never}
+      >
+        {linuxContent && (
+          <StyledTab eventKey={GettingStartedPlatform.Linux} title='Linux'>
+            {linuxContent}
+          </StyledTab>
+        )}
+
+        {macOSContent && (
+          <StyledTab eventKey={GettingStartedPlatform.MacOS} title='macOS'>
+            {macOSContent}
+          </StyledTab>
+        )}
+
+        {windowsContent && (
+          <StyledTab eventKey={GettingStartedPlatform.Windows} title='Windows'>
+            {windowsContent}
+          </StyledTab>
+        )}
+      </Tabs>
+    </Box>
+  );
+};
+
+GettingStartedPlatformTabs.propTypes = {
+  linuxContent: PropTypes.node,
+  macOSContent: PropTypes.node,
+  windowsContent: PropTypes.node,
+};
+
+export default GettingStartedPlatformTabs;

--- a/src/components/MAPI/clusters/GettingStarted/GettingStartedProvider.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/GettingStartedProvider.tsx
@@ -1,6 +1,12 @@
 import PropTypes from 'prop-types';
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
+
+export enum GettingStartedPlatform {
+  Linux,
+  MacOS,
+  Windows,
+}
 
 export interface IGettingStartedStep {
   title: string;
@@ -16,6 +22,8 @@ export interface IGettingStartedContext {
   currentStepIdx: number;
   prevStepPath: string | null;
   nextStepPath: string | null;
+  selectedPlatform: GettingStartedPlatform;
+  setSelectedPlatform: (platform: GettingStartedPlatform) => void;
 }
 
 const gettingStartedContext = createContext<IGettingStartedContext | null>(
@@ -55,6 +63,10 @@ const GettingStartedProvider: React.FC<
     return steps[nextIdx].url;
   }, [currentStepIdx, steps]);
 
+  const [selectedPlatform, setSelectedPlatform] = useState(
+    GettingStartedPlatform.Linux
+  );
+
   return (
     <gettingStartedContext.Provider
       value={{
@@ -63,6 +75,8 @@ const GettingStartedProvider: React.FC<
         prevStepPath,
         nextStepPath,
         steps,
+        selectedPlatform,
+        setSelectedPlatform,
       }}
     >
       {children}

--- a/src/components/MAPI/clusters/GettingStarted/GettingStartedProvider.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/GettingStartedProvider.tsx
@@ -1,0 +1,90 @@
+import PropTypes from 'prop-types';
+import React, { createContext, useContext, useMemo } from 'react';
+import { useLocation } from 'react-router';
+
+export interface IGettingStartedStep {
+  title: string;
+  description: string;
+  url: string;
+  path: string;
+  component: React.ComponentType;
+}
+
+export interface IGettingStartedContext {
+  homePath: string;
+  steps: readonly IGettingStartedStep[];
+  currentStepIdx: number;
+  prevStepPath: string | null;
+  nextStepPath: string | null;
+}
+
+const gettingStartedContext = createContext<IGettingStartedContext | null>(
+  null
+);
+
+interface IGettingStartedProviderProps {
+  homePath: string;
+  steps: IGettingStartedStep[];
+}
+
+const GettingStartedProvider: React.FC<
+  React.PropsWithChildren<IGettingStartedProviderProps>
+> = ({ homePath, steps, children }) => {
+  const { pathname } = useLocation();
+
+  const currentStepIdx = useMemo(
+    () => steps.findIndex((s) => s.url === pathname),
+    [steps, pathname]
+  );
+
+  const nextStepPath = useMemo(() => {
+    const nextIdx = currentStepIdx + 1;
+    if (nextIdx >= steps.length) {
+      return null;
+    }
+
+    return steps[nextIdx].url;
+  }, [currentStepIdx, steps]);
+
+  const prevStepPath = useMemo(() => {
+    const nextIdx = currentStepIdx - 1;
+    if (nextIdx < 0) {
+      return null;
+    }
+
+    return steps[nextIdx].url;
+  }, [currentStepIdx, steps]);
+
+  return (
+    <gettingStartedContext.Provider
+      value={{
+        homePath,
+        currentStepIdx,
+        prevStepPath,
+        nextStepPath,
+        steps,
+      }}
+    >
+      {children}
+    </gettingStartedContext.Provider>
+  );
+};
+
+GettingStartedProvider.propTypes = {
+  homePath: PropTypes.string.isRequired,
+  steps: PropTypes.array.isRequired,
+  children: PropTypes.node,
+};
+
+export default GettingStartedProvider;
+
+export function useGettingStartedContext(): IGettingStartedContext {
+  const value = useContext(gettingStartedContext);
+  if (!value) {
+    throw new Error(
+      'useGettingStartedContext must be used within a GettingStartedProvider.'
+    );
+  }
+
+  return useMemo(() => value, [value]);
+}

--- a/src/components/MAPI/clusters/GettingStarted/index.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/index.tsx
@@ -22,6 +22,7 @@ import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import DocumentTitle from 'shared/DocumentTitle';
 import { getProvider } from 'stores/main/selectors';
 import useSWR from 'swr';
+import GettingStartedGetAccess from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedGetAccess';
 import GettingStartedNavigation from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation';
 import GettingStartedOverview from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedOverview';
 
@@ -48,7 +49,7 @@ function computeSteps(
         pathParams
       ),
       path: OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl,
-      component: () => null,
+      component: GettingStartedGetAccess,
     },
     {
       title: 'Install an ingress controller',

--- a/src/components/MAPI/clusters/GettingStarted/index.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/index.tsx
@@ -25,6 +25,7 @@ import useSWR from 'swr';
 import GettingStartedGetAccess from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedGetAccess';
 import GettingStartedInstallIngress from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedInstallIngress';
 import GettingStartedNavigation from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation';
+import GettingStartedNextSteps from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedNextSteps';
 import GettingStartedOverview from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedOverview';
 import GettingStartedSimpleExample from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedSimpleExample';
 
@@ -82,7 +83,7 @@ function computeSteps(
         pathParams
       ),
       path: OrganizationsRoutes.Clusters.GettingStarted.NextSteps,
-      component: () => null,
+      component: GettingStartedNextSteps,
     },
   ];
 

--- a/src/components/MAPI/clusters/GettingStarted/index.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/index.tsx
@@ -26,6 +26,7 @@ import GettingStartedGetAccess from 'UI/Display/MAPI/clusters/GettingStarted/Get
 import GettingStartedInstallIngress from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedInstallIngress';
 import GettingStartedNavigation from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation';
 import GettingStartedOverview from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedOverview';
+import GettingStartedSimpleExample from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedSimpleExample';
 
 import GettingStartedProvider, {
   IGettingStartedStep,
@@ -70,7 +71,7 @@ function computeSteps(
         pathParams
       ),
       path: OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
-      component: () => null,
+      component: GettingStartedSimpleExample,
     },
     {
       title: 'Next steps',

--- a/src/components/MAPI/clusters/GettingStarted/index.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/index.tsx
@@ -23,6 +23,7 @@ import DocumentTitle from 'shared/DocumentTitle';
 import { getProvider } from 'stores/main/selectors';
 import useSWR from 'swr';
 import GettingStartedGetAccess from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedGetAccess';
+import GettingStartedInstallIngress from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedInstallIngress';
 import GettingStartedNavigation from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation';
 import GettingStartedOverview from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedOverview';
 
@@ -59,7 +60,7 @@ function computeSteps(
         pathParams
       ),
       path: OrganizationsRoutes.Clusters.GettingStarted.InstallIngress,
-      component: () => null,
+      component: GettingStartedInstallIngress,
     },
     {
       title: 'Run a simple example',

--- a/src/components/MAPI/clusters/GettingStarted/index.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/index.tsx
@@ -1,0 +1,212 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { push } from 'connected-react-router';
+import { Box } from 'grommet';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
+import RoutePath from 'lib/routePath';
+import {
+  extractErrorMessage,
+  getOrgNamespaceFromOrgName,
+} from 'MAPI/organizations/utils';
+import { Cluster } from 'MAPI/types';
+import { fetchCluster, fetchClusterKey } from 'MAPI/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import * as metav1 from 'model/services/mapi/metav1';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Breadcrumb } from 'react-breadcrumbs';
+import { useDispatch, useSelector } from 'react-redux';
+import { Redirect, Switch, useRouteMatch } from 'react-router';
+import Route from 'Route';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import DocumentTitle from 'shared/DocumentTitle';
+import { getProvider } from 'stores/main/selectors';
+import useSWR from 'swr';
+import GettingStartedNavigation from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation';
+import GettingStartedOverview from 'UI/Display/MAPI/clusters/GettingStarted/GettingStartedOverview';
+
+import GettingStartedProvider, {
+  IGettingStartedStep,
+} from './GettingStartedProvider';
+
+function computeSteps(
+  organizationName: string,
+  clusterName: string
+): IGettingStartedStep[] {
+  const pathParams = {
+    orgId: organizationName,
+    clusterId: clusterName,
+  };
+
+  const steps = [
+    {
+      title: 'Get access',
+      description:
+        'Enable your Kubernetes CLI to access your Kubernetes cluster at Giant Swarm',
+      url: RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl,
+        pathParams
+      ),
+      path: OrganizationsRoutes.Clusters.GettingStarted.ConfigureKubeCtl,
+      component: () => null,
+    },
+    {
+      title: 'Install an ingress controller',
+      description: `We'll need an ingress controller before we can access any services from the browser`,
+      url: RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.GettingStarted.InstallIngress,
+        pathParams
+      ),
+      path: OrganizationsRoutes.Clusters.GettingStarted.InstallIngress,
+      component: () => null,
+    },
+    {
+      title: 'Run a simple example',
+      description: `To make sure everything works as expected, let's start a hello world application`,
+      url: RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
+        pathParams
+      ),
+      path: OrganizationsRoutes.Clusters.GettingStarted.SimpleExample,
+      component: () => null,
+    },
+    {
+      title: 'Next steps',
+      description:
+        'We point you to some useful next best actions, like setting up the Kubernetes dashboard',
+      url: RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.GettingStarted.NextSteps,
+        pathParams
+      ),
+      path: OrganizationsRoutes.Clusters.GettingStarted.NextSteps,
+      component: () => null,
+    },
+  ];
+
+  return steps;
+}
+
+interface IGettingStartedProps {}
+
+const GettingStarted: React.FC<IGettingStartedProps> = () => {
+  const dispatch = useDispatch();
+
+  const match = useRouteMatch<{ orgId: string; clusterId: string }>();
+  const { orgId, clusterId } = match.params;
+
+  const provider = useSelector(getProvider);
+
+  const clientFactory = useHttpClientFactory();
+  const auth = useAuthProvider();
+
+  const namespace = getOrgNamespaceFromOrgName(orgId);
+
+  const clusterClient = useRef(clientFactory());
+  const { data: cluster, error: clusterError } = useSWR<
+    Cluster,
+    GenericResponseError
+  >(fetchClusterKey(provider, namespace, clusterId), () =>
+    fetchCluster(clusterClient.current, auth, provider, namespace, clusterId)
+  );
+
+  useEffect(() => {
+    if (clusterError) {
+      ErrorReporter.getInstance().notify(clusterError);
+    }
+
+    if (
+      metav1.isStatusError(
+        clusterError?.data,
+        metav1.K8sStatusErrorReasons.NotFound
+      )
+    ) {
+      new FlashMessage(
+        `Cluster <code>${clusterId}</code> not found`,
+        messageType.ERROR,
+        messageTTL.FOREVER,
+        'Please make sure the Cluster name is correct and that you have access to it.'
+      );
+
+      dispatch(push(MainRoutes.Home));
+    } else if (clusterError) {
+      const errorMessage = extractErrorMessage(clusterError);
+      new FlashMessage(
+        `There was a problem loading cluster <code>${clusterId}</code>`,
+        messageType.ERROR,
+        messageTTL.FOREVER,
+        errorMessage
+      );
+
+      if (!cluster) {
+        dispatch(push(MainRoutes.Home));
+      }
+    }
+  }, [cluster, clusterError, clusterId, dispatch]);
+
+  useEffect(() => {
+    if (typeof cluster?.metadata.deletionTimestamp !== 'undefined') {
+      new FlashMessage(
+        `Cluster <code>${cluster.metadata.name}</code> is currently being deleted`,
+        messageType.INFO,
+        messageTTL.MEDIUM
+      );
+
+      dispatch(push(MainRoutes.Home));
+    }
+  }, [cluster, dispatch]);
+
+  const homePath = useMemo(
+    () =>
+      RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.GettingStarted.Overview,
+        { orgId, clusterId }
+      ),
+    [clusterId, orgId]
+  );
+
+  const steps = useMemo(() => computeSteps(orgId, clusterId), [
+    orgId,
+    clusterId,
+  ]);
+
+  return (
+    <DocumentTitle title={`Getting Started | ${clusterId}`}>
+      <Breadcrumb
+        data={{
+          title: 'GETTING STARTED',
+          pathname: match.url,
+        }}
+      >
+        <GettingStartedProvider steps={steps} homePath={homePath}>
+          <Box width={{ max: 'xlarge' }} margin='auto'>
+            <Switch>
+              <Route
+                component={GettingStartedOverview}
+                exact={true}
+                path={OrganizationsRoutes.Clusters.GettingStarted.Overview}
+              />
+
+              {steps.map((step) => (
+                <Route
+                  key={step.path}
+                  component={step.component}
+                  path={step.path}
+                  exact={true}
+                />
+              ))}
+
+              <Redirect
+                to={OrganizationsRoutes.Clusters.GettingStarted.Overview}
+              />
+            </Switch>
+          </Box>
+          <GettingStartedNavigation />
+        </GettingStartedProvider>
+      </Breadcrumb>
+    </DocumentTitle>
+  );
+};
+
+GettingStarted.propTypes = {};
+
+export default GettingStarted;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1,13 +1,16 @@
 import { HttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
 import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
-import { Constants } from 'shared/constants';
+import { Constants, Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
 import { IState } from 'stores/state';
 
 import {
+  Cluster,
   ControlPlaneNodeList,
   NodePool,
   NodePoolList,
@@ -228,6 +231,24 @@ export function fetchProviderNodePoolsForNodePoolsKey(
   }
 
   return keys.join();
+}
+
+export async function fetchCluster(
+  httpClient: IHttpClient,
+  auth: IOAuth2Provider,
+  _provider: PropertiesOf<typeof Providers>,
+  namespace: string,
+  name: string
+): Promise<Cluster> {
+  return capiv1alpha3.getCluster(httpClient, auth, namespace, name);
+}
+
+export function fetchClusterKey(
+  _provider: PropertiesOf<typeof Providers>,
+  namespace: string,
+  name: string
+): string {
+  return capiv1alpha3.getClusterKey(namespace, name);
 }
 
 export async function fetchMasterListForCluster(

--- a/src/components/UI/Display/Documentation/Styles.js
+++ b/src/components/UI/Display/Documentation/Styles.js
@@ -3,8 +3,6 @@ import styled from 'styled-components';
 const Styles = styled.div`
   .codeblock--container {
     font-family: 'Inconsolata';
-    margin-bottom: 25px;
-    margin-top: 25px;
     line-height: 24px;
   }
   .codeblock--container:hover pre {

--- a/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedGetAccess.tsx
+++ b/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedGetAccess.tsx
@@ -1,0 +1,213 @@
+import { Box, Heading, Paragraph } from 'grommet';
+import GettingStartedPlatformTabs from 'MAPI/clusters/GettingStarted/GettingStartedPlatformTabs';
+import React from 'react';
+import { Breadcrumb } from 'react-breadcrumbs';
+import { useSelector } from 'react-redux';
+import { useRouteMatch } from 'react-router';
+import { getLoggedInUser } from 'stores/main/selectors';
+import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
+import { CodeBlock, Prompt } from 'UI/Display/Documentation/CodeBlock';
+import Aside from 'UI/Layout/Aside';
+
+interface IGettingStartedGetAccessProps {}
+
+const GettingStartedGetAccess: React.FC<IGettingStartedGetAccessProps> = () => {
+  const match = useRouteMatch<{ orgId: string; clusterId: string }>();
+  const { clusterId } = match.params;
+
+  const loggedInUser = useSelector(getLoggedInUser)!;
+
+  return (
+    <Breadcrumb
+      data={{
+        title: 'CONFIGURE',
+        pathname: match.url,
+      }}
+    >
+      <Box>
+        <Heading level={1}>
+          Configure kubectl for cluster <ClusterIDLabel clusterID={clusterId} />
+        </Heading>
+        <Paragraph fill={true}>
+          The <code>gsctl</code> command line utility provides access to your
+          Giant Swarm resources. It&apos;s perfectly suited to create
+          credentials for <code>kubectl</code> in one step. Let&apos;s install{' '}
+          <code>gsctl</code> quickly.
+        </Paragraph>
+        <GettingStartedPlatformTabs
+          margin={{ top: 'medium', bottom: 'large' }}
+          linuxContent={
+            <Paragraph fill={true}>
+              Download the latest release{' '}
+              <a
+                href='https://github.com/giantswarm/gsctl/releases'
+                rel='noopener noreferrer'
+              >
+                from GitHub
+              </a>
+              , unpack the binary and move it to a location covered by your{' '}
+              <code>PATH</code> environment variable.
+            </Paragraph>
+          }
+          macOSContent={
+            <>
+              <Paragraph fill={true}>
+                Homebrew provides the most convenient way to install gsctl and
+                keep it up to date. To install, use this command:
+              </Paragraph>
+              <CodeBlock>
+                <Prompt>brew tap giantswarm/giantswarm</Prompt>
+                <Prompt>brew install gsctl</Prompt>
+              </CodeBlock>
+              <Paragraph fill={true}>For updating:</Paragraph>
+              <CodeBlock>
+                <Prompt>brew upgrade gsctl</Prompt>
+              </CodeBlock>
+              <Paragraph fill={true}>
+                To install without homebrew, download the latest release{' '}
+                <a
+                  href='https://github.com/giantswarm/gsctl/releases'
+                  rel='noopener noreferrer'
+                >
+                  from GitHub
+                </a>
+                , unpack the binary and move it to a location covered by your{' '}
+                <code>PATH</code> environment variable.
+              </Paragraph>
+            </>
+          }
+          windowsContent={
+            <>
+              <Paragraph fill={true}>
+                <a href='http://scoop.sh/' rel='noopener noreferrer'>
+                  scoop
+                </a>{' '}
+                enables convenient installs and updates for Windows PowerShell
+                users. Before you can install gsctl for the first time, execute
+                this:
+              </Paragraph>
+              <CodeBlock>
+                <Prompt>
+                  scoop bucket add giantswarm
+                  https://github.com/giantswarm/scoop-bucket.git
+                </Prompt>
+              </CodeBlock>
+              <Paragraph fill={true}>To install:</Paragraph>
+              <CodeBlock>
+                <Prompt>scoop install gsctl</Prompt>
+              </CodeBlock>
+              <Paragraph fill={true}>To update:</Paragraph>
+              <CodeBlock>
+                <Prompt>scoop update gsctl</Prompt>
+              </CodeBlock>
+              <Paragraph fill={true}>
+                To install without scoop, download the latest release{' '}
+                <a
+                  href='https://github.com/giantswarm/gsctl/releases'
+                  rel='noopener noreferrer'
+                >
+                  from GitHub
+                </a>
+                , unpack the binary and move it to a location covered by your{' '}
+                <code>PATH</code> environment variable.
+              </Paragraph>
+            </>
+          }
+        />
+        <Paragraph fill={true}>
+          Run this command to make sure the installation succeeded:
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>{`gsctl --endpoint ${window.config.apiEndpoint} info`}</Prompt>
+        </CodeBlock>
+        <Paragraph fill={true}>
+          Next, we let <code>gsctl</code> do several things in one step:
+        </Paragraph>
+        <ul>
+          <li>
+            Create a new key pair (certificate and private key) for you to
+            access this cluster
+          </li>
+          <li>Download your key pair</li>
+          <li>Download the CA certificate for your cluster</li>
+          <li>
+            Update your kubectl configuration to add settings and credentials
+            for the cluster
+          </li>
+        </ul>
+        <Paragraph fill={true}>
+          Here is the command that you need to execute for all this:
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>
+            {`
+                gsctl --endpoint ${window.config.apiEndpoint} \\
+                  create kubeconfig \\
+                  --cluster ${clusterId} \\
+                  --certificate-organizations system:masters \\
+                  --auth-token ${loggedInUser.auth.token}`}
+          </Prompt>
+        </CodeBlock>
+        <Paragraph fill={true}>In case you wonder:</Paragraph>
+        <ul>
+          <li>
+            <code>--endpoint</code> sets the right API endpoint to use for your
+            installation.
+          </li>
+          <li>
+            <code>--cluster &lt;cluster_id&gt;</code> selects the cluster to
+            provide access to.
+          </li>
+          <li>
+            <code>--certificate-organizations system:masters</code> ensures that
+            you will be authorized as an administrator when using this keypair.
+          </li>
+          <li>
+            <code>--auth-token &lt;token&gt;</code> saves you from having to
+            enter you password again in <code>gsctl</code>, by re-using the
+            token from your current web UI session.
+          </li>
+        </ul>
+        <Aside>
+          <i
+            className='fa fa-info'
+            aria-label='For learners'
+            role='presentation'
+            aria-hidden={true}
+          />{' '}
+          <code>--certificate-organizations</code> is a flag that sets what
+          group you belong to when authenticating against the Kubernetes API.
+          The default superadmin group on RBAC (Role Based Access Control)
+          enabled clusters is <code>system:masters</code> . All clusters on AWS
+          have RBAC enabled, some of our on-prem (KVM) clusters do not.
+        </Aside>
+        <Paragraph fill={true}>
+          After execution, you should see what happened in detail. After
+          credentials and settings have been added, the context matching your
+          Giant Swarm Kubernetes cluster has been selected for use in{' '}
+          <code>kubectl</code>. You can now check things using these commands:
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>kubectl cluster-info</Prompt>
+        </CodeBlock>
+        <Paragraph fill={true}>
+          This should print some information on your cluster.
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>kubectl get nodes</Prompt>
+        </CodeBlock>
+        <Paragraph fill={true}>
+          Here you should see a list of the worker nodes in your cluster.
+        </Paragraph>
+        <Paragraph fill={true}>
+          Now that this is done, let&apos;s deploy some software on your cluster
+          and dig a little deeper.
+        </Paragraph>
+      </Box>
+    </Breadcrumb>
+  );
+};
+
+GettingStartedGetAccess.propTypes = {};
+
+export default GettingStartedGetAccess;

--- a/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedInstallIngress.tsx
+++ b/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedInstallIngress.tsx
@@ -1,0 +1,47 @@
+import { Box, Heading, Paragraph } from 'grommet';
+import InstallIngressButton from 'MAPI/apps/InstallIngressButton';
+import React from 'react';
+import { Breadcrumb } from 'react-breadcrumbs';
+import { useRouteMatch } from 'react-router';
+
+interface IGettingStartedInstallIngressProps {}
+
+const GettingStartedInstallIngress: React.FC<IGettingStartedInstallIngressProps> = () => {
+  const match = useRouteMatch<{ orgId: string; clusterId: string }>();
+  const { clusterId } = match.params;
+
+  return (
+    <Breadcrumb
+      data={{
+        title: 'INSTALL INGRESS',
+        pathname: match.url,
+      }}
+    >
+      <Box>
+        <Heading level={1}>Install an ingress controller</Heading>
+        <Paragraph fill={true}>
+          Your cluster does not come with an ingress controller installed by
+          default. Without an ingress controller you won&apos;t be able to
+          access any services running on the cluster from the browser.
+        </Paragraph>
+        <Heading level={2}>Using the Giant Swarm App Platform</Heading>
+        <Paragraph fill={true}>
+          You can use our app platform to install the popular nginx ingress
+          controller. We provide a tuned implementation in the &quot;Giant Swarm
+          Catalog&quot;, which you can browse by clicking &quot;App
+          Catalogs&quot; in the navigation above.
+        </Paragraph>
+        <Paragraph fill={true}>
+          For convenience however, you can click on the &apos;Install Ingress
+          Controller&apos; button below to immediately install the nginx ingress
+          controller on your cluster.
+        </Paragraph>
+        <InstallIngressButton clusterID={clusterId} />
+      </Box>
+    </Breadcrumb>
+  );
+};
+
+GettingStartedInstallIngress.propTypes = {};
+
+export default GettingStartedInstallIngress;

--- a/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation.tsx
+++ b/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation.tsx
@@ -1,0 +1,98 @@
+import { Box } from 'grommet';
+import { useGettingStartedContext } from 'MAPI/clusters/GettingStarted/GettingStartedProvider';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Button from 'UI/Controls/Button';
+import GettingStartedBottomNav from 'UI/Display/Documentation/GettingStartedBottomNav';
+
+interface IGettingStartedNavigationProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {}
+
+const GettingStartedNavigation: React.FC<IGettingStartedNavigationProps> = (
+  props
+) => {
+  const {
+    nextStepPath,
+    prevStepPath,
+    currentStepIdx,
+    steps,
+    homePath,
+  } = useGettingStartedContext();
+
+  const isHome = currentStepIdx < 0;
+  const isFirstStep = currentStepIdx === 0;
+  const isPenultimateStep = currentStepIdx === steps.length - 2;
+
+  return (
+    <GettingStartedBottomNav {...props}>
+      {!isFirstStep && prevStepPath && (
+        <Link to={prevStepPath} key='prev-step'>
+          <Button bsStyle='default'>
+            <i
+              className='fa fa-chevron-left'
+              aria-hidden={true}
+              role='presentation'
+            />{' '}
+            Back
+          </Button>
+        </Link>
+      )}
+
+      {isFirstStep && !prevStepPath && (
+        <Link to={homePath} key='prev-step'>
+          <Button bsStyle='default'>
+            <i
+              className='fa fa-chevron-left'
+              aria-hidden={true}
+              role='presentation'
+            />{' '}
+            Back
+          </Button>
+        </Link>
+      )}
+
+      {!isPenultimateStep && !isHome && nextStepPath && (
+        <Link to={nextStepPath} key='next-step'>
+          <Button bsStyle='primary'>
+            Continue{' '}
+            <i
+              className='fa fa-chevron-right'
+              aria-hidden={true}
+              role='presentation'
+            />
+          </Button>
+        </Link>
+      )}
+
+      {isPenultimateStep && nextStepPath && (
+        <Link to={nextStepPath} key='next-step'>
+          <Button bsStyle='primary'>
+            Finish{' '}
+            <i
+              className='fa fa-chevron-right'
+              aria-hidden={true}
+              role='presentation'
+            />
+          </Button>
+        </Link>
+      )}
+
+      {isHome && nextStepPath && (
+        <Link to={nextStepPath} key='next-step'>
+          <Button bsStyle='primary'>
+            Start{' '}
+            <i
+              className='fa fa-chevron-right'
+              aria-hidden={true}
+              role='presentation'
+            />
+          </Button>
+        </Link>
+      )}
+    </GettingStartedBottomNav>
+  );
+};
+
+GettingStartedNavigation.propTypes = {};
+
+export default GettingStartedNavigation;

--- a/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedNextSteps.tsx
+++ b/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedNextSteps.tsx
@@ -1,0 +1,86 @@
+import { Box, Heading, Paragraph } from 'grommet';
+import * as blog from 'lib/blog';
+import * as docs from 'lib/docs';
+import React from 'react';
+import { Breadcrumb } from 'react-breadcrumbs';
+import { useRouteMatch } from 'react-router';
+
+interface IGettingStartedNextStepsProps {}
+
+const GettingStartedNextSteps: React.FC<IGettingStartedNextStepsProps> = () => {
+  const match = useRouteMatch<{ orgId: string; clusterId: string }>();
+
+  return (
+    <Breadcrumb
+      data={{
+        title: 'NEXT STEPS',
+        pathname: match.url,
+      }}
+    >
+      <Box>
+        <Heading level={1}>🎉 Congratulations</Heading>
+        <Paragraph fill={true}>
+          You have created &ndash; and destroyed &ndash; your first application
+          on your brand new Kubernetes cluster on Giant Swarm.
+        </Paragraph>
+        <Heading level={2} margin={{ top: 'medium' }}>
+          Where to go from here?
+        </Heading>
+        <Paragraph fill={true}>
+          Now that you have a running Kubernetes cluster, you can use it to
+          deploy anything you like on it.
+        </Paragraph>
+        <Paragraph fill={true}>
+          We recommend to{' '}
+          <a
+            href={blog.gettingStartedWithAK8sEnvironment}
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            choose a local development environment
+          </a>{' '}
+          so you can test your apps before deploying to your Giant Swarm
+          cluster.
+        </Paragraph>
+        <Paragraph fill={true}>
+          If you have not done so already, you should get acquainted with the{' '}
+          <a
+            href={blog.understandingBasicK8sConcepts}
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            basic concepts of Kubernetes
+          </a>
+          .
+        </Paragraph>
+        <Paragraph fill={true}>
+          Last but not least, you should check out our{' '}
+          <a href={docs.homeURL} rel='noopener noreferrer' target='_blank'>
+            Documentation
+          </a>
+          , including an{' '}
+          <a
+            href={docs.kubernetesResourcesURL}
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            overview of Kubernetes resources
+          </a>{' '}
+          and a selection of{' '}
+          <a
+            href={docs.gettingStartedURL}
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            guides
+          </a>{' '}
+          that help you set up basic metrics, RBAC, and more.
+        </Paragraph>
+      </Box>
+    </Breadcrumb>
+  );
+};
+
+GettingStartedNextSteps.propTypes = {};
+
+export default GettingStartedNextSteps;

--- a/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedOverview.tsx
+++ b/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedOverview.tsx
@@ -1,0 +1,83 @@
+import {
+  Box,
+  Card,
+  CardBody,
+  CardHeader,
+  Heading,
+  Keyboard,
+  Text,
+} from 'grommet';
+import { useGettingStartedContext } from 'MAPI/clusters/GettingStarted/GettingStartedProvider';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const StyledLink = styled(Link)`
+  :hover {
+    text-decoration: none;
+  }
+`;
+
+const StyledCard = styled(Card)`
+  transition: opacity 0.1s ease-out, box-shadow 0.1s ease-in-out;
+
+  :hover,
+  :focus {
+    box-shadow: ${(props) =>
+      `0 0 0 1px ${props.theme.global.colors.text.dark}`};
+  }
+
+  :active {
+    opacity: 0.7;
+  }
+`;
+
+interface IGettingStartedOverviewProps {}
+
+const GettingStartedOverview: React.FC<IGettingStartedOverviewProps> = () => {
+  const { steps } = useGettingStartedContext();
+
+  const handleLinkKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.preventDefault();
+
+    (e.target as HTMLElement).click();
+  };
+
+  return (
+    <Box>
+      <Heading level={1}>Get started with your Kubernetes cluster</Heading>
+      <Box margin={{ top: 'medium' }} gap='small'>
+        {steps.map((step, idx) => (
+          <Keyboard key={step.path} onSpace={handleLinkKeyDown}>
+            <StyledLink to={step.url}>
+              <StyledCard
+                pad={{ horizontal: 'medium', top: 'small', bottom: 'medium' }}
+                round='xsmall'
+                elevation='none'
+                overflow='visible'
+                background='background-front'
+                aria-label={step.title}
+              >
+                <CardHeader>
+                  <Box direction='row' align='center' gap='small'>
+                    <Text size='xxlarge' weight='bold' color='text-xweak'>
+                      {idx + 1}.
+                    </Text>
+                    <Text weight='bold'>{step.title}</Text>
+                  </Box>
+                </CardHeader>
+                <CardBody>
+                  <Text>{step.description}</Text>
+                </CardBody>
+              </StyledCard>
+            </StyledLink>
+          </Keyboard>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+GettingStartedOverview.propTypes = {};
+
+export default GettingStartedOverview;

--- a/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedSimpleExample.tsx
+++ b/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedSimpleExample.tsx
@@ -1,0 +1,238 @@
+import { Box, Heading, Paragraph } from 'grommet';
+import GettingStartedPlatformTabs from 'MAPI/clusters/GettingStarted/GettingStartedPlatformTabs';
+import React from 'react';
+import { Breadcrumb } from 'react-breadcrumbs';
+import { useRouteMatch } from 'react-router';
+import { CodeBlock, Output, Prompt } from 'UI/Display/Documentation/CodeBlock';
+import Aside from 'UI/Layout/Aside';
+
+function getClusterBaseDomain(
+  clusterName: string,
+  ingressBaseDomain: string
+): string {
+  return `${clusterName}.${ingressBaseDomain}`;
+}
+
+function getHelloWorldURL(clusterBaseDomain: string) {
+  return `http://helloworld.${clusterBaseDomain}`;
+}
+
+interface IGettingStartedSimpleExampleProps {}
+
+const GettingStartedSimpleExample: React.FC<IGettingStartedSimpleExampleProps> = () => {
+  const match = useRouteMatch<{ orgId: string; clusterId: string }>();
+  const { clusterId } = match.params;
+
+  const clusterBaseDomain = getClusterBaseDomain(
+    clusterId,
+    window.config.ingressBaseDomain
+  );
+  const helloWorldURL = getHelloWorldURL(clusterBaseDomain);
+
+  return (
+    <Breadcrumb
+      data={{
+        title: 'SIMPLE EXAMPLE',
+        pathname: match.url,
+      }}
+    >
+      <Box>
+        <Heading level={1}>Let&apos;s create an example application</Heading>
+        <Paragraph fill={true}>
+          To check if every part of your cluster is running as it should,
+          let&apos;s create an entire application. When set up, this application
+          will provide a little web server running in multiple pods.
+        </Paragraph>
+        <Paragraph fill={true}>
+          We use <code>kubectl</code> to create the service, deployment, and
+          ingress resource from a manifest hosted on GitHub.
+        </Paragraph>
+        <Aside>
+          <i
+            className='fa fa-info'
+            aria-label='For learners'
+            role='presentation'
+            aria-hidden={true}
+          />{' '}
+          If you&apos;re new to Kubernetes: A manifest describes things to
+          create in Kubernetes. In this case the manifest describes two
+          different things, a service and a deployment. The service is there to
+          expose containers (here: the ones with the label app: helloworld)
+          inside your cluster via a certain hostname and port. The deployment
+          describes your helloworld deployment. It manages a replica set, which
+          ensures that a number of pods (two, actually) containing Docker
+          containers from a certain image are running.
+        </Aside>
+        <Paragraph fill={true}>First we download the manifest:</Paragraph>
+        <CodeBlock>
+          <Prompt>
+            {`
+                  wget https://raw.githubusercontent.com/giantswarm/helloworld/master/helloworld-manifest.yaml
+                `}
+          </Prompt>
+        </CodeBlock>
+        <Paragraph fill={true}>
+          Next replace the placeholder <code>YOUR_CLUSTER_BASE_DOMAIN</code>{' '}
+          with <code>{clusterBaseDomain}</code>.
+        </Paragraph>
+        <Paragraph fill={true}>
+          If you are on Linux or Mac OS you can use the command below to do
+          this. Windows users willl have to use their favorite text editor and
+          manually edit the <code>helloworld-manifest.yaml</code> file.
+        </Paragraph>
+        <GettingStartedPlatformTabs
+          margin={{ top: 'medium', bottom: 'large' }}
+          linuxContent={
+            <CodeBlock>
+              <Prompt>
+                {`sed -i"" "s/YOUR_CLUSTER_BASE_DOMAIN/${clusterBaseDomain}/" helloworld-manifest.yaml`}
+              </Prompt>
+            </CodeBlock>
+          }
+          macOSContent={
+            <CodeBlock>
+              <Prompt>
+                {`sed -i "" "s/YOUR_CLUSTER_BASE_DOMAIN/${clusterBaseDomain}/" helloworld-manifest.yaml`}
+              </Prompt>
+            </CodeBlock>
+          }
+          windowsContent={
+            <Paragraph fill={true} margin='none'>
+              Edit the <code>helloworld-manifest.yaml</code> file manually in
+              your favourite code editor.
+            </Paragraph>
+          }
+        />
+        <Paragraph fill={true}>
+          Finally apply the manifest to your cluster:
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>
+            {`
+                 kubectl apply -f helloworld-manifest.yaml
+                `}
+          </Prompt>
+          <Output>
+            {`
+                  service/helloworld created
+                  deployment.apps/helloworld created
+                  poddisruptionbudget.policy/helloworld-pdb created
+                  ingress.networking.k8s.io/helloworld created
+                `}
+          </Output>
+        </CodeBlock>
+        <Paragraph fill={true}>
+          The deployment will create a replica set, which in turn will create
+          pods with the Docker containers running. Once they are up, which
+          should take only a few seconds, you can access them using this URL:
+        </Paragraph>
+        <Paragraph fill={true}>
+          <a href={helloWorldURL} rel='noopener noreferrer' target='_blank'>
+            {helloWorldURL}
+          </a>
+        </Paragraph>
+        <Paragraph fill={true}>
+          This should show a little welcome message from the Giant Swarm team.
+        </Paragraph>
+        <Heading level={1} margin={{ top: 'large' }}>
+          Inspecting your service
+        </Heading>
+        <Paragraph fill={true}>
+          Let&apos;s inspect what has actually been generated by Kubernetes
+          based on our manifest. This first command lists all deployments,
+          filtered to those that have a label <code>app: helloworld</code>:
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>kubectl get deployment -l app=helloworld</Prompt>
+          <Output>
+            {`
+                  NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+                  helloworld   2/2     2            2           2m
+                `}
+          </Output>
+        </CodeBlock>
+        <Paragraph fill={true}>
+          It should tell us that 2 of our 2 desired pods are currently running.
+          Then we list the available services with the according label:
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>kubectl get svc -l app=helloworld</Prompt>
+          <Output>
+            {`
+                  NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+                  helloworld   ClusterIP   172.31.144.55   <none>        8080/TCP   2m
+                `}
+          </Output>
+        </CodeBlock>
+        <Paragraph fill={true}>And finally we list the pods:</Paragraph>
+        <CodeBlock>
+          <Prompt>kubectl get pods -l app=helloworld</Prompt>
+          <Output>
+            {`
+                  NAME                          READY     STATUS    RESTARTS   AGE
+                  helloworld-3495070191-0ynir   1/1       Running   0          3m
+                  helloworld-3495070191-onuik   1/1       Running   0          3m
+                `}
+          </Output>
+        </CodeBlock>
+        <Aside>
+          <i
+            className='fa fa-info'
+            aria-label='For learners'
+            role='presentation'
+            aria-hidden={true}
+          />{' '}
+          The exact pod names vary in each case, the first suffix functions a
+          bit like a version number for your deployment, this changes with
+          updates to the deployment. The last part of the pod name is used by
+          Kubernetes to disambiguate the name using a unique suffixes.
+        </Aside>
+        <Paragraph fill={true}>
+          To investigate a bit closer what our containers are doing inside their
+          pods, we can look at their logs, one pod at a time. Be sure to replace
+          the version and suffix fields (in brackets) with the actual ones you
+          got from the
+          <code>get pods</code> command above.
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>kubectl logs --selector app=helloworld</Prompt>
+          <Output>
+            {`
+                  2014/07/01 09:57:30 Starting up at :8080
+                  2014/07/01 09:57:40 GET /giant-swarm-logo.svg
+                  2014/07/01 09:57:41 GET /favicon32.ico
+                  2014/07/01 09:57:30 Starting up at :8080
+                  2014/07/01 09:57:40 GET /
+                  2014/07/01 09:57:40 GET /blue-bg.jpg
+                `}
+          </Output>
+        </CodeBlock>
+        <Paragraph fill={true}>
+          You should see in the log entries that the requests for the HTML page,
+          the logo, the favicon, and the background images have been distributed
+          over both running pods and their respective containers pretty much
+          randomly.
+        </Paragraph>
+        <Paragraph fill={true}>
+          To clean things up, we use the <code>kubectl delete</code> command on
+          the service, deployment, and ingress we created initially:
+        </Paragraph>
+        <CodeBlock>
+          <Prompt>kubectl delete -f helloworld-manifest.yaml</Prompt>
+          <Output>
+            {`
+                  service "helloworld" deleted
+                  deployment.apps "helloworld" deleted
+                  poddisruptionbudget.policy "helloworld-pdb" deleted
+                  ingress.networking.k8s.io "helloworld" deleted
+                `}
+          </Output>
+        </CodeBlock>
+      </Box>
+    </Breadcrumb>
+  );
+};
+
+GettingStartedSimpleExample.propTypes = {};
+
+export default GettingStartedSimpleExample;

--- a/src/components/shared/Tabs/index.tsx
+++ b/src/components/shared/Tabs/index.tsx
@@ -3,7 +3,8 @@ import React, { ReactNode } from 'react';
 import BootstrapTabs from 'react-bootstrap/lib/Tabs';
 import { useHistory, useLocation } from 'react-router';
 
-interface ITabsProps {
+interface ITabsProps
+  extends React.ComponentPropsWithoutRef<typeof BootstrapTabs> {
   defaultActiveKey: string;
   children: ReactNode;
   useRoutes?: boolean;
@@ -13,6 +14,7 @@ const Tabs: React.FC<ITabsProps> = ({
   defaultActiveKey,
   children,
   useRoutes,
+  ...props
 }) => {
   const history = useHistory();
   const { pathname } = useLocation();
@@ -38,6 +40,7 @@ const Tabs: React.FC<ITabsProps> = ({
       id='tabs'
       mountOnEnter={true}
       unmountOnExit={true}
+      {...props}
     >
       {children}
     </BootstrapTabs>

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,5 @@
+export const gettingStartedWithAK8sEnvironment =
+  'https://www.giantswarm.io/blog/getting-started-with-a-local-kubernetes-environment';
+
+export const understandingBasicK8sConcepts =
+  'https://www.giantswarm.io/blog/understanding-basic-kubernetes-concepts-i-introduction-to-pods-labels-replicas';


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/17531

This PR adds the MAPI-specific getting started guide for clusters.
The information displayed is *almost* the same as the GS API one. The difference is that the MAPI one doesn't have the alternative keypair creation method (since it is unsupported via MAPI at the moment).

Implementation wise, the new MAPI-specific components are brand new, and they use `grommet` for styling (the old mostly used SASS and were dependent on the clusters coming from the global state).

> ⚠️  In the screenshots the cluster base URL includes `localhost`. This is not the case when deployed in production.

## Preview

<details>
<summary>Overview</summary>

![image](https://user-images.githubusercontent.com/13508038/124629632-eccdf480-de81-11eb-939a-29a4d2c1320a.png)

</details>

<details>
<summary>Configure kubectl</summary>

![image](https://user-images.githubusercontent.com/13508038/124629795-1129d100-de82-11eb-9d9c-0cd3c6e5aaec.png)

</details>

<details>
<summary>Install ingress</summary>

![image](https://user-images.githubusercontent.com/13508038/124629847-21da4700-de82-11eb-8c5e-d55b2123c3fa.png)

</details>

<details>
<summary>Create example application</summary>

![image](https://user-images.githubusercontent.com/13508038/124630474-c0ff3e80-de82-11eb-8fbc-9546364454eb.png)

</details>

<details>
<summary>Final step</summary>

![image](https://user-images.githubusercontent.com/13508038/124630015-49c9aa80-de82-11eb-96a8-d17db42bde9e.png)

</details>
