### PR TITLE
clusters: add support for really basic cluster creation via the MAPI cluster creation page

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -61,7 +61,7 @@ module.exports = {
     },
     featureFlags: {
       FEATURE_MAPI_AUTH: true,
-      FEATURE_MAPI_CLUSTERS: true,
+      FEATURE_MAPI_CLUSTERS: false,
       FEATURE_MONITORING: true,
     },
   },

--- a/src/components/MAPI/clusters/Cluster.tsx
+++ b/src/components/MAPI/clusters/Cluster.tsx
@@ -1,17 +1,17 @@
-import NewClusterWrapper from 'Cluster/NewCluster/NewClusterWrapper';
 import React from 'react';
 import { Redirect, Switch } from 'react-router';
 import Route from 'Route';
 import { OrganizationsRoutes } from 'shared/constants/routes';
 
 import ClusterDetail from './ClusterDetail';
+import CreateCluster from './CreateCluster';
 import GettingStarted from './GettingStarted';
 
 const Cluster: React.FC<{}> = () => {
   return (
     <Switch>
       <Route
-        component={NewClusterWrapper}
+        component={CreateCluster}
         exact
         path={OrganizationsRoutes.Clusters.New}
       />

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterDescription.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterDescription.tsx
@@ -1,0 +1,76 @@
+import { hasAppropriateLength } from 'lib/helpers';
+import { Cluster } from 'MAPI/types';
+import { getClusterDescription } from 'MAPI/utils';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { Constants } from 'shared/constants';
+import InputGroup from 'UI/Inputs/InputGroup';
+import TextInput from 'UI/Inputs/TextInput';
+
+import { IClusterPropertyProps, withClusterDescription } from './patches';
+
+function validateValue(newValue: string): string {
+  const { message } = hasAppropriateLength(
+    newValue,
+    Constants.MIN_NAME_LENGTH,
+    Constants.MAX_NAME_LENGTH
+  );
+
+  return message;
+}
+
+interface IWorkerNodesCreateClusterDescriptionProps
+  extends IClusterPropertyProps,
+    Omit<React.ComponentPropsWithoutRef<typeof InputGroup>, 'onChange' | 'id'> {
+  autoFocus?: boolean;
+}
+
+const WorkerNodesCreateClusterDescription: React.FC<IWorkerNodesCreateClusterDescriptionProps> = ({
+  id,
+  cluster,
+  onChange,
+  readOnly,
+  disabled,
+  autoFocus,
+  ...props
+}) => {
+  const [validationError, setValidationError] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const validationResult = validateValue(e.target.value);
+    setValidationError(validationResult);
+
+    onChange({
+      isValid: validationResult.length < 1,
+      patch: withClusterDescription(e.target.value),
+    });
+  };
+
+  const value = getClusterDescription(cluster);
+
+  return (
+    <InputGroup htmlFor={id} label='Description' {...props}>
+      <TextInput
+        value={value}
+        id={id}
+        error={validationError}
+        onChange={handleChange}
+        help='Pick a description that helps team mates to understand what the cluster is for. You can change this later.'
+        readOnly={readOnly}
+        disabled={disabled}
+        autoFocus={autoFocus}
+      />
+    </InputGroup>
+  );
+};
+
+WorkerNodesCreateClusterDescription.propTypes = {
+  id: PropTypes.string.isRequired,
+  cluster: (PropTypes.object as PropTypes.Requireable<Cluster>).isRequired,
+  onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
+};
+
+export default WorkerNodesCreateClusterDescription;

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterDescription.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterDescription.tsx
@@ -2,7 +2,7 @@ import { hasAppropriateLength } from 'lib/helpers';
 import { Cluster } from 'MAPI/types';
 import { getClusterDescription } from 'MAPI/utils';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Constants } from 'shared/constants';
 import InputGroup from 'UI/Inputs/InputGroup';
 import TextInput from 'UI/Inputs/TextInput';
@@ -48,6 +48,17 @@ const WorkerNodesCreateClusterDescription: React.FC<IWorkerNodesCreateClusterDes
 
   const value = getClusterDescription(cluster);
 
