### PR TITLE
Control MAPI cluster management feature flag from the config repo

### DIFF
--- a/helm/happa/Chart.yaml
+++ b/helm/happa/Chart.yaml
@@ -6,4 +6,4 @@ home: https://github.com/giantswarm/happa
 version: [[ .Version ]]
 appVersion: [[ .AppVersion ]]
 annotations:
-  config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: "add-happa-mapi-clusters-feature-flag"

--- a/helm/happa/Chart.yaml
+++ b/helm/happa/Chart.yaml
@@ -6,4 +6,4 @@ home: https://github.com/giantswarm/happa
 version: [[ .Version ]]
 appVersion: [[ .AppVersion ]]
 annotations:
-  config.giantswarm.io/version: "add-happa-mapi-clusters-feature-flag"
+  config.giantswarm.io/version: 1.x.x

--- a/helm/happa/templates/configmap.yaml
+++ b/helm/happa/templates/configmap.yaml
@@ -38,4 +38,4 @@ data:
   {{ else }}
   feature-mapi-auth: 'FALSE'
   {{ end }}
-  feature-mapi-clusters: 'FALSE'
+  feature-mapi-clusters: {{ .Values.happa.featureFlags.mapiClusters | quote | upper }}

--- a/helm/happa/values.yaml
+++ b/helm/happa/values.yaml
@@ -38,6 +38,8 @@ happa:
   address: ""
   host: ""
   letsencrypt: ""
+  featureFlags:
+    mapiClusters: false
 
 happaapi:
   address: ""


### PR DESCRIPTION
Needs https://github.com/giantswarm/config/pull/270/

This PR makes the MAPI cluster management feature flag controlled by the `giantswarm/config` repo.