### PR TITLE
clusters: write tests for MAPI node pool creation

### DIFF
--- a/src/components/Cluster/ClusterDetail/InstanceTypeSelector/InstanceTypeRow.tsx
+++ b/src/components/Cluster/ClusterDetail/InstanceTypeSelector/InstanceTypeRow.tsx
@@ -1,5 +1,8 @@
 import { Text } from 'grommet';
-import { IInstanceType } from 'lib/hooks/useInstanceTypeSelectionConfiguration';
+import {
+  IInstanceType,
+  useInstanceTypeSelectionLabels,
+} from 'lib/hooks/useInstanceTypeSelectionConfiguration';
 import PropTypes from 'prop-types';
 import React, { FC } from 'react';
 import RUMActionTarget from 'RUM/RUMActionTarget';
@@ -43,6 +46,8 @@ const InstanceTypeRow: FC<IInstanceTypeRow> = ({
   isSelected,
   selectInstanceType,
 }) => {
+  const { singular } = useInstanceTypeSelectionLabels();
+
   const handleTabSelect = (e: React.KeyboardEvent<HTMLTableRowElement>) => {
     // Handle tapping the space bar.
     if (e.key === ' ') {
@@ -58,6 +63,7 @@ const InstanceTypeRow: FC<IInstanceTypeRow> = ({
       role='radio'
       aria-checked={isSelected}
       onKeyDown={handleTabSelect}
+      aria-label={`${singular} ${name}`}
     >
       <TableCell>
         <RUMActionTarget name={RUMActions.SelectInstanceType}>

--- a/src/components/Cluster/ClusterDetail/InstanceTypeSelector/InstanceTypeSelector.tsx
+++ b/src/components/Cluster/ClusterDetail/InstanceTypeSelector/InstanceTypeSelector.tsx
@@ -48,7 +48,7 @@ const InstanceTypeSelector: FC<IInstanceTypeSelector> = ({
   selectedInstanceType,
 }) => {
   const [collapsed, setCollapsed] = useState(true);
-  const { plural } = useInstanceTypeSelectionLabels();
+  const { singular, plural } = useInstanceTypeSelectionLabels();
   const { cpu, ram } = useInstanceTypeCapabilities(selectedInstanceType);
   const allowedInstanceTypes = useAllowedInstanceTypes();
 
@@ -70,7 +70,9 @@ const InstanceTypeSelector: FC<IInstanceTypeSelector> = ({
   return (
     <>
       <SelectedWrapper>
-        <SelectedInstanceTypeItem>
+        <SelectedInstanceTypeItem
+          aria-label={`The currently selected ${singular} is ${selectedInstanceType}`}
+        >
           <SelectedInstanceType>{selectedInstanceType}</SelectedInstanceType>
         </SelectedInstanceTypeItem>
         <SelectedDescription>

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolAvailabilityZones.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolAvailabilityZones.tsx
@@ -149,7 +149,7 @@ const WorkerNodesCreateNodePoolAvailabilityZones: React.FC<IWorkerNodesCreateNod
   };
 
   return (
-    <InputGroup htmlFor={id} label='Availability zones selection' {...props}>
+    <InputGroup htmlFor={id} label='Availability zones' {...props}>
       {controlPlaneZones && (
         <AZSelection
           variant={AZSelectionVariants.NodePool}

--- a/src/components/MAPI/workernodes/__tests__/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/__tests__/WorkerNodesCreateNodePool.tsx
@@ -1,0 +1,484 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as MAPIUtils from 'MAPI/utils';
+import nock from 'nock';
+import React from 'react';
+import { Providers, StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import { withMarkup } from 'testUtils/assertUtils';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import * as capiexpv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3/exp';
+import * as capzv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3';
+import * as capzexpv1alpha3Mocks from 'testUtils/mockHttpCalls/capzv1alpha3/exp';
+import * as gscorev1alpha1Mocks from 'testUtils/mockHttpCalls/gscorev1alpha1';
+import preloginState from 'testUtils/preloginState';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import * as NodePoolUtils from '../utils';
+import WorkerNodesCreateNodePool from '../WorkerNodesCreateNodePool';
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof WorkerNodesCreateNodePool>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <WorkerNodesCreateNodePool {...p} />
+    </SWRConfig>
+  );
+
+  const state = {
+    ...preloginState,
+    main: {
+      ...preloginState.main,
+      info: {
+        ...preloginState.main.info,
+        general: {
+          ...preloginState.main.info.general,
+          availability_zones: {
+            default: 1,
+            max: 3,
+            zones: ['1', '2', '3'],
+          },
+          provider: Providers.AZURE,
+        },
+        workers: {
+          ...preloginState.main.info.workers,
+          vm_size: {
+            options: [
+              'Standard_D4s_v3',
+              'Standard_A2_v2',
+              'Standard_A4_v2',
+              'Standard_A8_v2',
+            ],
+          },
+        },
+      },
+    },
+  };
+
+  return getComponentWithStore(
+    Component,
+    props,
+    state,
+    undefined,
+    history,
+    auth
+  );
+}
+
+const generateUIDMockFn = jest.spyOn(MAPIUtils, 'generateUID');
+generateUIDMockFn.mockReturnValue(
+  capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata.name
+);
+
+describe('WorkerNodesCreateNodePool', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(
+      getComponent({
+        open: true,
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+        id: 'test',
+      })
+    );
+  });
+
+  it('can see the name that the resource will get', () => {
+    render(
+      getComponent({
+        open: true,
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+        id: 'test',
+      })
+    );
+
+    expect(screen.getByLabelText('Name')).toHaveValue('t6yo9');
+  });
+
+  it('can set the description', async () => {
+    const createNodePoolMockFn = jest.spyOn(NodePoolUtils, 'createNodePool');
+    createNodePoolMockFn.mockResolvedValue({
+      nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+      providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      bootstrapConfig: gscorev1alpha1Mocks.randomCluster1MachinePool1Spark,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
+
+    render(
+      getComponent({
+        open: true,
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+        id: 'test',
+      })
+    );
+
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'A new description' },
+    });
+
+    const createButton = screen.getByRole('button', {
+      name: 'Create node pool',
+    });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(createNodePoolMockFn).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        nodePool: expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              'machine-pool.giantswarm.io/name': 'A new description',
+            }),
+          }),
+        }),
+      })
+    );
+
+    expect(
+      await withMarkup(screen.findByText)(
+        'Node pool t6yo9 created successfully'
+      )
+    ).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => screen.getByRole('progressbar'));
+
+    createNodePoolMockFn.mockRestore();
+  });
+
+  it('can set the vm size', async () => {
+    const createNodePoolMockFn = jest.spyOn(NodePoolUtils, 'createNodePool');
+    createNodePoolMockFn.mockResolvedValue({
+      nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+      providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      bootstrapConfig: gscorev1alpha1Mocks.randomCluster1MachinePool1Spark,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
+
+    render(
+      getComponent({
+        open: true,
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+        id: 'test',
+      })
+    );
+
+    // Has the default VM size selected by default.
+    expect(
+      await screen.findByLabelText(
+        'The currently selected VM size is Standard_D4s_v3'
+      )
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Available VM sizes'));
+    fireEvent.click(screen.getByLabelText('VM size Standard_A8_v2'));
+
+    const createButton = screen.getByRole('button', {
+      name: 'Create node pool',
+    });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(createNodePoolMockFn).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        providerNodePool: expect.objectContaining({
+          spec: expect.objectContaining({
+            template: expect.objectContaining({
+              vmSize: 'Standard_A8_v2',
+            }),
+          }),
+        }),
+      })
+    );
+
+    expect(
+      await withMarkup(screen.findByText)(
+        'Node pool t6yo9 created successfully'
+      )
+    ).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => screen.getByRole('progressbar'));
+
+    createNodePoolMockFn.mockRestore();
+  });
+
+  it('can configure the availability zone', async () => {
+    const createNodePoolMockFn = jest.spyOn(NodePoolUtils, 'createNodePool');
+    createNodePoolMockFn.mockResolvedValue({
+      nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+      providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      bootstrapConfig: gscorev1alpha1Mocks.randomCluster1MachinePool1Spark,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
+
+    render(
+      getComponent({
+        open: true,
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+        id: 'test',
+      })
+    );
+
+    fireEvent.click(await screen.findByText('Manual selection'));
+    fireEvent.click(await screen.findByLabelText('Availability zone 2'));
+    fireEvent.click(await screen.findByLabelText('Availability zone 3'));
+
+    const createButton = screen.getByRole('button', {
+      name: 'Create node pool',
+    });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(createNodePoolMockFn).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        nodePool: expect.objectContaining({
+          spec: expect.objectContaining({
+            failureDomains: ['2', '3'],
+          }),
+        }),
+      })
+    );
+
+    expect(
+      await withMarkup(screen.findByText)(
+        'Node pool t6yo9 created successfully'
+      )
+    ).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => screen.getByRole('progressbar'));
+
+    createNodePoolMockFn.mockRestore();
+  });
+
+  it('can configure the autoscaler', async () => {
+    const createNodePoolMockFn = jest.spyOn(NodePoolUtils, 'createNodePool');
+    createNodePoolMockFn.mockResolvedValue({
+      nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+      providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      bootstrapConfig: gscorev1alpha1Mocks.randomCluster1MachinePool1Spark,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
+
+    render(
+      getComponent({
+        open: true,
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+        id: 'test',
+      })
+    );
+
+    fireEvent.change(await screen.findByLabelText('Minimum'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByLabelText('Maximum'), {
+      target: { value: '5' },
+    });
+
+    const createButton = screen.getByRole('button', {
+      name: 'Create node pool',
+    });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(createNodePoolMockFn).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        nodePool: expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({
+              'cluster.k8s.io/cluster-api-autoscaler-node-group-min-size': '1',
+              'cluster.k8s.io/cluster-api-autoscaler-node-group-max-size': '5',
+            }),
+          }),
+          spec: expect.objectContaining({
+            replicas: 1,
+          }),
+        }),
+      })
+    );
+
+    expect(
+      await withMarkup(screen.findByText)(
+        'Node pool t6yo9 created successfully'
+      )
+    ).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => screen.getByRole('progressbar'));
+
+    createNodePoolMockFn.mockRestore();
+  });
+
+  it('can configure spot VMs', async () => {
+    const createNodePoolMockFn = jest.spyOn(NodePoolUtils, 'createNodePool');
+    createNodePoolMockFn.mockResolvedValue({
+      nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+      providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      bootstrapConfig: gscorev1alpha1Mocks.randomCluster1MachinePool1Spark,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
+
+    render(
+      getComponent({
+        open: true,
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+        id: 'test',
+      })
+    );
+
+    fireEvent.click(await screen.findByText('Spot virtual machines'));
+    fireEvent.click(
+      await screen.findByText('Use the on-demand price as limit')
+    );
+
+    fireEvent.change(screen.getByLabelText('Price limit'), {
+      target: { value: '0.0035' },
+    });
+
+    const createButton = screen.getByRole('button', {
+      name: 'Create node pool',
+    });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(createNodePoolMockFn).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        providerNodePool: expect.objectContaining({
+          spec: expect.objectContaining({
+            template: expect.objectContaining({
+              spotVMOptions: {
+                maxPrice: '0.0035',
+              },
+            }),
+          }),
+        }),
+      })
+    );
+
+    expect(
+      await withMarkup(screen.findByText)(
+        'Node pool t6yo9 created successfully'
+      )
+    ).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => screen.getByRole('progressbar'));
+
+    createNodePoolMockFn.mockRestore();
+  });
+
+  it('creates a nod epool with default options', async () => {
+    const createNodePoolMockFn = jest.spyOn(NodePoolUtils, 'createNodePool');
+    createNodePoolMockFn.mockResolvedValue({
+      nodePool: capiexpv1alpha3Mocks.randomCluster1MachinePool1,
+      providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
+      bootstrapConfig: gscorev1alpha1Mocks.randomCluster1MachinePool1Spark,
+    });
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
+
+    render(
+      getComponent({
+        open: true,
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
+        id: 'test',
+      })
+    );
+
+    const createButton = screen.getByRole('button', {
+      name: 'Create node pool',
+    });
+
+    await waitFor(() => {
+      expect(createButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(createButton);
+
+    expect(
+      await withMarkup(screen.findByText)(
+        'Node pool t6yo9 created successfully'
+      )
+    ).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() => screen.getByRole('progressbar'));
+
+    createNodePoolMockFn.mockRestore();
+  });
+});