+  const textInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!textInputRef.current || !autoFocus) return;
+
+    textInputRef.current.select();
+
+    // Only run for the initial render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <InputGroup htmlFor={id} label='Description' {...props}>
       <TextInput
@@ -59,6 +70,7 @@ const WorkerNodesCreateClusterDescription: React.FC<IWorkerNodesCreateClusterDes
         readOnly={readOnly}
         disabled={disabled}
         autoFocus={autoFocus}
+        ref={textInputRef}
       />
     </InputGroup>
   );

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterName.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterName.tsx
@@ -1,17 +1,14 @@
+import { Box, Text } from 'grommet';
 import { Cluster } from 'MAPI/types';
 import PropTypes from 'prop-types';
 import React from 'react';
-import InputGroup from 'UI/Inputs/InputGroup';
-import TextInput from 'UI/Inputs/TextInput';
+import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
 
 import { IClusterPropertyProps } from './patches';
 
 interface ICreateClusterNameProps
   extends IClusterPropertyProps,
-    Omit<
-      React.ComponentPropsWithoutRef<typeof InputGroup>,
-      'onChange' | 'id'
-    > {}
+    Omit<React.ComponentPropsWithoutRef<typeof Box>, 'onChange' | 'id'> {}
 
 const CreateClusterName: React.FC<ICreateClusterNameProps> = ({
   id,
@@ -22,14 +19,12 @@ const CreateClusterName: React.FC<ICreateClusterNameProps> = ({
   ...props
 }) => {
   return (
-    <InputGroup htmlFor={id} label='Name' {...props}>
-      <TextInput
-        value={cluster.metadata.name}
-        id={id}
-        readOnly={readOnly}
-        disabled={disabled}
-      />
-    </InputGroup>
+    <Box direction='row' gap='small' align='center' {...props}>
+      <Text size='large' weight='bold'>
+        Name
+      </Text>
+      <ClusterIDLabel clusterID={cluster.metadata.name} />
+    </Box>
   );
 };
 

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterName.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterName.tsx
@@ -1,0 +1,44 @@
+import { Cluster } from 'MAPI/types';
+import PropTypes from 'prop-types';
+import React from 'react';
+import InputGroup from 'UI/Inputs/InputGroup';
+import TextInput from 'UI/Inputs/TextInput';
+
+import { IClusterPropertyProps } from './patches';
+
+interface ICreateClusterNameProps
+  extends IClusterPropertyProps,
+    Omit<
+      React.ComponentPropsWithoutRef<typeof InputGroup>,
+      'onChange' | 'id'
+    > {}
+
+const CreateClusterName: React.FC<ICreateClusterNameProps> = ({
+  id,
+  cluster,
+  onChange,
+  readOnly,
+  disabled,
+  ...props
+}) => {
+  return (
+    <InputGroup htmlFor={id} label='Name' {...props}>
+      <TextInput
+        value={cluster.metadata.name}
+        id={id}
+        readOnly={readOnly}
+        disabled={disabled}
+      />
+    </InputGroup>
+  );
+};
+
+CreateClusterName.propTypes = {
+  id: PropTypes.string.isRequired,
+  cluster: (PropTypes.object as PropTypes.Requireable<Cluster>).isRequired,
+  onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
+};
+
+export default CreateClusterName;

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -90,17 +90,12 @@ function makeInitialState(
   const name = generateUID(5);
 
   const resourceConfig = { ...config, name, releaseVersion: '' };
-  const controlPlaneNode = createDefaultControlPlaneNode(
-    provider,
-    resourceConfig
-  );
   const providerCluster = createDefaultProviderCluster(
     provider,
     resourceConfig
   );
-  const cluster = createDefaultCluster({
-    providerCluster,
-  });
+  const controlPlaneNode = createDefaultControlPlaneNode({ providerCluster });
+  const cluster = createDefaultCluster({ providerCluster });
 
   return {
     provider,

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -286,7 +286,6 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               providerCluster={state.providerCluster}
               controlPlaneNode={state.controlPlaneNode}
               onChange={handleChange(ClusterPropertyField.Name)}
-              disabled={true}
             />
             <WorkerNodesCreateClusterDescription
               id={`cluster-${ClusterPropertyField.Description}`}

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -303,7 +303,7 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
                 type='submit'
                 loading={state.isCreating}
               >
-                Create Cluster
+                Create cluster
               </Button>
 
               {!state.isCreating && (

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -1,0 +1,238 @@
+import { push } from 'connected-react-router';
+import { Box, Heading, Text } from 'grommet';
+import produce from 'immer';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import RoutePath from 'lib/routePath';
+import { extractErrorMessage } from 'MAPI/organizations/utils';
+import { Cluster, ControlPlaneNode, ProviderCluster } from 'MAPI/types';
+import { generateUID } from 'MAPI/utils';
+import React, { useReducer } from 'react';
+import { Breadcrumb } from 'react-breadcrumbs';
+import { useDispatch, useSelector } from 'react-redux';
+import { useRouteMatch } from 'react-router';
+import { Providers } from 'shared/constants';
+import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
+import DocumentTitle from 'shared/DocumentTitle';
+import { PropertiesOf } from 'shared/types';
+import { getProvider } from 'stores/main/selectors';
+import { getNamespaceFromOrgName } from 'stores/main/utils';
+import Button from 'UI/Controls/Button';
+
+import {
+  createDefaultCluster,
+  createDefaultControlPlaneNode,
+  createDefaultProviderCluster,
+} from '../utils';
+import { ClusterPatch } from './patches';
+
+enum ClusterPropertyField {
+  Name,
+}
+
+interface IApplyPatchAction {
+  type: 'applyPatch';
+  property: ClusterPropertyField;
+  value: ClusterPatch;
+}
+
+interface IChangeValidationResultAction {
+  type: 'changeValidationStatus';
+  property: ClusterPropertyField;
+  value: boolean;
+}
+
+interface IStartCreationAction {
+  type: 'startCreation';
+}
+
+interface IEndCreationAction {
+  type: 'endCreation';
+}
+
+type ClusterAction =
+  | IApplyPatchAction
+  | IChangeValidationResultAction
+  | IStartCreationAction
+  | IEndCreationAction;
+
+interface IClusterState {
+  provider: PropertiesOf<typeof Providers>;
+  cluster: Cluster;
+  providerCluster: ProviderCluster;
+  controlPlaneNode: ControlPlaneNode;
+  validationResults: Record<ClusterPropertyField, boolean>;
+  isCreating: boolean;
+}
+
+interface IReducerConfig {
+  namespace: string;
+  organization: string;
+  releaseVersion: string;
+}
+
+function makeInitialState(
+  provider: PropertiesOf<typeof Providers>,
+  config: IReducerConfig
+): IClusterState {
+  const name = generateUID(5);
+
+  const resourceConfig = { ...config, name };
+  const controlPlaneNode = createDefaultControlPlaneNode(
+    provider,
+    resourceConfig
+  );
+  const providerCluster = createDefaultProviderCluster(
+    provider,
+    resourceConfig
+  );
+  const cluster = createDefaultCluster({
+    providerCluster,
+  });
+
+  return {
+    provider,
+    cluster,
+    providerCluster,
+    controlPlaneNode,
+    validationResults: {
+      [ClusterPropertyField.Name]: true,
+    },
+    isCreating: false,
+  };
+}
+
+const reducer: React.Reducer<IClusterState, ClusterAction> = produce(
+  (draft, action) => {
+    switch (action.type) {
+      case 'applyPatch':
+        action.value(
+          draft.cluster,
+          draft.providerCluster,
+          draft.controlPlaneNode
+        );
+        break;
+      case 'changeValidationStatus':
+        draft.validationResults[action.property] = action.value;
+        break;
+      case 'startCreation':
+        draft.isCreating = true;
+        break;
+      case 'endCreation': {
+        draft.isCreating = false;
+        break;
+      }
+    }
+  }
+);
+
+interface ICreateClusterProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {}
+
+const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
+  const match = useRouteMatch<{ orgId: string }>();
+  const { orgId } = match.params;
+  const namespace = getNamespaceFromOrgName(orgId);
+
+  // TODO(axbarsan): Compute latest release.
+  const latestRelease = '';
+
+  const provider = useSelector(getProvider);
+
+  const [state, dispatch] = useReducer(
+    reducer,
+    makeInitialState(provider, {
+      namespace,
+      organization: orgId,
+      releaseVersion: latestRelease,
+    })
+  );
+
+  const globalDispatch = useDispatch();
+
+  const handleCancel = () => {
+    dispatch({ type: 'endCreation' });
+
+    globalDispatch(push(MainRoutes.Home));
+  };
+
+  const isValid = Object.values(state.validationResults).every((r) => r);
+
+  const handleCreation = (e: React.FormEvent<HTMLElement>) => {
+    e.preventDefault();
+
+    dispatch({ type: 'startCreation' });
+
+    try {
+      // TODO(axbarsan): Actually create the cluster.
+
+      dispatch({ type: 'endCreation' });
+
+      new FlashMessage(
+        `Cluster <code>${state.cluster.metadata.name}</code> created successfully`,
+        messageType.SUCCESS,
+        messageTTL.SHORT
+      );
+
+      // Navigate to the cluster's detail page.
+      const detailPath = RoutePath.createUsablePath(
+        OrganizationsRoutes.Clusters.Detail.Home,
+        { orgId, clusterId: state.cluster.metadata.name }
+      );
+      globalDispatch(push(detailPath));
+    } catch (err) {
+      dispatch({ type: 'endCreation' });
+
+      const errorMessage = extractErrorMessage(err);
+
+      new FlashMessage(
+        `Could not create cluster <code>${state.cluster.metadata.name}</code>`,
+        messageType.ERROR,
+        messageTTL.LONG,
+        errorMessage
+      );
+
+      ErrorReporter.getInstance().notify(err);
+    }
+  };
+
+  return (
+    <Breadcrumb data={{ title: 'CREATE CLUSTER', pathname: match.url }}>
+      <DocumentTitle title={`Create Cluster | ${orgId}`}>
+        <Box {...props}>
+          <Box border={{ side: 'bottom' }} margin={{ bottom: 'large' }}>
+            <Heading level={1}>Create a cluster</Heading>
+          </Box>
+          <Box as='form' onSubmit={handleCreation}>
+            <Box direction='row' margin={{ top: 'medium' }}>
+              <Button
+                bsStyle='primary'
+                disabled={!isValid}
+                type='submit'
+                loading={state.isCreating}
+              >
+                Create Cluster
+              </Button>
+
+              {!state.isCreating && (
+                <Button bsStyle='default' onClick={handleCancel}>
+                  Cancel
+                </Button>
+              )}
+            </Box>
+            <Box margin={{ top: 'medium' }}>
+              <Text color='text-weak'>
+                Note that it takes around 30 minutes on average until a new
+                cluster is fully available.
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+      </DocumentTitle>
+    </Breadcrumb>
+  );
+};
+
+CreateCluster.propTypes = {};
+
+export default CreateCluster;

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -30,10 +30,17 @@ import {
   createDefaultProviderCluster,
   findLatestReleaseVersion,
 } from '../utils';
-import { ClusterPatch, withClusterReleaseVersion } from './patches';
+import WorkerNodesCreateClusterDescription from './CreateClusterDescription';
+import CreateClusterName from './CreateClusterName';
+import {
+  ClusterPatch,
+  IClusterPropertyValue,
+  withClusterReleaseVersion,
+} from './patches';
 
 enum ClusterPropertyField {
   Name,
+  Description,
 }
 
 interface IApplyPatchAction {
@@ -104,6 +111,7 @@ function makeInitialState(
     controlPlaneNode,
     validationResults: {
       [ClusterPropertyField.Name]: true,
+      [ClusterPropertyField.Description]: true,
     },
     isCreating: false,
     latestRelease: '',
@@ -169,6 +177,21 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
     dispatch({ type: 'endCreation' });
 
     globalDispatch(push(MainRoutes.Home));
+  };
+
+  const handleChange = (property: ClusterPropertyField) => (
+    newValue: IClusterPropertyValue
+  ) => {
+    dispatch({
+      type: 'applyPatch',
+      property,
+      value: newValue.patch,
+    });
+    dispatch({
+      type: 'changeValidationStatus',
+      property,
+      value: newValue.isValid,
+    });
   };
 
   const isValid =
@@ -243,10 +266,36 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
     <Breadcrumb data={{ title: 'CREATE CLUSTER', pathname: match.url }}>
       <DocumentTitle title={`Create Cluster | ${orgId}`}>
         <Box {...props}>
-          <Box border={{ side: 'bottom' }} margin={{ bottom: 'large' }}>
+          <Box
+            fill={true}
+            border={{ side: 'bottom' }}
+            margin={{ bottom: 'large' }}
+          >
             <Heading level={1}>Create a cluster</Heading>
           </Box>
-          <Box as='form' onSubmit={handleCreation}>
+          <Box
+            as='form'
+            onSubmit={handleCreation}
+            width={{ max: '100%', width: 'large' }}
+            gap='small'
+            margin='auto'
+          >
+            <CreateClusterName
+              id={`cluster-${ClusterPropertyField.Name}`}
+              cluster={state.cluster}
+              providerCluster={state.providerCluster}
+              controlPlaneNode={state.controlPlaneNode}
+              onChange={handleChange(ClusterPropertyField.Name)}
+              disabled={true}
+            />
+            <WorkerNodesCreateClusterDescription
+              id={`cluster-${ClusterPropertyField.Description}`}
+              cluster={state.cluster}
+              providerCluster={state.providerCluster}
+              controlPlaneNode={state.controlPlaneNode}
+              onChange={handleChange(ClusterPropertyField.Description)}
+              autoFocus={true}
+            />
             <Box direction='row' margin={{ top: 'medium' }}>
               <Button
                 bsStyle='primary'

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -1,0 +1,21 @@
+import { Cluster, ControlPlaneNode, ProviderCluster } from 'MAPI/types';
+
+export type ClusterPatch = (
+  cluster: Cluster,
+  providerCluster: ProviderCluster,
+  controlPlaneNode: ControlPlaneNode
+) => void;
+
+export interface IClusterPropertyValue {
+  patch: ClusterPatch;
+  isValid: boolean;
+}
+
+export interface IClusterPropertyProps {
+  cluster: Cluster;
+  providerCluster: ProviderCluster;
+  controlPlaneNode: ControlPlaneNode;
+  onChange: (value: IClusterPropertyValue) => void;
+  disabled?: boolean;
+  readOnly?: boolean;
+}

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -13,6 +13,7 @@ export interface IClusterPropertyValue {
 }
 
 export interface IClusterPropertyProps {
+  id: string;
   cluster: Cluster;
   providerCluster: ProviderCluster;
   controlPlaneNode: ControlPlaneNode;
@@ -35,5 +36,14 @@ export function withClusterReleaseVersion(newVersion: string): ClusterPatch {
     controlPlaneNode.metadata.labels[
       capiv1alpha3.labelReleaseVersion
     ] = newVersion;
+  };
+}
+
+export function withClusterDescription(newDescription: string): ClusterPatch {
+  return (cluster) => {
+    cluster.metadata.annotations ??= {};
+    cluster.metadata.annotations[
+      capiv1alpha3.annotationClusterDescription
+    ] = newDescription;
   };
 }

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -1,4 +1,5 @@
 import { Cluster, ControlPlaneNode, ProviderCluster } from 'MAPI/types';
+import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 
 export type ClusterPatch = (
   cluster: Cluster,
@@ -18,4 +19,21 @@ export interface IClusterPropertyProps {
   onChange: (value: IClusterPropertyValue) => void;
   disabled?: boolean;
   readOnly?: boolean;
+}
+
+export function withClusterReleaseVersion(newVersion: string): ClusterPatch {
+  return (nodePool, providerCluster, controlPlaneNode) => {
+    nodePool.metadata.labels ??= {};
+    nodePool.metadata.labels[capiv1alpha3.labelReleaseVersion] = newVersion;
+
+    providerCluster.metadata.labels ??= {};
+    providerCluster.metadata.labels[
+      capiv1alpha3.labelReleaseVersion
+    ] = newVersion;
+
+    controlPlaneNode.metadata.labels ??= {};
+    controlPlaneNode.metadata.labels[
+      capiv1alpha3.labelReleaseVersion
+    ] = newVersion;
+  };
 }

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -275,16 +275,10 @@ function createDefaultV1Alpha3Cluster(config: {
   };
 }
 
-export function createDefaultControlPlaneNode(
-  provider: PropertiesOf<typeof Providers>,
-  config: {
-    namespace: string;
-    name: string;
-    organization: string;
-    releaseVersion: string;
-  }
-) {
-  if (provider === Providers.AZURE) {
+export function createDefaultControlPlaneNode(config: {
+  providerCluster: ProviderCluster;
+}) {
+  if (config.providerCluster?.kind === capzv1alpha3.AzureCluster) {
     return createDefaultAzureMachine(config);
   }
 
@@ -292,23 +286,29 @@ export function createDefaultControlPlaneNode(
 }
 
 function createDefaultAzureMachine(config: {
-  namespace: string;
-  name: string;
-  organization: string;
-  releaseVersion: string;
+  providerCluster: ProviderCluster;
 }): capzv1alpha3.IAzureMachine {
+  const namespace = config.providerCluster.metadata.namespace;
+  const name = config.providerCluster.metadata.name;
+  const organization = config.providerCluster.metadata.labels![
+    capiv1alpha3.labelOrganization
+  ];
+  const releaseVersion = config.providerCluster.metadata.labels![
+    capiv1alpha3.labelReleaseVersion
+  ];
+
   return {
     apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3',
     kind: capzv1alpha3.AzureMachine,
     metadata: {
-      namespace: config.namespace,
-      name: `${config.name}-master-0`,
+      namespace: namespace,
+      name: `${name}-master-0`,
       labels: {
-        [capiv1alpha3.labelCluster]: config.name,
-        [capiv1alpha3.labelClusterName]: config.name,
+        [capiv1alpha3.labelCluster]: name,
+        [capiv1alpha3.labelClusterName]: name,
         [capiv1alpha3.labelMachineControlPlane]: 'true',
-        [capiv1alpha3.labelOrganization]: config.organization,
-        [capiv1alpha3.labelReleaseVersion]: config.releaseVersion,
+        [capiv1alpha3.labelOrganization]: organization,
+        [capiv1alpha3.labelReleaseVersion]: releaseVersion,
       },
     },
     spec: {

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -430,9 +430,8 @@ export function getNodePoolScaling(nodePool: NodePool): INodesStatus {
         current: -1,
       };
 
-      [status.min, status.max] = capiexpv1alpha3.getMachinePoolScaling(
-        nodePool
-      );
+      [status.min, status.max] =
+        capiexpv1alpha3.getMachinePoolScaling(nodePool);
 
       status.desired = nodePool.status?.replicas ?? -1;
       status.current = nodePool.status?.readyReplicas ?? -1;
@@ -463,6 +462,15 @@ export function getClusterReleaseVersion(cluster: Cluster) {
   }
 }
 
+export function getClusterDescription(cluster: Cluster): string {
+  switch (cluster.kind) {
+    case capiv1alpha3.Cluster:
+      return capiv1alpha3.getClusterDescription(cluster);
+    default:
+      return Constants.DEFAULT_CLUSTER_DESCRIPTION;
+  }
+}
+
 export function getProviderClusterLocation(
   providerCluster: ProviderCluster
 ): string {
@@ -486,9 +494,7 @@ export function getProviderNodePoolLocation(
 }
 
 // TODO(axbarsan): Get this info from the environment, rather than the info response.
-export function getSupportedAvailabilityZones(
-  state: IState
-): {
+export function getSupportedAvailabilityZones(state: IState): {
   minCount: number;
   maxCount: number;
   defaultCount: number;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -430,8 +430,9 @@ export function getNodePoolScaling(nodePool: NodePool): INodesStatus {
         current: -1,
       };
 
-      [status.min, status.max] =
-        capiexpv1alpha3.getMachinePoolScaling(nodePool);
+      [status.min, status.max] = capiexpv1alpha3.getMachinePoolScaling(
+        nodePool
+      );
 
       status.desired = nodePool.status?.replicas ?? -1;
       status.current = nodePool.status?.readyReplicas ?? -1;
@@ -494,7 +495,9 @@ export function getProviderNodePoolLocation(
 }
 
 // TODO(axbarsan): Get this info from the environment, rather than the info response.
-export function getSupportedAvailabilityZones(state: IState): {
+export function getSupportedAvailabilityZones(
+  state: IState
+): {
   minCount: number;
   maxCount: number;
   defaultCount: number;

--- a/src/model/services/mapi/capiv1alpha3/createCluster.ts
+++ b/src/model/services/mapi/capiv1alpha3/createCluster.ts
@@ -1,0 +1,22 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { createResource } from '../generic/createResource';
+import { ICluster } from './';
+
+export function createCluster(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  cluster: ICluster
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha3',
+    kind: 'clusters',
+    namespace: cluster.metadata.namespace!,
+    name: cluster.metadata.name,
+  } as k8sUrl.IK8sCreateOptions);
+
+  return createResource<ICluster>(client, auth, url.toString(), cluster);
+}

--- a/src/model/services/mapi/capiv1alpha3/index.ts
+++ b/src/model/services/mapi/capiv1alpha3/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 export * from './getClusterList';
 export * from './getCluster';
+export * from './createCluster';
 export * from './updateCluster';
 export * from './deleteCluster';
 export * from './getMachineDeploymentList';

--- a/src/model/services/mapi/capiv1alpha3/key.ts
+++ b/src/model/services/mapi/capiv1alpha3/key.ts
@@ -6,6 +6,7 @@ export const labelOrganization = 'giantswarm.io/organization';
 export const labelCluster = 'giantswarm.io/cluster';
 export const labelClusterName = 'cluster.x-k8s.io/cluster-name';
 export const labelReleaseVersion = 'release.giantswarm.io/version';
+export const labelMachineControlPlane = 'cluster.x-k8s.io/control-plane';
 
 export const annotationClusterDescription = 'cluster.giantswarm.io/description';
 

--- a/src/model/services/mapi/capzv1alpha3/createAzureCluster.ts
+++ b/src/model/services/mapi/capzv1alpha3/createAzureCluster.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { createResource } from '../generic/createResource';
+import { IAzureCluster } from './';
+
+export function createAzureCluster(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  azureCluster: IAzureCluster
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3',
+    kind: 'azureclusters',
+    namespace: azureCluster.metadata.namespace!,
+    name: azureCluster.metadata.name,
+  } as k8sUrl.IK8sCreateOptions);
+
+  return createResource<IAzureCluster>(
+    client,
+    auth,
+    url.toString(),
+    azureCluster
+  );
+}

--- a/src/model/services/mapi/capzv1alpha3/createAzureMachine.ts
+++ b/src/model/services/mapi/capzv1alpha3/createAzureMachine.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { createResource } from '../generic/createResource';
+import { IAzureMachine } from './';
+
+export function createAzureMachine(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  azureMachine: IAzureMachine
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3',
+    kind: 'azuremachines',
+    namespace: azureMachine.metadata.namespace!,
+    name: azureMachine.metadata.name,
+  } as k8sUrl.IK8sCreateOptions);
+
+  return createResource<IAzureMachine>(
+    client,
+    auth,
+    url.toString(),
+    azureMachine
+  );
+}

--- a/src/model/services/mapi/capzv1alpha3/index.ts
+++ b/src/model/services/mapi/capzv1alpha3/index.ts
@@ -1,4 +1,6 @@
 export * from './types';
 export * from './key';
 export * from './getAzureCluster';
+export * from './createAzureCluster';
+export * from './createAzureMachine';
 export * from './getAzureMachineList';

--- a/src/model/services/mapi/capzv1alpha3/types.ts
+++ b/src/model/services/mapi/capzv1alpha3/types.ts
@@ -86,14 +86,17 @@ export interface IAzureClusterStatus {
 }
 
 export interface IAzureCluster {
-  apiVersion: string;
-  kind: string;
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3';
+  kind: typeof AzureCluster;
   metadata: metav1.IObjectMeta;
   spec: IAzureClusterSpec;
-  status: capiv1alpha3.IClusterStatus;
+  status?: capiv1alpha3.IClusterStatus;
 }
 
-export interface IAzureClusterList extends metav1.IList<IAzureCluster> {}
+export interface IAzureClusterList extends metav1.IList<IAzureCluster> {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3';
+  kind: typeof AzureClusterList;
+}
 
 export const AzureCluster = 'AzureCluster';
 export const AzureClusterList = 'AzureClusterList';

--- a/src/model/services/mapi/capzv1alpha3/types.ts
+++ b/src/model/services/mapi/capzv1alpha3/types.ts
@@ -74,7 +74,7 @@ export interface IAzureClusterSpec {
   networkSpec?: INetworkSpec;
   resourceGroup?: string;
   subscriptionID?: string;
-  contronPlaneEndpoint?: capiv1alpha3.IApiEndpoint;
+  controlPlaneEndpoint?: capiv1alpha3.IApiEndpoint;
   additionalTags?: Tags;
   identityRef?: corev1.IObjectReference;
 }
@@ -168,6 +168,10 @@ export interface IAzureMachineSpec {
   vmSize: string;
   osDisk: IOSDisk;
   sshPublicKey: string;
+  /**
+   * @deprecated
+   *  */
+  location: string;
   providerID?: string;
   failureDomain?: string;
   image?: IImage;

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -23,7 +23,9 @@ export const Constants = {
 
   DEFAULT_NODEPOOL_NAME: 'Unnamed node pool',
   DEFAULT_NODEPOOL_DESCRIPTION: 'Please add description',
+  DEFAULT_CLUSTER_DESCRIPTION: 'Please add description',
   AZURE_NODEPOOL_DEFAULT_VM_SIZE: 'Standard_D4s_v3',
+  AZURE_CONTROL_PLANE_DEFAULT_VM_SIZE: 'Standard_D4s_v3',
   AWS_V5_VERSION: '10.0.0',
   AZURE_V5_VERSION: '13.0.0-alpha',
 

--- a/testUtils/mockHttpCalls/capzv1alpha3/azureMachines.ts
+++ b/testUtils/mockHttpCalls/capzv1alpha3/azureMachines.ts
@@ -28,6 +28,7 @@ export const randomAzureMachine1: capzv1alpha3.IAzureMachine = {
     uid: '9f42172b-f87e-41ac-8fb6-49e0247ad1dc',
   },
   spec: {
+    location: 'westeurope',
     failureDomain: '2',
     identity: 'None',
     image: {
@@ -116,6 +117,7 @@ export const randomAzureMachine2: capzv1alpha3.IAzureMachine = {
     uid: '9f42172b-f87e-41ac-8fb6-49e0247ad1dc',
   },
   spec: {
+    location: 'westeurope',
     failureDomain: '2',
     identity: 'None',
     image: {
@@ -204,6 +206,7 @@ export const randomAzureMachine3: capzv1alpha3.IAzureMachine = {
     uid: '9f42172b-f87e-41ac-8fb6-49e0247ad1dc',
   },
   spec: {
+    location: 'westeurope',
     failureDomain: '2',
     identity: 'None',
     image: {


### PR DESCRIPTION
Towards giantswarm/roadmap#341

This PR adds support for basic cluster creation via the MAPI cluster creation page. It includes defaulting, viewing the cluster name in a disabled form and modifying the cluster description.

As for the implementation, it is pretty much the same as with node pool creation. I re-used the same `patch` pattern as I used there. The only twist is that we have to fetch all releases and determine the latest (active and non-prerelease) release that we can use. Until that data is fetched, the `Create cluster` button is disabled.

## Preview

<details>
<summary>The form</summary>

![image](https://user-images.githubusercontent.com/13508038/124800395-e1e49400-df55-11eb-84f0-6dfcf496cd29.png)

</details>