### PR TITLE
clusters: write tests for all the cluster details overview functionalities

### DIFF
--- a/src/components/MAPI/apps/__tests__/ClusterDetailWidgetApps.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailWidgetApps.tsx
@@ -1,0 +1,187 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import { generateRandomString } from 'testUtils/mockHttpCalls';
+import * as applicationv1alpha1Mocks from 'testUtils/mockHttpCalls/applicationv1alpha1';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailWidgetApps from '../ClusterDetailWidgetApps';
+
+function generateApp(
+  specName: string = 'some-app',
+  status = 'deployed' as 'deployed' | 'not-deployed'
+): applicationv1alpha1.IApp {
+  const appName = generateRandomString();
+  const namespace = capiv1alpha3Mocks.randomCluster1.metadata.name;
+
+  return {
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'App',
+    metadata: {
+      annotations: {
+        'chart-operator.giantswarm.io/force-helm-upgrade': 'true',
+      },
+      creationTimestamp: new Date().toISOString(),
+      finalizers: ['operatorkit.giantswarm.io/app-operator-app'],
+      generation: 1,
+      labels: {
+        app: appName,
+        'app-operator.giantswarm.io/version': '3.2.1',
+        'giantswarm.io/cluster': namespace,
+        'giantswarm.io/managed-by': 'Helm',
+        'giantswarm.io/organization': 'org1',
+        'giantswarm.io/service-type': 'managed',
+      },
+      name: appName,
+      namespace,
+      resourceVersion: '294675096',
+      selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${appName}`,
+      uid: '859c4eb1-ece4-4eca-85b2-a4a456b6ae81',
+    },
+    spec: {
+      catalog: 'default',
+      config: {
+        configMap: {
+          name: `${namespace}-cluster-values`,
+          namespace,
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      kubeConfig: {
+        context: {
+          name: `${namespace}-kubeconfig`,
+        },
+        inCluster: false,
+        secret: {
+          name: `${namespace}-kubeconfig`,
+          namespace,
+        },
+      },
+      name: specName,
+      namespace: 'giantswarm',
+      userConfig: {
+        configMap: {
+          name: '',
+          namespace: '',
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      version: '1.2.1',
+    },
+    status: {
+      appVersion: '0.4.1',
+      release: {
+        lastDeployed: '2021-04-27T16:21:37Z',
+        status,
+      },
+      version: '1.2.1',
+    },
+  };
+}
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailWidgetApps>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailWidgetApps {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useParams: jest.fn().mockReturnValue({
+    orgId: 'org1',
+    clusterId: capiv1alpha3Mocks.randomCluster1.metadata.name,
+  }),
+}));
+
+describe('ClusterDetailWidgetApps', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    render(getComponent({}));
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(3);
+  });
+
+  it('displays a placeholder if there are no apps', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/application.giantswarm.io/v1alpha1/namespaces/${capiv1alpha3Mocks.randomCluster1.metadata.name}/apps/`
+      )
+      .reply(StatusCodes.Ok, {
+        apiVersion: 'application.giantswarm.io/v1alpha1',
+        kind: applicationv1alpha1.AppList,
+        items: [],
+        metadata: {
+          resourceVersion: '294675100',
+          selfLink:
+            '/apis/application.giantswarm.io/v1alpha1/namespaces/j5y9m/apps/',
+        },
+      });
+
+    render(getComponent({}));
+
+    expect(await screen.findByText('No apps installed')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => {
+        return (
+          node?.textContent === 'To find apps to install, browse our apps.'
+        );
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('displays stats about the apps installed in the cluster', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/application.giantswarm.io/v1alpha1/namespaces/${capiv1alpha3Mocks.randomCluster1.metadata.name}/apps/`
+      )
+      .reply(StatusCodes.Ok, {
+        ...applicationv1alpha1Mocks.randomCluster1AppsList,
+        items: [
+          ...applicationv1alpha1Mocks.randomCluster1AppsList.items,
+          generateApp('some-random-app'),
+          generateApp(),
+          generateApp(undefined, 'not-deployed'),
+          generateApp(),
+          generateApp('some-random-app'),
+          generateApp(),
+        ],
+      });
+
+    render(getComponent({}));
+
+    expect(await screen.findByLabelText('6 apps')).toBeInTheDocument();
+    expect(await screen.findByLabelText('2 unique apps')).toBeInTheDocument();
+    expect(await screen.findByLabelText('5 deployed')).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -17,13 +17,13 @@ import styled from 'styled-components';
 import useSWR from 'swr';
 
 import ClusterDetailWidgetKeyPairs from '../../keypairs/ClusterDetailWidgetKeyPairs';
+import ClusterDetailWidgetWorkerNodes from '../../workernodes/ClusterDetailWidgetWorkerNodes';
 import ClusterDetailOverviewDelete from './ClusterDetailOverviewDelete';
 import ClusterDetailWidgetControlPlaneNodes from './ClusterDetailWidgetControlPlaneNodes';
 import ClusterDetailWidgetCreated from './ClusterDetailWidgetCreated';
 import ClusterDetailWidgetKubernetesAPI from './ClusterDetailWidgetKubernetesAPI';
 import ClusterDetailWidgetLabels from './ClusterDetailWidgetLabels';
 import ClusterDetailWidgetProvider from './ClusterDetailWidgetProvider';
-import ClusterDetailWidgetWorkerNodes from './ClusterDetailWidgetWorkerNodes';
 
 const StyledBox = styled(Box)`
   gap: ${({ theme }) => theme.global.edgeSize.small};

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverviewDelete.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverviewDelete.tsx
@@ -99,9 +99,9 @@ const ClusterDetailOverviewDelete: React.FC<IClusterDetailOverviewDeleteProps> =
         errorMessage
       );
 
-      ErrorReporter.getInstance().notify(err as never);
-    } finally {
       setIsLoading(false);
+
+      ErrorReporter.getInstance().notify(err as never);
     }
   };
 

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetControlPlaneNodes.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetControlPlaneNodes.tsx
@@ -128,7 +128,7 @@ const ClusterDetailWidgetControlPlaneNodes: React.FC<IClusterDetailWidgetControl
       >
         {(value) =>
           value ? (
-            <Text>
+            <Text aria-label={`${value} ready`}>
               {value} <code>Ready</code>
             </Text>
           ) : (

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
@@ -1,21 +1,13 @@
-import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { Text } from 'grommet';
-import ErrorReporter from 'lib/errors/ErrorReporter';
-import { useHttpClient } from 'lib/hooks/useHttpClient';
 import { ProviderCluster } from 'MAPI/types';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
-import * as legacyCredentials from 'model/services/mapi/legacy/credentials';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
-import { useParams } from 'react-router';
+import React from 'react';
 import styled from 'styled-components';
 import { Dot } from 'styles';
-import useSWR from 'swr';
 import ClusterDetailWidget from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget';
 import ClusterDetailWidgetOptionalValue from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue';
-
-import { getCredentialsAccountID } from './utils';
 
 export function getClusterRegionLabel(cluster?: capiv1alpha3.ICluster) {
   if (!cluster) return undefined;
@@ -90,27 +82,9 @@ const ClusterDetailWidgetProvider: React.FC<IClusterDetailWidgetProviderProps> =
   providerCluster,
   ...props
 }) => {
-  const { orgId } = useParams<{ clusterId: string; orgId: string }>();
-
-  const credentialsClient = useHttpClient();
-  const auth = useAuthProvider();
-
-  const {
-    data: credentials,
-    error: credentialsError,
-  } = useSWR(legacyCredentials.getCredentialListKey(orgId), () =>
-    legacyCredentials.getCredentialList(credentialsClient, auth, orgId)
-  );
-
-  useEffect(() => {
-    if (credentialsError) {
-      ErrorReporter.getInstance().notify(credentialsError);
-    }
-  }, [credentialsError]);
-
-  const accountID = getCredentialsAccountID(credentials?.items);
-
   const region = providerCluster?.spec.location;
+
+  const accountID = providerCluster?.spec.subscriptionID;
   const accountIDPath = getClusterAccountIDPath(cluster, accountID);
 
   return (

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailOverviewDelete.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailOverviewDelete.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as metav1 from 'model/services/mapi/metav1';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailOverviewDelete from '../ClusterDetailOverviewDelete';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailOverviewDelete>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailOverviewDelete {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useRouteMatch: jest.fn().mockReturnValue({
+    url: '',
+    params: {
+      orgId: 'org1',
+      clusterId: capiv1alpha3Mocks.randomCluster1.metadata.name,
+    },
+  }),
+}));
+
+describe('ClusterDetail', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+  });
+
+  it('can delete a cluster', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .delete(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, {
+        apiVersion: 'v1',
+        kind: 'Status',
+        message: 'Resource deleted.',
+        status: metav1.K8sStatuses.Success,
+        reason: '',
+        code: StatusCodes.Ok,
+      });
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Delete cluster/ })
+    );
+    fireEvent.click(
+      await screen.findByText(
+        `Delete ${capiv1alpha3Mocks.randomCluster1.metadata.name}`
+      )
+    );
+
+    expect(
+      await screen.findByText(
+        `Cluster ${capiv1alpha3Mocks.randomCluster1.metadata.name} deleted successfully.`
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetControlPlaneNodes.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetControlPlaneNodes.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import * as capzv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailWidgetControlPlaneNodes from '../ClusterDetailWidgetControlPlaneNodes';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<
+    typeof ClusterDetailWidgetControlPlaneNodes
+  >
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailWidgetControlPlaneNodes {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+describe('ClusterDetailWidgetControlPlaneNodes', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    render(
+      getComponent({
+        cluster: undefined,
+      })
+    );
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(2);
+  });
+
+  it('displays the number of control plane nodes that are ready on Azure', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster2.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList2);
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster2,
+      })
+    );
+
+    expect(
+      await screen.findByLabelText('0 of 1 control plane node ready')
+    ).toBeInTheDocument();
+  });
+
+  it('displays if all control planes are ready on Azure', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(
+      await screen.findByLabelText('Control plane node ready')
+    ).toBeInTheDocument();
+  });
+
+  it('displays if the cluster is not in an availability zone', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster2.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList2);
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster2,
+      })
+    );
+
+    expect(await screen.findByText('Availability zones'));
+    expect(await screen.findByLabelText('no information available'));
+  });
+
+  it(`displays the cluster's availability zone`, async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(await screen.findByText('Availability zone'));
+    expect(await screen.findByText('2'));
+  });
+});

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetCreated.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetCreated.tsx
@@ -1,0 +1,54 @@
+import { screen } from '@testing-library/react';
+import sub from 'date-fns/fp/sub';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import ClusterDetailWidgetCreated from '../ClusterDetailWidgetCreated';
+
+type ComponentProps = React.ComponentPropsWithoutRef<
+  typeof ClusterDetailWidgetCreated
+>;
+
+describe('ClusterDetailWidgetCreated', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(ClusterDetailWidgetCreated, {} as ComponentProps);
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    renderWithTheme(ClusterDetailWidgetCreated, {
+      cluster: undefined,
+    } as ComponentProps);
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(2);
+  });
+
+  it('displays the absolute date when the cluster was created', () => {
+    renderWithTheme(ClusterDetailWidgetCreated, {
+      cluster: capiv1alpha3Mocks.randomCluster1,
+    } as ComponentProps);
+
+    expect(screen.getByLabelText('Created')).toBeInTheDocument();
+    expect(screen.getByText('27 Apr 2021, 10:46 UTC'));
+  });
+
+  it('displays the date when the cluster was created, relative to now', () => {
+    const creationDate = sub({
+      hours: 1,
+    })(new Date());
+
+    const cluster: typeof capiv1alpha3Mocks.randomCluster1 = {
+      ...capiv1alpha3Mocks.randomCluster1,
+      metadata: {
+        ...capiv1alpha3Mocks.randomCluster1.metadata,
+        creationTimestamp: creationDate.toISOString(),
+      },
+    };
+
+    renderWithTheme(ClusterDetailWidgetCreated, {
+      cluster,
+    } as ComponentProps);
+
+    expect(screen.getByLabelText('Created')).toBeInTheDocument();
+    expect(screen.getByText('about 1 hour ago'));
+  });
+});

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
@@ -1,0 +1,43 @@
+import { screen } from '@testing-library/react';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { renderWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailWidgetKubernetesAPI from '../ClusterDetailWidgetKubernetesAPI';
+
+type ComponentProps = React.ComponentPropsWithoutRef<
+  typeof ClusterDetailWidgetKubernetesAPI
+>;
+
+describe('ClusterDetailWidgetKubernetesAPI', () => {
+  it('renders without crashing', () => {
+    renderWithStore(ClusterDetailWidgetKubernetesAPI, {} as ComponentProps);
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    renderWithStore(ClusterDetailWidgetKubernetesAPI, {
+      cluster: undefined,
+    } as ComponentProps);
+
+    expect(screen.getByLabelText('Loading...')).toBeInTheDocument();
+  });
+
+  it('displays the kubernetes API endpoint URL for the cluster', () => {
+    renderWithStore(ClusterDetailWidgetKubernetesAPI, {
+      cluster: capiv1alpha3Mocks.randomCluster1,
+    } as ComponentProps);
+
+    expect(screen.getByText('https://test.k8s.gs.com')).toBeInTheDocument();
+  });
+
+  it('displays the getting started button', () => {
+    renderWithStore(ClusterDetailWidgetKubernetesAPI, {
+      cluster: capiv1alpha3Mocks.randomCluster1,
+    } as ComponentProps);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Get Started',
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetLabels.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetLabels.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailWidgetLabels from '../ClusterDetailWidgetLabels';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailWidgetLabels>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailWidgetLabels {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+describe('ClusterDetailWidgetLabels', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    render(
+      getComponent({
+        cluster: undefined,
+      })
+    );
+
+    expect(screen.getByLabelText('Loading...')).toBeInTheDocument();
+  });
+
+  it('displays the label editor', () => {
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(screen.getByText('This cluster has no labels.')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Add label',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('can add a new label to the cluster', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .put(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, {
+        ...capiv1alpha3Mocks.randomCluster1,
+        metadata: {
+          ...capiv1alpha3Mocks.randomCluster1.metadata,
+          labels: {
+            ...capiv1alpha3Mocks.randomCluster1.metadata.labels!,
+            'some-key': 'some-value',
+          },
+        },
+      });
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Add label',
+      })
+    );
+
+    fireEvent.change(screen.getByLabelText('Label key'), {
+      target: { value: 'some-key' },
+    });
+    fireEvent.change(screen.getByLabelText('Label value'), {
+      target: { value: 'some-value' },
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Save',
+      })
+    );
+
+    expect(
+      await screen.findByText(`Successfully updated the cluster's labels`)
+    ).toBeInTheDocument();
+  });
+
+  it('can remove a label from a cluster', async () => {
+    const cluster = {
+      ...capiv1alpha3Mocks.randomCluster1,
+      metadata: {
+        ...capiv1alpha3Mocks.randomCluster1.metadata,
+        labels: {
+          ...capiv1alpha3Mocks.randomCluster1.metadata.labels!,
+          'some-key': 'some-value',
+        },
+      },
+    };
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, cluster);
+
+    nock(window.config.mapiEndpoint)
+      .put(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    render(getComponent({ cluster }));
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: `Delete 'some-key' label`,
+      })
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Delete',
+      })
+    );
+
+    expect(
+      await screen.findByText(`Successfully updated the cluster's labels`)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetProvider.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetProvider.tsx
@@ -1,0 +1,44 @@
+import { screen } from '@testing-library/react';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import * as capzv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import ClusterDetailWidgetProvider from '../ClusterDetailWidgetProvider';
+
+type ComponentProps = React.ComponentPropsWithoutRef<
+  typeof ClusterDetailWidgetProvider
+>;
+
+describe('ClusterDetailWidgetProvider', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(ClusterDetailWidgetProvider, {} as ComponentProps);
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    renderWithTheme(ClusterDetailWidgetProvider, {
+      cluster: undefined,
+    } as ComponentProps);
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(4);
+  });
+
+  it('displays the cluster region on Azure', () => {
+    renderWithTheme(ClusterDetailWidgetProvider, {
+      cluster: capiv1alpha3Mocks.randomCluster1,
+      providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+    } as ComponentProps);
+
+    expect(screen.getByText('Azure region')).toBeInTheDocument();
+    expect(screen.getByText('westeurope')).toBeInTheDocument();
+  });
+
+  it('displays the subscription ID on Azure', () => {
+    renderWithTheme(ClusterDetailWidgetProvider, {
+      cluster: capiv1alpha3Mocks.randomCluster1,
+      providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+    } as ComponentProps);
+
+    expect(screen.getByText('Subscription ID')).toBeInTheDocument();
+    expect(screen.getByText('test-subscription')).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/index.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetail from '../';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetail>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetail {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useRouteMatch: jest.fn().mockReturnValue({
+    url: '',
+    params: {
+      orgId: 'org1',
+      clusterId: capiv1alpha3Mocks.randomCluster1.metadata.name,
+    },
+  }),
+}));
+
+describe('ClusterDetail', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    render(getComponent({}));
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(1);
+  });
+
+  it(`displays the cluster's description`, async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    render(getComponent({}));
+
+    expect(await screen.findByText('Random Cluster')).toBeInTheDocument();
+  });
+
+  it(`can edit the cluster's description`, async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .put(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, {
+        ...capiv1alpha3Mocks.randomCluster1,
+        metadata: {
+          ...capiv1alpha3Mocks.randomCluster1.metadata,
+          annotations: {
+            ...capiv1alpha3Mocks.randomCluster1.metadata.annotations,
+            'cluster.giantswarm.io/description': 'Some Cluster',
+          },
+        },
+      });
+
+    render(getComponent({}));
+
+    fireEvent.click(await screen.findByText('Random Cluster'));
+    fireEvent.change(screen.getByDisplayValue('Random Cluster'), {
+      target: { value: 'Some Cluster' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+    expect(
+      await screen.findByText(`Successfully updated the cluster's description`)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -49,7 +49,9 @@ export function getWorkerNodesCPU(
     const vmSize = providerNodePools[i]?.spec?.template.vmSize;
     const readyReplicas = nodePools[i].status?.readyReplicas;
 
-    if (typeof vmSize !== 'undefined' && typeof readyReplicas !== 'undefined') {
+    if (!vmSize) return -1;
+
+    if (typeof readyReplicas !== 'undefined') {
       const machineTypeProperties = machineTypes[vmSize];
       if (!machineTypeProperties) {
         return -1;
@@ -75,7 +77,9 @@ export function getWorkerNodesMemory(
     const vmSize = providerNodePools[i]?.spec?.template.vmSize;
     const readyReplicas = nodePools[i].status?.readyReplicas;
 
-    if (typeof vmSize !== 'undefined' && typeof readyReplicas !== 'undefined') {
+    if (!vmSize) return -1;
+
+    if (typeof readyReplicas !== 'undefined') {
       const machineTypeProperties = machineTypes[vmSize];
       if (!machineTypeProperties) {
         return -1;

--- a/src/components/MAPI/keypairs/__tests__/ClusterDetailWidgetKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/__tests__/ClusterDetailWidgetKeyPairs.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as gscorev1alpha1 from 'model/services/mapi/gscorev1alpha1';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import * as legacyMocks from 'testUtils/mockHttpCalls/legacy';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailWidgetKeyPairs from '../ClusterDetailWidgetKeyPairs';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailWidgetKeyPairs>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailWidgetKeyPairs {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useParams: jest.fn().mockReturnValue({
+    orgId: 'org1',
+    clusterId: capiv1alpha3Mocks.randomCluster1.metadata.name,
+  }),
+}));
+
+describe('ClusterDetailWidgetKeyPairs', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    render(getComponent({}));
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(1);
+  });
+
+  it('displays a placeholder if there are no keypairs', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/core.giantswarm.io/v1alpha1/namespaces/giantswarm/storageconfigs/cluster-service/`
+      )
+      .reply(StatusCodes.Ok, {
+        apiVersion: 'core.giantswarm.io/v1alpha1',
+        kind: gscorev1alpha1.StorageConfig,
+        metadata: {
+          name: 'cluster-service',
+          namespace: 'giantswarm',
+          resourceVersion: '294675100',
+          selfLink:
+            '/apis/core.giantswarm.io/v1alpha1/namespaces/giantswarm/storageconfigs/cluster-service/',
+        },
+        spec: {
+          storage: {
+            data: {},
+          },
+        },
+      });
+
+    render(getComponent({}));
+
+    expect(await screen.findByText('No key pairs')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => {
+        return (
+          node?.textContent === 'Use gsctl create kubeconfig to create one.'
+        );
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('displays stats about the keypairs created for this cluster', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/core.giantswarm.io/v1alpha1/namespaces/giantswarm/storageconfigs/cluster-service/`
+      )
+      .reply(StatusCodes.Ok, legacyMocks.clusterServiceStorage);
+
+    render(getComponent({}));
+
+    expect(await screen.findByLabelText('2 key pairs')).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
@@ -40,7 +40,7 @@ const ClusterDetailReleaseDetailsModal: React.FC<IClusterDetailReleaseDetailsMod
   releaseNotesURL,
   supportedUpgradeVersions,
 }) => {
-  const title = `Details for release v${version}`;
+  const title = `Details for release ${version}`;
 
   const sortedComponents = useMemo(() => {
     if (!components) return [];

--- a/src/components/MAPI/releases/__tests__/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/__tests__/ClusterDetailWidgetRelease.tsx
@@ -1,0 +1,234 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import * as releasev1alpha1Mocks from 'testUtils/mockHttpCalls/releasev1alpha1';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+import * as ui from 'UI/Display/MAPI/releases/types';
+
+import ClusterDetailWidgetRelease from '../ClusterDetailWidgetRelease';
+import { getReleaseComponentsDiff } from '../utils';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailWidgetRelease>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailWidgetRelease {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+describe('ClusterDetailWidgetRelease', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    render(
+      getComponent({
+        cluster: undefined,
+      })
+    );
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(2);
+  });
+
+  it('displays the Kubernetes version used', async () => {
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(await screen.findByText('1.19.10')).toBeInTheDocument();
+  });
+
+  it('displays details about the release when clicking on the release version', async () => {
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading...'));
+
+    const version = screen.getByText('14.1.5');
+    expect(version).toBeInTheDocument();
+    fireEvent.click(version);
+
+    expect(await screen.findByText('Details for release 14.1.5'));
+
+    const components = [
+      ...releasev1alpha1Mocks.v14_1_5.spec.components,
+      ...releasev1alpha1Mocks.v14_1_5.spec.apps!,
+    ];
+    for (const component of components) {
+      expect(
+        screen.getByLabelText(`${component.name} version ${component.version}`)
+      ).toBeInTheDocument();
+    }
+
+    expect(screen.getByText('Release notes')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name:
+          'https://github.com/giantswarm/releases/tree/master/azure/v14.1.5',
+      })
+    );
+
+    expect(
+      screen.getByText(/This cluster can be upgraded to/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('v15.0.0')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close' })[1]);
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText('Details for release 14.1.5')
+    );
+  });
+
+  it('displays a warning when there is an upgrade available', async () => {
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(await screen.findByText('Upgrade available')).toBeInTheDocument();
+  });
+
+  it('can upgrade a cluster', async () => {
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .put(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, {
+        ...capiv1alpha3Mocks.randomCluster1,
+        metadata: {
+          ...capiv1alpha3Mocks.randomCluster1.metadata,
+          labels: {
+            ...capiv1alpha3Mocks.randomCluster1.metadata.labels,
+            'release.giantswarm.io/version': releasev1alpha1Mocks.v15_0_0.metadata.name.slice(
+              1
+            ),
+          },
+        },
+      });
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Upgrade cluster…' })
+    );
+
+    expect(await screen.findByText('Upgrade to 15.0.0')).toBeInTheDocument();
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Inspect changes' })
+    );
+
+    expect(
+      await screen.findByText('Changes from 14.1.5 to 15.0.0')
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Component changes')).toBeInTheDocument();
+    const versionDiff = getReleaseComponentsDiff(
+      releasev1alpha1Mocks.v14_1_5,
+      releasev1alpha1Mocks.v15_0_0
+    );
+    for (const change of versionDiff.changes) {
+      switch (change.changeType) {
+        case ui.ReleaseComponentsDiffChangeType.Add:
+          expect(
+            screen.getByLabelText(
+              `${change.component} version ${change.newVersion}`
+            )
+          ).toBeInTheDocument();
+          break;
+        case ui.ReleaseComponentsDiffChangeType.Update:
+          expect(
+            screen.getByLabelText(
+              `${change.component} version ${change.oldVersion} is upgraded to version ${change.newVersion}`
+            )
+          ).toBeInTheDocument();
+          break;
+        case ui.ReleaseComponentsDiffChangeType.Delete:
+          expect(
+            screen.getByLabelText(
+              `${change.component} version ${change.oldVersion} is removed`
+            )
+          ).toBeInTheDocument();
+          break;
+      }
+    }
+
+    expect(screen.getByText('Release notes')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name:
+          'https://github.com/giantswarm/releases/tree/master/azure/v15.0.0',
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Start upgrade' })
+    );
+
+    expect(
+      await screen.findByText('Cluster upgrade initiated.')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/workernodes/ClusterDetailWidgetWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWidgetWorkerNodes.tsx
@@ -24,7 +24,7 @@ import {
   getWorkerNodesCount,
   getWorkerNodesCPU,
   getWorkerNodesMemory,
-} from '../utils';
+} from '../clusters/utils';
 
 function formatMemory(value?: number) {
   if (typeof value === 'undefined') return undefined;

--- a/src/components/MAPI/workernodes/__tests__/ClusterDetailWidgetWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/__tests__/ClusterDetailWidgetWorkerNodes.tsx
@@ -1,0 +1,223 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
+import * as metav1 from 'model/services/mapi/metav1';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import * as capiexpv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3/exp';
+import * as capzexpv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3/exp';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailWidgetWorkerNodes from '../ClusterDetailWidgetWorkerNodes';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailWidgetWorkerNodes>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailWidgetWorkerNodes {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+describe('ClusterDetailWidgetWorkerNodes', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    render(
+      getComponent({
+        cluster: undefined,
+      })
+    );
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(4);
+  });
+
+  it('displays a placeholder if there are no node pools', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/machinepools/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}`
+      )
+      .reply(StatusCodes.Ok, {
+        apiVersion: 'exp.cluster.x-k8s.io/v1alpha3',
+        kind: capiexpv1alpha3.MachinePoolList,
+        metadata: {},
+        items: [],
+      });
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(await screen.findByText('No node pools')).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => {
+        return (
+          node?.textContent ===
+          'To create node pools, switch to the worker nodes tab.'
+        );
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('displays stats about node pools', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/machinepools/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}`
+      )
+      .reply(
+        StatusCodes.Ok,
+        capiexpv1alpha3Mocks.randomCluster1MachinePoolList
+      );
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachinepools/${capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1.metadata.name}/`
+      )
+      .reply(
+        StatusCodes.Ok,
+        capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1
+      );
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachinepools/${capzexpv1alpha3Mocks.randomCluster1AzureMachinePool2.metadata.name}/`
+      )
+      .reply(
+        StatusCodes.Ok,
+        capzexpv1alpha3Mocks.randomCluster1AzureMachinePool2
+      );
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(await screen.findByLabelText('2 node pools')).toBeInTheDocument();
+    expect(await screen.findByLabelText('10 nodes')).toBeInTheDocument();
+    expect(await screen.findByLabelText('80 CPUs')).toBeInTheDocument();
+    expect(await screen.findByLabelText('172 GB RAM')).toBeInTheDocument();
+  });
+
+  it('only displays a part of the stats if provider-specific resources fail to load', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/machinepools/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}`
+      )
+      .reply(
+        StatusCodes.Ok,
+        capiexpv1alpha3Mocks.randomCluster1MachinePoolList
+      );
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachinepools/${capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.NotFound, {
+        apiVersion: 'v1',
+        kind: 'Status',
+        message: 'Lolz',
+        status: metav1.K8sStatuses.Failure,
+        reason: metav1.K8sStatusErrorReasons.NotFound,
+        code: StatusCodes.NotFound,
+      });
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachinepools/${capzexpv1alpha3Mocks.randomCluster1AzureMachinePool2.metadata.name}/`
+      )
+      .reply(StatusCodes.NotFound, {
+        apiVersion: 'v1',
+        kind: 'Status',
+        message: 'Lolz',
+        status: metav1.K8sStatuses.Failure,
+        reason: metav1.K8sStatusErrorReasons.NotFound,
+        code: StatusCodes.NotFound,
+      });
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(await screen.findByLabelText('2 node pools')).toBeInTheDocument();
+    expect(await screen.findByLabelText('10 nodes')).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText('CPUs not available')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText('GB RAM not available')
+    ).toBeInTheDocument();
+  });
+
+  it('only displays a part of the stats if one of the machine types is unknown', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/machinepools/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}`
+      )
+      .reply(
+        StatusCodes.Ok,
+        capiexpv1alpha3Mocks.randomCluster1MachinePoolList
+      );
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachinepools/${capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, {
+        ...capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+        spec: {
+          ...capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1.spec,
+          template: {
+            ...capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1.spec!
+              .template,
+            vmSize: 'random_stuff',
+          },
+        },
+      });
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachinepools/${capzexpv1alpha3Mocks.randomCluster1AzureMachinePool2.metadata.name}/`
+      )
+      .reply(
+        StatusCodes.Ok,
+        capzexpv1alpha3Mocks.randomCluster1AzureMachinePool2
+      );
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+      })
+    );
+
+    expect(await screen.findByLabelText('2 node pools')).toBeInTheDocument();
+    expect(await screen.findByLabelText('10 nodes')).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText('CPUs not available')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText('GB RAM not available')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/UI/Display/Cluster/ReleaseComponentLabel/index.js
+++ b/src/components/UI/Display/Cluster/ReleaseComponentLabel/index.js
@@ -5,6 +5,19 @@ import theme from 'styles/theme';
 import ValueLabel from 'UI/Display/ValueLabel';
 import Truncated from 'UI/Util/Truncated';
 
