### PR TITLE
releases: use app `componentVersion` property where available in the MAPI world

### DIFF
--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -2,6 +2,7 @@ import ErrorReporter from 'lib/errors/ErrorReporter';
 import { HttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
 import { VersionImpl } from 'lib/Version';
+import * as releasesUtils from 'MAPI/releases/utils';
 import { GenericResponse } from 'model/clients/GenericResponse';
 import { IHttpClient } from 'model/clients/HttpClient';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
@@ -487,20 +488,11 @@ export function mapDefaultApps(release?: releasev1alpha1.IRelease) {
     ingress: {},
   };
 
-  const releaseComponents: (
-    | releasev1alpha1.IReleaseSpecComponent
-    | releasev1alpha1.IReleaseSpecApp
-  )[] = [];
+  const releaseComponents = release
+    ? releasesUtils.reduceReleaseToComponents(release)
+    : {};
 
-  if (release?.spec.components) {
-    releaseComponents.push(...release.spec.components);
-  }
-
-  if (release?.spec.apps) {
-    releaseComponents.push(...release.spec.apps);
-  }
-
-  for (const { name, version } of releaseComponents) {
+  for (const { name, version } of Object.values(releaseComponents)) {
     if (!AppConstants.appMetas.hasOwnProperty(name)) continue;
 
     let appMeta = AppConstants.appMetas[name];

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterRelease.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterRelease.tsx
@@ -5,6 +5,7 @@ import ReleaseSelector, {
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { useHttpClient } from 'lib/hooks/useHttpClient';
 import { extractErrorMessage } from 'MAPI/organizations/utils';
+import * as releasesUtils from 'MAPI/releases/utils';
 import { Cluster } from 'MAPI/types';
 import { getClusterReleaseVersion } from 'MAPI/utils';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
@@ -67,16 +68,13 @@ const CreateClusterRelease: React.FC<ICreateClusterReleaseProps> = ({
           return acc;
         }
 
-        const components = curr.spec.components.slice();
-        if (curr.spec.apps) {
-          components.push(...curr.spec.apps);
-        }
+        const components = releasesUtils.reduceReleaseToComponents(curr);
 
         acc[normalizedVersion] = {
           version: normalizedVersion,
           active: isActive,
           timestamp: curr.metadata.creationTimestamp ?? '',
-          components,
+          components: Object.values(components),
           kubernetesVersion: releasev1alpha1.getK8sVersion(curr),
           releaseNotesURL: releasev1alpha1.getReleaseNotesURL(curr),
         };

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -6,7 +6,10 @@ import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import * as clusterDetailUtils from 'MAPI/clusters/ClusterDetail/utils';
 import { isClusterCreating, isClusterUpgrading } from 'MAPI/clusters/utils';
 import { extractErrorMessage } from 'MAPI/organizations/utils';
-import * as releasesUtils from 'MAPI/releases/utils';
+import {
+  getSupportedUpgradeVersions,
+  reduceReleaseToComponents,
+} from 'MAPI/releases/utils';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import PropTypes from 'prop-types';
@@ -112,7 +115,7 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
   const supportedUpgradeVersions: ui.IReleaseVersion[] = useMemo(() => {
     if (!releaseList || !releaseVersion) return [];
 
-    return releasesUtils.getSupportedUpgradeVersions(
+    return getSupportedUpgradeVersions(
       releaseVersion,
       provider,
       isAdmin,
@@ -151,10 +154,7 @@ const ClusterDetailWidgetRelease: React.FC<IClusterDetailWidgetReleaseProps> = (
   const releaseComponents = useMemo(() => {
     if (!currentRelease) return undefined;
 
-    return [
-      ...currentRelease.spec.components,
-      ...(currentRelease.spec.apps ?? []),
-    ];
+    return Object.values(reduceReleaseToComponents(currentRelease));
   }, [currentRelease]);
 
   const releaseNotesURL = currentRelease

--- a/src/components/MAPI/releases/__tests__/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/__tests__/ClusterDetailWidgetRelease.tsx
@@ -6,6 +6,7 @@ import {
 } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as releasesUtils from 'MAPI/releases/utils';
 import nock from 'nock';
 import React from 'react';
 import { StatusCodes } from 'shared/constants';
@@ -92,11 +93,10 @@ describe('ClusterDetailWidgetRelease', () => {
 
     expect(await screen.findByText('Details for release 14.1.5'));
 
-    const components = [
-      ...releasev1alpha1Mocks.v14_1_5.spec.components,
-      ...releasev1alpha1Mocks.v14_1_5.spec.apps!,
-    ];
-    for (const component of components) {
+    const components = releasesUtils.reduceReleaseToComponents(
+      releasev1alpha1Mocks.v14_1_5
+    );
+    for (const component of Object.values(components)) {
       expect(
         screen.getByLabelText(`${component.name} version ${component.version}`)
       ).toBeInTheDocument();

--- a/src/components/MAPI/releases/__tests__/utils.ts
+++ b/src/components/MAPI/releases/__tests__/utils.ts
@@ -230,20 +230,8 @@ describe('releases::utils', () => {
           {
             changeType: 1,
             component: 'coredns',
-            newVersion: '1.4.1',
-            oldVersion: '1.2.0',
-          },
-          {
-            changeType: 1,
-            component: 'external-dns',
-            newVersion: '2.3.1',
-            oldVersion: '2.3.0',
-          },
-          {
-            changeType: 1,
-            component: 'kube-state-metrics',
-            newVersion: '1.3.1',
-            oldVersion: '1.3.0',
+            newVersion: '1.8.0',
+            oldVersion: '1.6.5',
           },
           {
             changeType: 1,
@@ -262,12 +250,6 @@ describe('releases::utils', () => {
             component: 'net-exporter',
             newVersion: '1.10.1',
             oldVersion: '1.9.2',
-          },
-          {
-            changeType: 1,
-            component: 'node-exporter',
-            newVersion: '1.7.2',
-            oldVersion: '1.7.1',
           },
         ],
       } as ui.IReleaseComponentsDiff);

--- a/src/components/MAPI/releases/utils.ts
+++ b/src/components/MAPI/releases/utils.ts
@@ -77,7 +77,7 @@ interface IComponent {
   version: string;
 }
 
-function reduceReleaseToComponents(
+export function reduceReleaseToComponents(
   release: releasev1alpha1.IRelease
 ): Record<string, IComponent> {
   const components: Record<string, IComponent> = {};
@@ -93,7 +93,7 @@ function reduceReleaseToComponents(
     for (const component of release.spec.apps) {
       components[component.name] = {
         name: component.name,
-        version: component.version,
+        version: component.componentVersion ?? component.version,
       };
     }
   }


### PR DESCRIPTION
This was different compared to the GS API implementation, because for release managed apps (such as `external-dns`), we would see the app version, and not the underlying component version (we would see the version of the `external-dns` GS app, and not the version of upstream `external-dns` used). This was also the case for release upgrade diffs.

Previous `cluster-service` implementation
https://github.com/giantswarm/cluster-service/blob/c457bd785a5bd61520b019bba8a00357534f46ee/server/endpoint/release/lister/endpoint.go#L105

With this PR, we use the `app.componentVersion` when available, and we fallback to `app.version` when not.