### PR TITLE
clusters: add release and CP node AZ configuration to MAPI cluster creation

### DIFF
--- a/src/components/Cluster/AZSelection/AZSelection.tsx
+++ b/src/components/Cluster/AZSelection/AZSelection.tsx
@@ -103,7 +103,7 @@ const AZSelection: React.FC<IAZSelectionProps> = ({
               onChange={onChange}
               value={value}
               uniqueIdentifier={uniqueIdentifier}
-              label='Automatic'
+              label='Automatic selection'
               type={AvailabilityZoneSelection.Automatic}
               baseActionName={baseActionName}
             />
@@ -127,7 +127,7 @@ const AZSelection: React.FC<IAZSelectionProps> = ({
               onChange={onChange}
               value={value}
               uniqueIdentifier={uniqueIdentifier}
-              label='Manual'
+              label='Manual selection'
               type={AvailabilityZoneSelection.Manual}
               baseActionName={baseActionName}
             />

--- a/src/components/Cluster/AZSelection/AZSelectionAutomatic.tsx
+++ b/src/components/Cluster/AZSelection/AZSelectionAutomatic.tsx
@@ -37,7 +37,7 @@ const AZSelectionAutomatic: React.FC<IAZSelectionAutomaticProps> = ({
   if (variant === AZSelectionVariants.Master) {
     return (
       <Text>
-        An Availabilty Zone will be automatically chosen from the existing ones.
+        An availabilty zone will be automatically chosen from the existing ones.
       </Text>
     );
   }

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -247,7 +247,7 @@ class CreateNodePoolsCluster extends Component {
                 onChange={this.updateMasterNodesHighAvailability}
               />
             ) : (
-              <InputGroup label='Master node availability zones selection'>
+              <InputGroup label='Master node availability zones'>
                 <AZSelection
                   variant={AZSelectionVariants.Master}
                   baseActionName={RUMActions.SelectMasterAZSelection}

--- a/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
+++ b/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
@@ -13,7 +13,16 @@ import { RouteComponentProps } from 'react-router-dom';
 import { Constants, Providers } from 'shared/constants';
 import { MainRoutes, OrganizationsRoutes } from 'shared/constants/routes';
 import { computeCapabilities } from 'stores/cluster/utils';
-import { getFirstNodePoolsRelease, getProvider } from 'stores/main/selectors';
+import {
+  getFirstNodePoolsRelease,
+  getProvider,
+  getUserIsAdmin,
+} from 'stores/main/selectors';
+import {
+  getReleases,
+  getReleasesError,
+  getReleasesIsFetching,
+} from 'stores/releases/selectors';
 import Headline from 'UI/Display/Cluster/ClusterCreation/Headline';
 import InputGroup from 'UI/Inputs/InputGroup';
 import TextInput from 'UI/Inputs/TextInput';
@@ -91,6 +100,12 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = ({
     dispatch(push(MainRoutes.Home));
   };
 
+  const releases = useSelector(getReleases);
+  const releasesIsFetching = useSelector(getReleasesIsFetching);
+  const releasesError = useSelector(getReleasesError);
+
+  const isAdmin = useSelector(getUserIsAdmin);
+
   return (
     <Breadcrumb
       data={{
@@ -116,6 +131,10 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = ({
                 <ReleaseSelector
                   selectRelease={setSelectedRelease}
                   selectedRelease={selectedRelease}
+                  releases={releases}
+                  errorMessage={releasesError?.toString()}
+                  isAdmin={isAdmin}
+                  isLoading={releasesIsFetching}
                 />
               </InputGroup>
             </Box>

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
@@ -1,13 +1,11 @@
+import { Box, Keyboard, Text } from 'grommet';
 import { relativeDate } from 'lib/helpers';
 import PropTypes from 'prop-types';
 import React, { FC, useState } from 'react';
 import RUMActionTarget from 'RUM/RUMActionTarget';
 import { RUMActions } from 'shared/constants/realUserMonitoring';
 import styled from 'styled-components';
-import {
-  ComponentsWrapper,
-  TableButton,
-} from 'UI/Controls/ExpandableSelector/Items';
+import { TableButton } from 'UI/Controls/ExpandableSelector/Items';
 import KubernetesVersionLabel from 'UI/Display/Cluster/KubernetesVersionLabel';
 import ReleaseComponentLabel from 'UI/Display/Cluster/ReleaseComponentLabel';
 import { TableCell, TableRow } from 'UI/Display/Table';
@@ -69,6 +67,13 @@ const ReleaseRow: FC<IReleaseRow> = ({
     }
   };
 
+  const handleButtonKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+
+    (e.target as HTMLElement).click();
+  };
+
   return (
     <>
       <StyledTableRow
@@ -89,14 +94,17 @@ const ReleaseRow: FC<IReleaseRow> = ({
               onChange={() => selectRelease(version)}
               formFieldProps={{
                 margin: 'none',
+                tabIndex: -1,
               }}
               tabIndex={-1}
             />
           </RUMActionTarget>
         </TableCell>
-        <StyledTableCell active={active}>{version}</StyledTableCell>
-        <StyledTableCell active={active} align='center'>
-          {relativeDate(timestamp)}
+        <StyledTableCell size='small' active={active}>
+          <Text>{version}</Text>
+        </StyledTableCell>
+        <StyledTableCell size='medium' active={active} align='center'>
+          <Text>{relativeDate(timestamp)}</Text>
         </StyledTableCell>
         <StyledTableCell active={active} align='center'>
           <KubernetesVersionLabel
@@ -120,17 +128,26 @@ const ReleaseRow: FC<IReleaseRow> = ({
                 : RUMActions.HideReleaseDetails
             }
           >
-            <FixedWidthTableButton
-              data-testid={`show-components-${version}`}
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation();
-                e.preventDefault();
-                setCollapsed(!collapsed);
-              }}
+            <Keyboard
+              onEnter={handleButtonKeyDown}
+              onSpace={handleButtonKeyDown}
             >
-              <i className={`fa fa-${collapsed ? 'eye' : 'eye-with-line'}`} />
-              {collapsed ? 'Show' : 'Hide'}
-            </FixedWidthTableButton>
+              <FixedWidthTableButton
+                data-testid={`show-components-${version}`}
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  setCollapsed(!collapsed);
+                }}
+              >
+                <i
+                  role='presentation'
+                  aria-hidden={true}
+                  className={`fa fa-${collapsed ? 'eye' : 'eye-with-line'}`}
+                />
+                {collapsed ? 'Show' : 'Hide'}
+              </FixedWidthTableButton>
+            </Keyboard>
           </RUMActionTarget>
         </TableCell>
         <TableCell
@@ -140,33 +157,43 @@ const ReleaseRow: FC<IReleaseRow> = ({
             e.stopPropagation()
           }
         >
-          <TableButton
-            data-testid={`open-changelog-${version}`}
-            href={releaseNotesURL}
-            target='_blank'
-            rel='noopener noreferrer'
-            onClick={(e: React.MouseEvent) => e.stopPropagation()}
-          >
-            <i className='fa fa-open-in-new' />
-            Open
-          </TableButton>
+          <Keyboard onEnter={handleButtonKeyDown} onSpace={handleButtonKeyDown}>
+            <TableButton
+              data-testid={`open-changelog-${version}`}
+              href={releaseNotesURL}
+              target='_blank'
+              rel='noopener noreferrer'
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            >
+              <i
+                className='fa fa-open-in-new'
+                aria-hidden={true}
+                role='presentation'
+              />
+              Open
+            </TableButton>
+          </Keyboard>
         </TableCell>
       </StyledTableRow>
       {!collapsed && (
         <TableRow>
           <TableCell colSpan={6}>
-            <ComponentsWrapper data-testid={`components-${version}`}>
+            <Box wrap={true} direction='row'>
               {components
                 .slice()
                 .sort((a, b) => a.name.localeCompare(b.name))
                 .map((component) => (
-                  <ReleaseComponentLabel
+                  <Box
                     key={component.name}
-                    name={component.name}
-                    version={component.version}
-                  />
+                    margin={{ right: 'xsmall', bottom: 'xsmall' }}
+                  >
+                    <ReleaseComponentLabel
+                      name={component.name}
+                      version={component.version}
+                    />
+                  </Box>
                 ))}
-            </ComponentsWrapper>
+            </Box>
           </TableCell>
         </TableRow>
       )}

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
@@ -179,7 +179,11 @@ const ReleaseRow: FC<IReleaseRow> = ({
       {!collapsed && (
         <TableRow>
           <TableCell colSpan={6}>
-            <Box wrap={true} direction='row'>
+            <Box
+              wrap={true}
+              direction='row'
+              data-testid={`components-${version}`}
+            >
               {components
                 .slice()
                 .sort((a, b) => a.name.localeCompare(b.name))

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
@@ -13,6 +13,8 @@ import ReleaseComponentLabel from 'UI/Display/Cluster/ReleaseComponentLabel';
 import { TableCell, TableRow } from 'UI/Display/Table';
 import RadioInput from 'UI/Inputs/RadioInput';
 
+import { IRelease } from './ReleaseSelector';
+
 const INACTIVE_OPACITY = 0.4;
 
 const FixedWidthTableButton = styled(TableButton)`

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
@@ -164,6 +164,7 @@ const ReleaseRow: FC<IReleaseRow> = ({
               target='_blank'
               rel='noopener noreferrer'
               onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              disabled={!releaseNotesURL}
             >
               <i
                 className='fa fa-open-in-new'

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseSelector.tsx
@@ -1,3 +1,4 @@
+import { Box, Keyboard, Text } from 'grommet';
 import { compare } from 'lib/semver';
 import PropTypes from 'prop-types';
 import React, { FC, useEffect, useMemo, useState } from 'react';
@@ -152,22 +153,31 @@ const ReleaseSelector: FC<IReleaseSelectorProps> = ({
     }
   };
 
+  const handleKeyDownCancel = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setCollapsed(true);
+  };
+
   if (errorMessage) {
     return (
       <div>
-        <p>
+        <Text>
           There was an error loading releases.
           <br />
           {errorMessage}
           <br />
           Please try again later or contact support: support@giantswarm.io
-        </p>
+        </Text>
       </div>
     );
   } else if (!selectedKubernetesVersion) {
     return (
       <div>
-        <p>There is no active release currently available for this platform.</p>
+        <Text>
+          There is no active release currently available for this platform.
+        </Text>
       </div>
     );
   }
@@ -220,37 +230,46 @@ const ReleaseSelector: FC<IReleaseSelectorProps> = ({
       {!collapsed && (
         <>
           {isAdmin && (
-            <p>
-              <i className='fa fa-warning' /> Light font color indicates an
-              inactive or wip release only available to Giant Swarm staff
-            </p>
+            <Box margin={{ vertical: 'xsmall' }}>
+              <Text size='small' color='text-weak'>
+                <i
+                  className='fa fa-warning'
+                  aria-hidden={true}
+                  role='presentation'
+                />{' '}
+                Light font color indicates an inactive or wip release only
+                available to Giant Swarm staff
+              </Text>
+            </Box>
           )}
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableCell />
-                <TableCell>Version</TableCell>
-                <TableCell align='center'>Released</TableCell>
-                <TableCell align='center'>Kubernetes</TableCell>
-                <TableCell align='center'>Components</TableCell>
-                <TableCell align='center'>Notes</TableCell>
-              </TableRow>
-            </TableHeader>
-            <TableBody
-              role='radiogroup'
-              tabIndex={-1}
-              aria-labelledby='release-selector__toggler'
-            >
-              {sortedReleaseVersions.map((version) => (
-                <ReleaseRow
-                  key={version}
-                  {...allReleases[version]}
-                  isSelected={version === selectedRelease}
-                  selectRelease={selectRelease}
-                />
-              ))}
-            </TableBody>
-          </Table>
+          <Keyboard onEsc={handleKeyDownCancel}>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableCell />
+                  <TableCell>Version</TableCell>
+                  <TableCell align='center'>Released</TableCell>
+                  <TableCell align='center'>Kubernetes</TableCell>
+                  <TableCell align='center'>Components</TableCell>
+                  <TableCell align='center'>Notes</TableCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody
+                role='radiogroup'
+                tabIndex={-1}
+                aria-labelledby='release-selector__toggler'
+              >
+                {sortedReleaseVersions.map((version) => (
+                  <ReleaseRow
+                    key={version}
+                    {...allReleases[version]}
+                    isSelected={version === selectedRelease}
+                    selectRelease={selectRelease}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          </Keyboard>
         </>
       )}
     </LoadingOverlay>

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterControlPlaneNodeAZs.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterControlPlaneNodeAZs.tsx
@@ -95,11 +95,7 @@ const CreateClusterControlPlaneNodeAZs: React.FC<ICreateClusterControlPlaneNodeA
   }, [azSelector, manualZones, manualZonesIsValid]);
 
   return (
-    <InputGroup
-      htmlFor={id}
-      label='Control plane node availability zone selection'
-      {...props}
-    >
+    <InputGroup htmlFor={id} label='Control plane availability zone' {...props}>
       <AZSelection
         variant={AZSelectionVariants.Master}
         baseActionName={RUMActions.SelectMasterAZSelection}

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterControlPlaneNodeAZs.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterControlPlaneNodeAZs.tsx
@@ -1,0 +1,133 @@
+import AZSelection from 'Cluster/AZSelection/AZSelection';
+import {
+  AvailabilityZoneSelection,
+  AZSelectionVariants,
+  AZSelectionZonesUpdater,
+  IUpdateZoneLabelsPayload,
+} from 'Cluster/AZSelection/AZSelectionUtils';
+import { Cluster, ControlPlaneNode } from 'MAPI/types';
+import { determineRandomAZs, getSupportedAvailabilityZones } from 'MAPI/utils';
+import PropTypes from 'prop-types';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { RUMActions } from 'shared/constants/realUserMonitoring';
+import { getProvider } from 'stores/main/selectors';
+import InputGroup from 'UI/Inputs/InputGroup';
+
+import { computeControlPlaneNodesStats } from '../ClusterDetail/utils';
+import {
+  IClusterPropertyProps,
+  withClusterControlPlaneNodeAZs,
+} from './patches';
+
+interface ICreateClusterControlPlaneNodeAZsProps
+  extends IClusterPropertyProps,
+    Omit<
+      React.ComponentPropsWithoutRef<typeof InputGroup>,
+      'onChange' | 'id'
+    > {}
+
+const CreateClusterControlPlaneNodeAZs: React.FC<ICreateClusterControlPlaneNodeAZsProps> = ({
+  id,
+  cluster,
+  controlPlaneNode,
+  onChange,
+  ...props
+}) => {
+  const [azSelector, setAzSelector] = useState(
+    AvailabilityZoneSelection.Automatic
+  );
+
+  const provider = useSelector(getProvider);
+  const azStats = useSelector(getSupportedAvailabilityZones);
+
+  const value = useMemo(() => {
+    return computeControlPlaneNodesStats([controlPlaneNode]).availabilityZones;
+  }, [controlPlaneNode]);
+
+  const [manualZones, setManualZones] = useState<string[]>(value);
+  const [manualZonesIsValid, setManualZonesIsValid] = useState(false);
+
+  const handleZoneChange: AZSelectionZonesUpdater = (azSelection) => (
+    payload
+  ) => {
+    switch (azSelection) {
+      case AvailabilityZoneSelection.Automatic:
+        break;
+
+      case AvailabilityZoneSelection.Manual:
+        setManualZonesIsValid(payload.valid);
+        setManualZones((payload as IUpdateZoneLabelsPayload).zonesArray);
+        break;
+    }
+  };
+
+  const handleChange = (selector: AvailabilityZoneSelection) => {
+    setAzSelector(selector);
+  };
+
+  useEffect(() => {
+    switch (azSelector) {
+      case AvailabilityZoneSelection.Automatic:
+        onChange({
+          isValid: true,
+          patch: withClusterControlPlaneNodeAZs(
+            determineRandomAZs(1, azStats.all)
+          ),
+        });
+        break;
+
+      case AvailabilityZoneSelection.Manual:
+        onChange({
+          isValid: manualZonesIsValid,
+          patch: withClusterControlPlaneNodeAZs(manualZones),
+        });
+        break;
+
+      case AvailabilityZoneSelection.NotSpecified:
+        onChange({
+          isValid: true,
+          patch: withClusterControlPlaneNodeAZs(undefined),
+        });
+        break;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [azSelector, manualZones, manualZonesIsValid]);
+
+  return (
+    <InputGroup
+      htmlFor={id}
+      label='Control plane node availability zone selection'
+      {...props}
+    >
+      <AZSelection
+        variant={AZSelectionVariants.Master}
+        baseActionName={RUMActions.SelectMasterAZSelection}
+        value={azSelector}
+        provider={provider}
+        onChange={handleChange}
+        minNumOfZones={azStats.minCount}
+        maxNumOfZones={azStats.maxCount}
+        defaultNumOfZones={azStats.defaultCount}
+        allZones={azStats.all}
+        numOfZones={manualZones.length}
+        selectedZones={manualZones}
+        onUpdateZones={handleZoneChange}
+        uniqueIdentifier={id}
+      />
+    </InputGroup>
+  );
+};
+
+CreateClusterControlPlaneNodeAZs.propTypes = {
+  id: PropTypes.string.isRequired,
+  cluster: (PropTypes.object as PropTypes.Requireable<Cluster>).isRequired,
+  controlPlaneNode: (PropTypes.object as PropTypes.Requireable<ControlPlaneNode>)
+    .isRequired,
+  onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
+};
+
+export default CreateClusterControlPlaneNodeAZs;

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterDescription.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterDescription.tsx
@@ -19,13 +19,13 @@ function validateValue(newValue: string): string {
   return message;
 }
 
-interface IWorkerNodesCreateClusterDescriptionProps
+interface ICreateClusterDescriptionProps
   extends IClusterPropertyProps,
     Omit<React.ComponentPropsWithoutRef<typeof InputGroup>, 'onChange' | 'id'> {
   autoFocus?: boolean;
 }
 
-const WorkerNodesCreateClusterDescription: React.FC<IWorkerNodesCreateClusterDescriptionProps> = ({
+const CreateClusterDescription: React.FC<ICreateClusterDescriptionProps> = ({
   id,
   cluster,
   onChange,
@@ -76,7 +76,7 @@ const WorkerNodesCreateClusterDescription: React.FC<IWorkerNodesCreateClusterDes
   );
 };
 
-WorkerNodesCreateClusterDescription.propTypes = {
+CreateClusterDescription.propTypes = {
   id: PropTypes.string.isRequired,
   cluster: (PropTypes.object as PropTypes.Requireable<Cluster>).isRequired,
   onChange: PropTypes.func.isRequired,
@@ -85,4 +85,4 @@ WorkerNodesCreateClusterDescription.propTypes = {
   autoFocus: PropTypes.bool,
 };
 
-export default WorkerNodesCreateClusterDescription;
+export default CreateClusterDescription;

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterRelease.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterRelease.tsx
@@ -1,0 +1,116 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import ReleaseSelector, {
+  IRelease,
+} from 'Cluster/NewCluster/ReleaseSelector/ReleaseSelector';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { useHttpClient } from 'lib/hooks/useHttpClient';
+import { extractErrorMessage } from 'MAPI/organizations/utils';
+import { Cluster } from 'MAPI/types';
+import { getClusterReleaseVersion } from 'MAPI/utils';
+import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
+import PropTypes from 'prop-types';
+import React, { useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { getUserIsAdmin } from 'stores/main/selectors';
+import useSWR from 'swr';
+import InputGroup from 'UI/Inputs/InputGroup';
+
+import { IClusterPropertyProps, withClusterReleaseVersion } from './patches';
+
+interface ICreateClusterReleaseProps
+  extends IClusterPropertyProps,
+    Omit<
+      React.ComponentPropsWithoutRef<typeof InputGroup>,
+      'onChange' | 'id'
+    > {}
+
+const CreateClusterRelease: React.FC<ICreateClusterReleaseProps> = ({
+  id,
+  cluster,
+  onChange,
+  ...props
+}) => {
+  const releaseListClient = useHttpClient();
+  const auth = useAuthProvider();
+
+  const {
+    data: releaseList,
+    error: releaseListError,
+    isValidating: releaseIsValidating,
+  } = useSWR(releasev1alpha1.getReleaseListKey(), () =>
+    releasev1alpha1.getReleaseList(releaseListClient, auth)
+  );
+
+  useEffect(() => {
+    if (releaseListError) {
+      ErrorReporter.getInstance().notify(releaseListError);
+    }
+  }, [releaseListError]);
+
+  const releaseIsLoading =
+    releaseIsValidating &&
+    typeof releaseList === 'undefined' &&
+    typeof releaseListError === 'undefined';
+
+  const releases = useMemo(() => {
+    if (!releaseList) return {};
+
+    return releaseList.items.reduce(
+      (acc: Record<string, IRelease>, curr: releasev1alpha1.IRelease) => {
+        const normalizedVersion = curr.metadata.name.slice(1);
+        const components = curr.spec.components.slice();
+        if (curr.spec.apps) {
+          components.push(...curr.spec.apps);
+        }
+
+        acc[normalizedVersion] = {
+          version: normalizedVersion,
+          active: curr.spec.state === 'active',
+          timestamp: curr.metadata.creationTimestamp ?? '',
+          components,
+          kubernetesVersion: releasev1alpha1.getK8sVersion(curr),
+          releaseNotesURL: releasev1alpha1.getReleaseNotesURL(curr),
+        };
+
+        return acc;
+      },
+      {}
+    );
+  }, [releaseList]);
+
+  const isAdmin = useSelector(getUserIsAdmin);
+
+  const handleChange = (newVersion: string) => {
+    onChange({
+      isValid: true,
+      patch: withClusterReleaseVersion(newVersion),
+    });
+  };
+
+  const value = getClusterReleaseVersion(cluster) ?? '';
+
+  return (
+    <InputGroup label='Release version' {...props}>
+      <ReleaseSelector
+        releases={releases}
+        isAdmin={isAdmin}
+        errorMessage={extractErrorMessage(releaseListError)}
+        isLoading={releaseIsLoading}
+        selectRelease={handleChange}
+        selectedRelease={value}
+        autoSelectLatest={false}
+      />
+    </InputGroup>
+  );
+};
+
+CreateClusterRelease.propTypes = {
+  id: PropTypes.string.isRequired,
+  cluster: (PropTypes.object as PropTypes.Requireable<Cluster>).isRequired,
+  onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
+};
+
+export default CreateClusterRelease;

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -334,8 +334,8 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               </Box>
               <Box margin={{ top: 'medium' }}>
                 <Text color='text-weak'>
-                  Note that it takes around 30 minutes on average until a new
-                  cluster is fully available.
+                  It will take around 15 minutes for the control plane to become
+                  available.
                 </Text>
               </Box>
             </Box>

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -32,6 +32,7 @@ import {
 } from '../utils';
 import CreateClusterDescription from './CreateClusterDescription';
 import CreateClusterName from './CreateClusterName';
+import CreateClusterRelease from './CreateClusterRelease';
 import {
   ClusterPatch,
   IClusterPropertyValue,
@@ -41,6 +42,7 @@ import {
 enum ClusterPropertyField {
   Name,
   Description,
+  Release,
 }
 
 interface IApplyPatchAction {
@@ -112,6 +114,7 @@ function makeInitialState(
     validationResults: {
       [ClusterPropertyField.Name]: true,
       [ClusterPropertyField.Description]: true,
+      [ClusterPropertyField.Release]: true,
     },
     isCreating: false,
     latestRelease: '',
@@ -294,6 +297,13 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               controlPlaneNode={state.controlPlaneNode}
               onChange={handleChange(ClusterPropertyField.Description)}
               autoFocus={true}
+            />
+            <CreateClusterRelease
+              id={`cluster-${ClusterPropertyField.Release}`}
+              cluster={state.cluster}
+              providerCluster={state.providerCluster}
+              controlPlaneNode={state.controlPlaneNode}
+              onChange={handleChange(ClusterPropertyField.Release)}
             />
             <Box direction='row' margin={{ top: 'medium' }}>
               <Button

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -30,7 +30,7 @@ import {
   createDefaultProviderCluster,
   findLatestReleaseVersion,
 } from '../utils';
-import WorkerNodesCreateClusterDescription from './CreateClusterDescription';
+import CreateClusterDescription from './CreateClusterDescription';
 import CreateClusterName from './CreateClusterName';
 import {
   ClusterPatch,
@@ -287,7 +287,7 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               controlPlaneNode={state.controlPlaneNode}
               onChange={handleChange(ClusterPropertyField.Name)}
             />
-            <WorkerNodesCreateClusterDescription
+            <CreateClusterDescription
               id={`cluster-${ClusterPropertyField.Description}`}
               cluster={state.cluster}
               providerCluster={state.providerCluster}

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -283,7 +283,7 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
             as='form'
             onSubmit={handleCreation}
             width={{ max: '100%', width: 'large' }}
-            gap='small'
+            gap='medium'
             margin='auto'
           >
             <CreateClusterName
@@ -315,27 +315,29 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               controlPlaneNode={state.controlPlaneNode}
               onChange={handleChange(ClusterPropertyField.ControlPlaneNodeAZs)}
             />
-            <Box direction='row' margin={{ top: 'medium' }}>
-              <Button
-                bsStyle='primary'
-                disabled={!isValid}
-                type='submit'
-                loading={state.isCreating}
-              >
-                Create cluster
-              </Button>
-
-              {!state.isCreating && (
-                <Button bsStyle='default' onClick={handleCancel}>
-                  Cancel
-                </Button>
-              )}
-            </Box>
             <Box margin={{ top: 'medium' }}>
-              <Text color='text-weak'>
-                Note that it takes around 30 minutes on average until a new
-                cluster is fully available.
-              </Text>
+              <Box direction='row'>
+                <Button
+                  bsStyle='primary'
+                  disabled={!isValid}
+                  type='submit'
+                  loading={state.isCreating}
+                >
+                  Create cluster
+                </Button>
+
+                {!state.isCreating && (
+                  <Button bsStyle='default' onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                )}
+              </Box>
+              <Box margin={{ top: 'medium' }}>
+                <Text color='text-weak'>
+                  Note that it takes around 30 minutes on average until a new
+                  cluster is fully available.
+                </Text>
+              </Box>
             </Box>
           </Box>
         </Box>

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -30,6 +30,7 @@ import {
   createDefaultProviderCluster,
   findLatestReleaseVersion,
 } from '../utils';
+import CreateClusterControlPlaneNodeAZs from './CreateClusterControlPlaneNodeAZs';
 import CreateClusterDescription from './CreateClusterDescription';
 import CreateClusterName from './CreateClusterName';
 import CreateClusterRelease from './CreateClusterRelease';
@@ -43,6 +44,7 @@ enum ClusterPropertyField {
   Name,
   Description,
   Release,
+  ControlPlaneNodeAZs,
 }
 
 interface IApplyPatchAction {
@@ -115,6 +117,7 @@ function makeInitialState(
       [ClusterPropertyField.Name]: true,
       [ClusterPropertyField.Description]: true,
       [ClusterPropertyField.Release]: true,
+      [ClusterPropertyField.ControlPlaneNodeAZs]: true,
     },
     isCreating: false,
     latestRelease: '',
@@ -304,6 +307,13 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               providerCluster={state.providerCluster}
               controlPlaneNode={state.controlPlaneNode}
               onChange={handleChange(ClusterPropertyField.Release)}
+            />
+            <CreateClusterControlPlaneNodeAZs
+              id={`cluster-${ClusterPropertyField.ControlPlaneNodeAZs}`}
+              cluster={state.cluster}
+              providerCluster={state.providerCluster}
+              controlPlaneNode={state.controlPlaneNode}
+              onChange={handleChange(ClusterPropertyField.ControlPlaneNodeAZs)}
             />
             <Box direction='row' margin={{ top: 'medium' }}>
               <Button

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -1,5 +1,6 @@
 import { Cluster, ControlPlaneNode, ProviderCluster } from 'MAPI/types';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
 
 export type ClusterPatch = (
   cluster: Cluster,
@@ -45,5 +46,12 @@ export function withClusterDescription(newDescription: string): ClusterPatch {
     cluster.metadata.annotations[
       capiv1alpha3.annotationClusterDescription
     ] = newDescription;
+  };
+}
+
+export function withClusterControlPlaneNodeAZs(zones?: string[]): ClusterPatch {
+  return (_, _p, controlPlaneNode) => {
+    if (controlPlaneNode.kind === capzv1alpha3.AzureMachine)
+      controlPlaneNode.spec!.failureDomain = zones?.[0];
   };
 }

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -23,9 +23,9 @@ export interface IClusterPropertyProps {
 }
 
 export function withClusterReleaseVersion(newVersion: string): ClusterPatch {
-  return (nodePool, providerCluster, controlPlaneNode) => {
-    nodePool.metadata.labels ??= {};
-    nodePool.metadata.labels[capiv1alpha3.labelReleaseVersion] = newVersion;
+  return (cluster, providerCluster, controlPlaneNode) => {
+    cluster.metadata.labels ??= {};
+    cluster.metadata.labels[capiv1alpha3.labelReleaseVersion] = newVersion;
 
     providerCluster.metadata.labels ??= {};
     providerCluster.metadata.labels[

--- a/src/components/UI/Controls/ExpandableSelector/Items.tsx
+++ b/src/components/UI/Controls/ExpandableSelector/Items.tsx
@@ -12,10 +12,6 @@ export const TableButton = styled(Button)`
   }
 `;
 
-export const ComponentsWrapper = styled.div`
-  margin-left: ${({ theme }) => theme.spacingPx * 9}px;
-`;
-
 export const Tr = styled.tr<{ isSelected: boolean; toneDown?: boolean }>`
   background-color: ${({ isSelected, theme }) =>
     isSelected ? theme.colors.foreground : 'transparent'};

--- a/src/components/UI/Display/Cluster/ReleaseComponentLabel/index.js
+++ b/src/components/UI/Display/Cluster/ReleaseComponentLabel/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 import theme from 'styles/theme';
 import ValueLabel from 'UI/Display/ValueLabel';
+import Truncated from 'UI/Util/Truncated';
 
 const OldVersion = styled.span`
   color: ${(p) => p.theme.colors.redOld};
@@ -22,24 +23,30 @@ const VersionLabel = (props) => {
   if (oldVersion) {
     return (
       <>
-        <OldVersion aria-label={`version ${oldVersion}`}>
+        <Truncated as={OldVersion} aria-label={`version ${oldVersion}`}>
           {oldVersion}
-        </OldVersion>
+        </Truncated>
         <ChangeArrow aria-label='is upgraded to'>➞</ChangeArrow>
-        <NewVersion aria-label={`version ${newVersion}`}>
+        <Truncated as={NewVersion} aria-label={`version ${newVersion}`}>
           {newVersion}
-        </NewVersion>
+        </Truncated>
       </>
     );
   } else if (isRemoved) {
     return 'removed';
   } else if (isAdded) {
     return (
-      <span aria-label={`version ${newVersion}`}>{newVersion} (added)</span>
+      <Truncated as='span' aria-label={`version ${newVersion}`}>
+        {newVersion} (added)
+      </Truncated>
     );
   }
 
-  return <span aria-label={`version ${newVersion}`}>{newVersion}</span>;
+  return (
+    <Truncated as='span' aria-label={`version ${newVersion}`}>
+      {newVersion}
+    </Truncated>
+  );
 };
 
 VersionLabel.propTypes = {

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         class="StyledBox-sc-13pk1d4-0 eITwkI"
       >
         <div
-          class="sc-dFtzdE eKjOri sc-iboBCu eEYgJT"
+          class="sc-dFtzdE eKjOri sc-cdJjZP gDgffG"
         >
           <span
             aria-label="35 dogs"
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-lepKoB eHdFvu"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-hFLmgA bLwsQw"
       >
         dogs
       </span>
@@ -48,7 +48,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         class="StyledBox-sc-13pk1d4-0 eITwkI"
       >
         <div
-          class="sc-dFtzdE eKjOri sc-iboBCu eEYgJT"
+          class="sc-dFtzdE eKjOri sc-cdJjZP gDgffG"
         >
           <span
             aria-label="1 dog"
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-lepKoB eHdFvu"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-hFLmgA bLwsQw"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 dLeNOM"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-hDzdky Pzgnt"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-lepKoB eHdFvu"
         >
           Some widget
         </span>
@@ -47,7 +47,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 kYALZS"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-hDzdky Pzgnt"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-lepKoB eHdFvu"
         >
           Some widget
         </span>

--- a/src/components/UI/Inputs/RadioInput/index.tsx
+++ b/src/components/UI/Inputs/RadioInput/index.tsx
@@ -33,7 +33,7 @@ interface IRadioInputProps
   /**
    * Props to be passed to the form field.
    */
-  formFieldProps?: FormFieldProps & { className?: string };
+  formFieldProps?: FormFieldProps & { className?: string; tabIndex?: number };
   /**
    * Whether the input is required or not.
    */


### PR DESCRIPTION
Towards giantswarm/roadmap#341

This PR adds the rest of the inputs required for creating clusters via the MAPI cluster creation UI:
* Release version
* Control plane node availability zone selection
These are implemented using the GS API components, so no major changes there.

The PR also includes a few accessibility-related changes to the `ReleaseSelector` component.

## Preview

<details>
<summary>The form</summary>

![image](https://user-images.githubusercontent.com/13508038/125103520-b6d87c80-e0dc-11eb-8fc7-1381aa221a6b.png)

</details>

<details>
<summary>Some releases</summary>

![image](https://user-images.githubusercontent.com/13508038/125103575-c788f280-e0dc-11eb-8219-7c6b7a20b2f0.png)

</details>

<details>
<summary>A custom AZ</summary>

![image](https://user-images.githubusercontent.com/13508038/125103670-dec7e000-e0dc-11eb-942f-e4274d356518.png)

</details>