+function formatValueLabel(component, oldVersion, newVersion) {
+  switch (true) {
+    case Boolean(oldVersion) && Boolean(newVersion):
+      return `${component} version ${oldVersion} is upgraded to version ${newVersion}`;
+    case Boolean(newVersion):
+      return `${component} version ${newVersion}`;
+    case !oldVersion && !newVersion:
+      return `${component} is removed`;
+    default:
+      return '';
+  }
+}
+
 const OldVersion = styled.span`
   color: ${(p) => p.theme.colors.redOld};
 `;
@@ -23,30 +36,18 @@ const VersionLabel = (props) => {
   if (oldVersion) {
     return (
       <>
-        <Truncated as={OldVersion} aria-label={`version ${oldVersion}`}>
-          {oldVersion}
-        </Truncated>
-        <ChangeArrow aria-label='is upgraded to'>➞</ChangeArrow>
-        <Truncated as={NewVersion} aria-label={`version ${newVersion}`}>
-          {newVersion}
-        </Truncated>
+        <Truncated as={OldVersion}>{oldVersion}</Truncated>
+        <ChangeArrow>➞</ChangeArrow>
+        <Truncated as={NewVersion}>{newVersion}</Truncated>
       </>
     );
   } else if (isRemoved) {
     return 'removed';
   } else if (isAdded) {
-    return (
-      <Truncated as='span' aria-label={`version ${newVersion}`}>
-        {newVersion} (added)
-      </Truncated>
-    );
+    return <Truncated as='span'>{newVersion} (added)</Truncated>;
   }
 
-  return (
-    <Truncated as='span' aria-label={`version ${newVersion}`}>
-      {newVersion}
-    </Truncated>
-  );
+  return <Truncated as='span'>{newVersion}</Truncated>;
 };
 
 VersionLabel.propTypes = {
@@ -73,6 +74,7 @@ const ReleaseComponentLabel = (props) => {
           oldVersion={oldVersion}
         />
       }
+      aria-label={formatValueLabel(name, oldVersion, version)}
     />
   );
 };

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/index.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/index.tsx
@@ -32,10 +32,13 @@ const ClusterDetailCounter: React.FC<IClusterDetailCounterProps> = ({
   ...props
 }) => {
   const formattedLabel = pluralize ? pluralizeLabel(value, label) : label;
-  const a11yLabel =
-    typeof value === 'number' && value >= 0
-      ? `${value} ${formattedLabel}`
-      : `Loading ${formattedLabel}...`;
+
+  let a11yLabel = `Loading ${formattedLabel}...`;
+  if (typeof value === 'number' && value >= 0) {
+    a11yLabel = `${value} ${formattedLabel}`;
+  } else if (typeof value === 'number' && value < 0) {
+    a11yLabel = `${formattedLabel} not available`;
+  }
 
   return (
     <Box align='center' basis='100px' flex={{ grow: 0, shrink: 1 }} {...props}>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -8,6 +8,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
+      aria-label="Some widget"
       class="StyledBox-sc-13pk1d4-0 cPuPbk"
     >
       <header
@@ -41,6 +42,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
+      aria-label="Some widget"
       class="StyledBox-sc-13pk1d4-0 cPuPbk"
     >
       <header

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/index.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/index.tsx
@@ -30,6 +30,7 @@ const ClusterDetailWidget: React.FC<IClusterDetailWidgetProps> = ({
       round='xsmall'
       pad='xsmall'
       wrap={true}
+      aria-label={title}
       {...props}
     >
       <CardHeader

--- a/src/model/services/mapi/capiv1alpha3/key.ts
+++ b/src/model/services/mapi/capiv1alpha3/key.ts
@@ -39,7 +39,7 @@ export function getKubernetesAPIEndpointURL(
   cluster: ICluster
 ): string | undefined {
   const hostname = cluster.spec?.controlPlaneEndpoint?.host;
-  if (!hostname) return undefined;
+  if (!hostname) return '';
 
   return `https://${hostname}`;
 }

--- a/testUtils/mockHttpCalls/capiv1alpha3/clusters.ts
+++ b/testUtils/mockHttpCalls/capiv1alpha3/clusters.ts
@@ -34,7 +34,7 @@ export const randomCluster1: capiv1alpha3.ICluster = {
       },
     },
     controlPlaneEndpoint: {
-      host: '',
+      host: 'test.k8s.gs.com',
       port: 0,
     },
     infrastructureRef: {
@@ -86,7 +86,7 @@ export const randomCluster2: capiv1alpha3.ICluster = {
       },
     },
     controlPlaneEndpoint: {
-      host: '',
+      host: 'test.k8s.gs.com',
       port: 0,
     },
     infrastructureRef: {
@@ -138,7 +138,7 @@ export const randomCluster3: capiv1alpha3.ICluster = {
       },
     },
     controlPlaneEndpoint: {
-      host: '',
+      host: 'test.k8s.gs.com',
       port: 0,
     },
     infrastructureRef: {

--- a/testUtils/mockHttpCalls/capzv1alpha3/azureClusters.ts
+++ b/testUtils/mockHttpCalls/capzv1alpha3/azureClusters.ts
@@ -1,0 +1,287 @@
+import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
+
+export const randomAzureCluster1: capzv1alpha3.IAzureCluster = {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3',
+  kind: 'AzureCluster',
+  metadata: {
+    creationTimestamp: '2021-04-27T10:45:06Z',
+    finalizers: [
+      'operatorkit.giantswarm.io/azure-operator-azurecluster-controller',
+    ],
+    generation: 4,
+    labels: {
+      'azure-operator.giantswarm.io/version': '5.5.2',
+      'cluster-operator.giantswarm.io/version': '0.23.22',
+      'cluster.x-k8s.io/cluster-name': 'j5y9m',
+      'giantswarm.io/cluster': 'j5y9m',
+      'giantswarm.io/organization': 'org1',
+      'release.giantswarm.io/version': '14.1.5',
+    },
+    name: 'j5y9m',
+    namespace: 'org-org1',
+    resourceVersion: '391239110',
+    selfLink:
+      '/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azureclusters/j5y9m',
+    uid: 'a4eeba9e-6a58-4151-b8ad-d1389ae1e223',
+  },
+  spec: {
+    contronPlaneEndpoint: {
+      host: '',
+      port: 443,
+    },
+    location: 'westeurope',
+    networkSpec: {
+      apiServerLB: {
+        frontendIPs: [{ name: 'j5y9m-API-PublicLoadBalancer-Frontend' }],
+        name: 'j5y9m-API-PublicLoadBalancer',
+        sku: 'Standard',
+        type: 'Public',
+      },
+      subnets: [
+        {
+          cidrBlocks: ['10.14.3.0/24'],
+          id:
+            '/subscriptions/test-subscription/resourceGroups/j5y9m/providers/Microsoft.Network/virtualNetworks/j5y9m-VirtualNetwork/subnets/j5y9m',
+          name: 'j5y9m',
+          role: 'node',
+          routeTable: {},
+          securityGroup: {},
+        },
+        {
+          cidrBlocks: ['10.14.5.0/24'],
+          id:
+            '/subscriptions/test-subscription/resourceGroups/j5y9m/providers/Microsoft.Network/virtualNetworks/j5y9m-VirtualNetwork/subnets/ew87z',
+          name: 'ew87z',
+          role: 'node',
+          routeTable: {},
+          securityGroup: {},
+        },
+      ],
+      vnet: {
+        cidrBlocks: ['10.14.0.0/16'],
+        name: 'j5y9m-VirtualNetwork',
+        resourceGroup: 'j5y9m',
+      },
+    },
+    resourceGroup: 'j5y9m',
+    subscriptionID: 'test-subscription',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2021-05-14T16:01:57Z',
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: '2020-11-23T13:43:31Z',
+        status: 'True',
+        type: 'ResourceGroupReady',
+      },
+      {
+        lastTransitionTime: '2021-05-14T16:01:57Z',
+        status: 'True',
+        type: 'VNetPeeringReady',
+      },
+      {
+        lastTransitionTime: '2021-05-14T11:37:34Z',
+        status: 'True',
+        type: 'VPNGatewayReady',
+      },
+    ],
+  },
+};
+
+export const randomCluster2: capzv1alpha3.IAzureCluster = {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3',
+  kind: 'AzureCluster',
+  metadata: {
+    creationTimestamp: '2021-02-27T08:40:06Z',
+    finalizers: [
+      'operatorkit.giantswarm.io/azure-operator-azurecluster-controller',
+    ],
+    generation: 4,
+    labels: {
+      'azure-operator.giantswarm.io/version': '5.5.2',
+      'cluster-operator.giantswarm.io/version': '0.23.22',
+      'cluster.x-k8s.io/cluster-name': 'as43z',
+      'giantswarm.io/cluster': 'as43z',
+      'giantswarm.io/organization': 'org1',
+      'release.giantswarm.io/version': '14.0.1',
+    },
+    name: 'as43z',
+    namespace: 'org-org1',
+    resourceVersion: '391239110',
+    selfLink:
+      '/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azureclusters/as43z',
+    uid: 'a4eeba9e-6a58-4151-b8ad-d1389ae1e223',
+  },
+  spec: {
+    contronPlaneEndpoint: {
+      host: '',
+      port: 443,
+    },
+    location: 'westeurope',
+    networkSpec: {
+      apiServerLB: {
+        frontendIPs: [{ name: 'as43z-API-PublicLoadBalancer-Frontend' }],
+        name: 'as43z-API-PublicLoadBalancer',
+        sku: 'Standard',
+        type: 'Public',
+      },
+      subnets: [
+        {
+          cidrBlocks: ['10.14.3.0/24'],
+          id:
+            '/subscriptions/test-subscription/resourceGroups/as43z/providers/Microsoft.Network/virtualNetworks/as43z-VirtualNetwork/subnets/as43z',
+          name: 'as43z',
+          role: 'node',
+          routeTable: {},
+          securityGroup: {},
+        },
+        {
+          cidrBlocks: ['10.14.5.0/24'],
+          id:
+            '/subscriptions/test-subscription/resourceGroups/as43z/providers/Microsoft.Network/virtualNetworks/as43z-VirtualNetwork/subnets/ew87z',
+          name: 'ew87z',
+          role: 'node',
+          routeTable: {},
+          securityGroup: {},
+        },
+      ],
+      vnet: {
+        cidrBlocks: ['10.14.0.0/16'],
+        name: 'as43z-VirtualNetwork',
+        resourceGroup: 'as43z',
+      },
+    },
+    resourceGroup: 'as43z',
+    subscriptionID: 'test-subscription',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2021-05-14T16:01:57Z',
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: '2020-11-23T13:43:31Z',
+        status: 'True',
+        type: 'ResourceGroupReady',
+      },
+      {
+        lastTransitionTime: '2021-05-14T16:01:57Z',
+        status: 'True',
+        type: 'VNetPeeringReady',
+      },
+      {
+        lastTransitionTime: '2021-05-14T11:37:34Z',
+        status: 'True',
+        type: 'VPNGatewayReady',
+      },
+    ],
+  },
+};
+
+export const randomCluster3: capzv1alpha3.IAzureCluster = {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3',
+  kind: 'AzureCluster',
+  metadata: {
+    creationTimestamp: '2020-12-01T08:40:06Z',
+    finalizers: [
+      'operatorkit.giantswarm.io/azure-operator-azurecluster-controller',
+    ],
+    generation: 4,
+    labels: {
+      'azure-operator.giantswarm.io/version': '5.5.2',
+      'cluster-operator.giantswarm.io/version': '0.23.22',
+      'cluster.x-k8s.io/cluster-name': '0fa12',
+      'giantswarm.io/cluster': '0fa12',
+      'giantswarm.io/organization': 'org1',
+      'release.giantswarm.io/version': '13.1.0',
+    },
+    name: '0fa12',
+    namespace: 'org-org1',
+    resourceVersion: '391239110',
+    selfLink:
+      '/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azureclusters/0fa12',
+    uid: 'a4eeba9e-6a58-4151-b8ad-d1389ae1e223',
+  },
+  spec: {
+    contronPlaneEndpoint: {
+      host: '',
+      port: 443,
+    },
+    location: 'westeurope',
+    networkSpec: {
+      apiServerLB: {
+        frontendIPs: [{ name: '0fa12-API-PublicLoadBalancer-Frontend' }],
+        name: '0fa12-API-PublicLoadBalancer',
+        sku: 'Standard',
+        type: 'Public',
+      },
+      subnets: [
+        {
+          cidrBlocks: ['10.14.3.0/24'],
+          id:
+            '/subscriptions/test-subscription/resourceGroups/0fa12/providers/Microsoft.Network/virtualNetworks/0fa12-VirtualNetwork/subnets/0fa12',
+          name: '0fa12',
+          role: 'node',
+          routeTable: {},
+          securityGroup: {},
+        },
+        {
+          cidrBlocks: ['10.14.5.0/24'],
+          id:
+            '/subscriptions/test-subscription/resourceGroups/0fa12/providers/Microsoft.Network/virtualNetworks/0fa12-VirtualNetwork/subnets/ew87z',
+          name: 'ew87z',
+          role: 'node',
+          routeTable: {},
+          securityGroup: {},
+        },
+      ],
+      vnet: {
+        cidrBlocks: ['10.14.0.0/16'],
+        name: '0fa12-VirtualNetwork',
+        resourceGroup: '0fa12',
+      },
+    },
+    resourceGroup: '0fa12',
+    subscriptionID: 'test-subscription',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2021-05-14T16:01:57Z',
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: '2020-11-23T13:43:31Z',
+        status: 'True',
+        type: 'ResourceGroupReady',
+      },
+      {
+        lastTransitionTime: '2021-05-14T16:01:57Z',
+        status: 'True',
+        type: 'VNetPeeringReady',
+      },
+      {
+        lastTransitionTime: '2021-05-14T11:37:34Z',
+        status: 'True',
+        type: 'VPNGatewayReady',
+      },
+    ],
+  },
+};
+
+export const randomAzureClusterList: capzv1alpha3.IAzureClusterList = {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha3',
+  kind: 'AzureClusterList',
+  metadata: {
+    resourceVersion: '294659579',
+    selfLink: '/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azureclusters/',
+  },
+  items: [randomAzureCluster1, randomCluster2, randomCluster3],
+};

