### PR TITLE
clusters: display MAPI cluster release version k8s component version as `n/a` when the release cannot be found

### DIFF
--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -108,10 +108,12 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
   const k8sVersion = useMemo(() => {
     const formattedReleaseVersion = `v${releaseVersion}`;
 
-    const release = releases?.find(
+    if (!releases) return undefined;
+
+    const release = releases.find(
       (r) => r.metadata.name === formattedReleaseVersion
     );
-    if (!release) return undefined;
+    if (!release) return '';
 
     const version = releasev1alpha1.getK8sVersion(release);
     if (typeof version === 'undefined') return '';


### PR DESCRIPTION
In the current implementation, in the MAPI cluster listing, if the `Release` CR that corresponds to the cluster's release version is not found, the k8s version will have an infinite loading animation. This PR fixes that.

### Before

![image](https://user-images.githubusercontent.com/13508038/125790301-e5539b01-748e-4fd1-84c4-cb14e468a587.png)

### After

![image](https://user-images.githubusercontent.com/13508038/125790359-133c6863-3fcd-4692-9a42-ec75717d6f1e.png)
