### PR TITLE
change right single quatation mark to single quatation mark

### DIFF
--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppForm.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppForm.tsx
@@ -124,7 +124,7 @@ const InstallAppForm: React.FC<IInstallAppFormProps> = ({
         />
       ) : (
         <TextInput
-          help='We recommend that you create a dedicated namespace. The namespace will be created if it doesn’t exist yet.'
+          help={`We recommend that you create a dedicated namespace. The namespace will be created if it doesn't exist yet.`}
           key='dedicated-namespace'
           label='Namespace'
           id='dedicated-namespace'


### PR DESCRIPTION
When installing an app the description text under Namespace showed an \u2019 instead of a right single quotation.

While changing the String to a Template-String I also noticed that happa codebase uses single quotation for doesn't and this was the only place with a right single quotation.

![image](https://user-images.githubusercontent.com/2079851/127289742-157bd3ac-769b-4c32-8466-32a8790aa668.png)