### PR TITLE
Fix cluster name in MAPI UI to display `Cluster name` label on hover.

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -27,7 +27,9 @@ import Tabs from 'shared/Tabs';
 import { getProvider } from 'stores/main/selectors';
 import styled from 'styled-components';
 import useSWR from 'swr';
-import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
+import ClusterIDLabel, {
+  ClusterIDLabelType,
+} from 'UI/Display/Cluster/ClusterIDLabel';
 import ClusterDetailWidgetOptionalValue from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue';
 import ViewAndEditName from 'UI/Inputs/ViewEditName';
 
@@ -199,7 +201,11 @@ const ClusterDetail: React.FC<{}> = () => {
       <Box>
         <Heading level={1} margin={{ bottom: 'large' }}>
           <Box direction='row' align='center'>
-            <ClusterIDLabel clusterID={clusterId} copyEnabled={true} />{' '}
+            <ClusterIDLabel
+              clusterID={clusterId}
+              copyEnabled={true}
+              variant={ClusterIDLabelType.Name}
+            />{' '}
             <ClusterDetailWidgetOptionalValue
               value={clusterDescription}
               loaderHeight={35}

--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -26,7 +26,9 @@ import { getProvider, getUserIsAdmin } from 'stores/main/selectors';
 import styled from 'styled-components';
 import useSWR from 'swr';
 import Button from 'UI/Controls/Button';
-import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
+import ClusterIDLabel, {
+  ClusterIDLabelType,
+} from 'UI/Display/Cluster/ClusterIDLabel';
 import ClusterListItemMainInfo from 'UI/Display/MAPI/clusters/ClusterList/ClusterListItemMainInfo';
 import ClusterListItemNodeInfo from 'UI/Display/MAPI/clusters/ClusterList/ClusterListItemNodeInfo';
 import ClusterListItemOptionalValue from 'UI/Display/MAPI/clusters/ClusterList/ClusterListItemOptionalValue';
@@ -226,6 +228,7 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
                 <Text size='large' aria-label={`Name: ${value}`}>
                   <ClusterIDLabel
                     clusterID={value as string}
+                    variant={ClusterIDLabelType.Name}
                     copyEnabled={true}
                   />
                 </Text>

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterName.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterName.tsx
@@ -2,7 +2,9 @@ import { Box, Text } from 'grommet';
 import { Cluster } from 'MAPI/types';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
+import ClusterIDLabel, {
+  ClusterIDLabelType,
+} from 'UI/Display/Cluster/ClusterIDLabel';
 
 import { IClusterPropertyProps } from './patches';
 
@@ -25,6 +27,7 @@ const CreateClusterName: React.FC<ICreateClusterNameProps> = ({
       </Text>
       <ClusterIDLabel
         clusterID={cluster.metadata.name}
+        variant={ClusterIDLabelType.Name}
         aria-label={`Cluster name: ${cluster.metadata.name}`}
       />
     </Box>

--- a/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
+++ b/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
@@ -56,7 +56,7 @@ interface IClusterIDLabelProps extends React.ComponentPropsWithoutRef<'span'> {
 const ClusterIDLabel: React.FC<IClusterIDLabelProps> = ({
   clusterID,
   copyEnabled,
-  variant = ClusterIDLabelType.ID,
+  variant,
   ...props
 }) => {
   const [hasContentInClipboard, setClipboardContent] = useCopyToClipboard();
@@ -129,6 +129,10 @@ ClusterIDLabel.propTypes = {
   clusterID: PropTypes.string.isRequired,
   copyEnabled: PropTypes.bool,
   variant: PropTypes.oneOf(Object.values(ClusterIDLabelType)),
+};
+
+ClusterIDLabel.defaultProps = {
+  variant: ClusterIDLabelType.ID,
 };
 
 export default ClusterIDLabel;

--- a/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
+++ b/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
@@ -42,14 +42,21 @@ const Label = styled.span<{ clusterID: string }>`
   border-radius: 0.2em;
 `;
 
+export enum ClusterIDLabelType {
+  Name = 'name',
+  ID = 'ID',
+}
+
 interface IClusterIDLabelProps extends React.ComponentPropsWithoutRef<'span'> {
   clusterID: string;
   copyEnabled?: boolean;
+  variant?: ClusterIDLabelType;
 }
 
 const ClusterIDLabel: React.FC<IClusterIDLabelProps> = ({
   clusterID,
   copyEnabled,
+  variant = ClusterIDLabelType.ID,
   ...props
 }) => {
   const [hasContentInClipboard, setClipboardContent] = useCopyToClipboard();
@@ -70,9 +77,7 @@ const ClusterIDLabel: React.FC<IClusterIDLabelProps> = ({
     <Label clusterID={clusterID}>
       <OverlayTrigger
         overlay={
-          <Tooltip id='idtooltip'>
-            <>Cluster name: {clusterID}</>
-          </Tooltip>
+          <Tooltip id='idtooltip'>{`Cluster ${variant}: ${clusterID}`}</Tooltip>
         }
         placement='top'
       >
@@ -101,7 +106,9 @@ const ClusterIDLabel: React.FC<IClusterIDLabelProps> = ({
             />
           ) : (
             <OverlayTrigger
-              overlay={<Tooltip id='tooltip'>Copy name to clipboard</Tooltip>}
+              overlay={
+                <Tooltip id='tooltip'>{`Copy ${variant} to clipboard`}</Tooltip>
+              }
               placement='top'
             >
               <i
@@ -121,6 +128,7 @@ const ClusterIDLabel: React.FC<IClusterIDLabelProps> = ({
 ClusterIDLabel.propTypes = {
   clusterID: PropTypes.string.isRequired,
   copyEnabled: PropTypes.bool,
+  variant: PropTypes.oneOf(Object.values(ClusterIDLabelType)),
 };
 
 export default ClusterIDLabel;

--- a/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
+++ b/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
@@ -71,7 +71,7 @@ const ClusterIDLabel: React.FC<IClusterIDLabelProps> = ({
       <OverlayTrigger
         overlay={
           <Tooltip id='idtooltip'>
-            <>Cluster ID: {clusterID}</>
+            <>Cluster name: {clusterID}</>
           </Tooltip>
         }
         placement='top'
@@ -101,7 +101,7 @@ const ClusterIDLabel: React.FC<IClusterIDLabelProps> = ({
             />
           ) : (
             <OverlayTrigger
-              overlay={<Tooltip id='tooltip'>Copy ID to clipboard</Tooltip>}
+              overlay={<Tooltip id='tooltip'>Copy name to clipboard</Tooltip>}
               placement='top'
             >
               <i

--- a/src/components/UI/Display/Cluster/ClusterIDLabel/stories/ClusterIDLabel.stories.tsx
+++ b/src/components/UI/Display/Cluster/ClusterIDLabel/stories/ClusterIDLabel.stories.tsx
@@ -1,12 +1,16 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import React, { ComponentPropsWithoutRef } from 'react';
 
-import ClusterIDLabel from '..';
+import ClusterIDLabel, { ClusterIDLabelType } from '..';
 
 const Template: Story<ComponentPropsWithoutRef<typeof ClusterIDLabel>> = (
   args
 ) => (
-  <ClusterIDLabel clusterID={args.clusterID} copyEnabled={args.copyEnabled} />
+  <ClusterIDLabel
+    clusterID={args.clusterID}
+    copyEnabled={args.copyEnabled}
+    variant={args.variant}
+  />
 );
 
 export const Normal = Template.bind({});
@@ -29,6 +33,19 @@ export const CopyEnabledTruncated = Template.bind({});
 CopyEnabledTruncated.args = {
   clusterID: 'another-long-cluster-id',
   copyEnabled: true,
+};
+
+export const NameVariant = Template.bind({});
+NameVariant.args = {
+  clusterID: 'rh62p',
+  variant: ClusterIDLabelType.Name,
+};
+
+export const NameVariantCopyEnabled = Template.bind({});
+NameVariantCopyEnabled.args = {
+  clusterID: 'rh62p',
+  copyEnabled: true,
+  variant: ClusterIDLabelType.Name,
 };
 
 export default {


### PR DESCRIPTION
Closes [giantswarm/giantswarm#18138](https://github.com/giantswarm/giantswarm/issues/18138)