### PR TITLE
clusters: write tests for MAPI cluster creation

### DIFF
--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -340,7 +340,7 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
                 title={
                   <>
                     {`Install ${props.app.name} on`}{' '}
-                    <ClusterIDLabel clusterID={clusterID} />
+                    <ClusterIDLabel clusterID={clusterID!} />
                   </>
                 }
                 visible={visible}

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
@@ -82,6 +82,7 @@ const ReleaseRow: FC<IReleaseRow> = ({
         aria-checked={isSelected}
         onClick={() => selectRelease(version)}
         onKeyDown={handleTabSelect}
+        aria-label={`Release version ${version}`}
       >
         <TableCell>
           <RUMActionTarget name={RUMActions.SelectRelease}>

--- a/src/components/MAPI/apps/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/AppInstallModal.tsx
@@ -358,7 +358,7 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
                 title={
                   <>
                     {`Install ${props.chartName} on`}{' '}
-                    <ClusterIDLabel clusterID={clusterID} />
+                    <ClusterIDLabel clusterID={clusterID!} />
                   </>
                 }
                 visible={visible}

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterDescription.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterDescription.tsx
@@ -21,9 +21,10 @@ function validateValue(newValue: string): string {
 
 interface ICreateClusterDescriptionProps
   extends IClusterPropertyProps,
-    Omit<React.ComponentPropsWithoutRef<typeof InputGroup>, 'onChange' | 'id'> {
-  autoFocus?: boolean;
-}
+    Omit<
+      React.ComponentPropsWithoutRef<typeof InputGroup>,
+      'onChange' | 'id'
+    > {}
 
 const CreateClusterDescription: React.FC<ICreateClusterDescriptionProps> = ({
   id,

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterName.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterName.tsx
@@ -23,7 +23,10 @@ const CreateClusterName: React.FC<ICreateClusterNameProps> = ({
       <Text size='large' weight='bold'>
         Name
       </Text>
-      <ClusterIDLabel clusterID={cluster.metadata.name} />
+      <ClusterIDLabel
+        clusterID={cluster.metadata.name}
+        aria-label={`Cluster name: ${cluster.metadata.name}`}
+      />
     </Box>
   );
 };

--- a/src/components/MAPI/clusters/CreateCluster/__tests__/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/__tests__/index.tsx
@@ -1,0 +1,327 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as MAPIUtils from 'MAPI/utils';
+import nock from 'nock';
+import React from 'react';
+import { Providers, StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import * as capzv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3';
+import * as releasev1alpha1Mocks from 'testUtils/mockHttpCalls/releasev1alpha1';
+import preloginState from 'testUtils/preloginState';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import * as CreateClusterUtils from '../../utils';
+import ClusterCreate from '../';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterCreate>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterCreate {...p} />
+    </SWRConfig>
+  );
+
+  const state = {
+    ...preloginState,
+    main: {
+      ...preloginState.main,
+      info: {
+        ...preloginState.main.info,
+        general: {
+          ...preloginState.main.info.general,
+          availability_zones: {
+            default: 1,
+            max: 3,
+            zones: ['1', '2', '3'],
+          },
+          provider: Providers.AZURE,
+        },
+      },
+    },
+  };
+
+  return getComponentWithStore(
+    Component,
+    props,
+    state,
+    undefined,
+    history,
+    auth
+  );
+}
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useRouteMatch: jest.fn().mockReturnValue({
+    url: '',
+    params: {
+      orgId: 'org1',
+    },
+  }),
+}));
+
+const generateUIDMockFn = jest.spyOn(MAPIUtils, 'generateUID');
+generateUIDMockFn.mockReturnValue(
+  capiv1alpha3Mocks.randomCluster1.metadata.name
+);
+
+describe('ClusterCreate', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('can see the name that the resource will get', () => {
+    render(getComponent({}));
+
+    expect(screen.getByLabelText('Cluster name: j5y9m')).toBeInTheDocument();
+  });
+
+  it('can set the description', async () => {
+    const createClusterMockFn = jest.spyOn(CreateClusterUtils, 'createCluster');
+    createClusterMockFn.mockResolvedValue({
+      cluster: capiv1alpha3Mocks.randomCluster1,
+      providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+      controlPlaneNode: capzv1alpha3Mocks.randomAzureMachine1,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    render(getComponent({}));
+
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'A new description' },
+    });
+
+    const createButton = screen.getByRole('button', { name: 'Create cluster' });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(createClusterMockFn).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        cluster: expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              'cluster.giantswarm.io/description': 'A new description',
+            }),
+          }),
+        }),
+      })
+    );
+
+    // TODO(axbarsan): Replace with assertion utility.
+    expect(
+      await screen.findByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === 'Cluster j5y9m created successfully';
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+
+    createClusterMockFn.mockRestore();
+  });
+
+  it('can set the release version', async () => {
+    const createClusterMockFn = jest.spyOn(CreateClusterUtils, 'createCluster');
+    createClusterMockFn.mockResolvedValue({
+      cluster: capiv1alpha3Mocks.randomCluster1,
+      providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+      controlPlaneNode: capzv1alpha3Mocks.randomAzureMachine1,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    render(getComponent({}));
+
+    // Has the latest version selected by default.
+    expect(
+      await screen.findByLabelText('The currently selected version is 15.0.0')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Available releases'));
+    fireEvent.click(screen.getByLabelText('Release version 14.1.5'));
+
+    const createButton = screen.getByRole('button', { name: 'Create cluster' });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(createClusterMockFn).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        cluster: expect.objectContaining({
+          metadata: expect.objectContaining({
+            labels: expect.objectContaining({
+              'release.giantswarm.io/version': '14.1.5',
+            }),
+          }),
+        }),
+        providerCluster: expect.objectContaining({
+          metadata: expect.objectContaining({
+            labels: expect.objectContaining({
+              'release.giantswarm.io/version': '14.1.5',
+            }),
+          }),
+        }),
+        controlPlaneNode: expect.objectContaining({
+          metadata: expect.objectContaining({
+            labels: expect.objectContaining({
+              'release.giantswarm.io/version': '14.1.5',
+            }),
+          }),
+        }),
+      })
+    );
+
+    // TODO(axbarsan): Replace with assertion utility.
+    expect(
+      await screen.findByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === 'Cluster j5y9m created successfully';
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+
+    createClusterMockFn.mockRestore();
+  });
+
+  it('can configure the availability zone', async () => {
+    const createClusterMockFn = jest.spyOn(CreateClusterUtils, 'createCluster');
+    createClusterMockFn.mockResolvedValue({
+      cluster: capiv1alpha3Mocks.randomCluster1,
+      providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+      controlPlaneNode: capzv1alpha3Mocks.randomAzureMachine1,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    render(getComponent({}));
+
+    fireEvent.click(screen.getByText('Manual selection'));
+    fireEvent.click(await screen.findByLabelText('Availability zone 3'));
+
+    const createButton = screen.getByRole('button', { name: 'Create cluster' });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(createClusterMockFn).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        controlPlaneNode: expect.objectContaining({
+          spec: expect.objectContaining({
+            failureDomain: '3',
+          }),
+        }),
+      })
+    );
+
+    // TODO(axbarsan): Replace with assertion utility.
+    expect(
+      await screen.findByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === 'Cluster j5y9m created successfully';
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+
+    createClusterMockFn.mockRestore();
+  });
+
+  it('creates a cluster with default options', async () => {
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    nock(window.config.mapiEndpoint)
+      .post(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Created, capiv1alpha3Mocks.randomCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .post(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azureclusters/${capzv1alpha3Mocks.randomAzureCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Created, capzv1alpha3Mocks.randomAzureCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .post(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachines/${capzv1alpha3Mocks.randomAzureMachine1.metadata.name}/`
+      )
+      .reply(StatusCodes.Created, capzv1alpha3Mocks.randomAzureMachine1);
+
+    render(getComponent({}));
+
+    const createButton = screen.getByRole('button', { name: 'Create cluster' });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    // TODO(axbarsan): Replace with assertion utility.
+    expect(
+      await screen.findByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === 'Cluster j5y9m created successfully';
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/clusters/CreateCluster/__tests__/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/__tests__/index.tsx
@@ -7,6 +7,7 @@ import nock from 'nock';
 import React from 'react';
 import { Providers, StatusCodes } from 'shared/constants';
 import { cache, SWRConfig } from 'swr';
+import { withMarkup } from 'testUtils/assertUtils';
 import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
 import * as capzv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3';
 import * as releasev1alpha1Mocks from 'testUtils/mockHttpCalls/releasev1alpha1';
@@ -127,19 +128,8 @@ describe('ClusterCreate', () => {
       })
     );
 
-    // TODO(axbarsan): Replace with assertion utility.
     expect(
-      await screen.findByText((_, node) => {
-        if (!node) return false;
-
-        const hasText = (n: Element) =>
-          n.textContent === 'Cluster j5y9m created successfully';
-        const hasTextInChildren = Array.from(node.children).some((child) =>
-          hasText(child)
-        );
-
-        return hasText(node) && !hasTextInChildren;
-      })
+      await withMarkup(screen.findByText)('Cluster j5y9m created successfully')
     ).toBeInTheDocument();
 
     createClusterMockFn.mockRestore();
@@ -203,19 +193,8 @@ describe('ClusterCreate', () => {
       })
     );
 
-    // TODO(axbarsan): Replace with assertion utility.
     expect(
-      await screen.findByText((_, node) => {
-        if (!node) return false;
-
-        const hasText = (n: Element) =>
-          n.textContent === 'Cluster j5y9m created successfully';
-        const hasTextInChildren = Array.from(node.children).some((child) =>
-          hasText(child)
-        );
-
-        return hasText(node) && !hasTextInChildren;
-      })
+      await withMarkup(screen.findByText)('Cluster j5y9m created successfully')
     ).toBeInTheDocument();
 
     createClusterMockFn.mockRestore();
@@ -258,19 +237,8 @@ describe('ClusterCreate', () => {
       })
     );
 
-    // TODO(axbarsan): Replace with assertion utility.
     expect(
-      await screen.findByText((_, node) => {
-        if (!node) return false;
-
-        const hasText = (n: Element) =>
-          n.textContent === 'Cluster j5y9m created successfully';
-        const hasTextInChildren = Array.from(node.children).some((child) =>
-          hasText(child)
-        );
-
-        return hasText(node) && !hasTextInChildren;
-      })
+      await withMarkup(screen.findByText)('Cluster j5y9m created successfully')
     ).toBeInTheDocument();
 
     createClusterMockFn.mockRestore();
@@ -309,19 +277,8 @@ describe('ClusterCreate', () => {
 
     fireEvent.click(createButton);
 
-    // TODO(axbarsan): Replace with assertion utility.
     expect(
-      await screen.findByText((_, node) => {
-        if (!node) return false;
-
-        const hasText = (n: Element) =>
-          n.textContent === 'Cluster j5y9m created successfully';
-        const hasTextInChildren = Array.from(node.children).some((child) =>
-          hasText(child)
-        );
-
-        return hasText(node) && !hasTextInChildren;
-      })
+      await withMarkup(screen.findByText)('Cluster j5y9m created successfully')
     ).toBeInTheDocument();
   });
 });

--- a/src/components/UI/Display/Cluster/AvailabilityZones/AvailabilityZonesLabel.js
+++ b/src/components/UI/Display/Cluster/AvailabilityZones/AvailabilityZonesLabel.js
@@ -131,6 +131,7 @@ function AvailabilityZonesLabel({
           bgColor={color}
           onClick={toggleChecked}
           tabIndex={0}
+          aria-label={`Availability zone ${value}`}
         >
           {label}
         </Wrapper>

--- a/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
+++ b/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
@@ -35,17 +35,26 @@ const Wrapper = styled.span`
   }
 `;
 
-const Label = styled.span`
+const Label = styled.span<{ clusterID: string }>`
   background-color: ${(props) => colorHash.calculateColor(props.clusterID)};
   font-family: ${(props) => props.theme.fontFamilies.console};
   padding: 0.2em 0.4em;
   border-radius: 0.2em;
 `;
 
-const ClusterIDLabel = ({ clusterID, copyEnabled }) => {
+interface IClusterIDLabelProps extends React.ComponentPropsWithoutRef<'span'> {
+  clusterID: string;
+  copyEnabled?: boolean;
+}
+
+const ClusterIDLabel: React.FC<IClusterIDLabelProps> = ({
+  clusterID,
+  copyEnabled,
+  ...props
+}) => {
   const [hasContentInClipboard, setClipboardContent] = useCopyToClipboard();
 
-  const copyToClipboard = (e) => {
+  const copyToClipboard = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
     e.stopPropagation();
 
@@ -72,15 +81,15 @@ const ClusterIDLabel = ({ clusterID, copyEnabled }) => {
     </Label>
   );
 
-  const handleOnFocusKeyDown = (e) => {
+  const handleOnFocusKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
     e.preventDefault();
 
-    e.target.click();
+    (e.target as HTMLElement).click();
   };
 
   return (
     <Keyboard onSpace={handleOnFocusKeyDown} onEnter={handleOnFocusKeyDown}>
-      <Wrapper onMouseLeave={() => setClipboardContent(null)}>
+      <Wrapper onMouseLeave={() => setClipboardContent(null)} {...props}>
         {labelComponent}
 
         {copyEnabled &&
@@ -110,7 +119,7 @@ const ClusterIDLabel = ({ clusterID, copyEnabled }) => {
 };
 
 ClusterIDLabel.propTypes = {
-  clusterID: PropTypes.string,
+  clusterID: PropTypes.string.isRequired,
   copyEnabled: PropTypes.bool,
 };
 

--- a/testUtils/assertUtils.ts
+++ b/testUtils/assertUtils.ts
@@ -1,23 +1,29 @@
-import { MatcherFunction, Nullish } from '@testing-library/react';
+import {
+  BoundFunction,
+  Nullish,
+  Queries,
+  queries,
+} from '@testing-library/react';
 
-type Query = (matcher: MatcherFunction) => HTMLElement;
+type BoundQuery<Q extends Queries = typeof queries> = BoundFunction<Q[keyof Q]>;
 
 /**
  * Decorate an existing query to match text across multiple
  * elements.
  * @param query
  */
-export function withMarkup(query: Query) {
+export function withMarkup<T extends BoundQuery>(query: T) {
   return (text: string) => {
     return query((_, node: Nullish<Element>) => {
       if (!node) return false;
 
       const hasText = (n: Element) => n.textContent === text;
-      const hasTextInChildren = Array.from(node.children).some((child) =>
-        hasText(child)
-      );
+      if (!hasText(node)) return false;
 
-      return hasText(node) && !hasTextInChildren;
+      const hasTextInChildren = Array.from(node.children).some(hasText);
+      if (hasTextInChildren) return false;
+
+      return true;
     });
   };
 }


### PR DESCRIPTION
Towards giantswarm/roadmap#341

This PR adds integration tests for cluster creation logic. As with the previous PRs, these are not exhaustive, but cover the most important cases.