--- a/testUtils/mockHttpCalls/gscorev1alpha1/index.ts
+++ b/testUtils/mockHttpCalls/gscorev1alpha1/index.ts
@@ -1,0 +1,1 @@
+export * from './sparks';

--- a/testUtils/mockHttpCalls/gscorev1alpha1/sparks.ts
+++ b/testUtils/mockHttpCalls/gscorev1alpha1/sparks.ts
@@ -1,0 +1,73 @@
+import * as gscorev1alpha1 from 'model/services/mapi/gscorev1alpha1';
+
+export const randomCluster1MachinePool1Spark: gscorev1alpha1.ISpark = {
+  apiVersion: 'core.giantswarm.io/v1alpha1',
+  kind: 'Spark',
+  metadata: {
+    namespace: 'org-org1',
+    name: 't6yo9',
+    labels: {
+      'cluster.x-k8s.io/cluster-name': 'j5y9m',
+      'giantswarm.io/cluster': 'j5y9m',
+    },
+  },
+  spec: {},
+  status: {
+    ready: true,
+    failureMessage: '',
+    dataSecretName: '',
+    failureReason: '',
+    verification: {
+      hash: '',
+      algorithm: '',
+    },
+  },
+};
+
+export const randomCluster1MachinePool2Spark: gscorev1alpha1.ISpark = {
+  apiVersion: 'core.giantswarm.io/v1alpha1',
+  kind: 'Spark',
+  metadata: {
+    namespace: 'org-org1',
+    name: 'f029a',
+    labels: {
+      'cluster.x-k8s.io/cluster-name': 'j5y9m',
+      'giantswarm.io/cluster': 'j5y9m',
+    },
+  },
+  spec: {},
+  status: {
+    ready: true,
+    failureMessage: '',
+    dataSecretName: '',
+    failureReason: '',
+    verification: {
+      hash: '',
+      algorithm: '',
+    },
+  },
+};
+
+export const randomCluster2MachinePool1Spark: gscorev1alpha1.ISpark = {
+  apiVersion: 'core.giantswarm.io/v1alpha1',
+  kind: 'Spark',
+  metadata: {
+    namespace: 'org-org1',
+    name: 't6yo9',
+    labels: {
+      'cluster.x-k8s.io/cluster-name': 'as43z',
+      'giantswarm.io/cluster': 'as43z',
+    },
+  },
+  spec: {},
+  status: {
+    ready: true,
+    failureMessage: '',
+    dataSecretName: '',
+    failureReason: '',
+    verification: {
+      hash: '',
+      algorithm: '',
+    },
+  },
+};


### PR DESCRIPTION
Towards giantswarm/roadmap#341

This PR adds integration tests for the MAPI node pool creation logic. As with the previous PRs, these are not exhaustive, but cover the most important cases.