--- a/testUtils/mockHttpCalls/capzv1alpha3/azureClusters.ts
+++ b/testUtils/mockHttpCalls/capzv1alpha3/azureClusters.ts
@@ -25,7 +25,7 @@ export const randomAzureCluster1: capzv1alpha3.IAzureCluster = {
     uid: 'a4eeba9e-6a58-4151-b8ad-d1389ae1e223',
   },
   spec: {
-    contronPlaneEndpoint: {
+    controlPlaneEndpoint: {
       host: '',
       port: 443,
     },
@@ -117,7 +117,7 @@ export const randomCluster2: capzv1alpha3.IAzureCluster = {
     uid: 'a4eeba9e-6a58-4151-b8ad-d1389ae1e223',
   },
   spec: {
-    contronPlaneEndpoint: {
+    controlPlaneEndpoint: {
       host: '',
       port: 443,
     },
@@ -209,7 +209,7 @@ export const randomCluster3: capzv1alpha3.IAzureCluster = {
     uid: 'a4eeba9e-6a58-4151-b8ad-d1389ae1e223',
   },
   spec: {
-    contronPlaneEndpoint: {
+    controlPlaneEndpoint: {
       host: '',
       port: 443,
     },

--- a/testUtils/mockHttpCalls/capzv1alpha3/azureMachines.ts
+++ b/testUtils/mockHttpCalls/capzv1alpha3/azureMachines.ts
@@ -143,19 +143,6 @@ export const randomAzureMachine2: capzv1alpha3.IAzureMachine = {
   status: {
     conditions: [
       {
-        lastTransitionTime: '2021-04-26T15:18:58Z',
-        status: 'True',
-        type: 'Ready',
-      },
-      {
-        lastTransitionTime: '2021-04-26T15:20:26Z',
-        message: 'Creation has been completed in 15m0.120533613s',
-        reason: 'CreationCompleted',
-        severity: 'Info',
-        status: 'False',
-        type: 'Creating',
-      },
-      {
         lastTransitionTime: '2021-04-26T15:09:11Z',
         status: 'True',
         type: 'SubnetReady',

--- a/testUtils/mockHttpCalls/capzv1alpha3/azureMachines.ts
+++ b/testUtils/mockHttpCalls/capzv1alpha3/azureMachines.ts
@@ -118,7 +118,6 @@ export const randomAzureMachine2: capzv1alpha3.IAzureMachine = {
   },
   spec: {
     location: 'westeurope',
-    failureDomain: '2',
     identity: 'None',
     image: {
       marketplace: {

--- a/testUtils/mockHttpCalls/capzv1alpha3/index.ts
+++ b/testUtils/mockHttpCalls/capzv1alpha3/index.ts
@@ -1,1 +1,2 @@
 export * from './azureMachines';
+export * from './azureClusters';

--- a/testUtils/mockHttpCalls/legacy/clusterService.ts
+++ b/testUtils/mockHttpCalls/legacy/clusterService.ts
@@ -1,0 +1,44 @@
+import * as gscorev1alpha1 from 'model/services/mapi/gscorev1alpha1';
+
+export const clusterServiceStorage: gscorev1alpha1.IStorageConfig = {
+  apiVersion: 'core.giantswarm.io/v1alpha1',
+  kind: gscorev1alpha1.StorageConfig,
+  metadata: {
+    name: 'cluster-service',
+    namespace: 'giantswarm',
+  },
+  spec: {
+    storage: {
+      data: {
+        '/serial-store/cluster/j5y9m/serial/as:df:3f:5f': JSON.stringify({
+          cluster_id: 'j5y9m',
+          common_name: 'test.user.api.j5y9m.k8s.test.gigantic.io',
+          create_date: new Date().toISOString(),
+          description: 'Added by user test@test.com using Happa',
+          certificate_organizations: '',
+          serial_number: 'as:df:3f:5f',
+          ttl: 24,
+        }),
+        '/serial-store/cluster/j5y9m/serial/5f:as:df:2f': JSON.stringify({
+          cluster_id: 'j5y9m',
+          common_name: 'test.user.api.j5y9m.k8s.test.gigantic.io',
+          create_date: new Date().toISOString(),
+          description: 'Added by user test2@test.com using Happa',
+          certificate_organizations: '',
+          serial_number: '5f:as:df:2f',
+          // eslint-disable-next-line no-magic-numbers
+          ttl: 7 * 24,
+        }),
+        '/serial-store/cluster/j5y9m/serial/2f:03:2s:ws': JSON.stringify({
+          cluster_id: 'j5y9m',
+          common_name: 'test.user.api.j5y9m.k8s.test.gigantic.io',
+          create_date: '2019-06-21T07:58:42.364252318Z',
+          description: 'Added by user test@test.com using Happa',
+          certificate_organizations: '',
+          serial_number: '2f:03:2s:ws',
+          ttl: 0,
+        }),
+      },
+    },
+  },
+};

--- a/testUtils/mockHttpCalls/legacy/index.ts
+++ b/testUtils/mockHttpCalls/legacy/index.ts
@@ -1,0 +1,1 @@
+export * from './clusterService';

--- a/testUtils/mockHttpCalls/releasev1alpha1/releases.ts
+++ b/testUtils/mockHttpCalls/releasev1alpha1/releases.ts
@@ -541,3 +541,13 @@ export const v15_0_0: releasev1alpha1.IRelease = {
     ready: true,
   },
 };
+
+export const releasesList: releasev1alpha1.IReleaseList = {
+  apiVersion: 'release.giantswarm.io/v1alpha1',
+  kind: 'ReleaseList',
+  metadata: {
+    resourceVersion: '294659579',
+    selfLink: '/apis/release.giantswarm.io/v1alpha1/releases/',
+  },
+  items: [v13_1_0, v14_0_1, v14_1_5, v15_0_0],
+};


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/341

This PR adds unit and integration tests for all the functionality on the `Cluster details` page - `Overview` tab.
These did uncover a few minor issues, which were also fixed in the PR.

These are just to gain a bit of confidence in the implementation, and to allow me to do some refactoring later.