### PR TITLE
clusters: write tests for MAPI node pools listing/updating

### DIFF
--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -40,7 +40,7 @@ import WorkerNodesNodePoolItem from './WorkerNodesNodePoolItem';
 
 const LOADING_COMPONENTS = new Array(4).fill(0);
 
-function getAdditionalColumns(
+export function getAdditionalColumns(
   provider: PropertiesOf<typeof Providers>
 ): IWorkerNodesAdditionalColumn[] {
   if (provider === Providers.AZURE) {

--- a/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
@@ -61,7 +61,7 @@ const WorkerNodesAzureMachinePoolSpotInstances: React.FC<IWorkerNodesAzureMachin
           }
           placement='top'
         >
-          <Text aria-label='Node pool spot virtual machines status'>
+          <Text>
             <i
               role='presentation'
               className={featureEnabled ? 'fa fa-done' : 'fa fa-close'}

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -32,10 +32,18 @@ import WorkerNodesNodePoolItemScale from './WorkerNodesNodePoolItemScale';
 function formatMachineTypeLabel(providerNodePool?: ProviderNodePool) {
   switch (providerNodePool?.kind) {
     case capzexpv1alpha3.AzureMachinePool:
-      return 'Node pool VM size';
+      return `VM size: ${getProviderNodePoolMachineType(providerNodePool)}`;
     default:
       return undefined;
   }
+}
+
+function formatAvailabilityZonesLabel(zones: string[]) {
+  if (zones.length < 1) {
+    return 'Availability zones: not available';
+  }
+
+  return `Availability zones: ${zones.join(', ')}`;
 }
 
 const Row = styled(Box)<{ additionalColumnsCount?: number }>`
@@ -205,7 +213,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
           >
             {(value) => (
               <Copyable copyText={value as string}>
-                <Text aria-label='Node pool name'>
+                <Text aria-label={`Name: ${value}`}>
                   <Code>{value}</Code>
                 </Text>
               </Copyable>
@@ -230,7 +238,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
                   value={value as string}
                   typeLabel='node pool'
                   onToggleEditingState={setIsEditingDescription}
-                  aria-label='Node pool description'
+                  aria-label={`Description: ${value}`}
                   onSave={updateDescription}
                   ref={viewAndEditNameRef}
                 />
@@ -258,7 +266,12 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
                 loaderHeight={26}
               >
                 {(value) => (
-                  <AvailabilityZonesLabels zones={value} labelsChecked={[]} />
+                  <Box
+                    direction='row'
+                    aria-label={formatAvailabilityZonesLabel(value as string[])}
+                  >
+                    <AvailabilityZonesLabels zones={value} labelsChecked={[]} />
+                  </Box>
                 )}
               </ClusterDetailWidgetOptionalValue>
             </Box>
@@ -269,7 +282,9 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
               >
                 {(value) => (
                   <Box pad={{ horizontal: 'xsmall', vertical: 'xxsmall' }}>
-                    <Text aria-label='Node pool autoscaler minimum node count'>
+                    <Text
+                      aria-label={`Autoscaler minimum node count: ${value}`}
+                    >
                       {value}
                     </Text>
                   </Box>
@@ -283,7 +298,9 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
               >
                 {(value) => (
                   <Box pad={{ horizontal: 'xsmall', vertical: 'xxsmall' }}>
-                    <Text aria-label='Node pool autoscaler maximum node count'>
+                    <Text
+                      aria-label={`Autoscaler maximum node count: ${value}`}
+                    >
                       {value}
                     </Text>
                   </Box>
@@ -297,7 +314,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
               >
                 {(value) => (
                   <Box pad={{ horizontal: 'xsmall', vertical: 'xxsmall' }}>
-                    <Text aria-label='Node pool autoscaler target node count'>
+                    <Text aria-label={`Autoscaler target node count: ${value}`}>
                       {value}
                     </Text>
                   </Box>
@@ -318,7 +335,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
                     }
                   >
                     <Text
-                      aria-label='Node pool autoscaler current node count'
+                      aria-label={`Autoscaler current node count: ${value}`}
                       color={isScalingInProgress ? 'background' : undefined}
                     >
                       {value}

--- a/src/components/MAPI/workernodes/__tests__/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/__tests__/ClusterDetailWorkerNodes.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as metav1 from 'model/services/mapi/metav1';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailWorkerNodes from '../ClusterDetailWorkerNodes';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailWorkerNodes>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailWorkerNodes {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useParams: jest.fn().mockReturnValue({
+    orgId: 'org1',
+    clusterId: capiv1alpha3Mocks.randomCluster1.metadata.name,
+  }),
+}));
+
+describe('ClusterDetailWorkerNodes', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays an error message if the list of node pools could not be fetched', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/machinepools/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}`
+      )
+      .reply(StatusCodes.NotFound, {
+        apiVersion: 'v1',
+        kind: 'Status',
+        message: 'Lolz',
+        status: metav1.K8sStatuses.Failure,
+        reason: metav1.K8sStatusErrorReasons.NotFound,
+        code: StatusCodes.NotFound,
+      });
+
+    render(getComponent({}));
+
+    expect(
+      await screen.findByText('There was a problem loading node pools.')
+    ).toBeInTheDocument();
+  });
+
+  it('displays a placeholder if there are no node pools', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/${capiv1alpha3Mocks.randomCluster1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiv1alpha3Mocks.randomCluster1);
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/machinepools/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}`
+      )
+      .reply(StatusCodes.Ok, {
+        apiVersion: 'exp.cluster.x-k8s.io/v1alpha3',
+        kind: 'MachinePoolList',
+        metadata: {},
+        items: [],
+      });
+
+    render(getComponent({}));
+
+    expect(
+      await screen.findByText(
+        'Add at least one node pool to the cluster so you could run workloads'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/workernodes/__tests__/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/__tests__/WorkerNodesNodePoolItem.tsx
@@ -7,6 +7,7 @@ import nock from 'nock';
 import React from 'react';
 import { Providers, StatusCodes } from 'shared/constants';
 import { cache, SWRConfig } from 'swr';
+import { withMarkup } from 'testUtils/assertUtils';
 import * as capiexpv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3/exp';
 import * as capzexpv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3/exp';
 import { getComponentWithStore } from 'testUtils/renderUtils';
@@ -224,19 +225,10 @@ describe('WorkerNodesNodePoolItem', () => {
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Delete t6yo9' }));
 
-    // TODO(axbarsan): Replace with assertion utility.
     expect(
-      await screen.findByText((_, node) => {
-        if (!node) return false;
-
-        const hasText = (n: Element) =>
-          n.textContent === 'Node pool t6yo9 deleted successfully';
-        const hasTextInChildren = Array.from(node.children).some((child) =>
-          hasText(child)
-        );
-
-        return hasText(node) && !hasTextInChildren;
-      })
+      await withMarkup(screen.findByText)(
+        'Node pool t6yo9 deleted successfully'
+      )
     ).toBeInTheDocument();
 
     jest.clearAllTimers();
@@ -268,19 +260,10 @@ describe('WorkerNodesNodePoolItem', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'OK' }));
 
-    // TODO(axbarsan): Replace with assertion utility.
     expect(
-      await screen.findByText((_, node) => {
-        if (!node) return false;
-
-        const hasText = (n: Element) =>
-          n.textContent === `Successfully updated the node pool's description`;
-        const hasTextInChildren = Array.from(node.children).some((child) =>
-          hasText(child)
-        );
-
-        return hasText(node) && !hasTextInChildren;
-      })
+      await screen.findByText(
+        `Successfully updated the node pool's description`
+      )
     ).toBeInTheDocument();
   });
 
@@ -312,19 +295,10 @@ describe('WorkerNodesNodePoolItem', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'OK' }));
 
-    // TODO(axbarsan): Replace with assertion utility.
     expect(
-      await screen.findByText((_, node) => {
-        if (!node) return false;
-
-        const hasText = (n: Element) =>
-          n.textContent === `Successfully updated the node pool's description`;
-        const hasTextInChildren = Array.from(node.children).some((child) =>
-          hasText(child)
-        );
-
-        return hasText(node) && !hasTextInChildren;
-      })
+      await screen.findByText(
+        `Successfully updated the node pool's description`
+      )
     ).toBeInTheDocument();
   });
 
@@ -411,19 +385,10 @@ describe('WorkerNodesNodePoolItem', () => {
 
     fireEvent.click(submitButton);
 
-    // TODO(axbarsan): Replace with assertion utility.
     expect(
-      await screen.findByText((_, node) => {
-        if (!node) return false;
-
-        const hasText = (n: Element) =>
-          n.textContent === `Node pool t6yo9 updated successfully`;
-        const hasTextInChildren = Array.from(node.children).some((child) =>
-          hasText(child)
-        );
-
-        return hasText(node) && !hasTextInChildren;
-      })
+      await withMarkup(screen.findByText)(
+        'Node pool t6yo9 updated successfully'
+      )
     ).toBeInTheDocument();
 
     jest.clearAllTimers();

--- a/src/components/MAPI/workernodes/__tests__/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/__tests__/WorkerNodesNodePoolItem.tsx
@@ -1,0 +1,431 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import sub from 'date-fns/fp/sub';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as metav1 from 'model/services/mapi/metav1';
+import nock from 'nock';
+import React from 'react';
+import { Providers, StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as capiexpv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3/exp';
+import * as capzexpv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3/exp';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import { getAdditionalColumns } from '../ClusterDetailWorkerNodes';
+import WorkerNodesNodePoolItem from '../WorkerNodesNodePoolItem';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof WorkerNodesNodePoolItem>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <WorkerNodesNodePoolItem {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+describe('WorkerNodesNodePoolItem', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays a loading animation if the node pool is not loaded yet', () => {
+    render(getComponent({}));
+
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(8);
+  });
+
+  it('displays if a node pool has been deleted', () => {
+    const deletionDate = sub({
+      hours: 1,
+    })(new Date());
+
+    render(
+      getComponent({
+        nodePool: {
+          ...capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+          metadata: {
+            ...capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata,
+            deletionTimestamp: deletionDate.toISOString(),
+          },
+        },
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      })
+    );
+
+    expect(
+      screen.getByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === 'Deleted about 1 hour ago';
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('displays various information about the node pool', () => {
+    render(
+      getComponent({
+        nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      })
+    );
+
+    expect(screen.getByLabelText('Name: t6yo9')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Description: Some node pool')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('VM size: Standard_A8_v2')
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Availability zones: 1')).toBeInTheDocument();
+  });
+
+  it('displays the lack of availability zones', () => {
+    render(
+      getComponent({
+        nodePool: {
+          ...capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+          spec: {
+            ...capiexpv1alpha3Mocks.randomCluster1MachinePool1.spec!,
+            failureDomains: undefined,
+          },
+        },
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      })
+    );
+
+    expect(
+      screen.getByLabelText('Availability zones: not available')
+    ).toBeInTheDocument();
+  });
+
+  it('displays the autoscaler configuration', () => {
+    render(
+      getComponent({
+        nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      })
+    );
+
+    expect(
+      screen.getByLabelText('Autoscaler minimum node count: 3')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Autoscaler maximum node count: 10')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Autoscaler target node count: 3')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Autoscaler current node count: 2')
+    ).toBeInTheDocument();
+  });
+
+  it('displays if spot instances are used', () => {
+    const { rerender } = render(
+      getComponent({
+        nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+        additionalColumns: getAdditionalColumns(Providers.AZURE),
+      })
+    );
+
+    expect(
+      screen.getByLabelText('Spot virtual machines disabled')
+    ).toBeInTheDocument();
+
+    rerender(
+      getComponent({
+        nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+        providerNodePool: {
+          ...capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+          spec: {
+            ...capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1.spec!,
+            template: {
+              ...capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1.spec!
+                .template,
+              spotVMOptions: {
+                maxPrice: '-1',
+              },
+            },
+          },
+        },
+        additionalColumns: getAdditionalColumns(Providers.AZURE),
+      })
+    );
+
+    expect(
+      screen.getByLabelText('Spot virtual machines enabled')
+    ).toBeInTheDocument();
+  });
+
+  it('can delete a node pool', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/machinepools/${capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiexpv1alpha3Mocks.randomCluster1MachinePool1);
+
+    nock(window.config.mapiEndpoint)
+      .delete(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/machinepools/${capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, {
+        apiVersion: 'v1',
+        kind: 'Status',
+        message: 'Resource deleted.',
+        status: metav1.K8sStatuses.Success,
+        reason: '',
+        code: StatusCodes.Ok,
+      });
+
+    render(
+      getComponent({
+        nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(await screen.findByText('Delete'));
+
+    expect(
+      await screen.findByText('Do you really want to delete node pool t6yo9?')
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete t6yo9' }));
+
+    // TODO(axbarsan): Replace with assertion utility.
+    expect(
+      await screen.findByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === 'Node pool t6yo9 deleted successfully';
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+
+    jest.clearAllTimers();
+  });
+
+  it('can edit the node pool description by clicking on the description', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/machinepools/${capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiexpv1alpha3Mocks.randomCluster1MachinePool1);
+
+    nock(window.config.mapiEndpoint)
+      .put(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/machinepools/${capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiexpv1alpha3Mocks.randomCluster1MachinePool1);
+
+    render(
+      getComponent({
+        nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      })
+    );
+
+    fireEvent.click(screen.getByText('Some node pool'));
+    fireEvent.change(screen.getByDisplayValue('Some node pool'), {
+      target: { value: 'A random node pool' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+    // TODO(axbarsan): Replace with assertion utility.
+    expect(
+      await screen.findByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === `Successfully updated the node pool's description`;
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('can edit the node pool description by using the action button', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/machinepools/${capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiexpv1alpha3Mocks.randomCluster1MachinePool1);
+
+    nock(window.config.mapiEndpoint)
+      .put(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/machinepools/${capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiexpv1alpha3Mocks.randomCluster1MachinePool1);
+
+    render(
+      getComponent({
+        nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(await screen.findByText('Rename'));
+
+    fireEvent.change(screen.getByDisplayValue('Some node pool'), {
+      target: { value: 'A random node pool' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+    // TODO(axbarsan): Replace with assertion utility.
+    expect(
+      await screen.findByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === `Successfully updated the node pool's description`;
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('can change the node pool scaling', async () => {
+    // eslint-disable-next-line no-magic-numbers
+    jest.setTimeout(10000);
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/machinepools/${capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiexpv1alpha3Mocks.randomCluster1MachinePool1);
+
+    nock(window.config.mapiEndpoint)
+      .put(
+        `/apis/exp.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/machinepools/${capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, capiexpv1alpha3Mocks.randomCluster1MachinePool1);
+
+    render(
+      getComponent({
+        nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+        providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    fireEvent.click(await screen.findByText('Edit scaling limits'));
+
+    fireEvent.change(await screen.findByLabelText('Minimum'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByLabelText('Maximum'), {
+      target: { value: '1' },
+    });
+
+    expect(
+      screen.getByText(
+        'The node pool currently has 3 worker nodes running. By setting the maximum lower than that, you enforce the removal of 2 nodes. This could result in unscheduled workloads.'
+      )
+    ).toBeInTheDocument();
+
+    let submitButton = screen.getByRole('button', { name: 'Remove 2 nodes' });
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).not.toBeDisabled();
+
+    fireEvent.change(await screen.findByLabelText('Minimum'), {
+      target: { value: '4' },
+    });
+    fireEvent.change(screen.getByLabelText('Maximum'), {
+      target: { value: '4' },
+    });
+
+    expect(
+      screen.queryByText(
+        'The node pool currently has 3 worker nodes running. By setting the maximum lower than that, you enforce the removal of 2 nodes. This could result in unscheduled workloads.'
+      )
+    ).not.toBeInTheDocument();
+
+    submitButton = screen.getByRole('button', {
+      name: 'Increase minimum number of nodes by 1',
+    });
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).not.toBeDisabled();
+
+    fireEvent.change(await screen.findByLabelText('Minimum'), {
+      target: { value: '3' },
+    });
+    fireEvent.change(screen.getByLabelText('Maximum'), {
+      target: { value: '20' },
+    });
+
+    expect(
+      screen.queryByText(
+        'The node pool currently has 3 worker nodes running. By setting the maximum lower than that, you enforce the removal of 2 nodes. This could result in unscheduled workloads.'
+      )
+    ).not.toBeInTheDocument();
+
+    submitButton = screen.getByRole('button', {
+      name: 'Apply',
+    });
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).not.toBeDisabled();
+
+    fireEvent.click(submitButton);
+
+    // TODO(axbarsan): Replace with assertion utility.
+    expect(
+      await screen.findByText((_, node) => {
+        if (!node) return false;
+
+        const hasText = (n: Element) =>
+          n.textContent === `Node pool t6yo9 updated successfully`;
+        const hasTextInChildren = Array.from(node.children).some((child) =>
+          hasText(child)
+        );
+
+        return hasText(node) && !hasTextInChildren;
+      })
+    ).toBeInTheDocument();
+
+    jest.clearAllTimers();
+  });
+});

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -105,7 +105,9 @@ export async function deleteNodePool(
           },
         },
       }),
-      produce((draft: capiexpv1alpha3.IMachinePoolList) => {
+      produce((draft?: capiexpv1alpha3.IMachinePoolList) => {
+        if (!draft) return;
+
         for (let i = 0; i < draft.items.length; i++) {
           if (draft.items[i].metadata.name === machinePool.metadata.name) {
             draft.items[i] = machinePool;
@@ -171,7 +173,7 @@ export async function updateNodePoolScaling(
       machinePool
     );
 
-    // Update the deleted machine pool in place.
+    // Update the updated machine pool in place.
     mutate(
       capiexpv1alpha3.getMachinePoolListKey({
         labelSelector: {
@@ -182,7 +184,9 @@ export async function updateNodePoolScaling(
           },
         },
       }),
-      produce((draft: capiexpv1alpha3.IMachinePoolList) => {
+      produce((draft?: capiexpv1alpha3.IMachinePoolList) => {
+        if (!draft) return;
+
         for (let i = 0; i < draft.items.length; i++) {
           if (draft.items[i].metadata.name === machinePool.metadata.name) {
             draft.items[i] = machinePool;
@@ -190,8 +194,6 @@ export async function updateNodePoolScaling(
         }
 
         draft.items = draft.items.sort(compareNodePools);
-
-        return draft;
       }),
       false
     );
@@ -415,11 +417,11 @@ export async function createNodePool(
           },
         },
       }),
-      produce((draft: capiexpv1alpha3.IMachinePoolList) => {
+      produce((draft?: capiexpv1alpha3.IMachinePoolList) => {
+        if (!draft) return;
+
         draft.items.push(nodePool);
         draft.items = draft.items.sort(compareNodePools);
-
-        return draft;
       }),
       false
     );

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
@@ -49,6 +49,7 @@ const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = (
             onClick={onClickHandler}
             onKeyDown={onKeyDownHandler}
             type='button'
+            aria-label='Actions'
           >
             &bull;&bull;&bull;
           </StyledDropdownTrigger>
@@ -59,7 +60,7 @@ const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> = (
               onSpace={handleListKeyDown}
               onEnter={handleListKeyDown}
             >
-              <List aria-label='Node pool actions' role='menu'>
+              <List role='menu'>
                 {onRenameClick && (
                   <li>
                     <Link

--- a/testUtils/mockHttpCalls/capiv1alpha3/exp/machinePools.ts
+++ b/testUtils/mockHttpCalls/capiv1alpha3/exp/machinePools.ts
@@ -7,7 +7,7 @@ export const randomCluster1MachinePool1: capiexpv1alpha3.IMachinePool = {
     annotations: {
       'cluster.k8s.io/cluster-api-autoscaler-node-group-max-size': '10',
       'cluster.k8s.io/cluster-api-autoscaler-node-group-min-size': '3',
-      'machine-pool.giantswarm.io/name': 'Unnamed node pool',
+      'machine-pool.giantswarm.io/name': 'Some node pool',
       'release.giantswarm.io/last-deployed-version': '14.1.5',
     },
     creationTimestamp: '2021-04-27T16:07:38Z',


### PR DESCRIPTION
Towards giantswarm/roadmap#341

This PR adds integration tests for MAPI node pool listing/updating logic. As with the previous PRs, these are not exhaustive, but cover the most important cases.