### PR TITLE
Use sentence casing for buttons

### DIFF
--- a/__tests__/AdminLogin.tsx
+++ b/__tests__/AdminLogin.tsx
@@ -56,7 +56,7 @@ describe('AdminLogin', () => {
       MapiAuthConnectors.GiantSwarm
     );
 
-    expect(await screen.findByText('Launch New Cluster')).toBeInTheDocument();
+    expect(await screen.findByText('Launch new cluster')).toBeInTheDocument();
     attemptLoginMockFn.mockRestore();
   });
 

--- a/__tests__/AppDetailPane.tsx
+++ b/__tests__/AppDetailPane.tsx
@@ -400,7 +400,7 @@ describe('Installed app detail pane', () => {
     const desiredVersion = within(modal).getByText(/1.1.1/i);
     fireEvent.click(desiredVersion);
 
-    const confirmButton = getByText('Update Chart Version');
+    const confirmButton = getByText('Update chart version');
     fireEvent.click(confirmButton);
 
     // Expect an error.

--- a/__tests__/ClusterManagement.js
+++ b/__tests__/ClusterManagement.js
@@ -100,12 +100,12 @@ describe('ClusterManagement', () => {
     } = renderRouteWithStore(newClusterPath);
 
     await waitFor(() => {
-      getByText('Create Cluster');
+      getByText('Create cluster');
       // Is this the v5 form?
       expect(getByTestId('nodepool-cluster-creation-view')).toBeInTheDocument();
     });
 
-    fireEvent.click(getByText('Create Cluster'));
+    fireEvent.click(getByText('Create cluster'));
     await waitFor(() => getByTestId('cluster-details-view'));
 
     // Expect we have been redirected to the cluster details view
@@ -168,7 +168,7 @@ details view`, async () => {
     );
 
     // Click the create cluster button.
-    fireEvent.click(await findByText('Create Cluster'));
+    fireEvent.click(await findByText('Create cluster'));
 
     // Wait till we're on the cluster detail page.
     await findByTestId('cluster-details-view');

--- a/__tests__/GettingStarted.js
+++ b/__tests__/GettingStarted.js
@@ -45,7 +45,7 @@ it('lets me get there from the dashboard and go through the pages', async () => 
 
   const { findByText } = renderRouteWithStore(MainRoutes.Home);
 
-  const getStartedButton = await findByText('Get Started');
+  const getStartedButton = await findByText('Get started');
   expect(getStartedButton).toBeInTheDocument();
 
   fireEvent.click(getStartedButton);

--- a/__tests__/KeyPairs.js
+++ b/__tests__/KeyPairs.js
@@ -83,7 +83,7 @@ it('lets me create a keypair', async () => {
   fireEvent.click(keyPairTab);
 
   // And I click the create key pair button.
-  const createKeyPairButton = getByText('Create Key Pair and Kubeconfig');
+  const createKeyPairButton = getByText('Create key pair and kubeconfig');
   fireEvent.click(createKeyPairButton);
 
   // Then I should see the create key pair modal on the screen.

--- a/__tests__/Login.tsx
+++ b/__tests__/Login.tsx
@@ -210,7 +210,7 @@ describe('Login', () => {
 
     expect(attemptLoginMockFn).toHaveBeenCalledWith(undefined);
 
-    expect(await screen.findByText('Launch New Cluster')).toBeInTheDocument();
+    expect(await screen.findByText('Launch new cluster')).toBeInTheDocument();
     attemptLoginMockFn.mockRestore();
   });
 
@@ -304,7 +304,7 @@ describe('Login', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Proceed to login' }));
 
-    const someButton = await screen.findByText('Launch New Cluster');
+    const someButton = await screen.findByText('Launch new cluster');
     expect(someButton).toBeInTheDocument();
 
     testAuth.expireUser();
@@ -350,7 +350,7 @@ describe('Login', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Proceed to login' }));
 
-    const someButton = await screen.findByText('Launch New Cluster');
+    const someButton = await screen.findByText('Launch new cluster');
     expect(someButton).toBeInTheDocument();
 
     testAuth.expireUser();

--- a/__tests__/Organization.js
+++ b/__tests__/Organization.js
@@ -121,7 +121,7 @@ describe('', () => {
         findByTestId,
       } = renderRouteWithStore(OrganizationsRoutes.Home);
 
-      const createOrgButton = await findByText('Create New Organization');
+      const createOrgButton = await findByText('Create new organization');
       fireEvent.click(createOrgButton);
 
       await findByText('Create an Organization');
@@ -133,7 +133,7 @@ describe('', () => {
         target: { value: newOrganizationId },
       });
 
-      fireEvent.click(getByText('Create Organization'));
+      fireEvent.click(getByText('Create organization'));
 
       await findByText(
         (_, element) =>
@@ -205,7 +205,7 @@ describe('', () => {
         organizationDetailsPath
       );
 
-      const addMemberButton = await findByText('Add Member');
+      const addMemberButton = await findByText('Add member');
       expect(addMemberButton).toBeInTheDocument();
 
       fireEvent.click(addMemberButton);
@@ -217,7 +217,7 @@ describe('', () => {
         target: { value: newMemberEmail },
       });
 
-      fireEvent.click(await findByText('Add Member to Organization'));
+      fireEvent.click(await findByText('Add member to organization'));
 
       expect(
         await findByText(
@@ -272,13 +272,13 @@ describe('', () => {
       expect(removalNotice).toBeInTheDocument();
 
       const removeUserButton = await findByText(
-        'Remove Member from Organization'
+        'Remove member from organization'
       );
       expect(removeUserButton).toBeInTheDocument();
 
       fireEvent.click(removeUserButton);
 
-      expect(removeUserButton.textContent).toBe('Removing Member');
+      expect(removeUserButton.textContent).toBe('Removing member');
 
       const flashMessage = await findByText(
         (_, element) =>
@@ -338,7 +338,7 @@ describe('Organization deletion', () => {
       organizationDetailsPath
     );
 
-    let deleteButton = await findByText('Delete Organization');
+    let deleteButton = await findByText('Delete organization');
     fireEvent.click(deleteButton);
 
     const modalTitle = await findByText((_, element) => {
@@ -350,7 +350,7 @@ describe('Organization deletion', () => {
     expect(modalTitle).toBeInTheDocument();
     expect(modalTitle.textContent.includes(organizationID)).toBeTruthy();
 
-    deleteButton = getAllByText('Delete Organization')[1];
+    deleteButton = getAllByText('Delete organization')[1];
     fireEvent.click(deleteButton);
 
     const flashMessages = await findAllByText((_, element) => {

--- a/__tests__/Users.js
+++ b/__tests__/Users.js
@@ -82,9 +82,12 @@ describe('Users', () => {
         status: 'READY',
       });
 
-    const { findByText, getByText, getByLabelText } = renderRouteWithStore(
-      UsersRoutes.Home
-    );
+    const {
+      findByText,
+      getByText,
+      getByLabelText,
+      getAllByText,
+    } = renderRouteWithStore(UsersRoutes.Home);
 
     let inviteButton = await findByText(/invite user/i);
     expect(inviteButton).toBeInTheDocument();
@@ -134,7 +137,7 @@ describe('Users', () => {
     // Check if the warning is gone
     expect(gsDomainOnlyWarning).not.toBeInTheDocument();
 
-    inviteButton = getByText('Invite User');
+    inviteButton = getAllByText('Invite user')[1];
     fireEvent.click(inviteButton);
 
     const progressText = await findByText(

--- a/__tests__/V4AWSClusterManagement.js
+++ b/__tests__/V4AWSClusterManagement.js
@@ -205,8 +205,8 @@ it('deletes a v4 cluster', async () => {
     expect(getByText(V4_CLUSTER.name)).toBeInTheDocument();
   });
 
-  await waitFor(() => getByText('Delete Cluster'));
-  fireEvent.click(getByText('Delete Cluster'));
+  await waitFor(() => getByText('Delete cluster'));
+  fireEvent.click(getByText('Delete cluster'));
 
   // Is the modal in the document?
   const titleText = /are you sure you want to delete/i;
@@ -216,7 +216,7 @@ it('deletes a v4 cluster', async () => {
   expect(modalTitle.textContent.includes(cluster.id)).toBeTruthy();
 
   // Click delete button.
-  const modalDeleteButton = getAllByText('Delete Cluster')[1];
+  const modalDeleteButton = getAllByText('Delete cluster')[1];
   fireEvent.click(modalDeleteButton);
 
   // Flash message confirming deletion.

--- a/__tests__/V4AzureClusterManagement.js
+++ b/__tests__/V4AzureClusterManagement.js
@@ -178,7 +178,7 @@ describe('V4AzureClusterManagement', () => {
     });
     expect(azInput.value).toBe(String(maxAZCount));
 
-    const createButton = getByText('Create Cluster');
+    const createButton = getByText('Create cluster');
     expect(createButton.disabled).toBeFalsy();
     fireEvent.click(createButton);
 

--- a/__tests__/V5ClusterManagement.js
+++ b/__tests__/V5ClusterManagement.js
@@ -310,7 +310,7 @@ scales node pools correctly`, async () => {
     expect(modalTitle.textContent.includes(cluster.id)).toBeTruthy();
 
     // Click delete button.
-    const modalDeleteButton = getAllByText('Delete Cluster')[1];
+    const modalDeleteButton = getAllByText('Delete cluster')[1];
     fireEvent.click(modalDeleteButton);
 
     // Flash message confirming deletion.
@@ -375,8 +375,8 @@ scales node pools correctly`, async () => {
     expect(getByText(bodyTextMultipleNP)).toBeInTheDocument();
 
     // Click delete button.
-    const deleteButtonText = 'Delete Node Pool';
-    fireEvent.click(getByText(deleteButtonText));
+    const deleteButtonText = 'Delete node pool';
+    fireEvent.click(getAllByText(deleteButtonText)[1]);
 
     // Flash message confirming deletion.
     await waitFor(() => {

--- a/src/components/AccountSettings/ChangeEmailForm.tsx
+++ b/src/components/AccountSettings/ChangeEmailForm.tsx
@@ -153,7 +153,7 @@ class ChangeEmailForm extends React.Component<
                 loading={this.state.isSubmitting}
                 type='submit'
               >
-                Set New Email
+                Set new email
               </Button>
             </SlideTransition>
           </ButtonPlaceholder>

--- a/src/components/AccountSettings/ChangePasswordForm.tsx
+++ b/src/components/AccountSettings/ChangePasswordForm.tsx
@@ -246,7 +246,7 @@ class ChangePassword extends React.Component<
                   loading={this.state.submitting}
                   type='submit'
                 >
-                  Set New Password
+                  Set new password
                 </Button>
               </SlideTransition>
             </div>

--- a/src/components/AccountSettings/__tests__/ChangeEmailForm.js
+++ b/src/components/AccountSettings/__tests__/ChangeEmailForm.js
@@ -7,7 +7,7 @@ import { renderWithTheme } from 'testUtils/renderUtils';
 import ChangeEmailForm from '../ChangeEmailForm';
 
 const inputInitialValue = USER_EMAIL;
-const buttonLabel = 'Set New Email';
+const buttonLabel = 'Set new email';
 
 const statusMessages = {
   Success: 'Your email has been updated',

--- a/src/components/AccountSettings/__tests__/ChangePasswordForm.js
+++ b/src/components/AccountSettings/__tests__/ChangePasswordForm.js
@@ -14,7 +14,7 @@ const elementLabels = {
   CurrPassword: 'Current Password',
   NewPassword: 'New Password',
   ConfirmNewPassword: 'New Password (once more)',
-  SetButton: 'Set New Password',
+  SetButton: 'Set new password',
 };
 
 const textInputLabels = [

--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -287,7 +287,7 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
     <>
       <Button bsStyle='primary' onClick={openModal}>
         <i className='fa fa-add-circle' />
-        Install in Cluster
+        Install in cluster
       </Button>
       {(() => {
         switch (pages[page]) {
@@ -326,10 +326,10 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
                       loading={loading}
                       onClick={createApp}
                     >
-                      Install App
+                      Install app
                     </Button>
                     <Button bsStyle='link' onClick={previous}>
-                      Pick a different Cluster
+                      Pick a different cluster
                     </Button>
                     <Button bsStyle='link' onClick={onClose}>
                       Cancel

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.tsx
@@ -227,7 +227,7 @@ const AppDetailsModal: React.FC<IAppDetailsModalProps> = ({
                 onClick={editChartVersion}
                 loading={isLoading}
               >
-                Update Chart Version
+                Update chart version
               </Button>
               <Button bsStyle='link' onClick={showPane(ModalPanes.Initial)}>
                 Cancel

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/InitialPane.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/InitialPane.tsx
@@ -171,7 +171,7 @@ const InitialPane: React.FC<IInitialPaneProps> = (props) => {
       <DetailItem title='Delete This App'>
         <Button bsStyle='danger' onClick={props.showDeleteAppPane}>
           <i className='fa fa-delete' />
-          Delete App
+          Delete app
         </Button>
       </DetailItem>
     </div>

--- a/src/components/Cluster/ClusterDetail/ClusterApps.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.tsx
@@ -231,7 +231,7 @@ const ClusterApps: React.FC<IClusterAppsProps> = ({
               onClick={openAppCatalog}
               disabled={isUpdatingOrCreating}
             >
-              <i className='fa fa-add-circle' /> Install App
+              <i className='fa fa-add-circle' /> Install app
             </BrowseButton>
 
             {isUpdatingOrCreating && (

--- a/src/components/Cluster/ClusterDetail/ClusterDetailView.js
+++ b/src/components/Cluster/ClusterDetail/ClusterDetailView.js
@@ -374,7 +374,7 @@ class ClusterDetailView extends React.Component {
                       bsStyle='danger'
                       onClick={this.showDeleteClusterModal.bind(this, cluster)}
                     >
-                      <i className='fa fa-delete' /> Delete Cluster
+                      <i className='fa fa-delete' /> Delete cluster
                     </Button>
                   </>
                 </Section>

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/EditLabelTooltip.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/EditLabelTooltip.tsx
@@ -64,10 +64,6 @@ const Buttons = styled(GridCell)`
   padding-bottom: 2px;
 `;
 
-const AddLabelButton = styled(Button)`
-  text-transform: uppercase;
-`;
-
 const Editable = styled.span<{ allowInteraction?: boolean }>`
   text-decoration: ${({ allowInteraction }) =>
     allowInteraction ? 'underline' : 'none'};
@@ -153,13 +149,13 @@ const EditLabelTooltip: FC<IEditLabelTooltip> = ({
   return (
     <EditLabelTooltipWrapper ref={divElement} className={className}>
       {label === '' ? (
-        <AddLabelButton
+        <Button
           disabled={!allowInteraction || currentlyEditing}
           onClick={open}
           data-testid='add-label-button'
         >
           <i className='fa fa-add-circle' /> Add label
-        </AddLabelButton>
+        </Button>
       ) : (
         <Keyboard onSpace={handleLabelKeyDown} onEnter={handleLabelKeyDown}>
           <StyledValueLabel

--- a/src/components/Cluster/ClusterDetail/Ingress/InstallIngressButton.tsx
+++ b/src/components/Cluster/ClusterDetail/Ingress/InstallIngressButton.tsx
@@ -156,7 +156,7 @@ const InstallIngressButton: React.FC<IInstallIngressButtonProps> = ({
           loadingTimeout={0}
           onClick={installIngressController}
         >
-          Install Ingress Controller
+          Install ingress controller
         </Button>
       )}
 

--- a/src/components/Cluster/ClusterDetail/KeypairCreateModal/KeyPairCreateModal.tsx
+++ b/src/components/Cluster/ClusterDetail/KeypairCreateModal/KeyPairCreateModal.tsx
@@ -185,7 +185,7 @@ const KeyPairCreateModal: React.FC<IKeyPairCreateModalProps> = (props) => {
   return (
     <>
       <Button bsStyle='default' onClick={show}>
-        <i className='fa fa-add-circle' /> Create Key Pair and Kubeconfig
+        <i className='fa fa-add-circle' /> Create key pair and kubeconfig
       </Button>
       <StyledModal
         data-testid='create-key-pair-modal'

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -203,7 +203,7 @@ class UpgradeClusterModal extends React.Component {
             bsStyle='primary'
             onClick={() => this.goToPage(Pages.InspectChanges)}
           >
-            Inspect Changes
+            Inspect changes
           </Button>
           <Button bsStyle='link' onClick={this.close}>
             Cancel
@@ -232,7 +232,7 @@ class UpgradeClusterModal extends React.Component {
             onClick={this.submit}
             loadingTimeout={0}
           >
-            Start Upgrade
+            Start upgrade
           </Button>
 
           {!loading && (

--- a/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
@@ -145,7 +145,7 @@ class V4ClusterDetailTable extends React.Component {
           </StyledURIBlock>
           <GetStartedWrapper>
             <Button onClick={this.props.accessCluster}>
-              <i className='fa fa-start' /> GET STARTED
+              <i className='fa fa-start' /> Get started
             </Button>
           </GetStartedWrapper>
         </KubernetesURIWrapper>

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -458,7 +458,7 @@ class V5ClusterDetailTable extends React.Component {
           </StyledURIBlock>
           <GetStartedWrapper>
             <Button onClick={accessCluster}>
-              <i className='fa fa-start' /> GET STARTED
+              <i className='fa fa-start' /> Get started
             </Button>
           </GetStartedWrapper>
         </KubernetesURIWrapper>
@@ -557,7 +557,7 @@ class V5ClusterDetailTable extends React.Component {
                     onClick={this.createNodePool}
                     type='button'
                   >
-                    Create Node Pool
+                    Create node pool
                   </Button>
                   {/* We want to hide cancel button when the Create NP button has been clicked */}
                   {!nodePoolForm.isSubmitting && (
@@ -587,7 +587,7 @@ class V5ClusterDetailTable extends React.Component {
             )}
             <RUMActionTarget name={RUMActions.AddNodePool}>
               <Button onClick={this.toggleAddNodePoolForm}>
-                <i className='fa fa-add-circle' /> ADD NODE POOL
+                <i className='fa fa-add-circle' /> Add node pool
               </Button>
             </RUMActionTarget>
             {nodePools && nodePools.length === 1 && (

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -297,7 +297,7 @@ class CreateNodePoolsCluster extends Component {
           </NodePoolsTransitionGroup>
           <RUMActionTarget name={RUMActions.AddNodePool}>
             <Button onClick={this.addNodePoolForm}>
-              <i className='fa fa-add-circle' /> ADD NODE POOL
+              <i className='fa fa-add-circle' /> Add node pool
             </Button>
           </RUMActionTarget>
           <HorizontalLine />
@@ -311,7 +311,7 @@ class CreateNodePoolsCluster extends Component {
               onClick={this.createCluster}
               type='button'
             >
-              Create Cluster
+              Create cluster
             </Button>
           </RUMActionTarget>
           {/* We want to hide cancel button when the Create NP button has been clicked */}

--- a/src/components/Cluster/NewCluster/CreateRegularCluster.js
+++ b/src/components/Cluster/NewCluster/CreateRegularCluster.js
@@ -351,7 +351,7 @@ class CreateRegularCluster extends React.Component {
               onClick={this.createCluster}
               type='submit'
             >
-              Create Cluster
+              Create cluster
             </Button>
           </RUMActionTarget>
           {!isClusterCreating && (

--- a/src/components/ExceptionNotificationTest/ExceptionNotificationTest.tsx
+++ b/src/components/ExceptionNotificationTest/ExceptionNotificationTest.tsx
@@ -25,7 +25,7 @@ function ExceptionNotificationTest(): ReactNode {
       <hr />
       <h3>Uncaught Exception</h3>
       <p>Click this button to generate an uncaught exception.</p>
-      <Button onClick={generateUncaughtException}>Break Me</Button>
+      <Button onClick={generateUncaughtException}>Break me</Button>
       <hr />
       <h3>Manually Reported Exception</h3>
       <p>
@@ -34,7 +34,7 @@ function ExceptionNotificationTest(): ReactNode {
         notification, and Slack are working as expected. It does not actually
         generate an exception.
       </p>
-      <Button onClick={reportException}>Report Exception</Button>
+      <Button onClick={reportException}>Report exception</Button>
     </>
   );
 }

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -115,10 +115,6 @@ const ButtonsWrapper = styled.div`
   }
 `;
 
-const GetStartedButton = styled(Button)`
-  text-transform: uppercase;
-`;
-
 const DeleteDateWrapper = styled.div`
   color: ${(props) => props.theme.colors.darkBlueLighter5};
 `;
@@ -289,10 +285,10 @@ function ClusterDashboardItem({
         <ButtonsWrapper>
           {clusterYoungerThan30Days() ? (
             <ButtonGroup>
-              <GetStartedButton onClick={accessCluster}>
+              <Button onClick={accessCluster}>
                 <i className='fa fa-start' />
-                Get Started
-              </GetStartedButton>
+                Get started
+              </Button>
             </ButtonGroup>
           ) : (
             ''

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -127,7 +127,7 @@ class Home extends React.Component {
             <div className='well launch-new-cluster'>
               <Link to={this.newClusterPath()}>
                 <Button bsStyle='primary' type='button'>
-                  <i className='fa fa-add-circle' /> Launch New Cluster
+                  <i className='fa fa-add-circle' /> Launch new cluster
                 </Button>
               </Link>
               {clusters.length === 0 &&

--- a/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
@@ -183,7 +183,7 @@ const AppDetailsModalInitialPane: React.FC<IAppDetailsModalInitialPaneProps> = (
       <DetailItem title='Delete This App'>
         <Button bsStyle='danger' onClick={props.showDeleteAppPane}>
           <i className='fa fa-delete' />
-          Delete App
+          Delete app
         </Button>
       </DetailItem>
     </div>

--- a/src/components/MAPI/apps/AppDetailsModal/__tests__/index.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/__tests__/index.tsx
@@ -195,7 +195,7 @@ describe('AppDetailsModal', () => {
 
     fireEvent.click(
       await screen.findByRole('button', {
-        name: 'Update Chart Version',
+        name: 'Update chart version',
       })
     );
 

--- a/src/components/MAPI/apps/AppDetailsModal/index.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/index.tsx
@@ -501,7 +501,7 @@ const AppDetailsModal: React.FC<IAppDetailsModalProps> = ({
                 onClick={editChartVersion}
                 loading={appUpdateIsLoading}
               >
-                Update Chart Version
+                Update chart version
               </Button>
               <Button bsStyle='link' onClick={showPane(ModalPanes.Initial)}>
                 Cancel
@@ -590,7 +590,7 @@ const AppDetailsModal: React.FC<IAppDetailsModalProps> = ({
           }
           footer={
             <DeleteConfirmFooter
-              cta='Delete App'
+              cta='Delete app'
               onConfirm={deleteApp}
               onCancel={showPane(ModalPanes.Initial)}
             />

--- a/src/components/MAPI/apps/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/AppInstallModal.tsx
@@ -312,7 +312,7 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
     <>
       <Button bsStyle='primary' onClick={openModal}>
         <i className='fa fa-add-circle' />
-        Install in Cluster
+        Install in cluster
       </Button>
       {(() => {
         switch (pages[page]) {
@@ -349,10 +349,10 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
                       loading={loading}
                       onClick={installApp}
                     >
-                      Install App
+                      Install app
                     </Button>
                     <Button bsStyle='link' onClick={previous}>
-                      Pick a different Cluster
+                      Pick a different cluster
                     </Button>
                     <Button bsStyle='link' onClick={onClose}>
                       Cancel

--- a/src/components/MAPI/apps/AppList/__tests__/index.tsx
+++ b/src/components/MAPI/apps/AppList/__tests__/index.tsx
@@ -140,7 +140,7 @@ describe('AppList', () => {
 
     fireEvent.click(
       within(filterWrapperElement).getByRole('button', {
-        name: 'Select None',
+        name: 'Select none',
       })
     );
 

--- a/src/components/MAPI/apps/ClusterDetailApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailApps.tsx
@@ -212,7 +212,7 @@ const ClusterDetailApps: React.FC<IClusterDetailApps> = ({
       >
         <BrowseButtonContainer>
           <BrowseButton onClick={openAppCatalog} disabled={appListIsLoading}>
-            <i className='fa fa-add-circle' /> Install App
+            <i className='fa fa-add-circle' /> Install app
           </BrowseButton>
         </BrowseButtonContainer>
       </UserInstalledApps>

--- a/src/components/MAPI/apps/InstallIngressButton.tsx
+++ b/src/components/MAPI/apps/InstallIngressButton.tsx
@@ -189,7 +189,7 @@ const InstallIngressButton: React.FC<IInstallIngressButtonProps> = ({
           disabled={installationIsDisabled}
           onClick={handleClick}
         >
-          Install Ingress Controller
+          Install ingress controller
         </Button>
       )}
 

--- a/src/components/MAPI/apps/__tests__/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/__tests__/AppInstallModal.tsx
@@ -71,7 +71,7 @@ describe('AppInstallModal', () => {
       })
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Install in Cluster' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Install in cluster' }));
 
     fireEvent.click(
       await screen.findByText(capiv1alpha3Mocks.randomCluster1.metadata.name)
@@ -83,7 +83,7 @@ describe('AppInstallModal', () => {
       )
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('Pick a different Cluster'));
+    fireEvent.click(screen.getByText('Pick a different cluster'));
 
     fireEvent.click(
       await screen.findByText(capiv1alpha3Mocks.randomCluster2.metadata.name)
@@ -152,13 +152,13 @@ describe('AppInstallModal', () => {
       })
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Install in Cluster' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Install in cluster' }));
 
     fireEvent.click(
       await screen.findByText(capiv1alpha3Mocks.randomCluster1.metadata.name)
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Install App' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Install app' }));
 
     expect(
       await withMarkup(screen.findByText)(

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
@@ -5,14 +5,9 @@ import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { OrganizationsRoutes } from 'shared/constants/routes';
-import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
 import ClusterDetailWidget from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget';
 import ClusterDetailWidgetOptionalValue from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidgetOptionalValue';
-
-const GetStartedButton = styled(Button)`
-  text-transform: uppercase;
-`;
 
 interface IClusterDetailWidgetKubernetesAPIProps
   extends Omit<
@@ -66,10 +61,10 @@ const ClusterDetailWidgetKubernetesAPI: React.FC<IClusterDetailWidgetKubernetesA
 
       {typeof k8sApiURL !== 'undefined' && (
         <Link to={gettingStartedPath}>
-          <GetStartedButton tabIndex={-1}>
+          <Button tabIndex={-1}>
             <i className='fa fa-start' aria-hidden={true} role='presentation' />
-            Get Started
-          </GetStartedButton>
+            Get started
+          </Button>
         </Link>
       )}
     </ClusterDetailWidget>

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
@@ -36,7 +36,7 @@ describe('ClusterDetailWidgetKubernetesAPI', () => {
 
     expect(
       screen.getByRole('button', {
-        name: 'Get Started',
+        name: 'Get started',
       })
     ).toBeInTheDocument();
   });

--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -63,10 +63,6 @@ const StyledLink = styled(Link)`
   }
 `;
 
-const GetStartedButton = styled(Button)`
-  text-transform: uppercase;
-`;
-
 interface IClusterListItemProps
   extends React.ComponentPropsWithoutRef<typeof Box> {
   cluster?: capiv1alpha3.ICluster;
@@ -235,7 +231,7 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
               )}
             </ClusterListItemOptionalValue>
           </Box>
-          <Box basis='80%'>
+          <Box basis='82%'>
             <Box direction='row' align='center' wrap={true} gap='small'>
               <ClusterListItemOptionalValue value={description}>
                 {(value) => (
@@ -288,15 +284,15 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
           </Box>
 
           {shouldDisplayGetStarted && (
-            <Box basis='10%'>
-              <GetStartedButton onClick={handleGetStartedClick}>
+            <Box basis='8%'>
+              <Button onClick={handleGetStartedClick}>
                 <i
                   className='fa fa-start'
                   aria-hidden={true}
                   role='presentation'
                 />
-                Get Started
-              </GetStartedButton>
+                Get started
+              </Button>
             </Box>
           )}
         </CardBody>

--- a/src/components/MAPI/clusters/ClusterList/__tests__/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/__tests__/ClusterListItem.tsx
@@ -98,7 +98,7 @@ describe('ClusterListItem', () => {
     );
 
     expect(
-      screen.getByRole('button', { name: 'Get Started' })
+      screen.getByRole('button', { name: 'Get started' })
     ).toBeInTheDocument();
 
     creationDate = sub({

--- a/src/components/MAPI/clusters/Clusters.tsx
+++ b/src/components/MAPI/clusters/Clusters.tsx
@@ -150,7 +150,7 @@ const Clusters: React.FC<{}> = () => {
           >
             <Link to={newClusterPath}>
               <Button bsStyle='primary' tabIndex={-1}>
-                <i className='fa fa-add-circle' /> Launch New Cluster
+                <i className='fa fa-add-circle' /> Launch new cluster
               </Button>
             </Link>
 

--- a/src/components/Modals/Modals.js
+++ b/src/components/Modals/Modals.js
@@ -169,8 +169,8 @@ class Modals extends React.Component {
                 type='submit'
               >
                 {this.props.modal.templateValues.loading
-                  ? 'Deleting Organization'
-                  : 'Delete Organization'}
+                  ? 'Deleting organization'
+                  : 'Delete organization'}
               </Button>
 
               {this.props.modal.templateValues.loading ? null : (
@@ -222,8 +222,8 @@ class Modals extends React.Component {
                 disabled={this.state.organizationNameValidationError.length > 0}
               >
                 {this.props.modal.templateValues.loading
-                  ? 'Creating Organization'
-                  : 'Create Organization'}
+                  ? 'Creating organization'
+                  : 'Create organization'}
               </Button>
 
               {this.props.modal.templateValues.loading ? null : (
@@ -269,8 +269,8 @@ class Modals extends React.Component {
                 type='submit'
               >
                 {this.props.modal.templateValues.loading
-                  ? 'Adding Member'
-                  : 'Add Member to Organization'}
+                  ? 'Adding member'
+                  : 'Add member to organization'}
               </Button>
 
               {this.props.modal.templateValues.loading ? null : (
@@ -304,8 +304,8 @@ class Modals extends React.Component {
                 type='submit'
               >
                 {this.props.modal.templateValues.loading
-                  ? 'Removing Member'
-                  : 'Remove Member from Organization'}
+                  ? 'Removing member'
+                  : 'Remove member from organization'}
               </Button>
 
               {this.props.modal.templateValues.loading ? null : (
@@ -349,8 +349,8 @@ class Modals extends React.Component {
                 type='submit'
               >
                 {this.props.modal.templateValues.loading
-                  ? 'Deleting Cluster'
-                  : 'Delete Cluster'}
+                  ? 'Deleting cluster'
+                  : 'Delete cluster'}
               </Button>
 
               {this.props.modal.templateValues.loading ? null : (
@@ -420,8 +420,8 @@ class Modals extends React.Component {
                 type='submit'
               >
                 {this.props.modal.templateValues.loading
-                  ? 'Deleting Node Pool'
-                  : 'Delete Node Pool'}
+                  ? 'Deleting node pool'
+                  : 'Delete node pool'}
               </Button>
 
               {this.props.modal.templateValues.loading ? null : (

--- a/src/components/Organizations/Detail/CredentialsDisplay.js
+++ b/src/components/Organizations/Detail/CredentialsDisplay.js
@@ -17,7 +17,7 @@ const CredentialsDisplay = (props) => {
   if (props.credentials.length === 0) {
     const button = (
       <Button bsStyle='default' onClick={props.onShowForm}>
-        Set Credentials
+        Set credentials
       </Button>
     );
 

--- a/src/components/Organizations/Detail/CredentialsForm.js
+++ b/src/components/Organizations/Detail/CredentialsForm.js
@@ -159,7 +159,7 @@ class CredentialsForm extends React.Component {
             disabled={!this.state.isValid}
             onClick={this.handleSubmit}
           >
-            Set Credentials
+            Set credentials
           </Button>
         </form>
       );
@@ -207,7 +207,7 @@ class CredentialsForm extends React.Component {
             disabled={!this.state.isValid}
             onClick={this.handleSubmit}
           >
-            Set Credentials
+            Set credentials
           </Button>
         </form>
       );

--- a/src/components/Organizations/Detail/View.js
+++ b/src/components/Organizations/Detail/View.js
@@ -214,7 +214,7 @@ class OrganizationDetail extends React.Component {
           )}
           <Link to={newClusterPath}>
             <Button bsStyle='default'>
-              <i className='fa fa-add-circle' /> Create Cluster
+              <i className='fa fa-add-circle' /> Create cluster
             </Button>
           </Link>
         </Section>
@@ -234,7 +234,7 @@ class OrganizationDetail extends React.Component {
               />
             )}
             <Button bsStyle='default' onClick={this.addMember}>
-              <i className='fa fa-add-circle' /> Add Member
+              <i className='fa fa-add-circle' /> Add member
             </Button>
           </MembersTable>
         </Section>
@@ -259,7 +259,7 @@ class OrganizationDetail extends React.Component {
             disabled={!supportsDeletion.status}
             aria-label='Delete organization'
           >
-            <i className='fa fa-delete' /> Delete Organization
+            <i className='fa fa-delete' /> Delete organization
           </Button>
         </Section>
       </DocumentTitle>

--- a/src/components/Organizations/List/List.js
+++ b/src/components/Organizations/List/List.js
@@ -44,7 +44,7 @@ class OrganizationListWrapper extends React.Component {
             />
           </EmptyStateDisplay>
           <Button bsStyle='default' onClick={this.createOrganization}>
-            <i className='fa fa-add-circle' /> Create New Organization
+            <i className='fa fa-add-circle' /> Create new organization
           </Button>
         </>
       </DocumentTitle>

--- a/src/components/UI/Controls/ExpandableSelector/Items.tsx
+++ b/src/components/UI/Controls/ExpandableSelector/Items.tsx
@@ -5,7 +5,6 @@ export const TableButton = styled(Button)`
   position: relative;
   margin-left: 0;
   padding: 0px 15px;
-  text-transform: uppercase;
 
   i {
     margin-right: 4px;

--- a/src/components/UI/Display/Apps/AppList/AppsListPage.tsx
+++ b/src/components/UI/Display/Apps/AppList/AppsListPage.tsx
@@ -101,7 +101,7 @@ const AppsList: React.FC<IAppsListPageProps> = (props) => {
                 apps from
               </p>
               <Button bsStyle='default' onClick={props.onResetSearch}>
-                RESET SEARCH
+                Reset search
               </Button>
             </div>
           </EmptyState>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -14,7 +14,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         class="StyledBox-sc-13pk1d4-0 eITwkI"
       >
         <div
-          class="sc-dFtzdE eKjOri sc-cdJjZP gDgffG"
+          class="sc-dFtzdE eKjOri sc-iMrple ksYbfI"
         >
           <span
             aria-label="35 dogs"
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-hFLmgA bLwsQw"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-eDtzrZ ERmKa"
       >
         dogs
       </span>
@@ -48,7 +48,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         class="StyledBox-sc-13pk1d4-0 eITwkI"
       >
         <div
-          class="sc-dFtzdE eKjOri sc-cdJjZP gDgffG"
+          class="sc-dFtzdE eKjOri sc-iMrple ksYbfI"
         >
           <span
             aria-label="1 dog"
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 bTNMGz sc-hFLmgA bLwsQw"
+        class="StyledText-sc-1sadyjn-0 bTNMGz sc-eDtzrZ ERmKa"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -15,7 +15,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 dLeNOM"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-lepKoB eHdFvu"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-bcCSnW eHbbkh"
         >
           Some widget
         </span>
@@ -49,7 +49,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 kYALZS"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 iFfteu sc-lepKoB eHdFvu"
+          class="StyledText-sc-1sadyjn-0 iFfteu sc-bcCSnW eHbbkh"
         >
           Some widget
         </span>

--- a/src/components/UI/Inputs/Facets.tsx
+++ b/src/components/UI/Inputs/Facets.tsx
@@ -69,10 +69,10 @@ const Facets: React.FC<IFacetsProps> = (props) => {
       <label>Filter by Catalog</label>
       <br />
       <StyledButton bsSize='sm' onClick={selectAll}>
-        Select All
+        Select all
       </StyledButton>{' '}
       <StyledButton bsSize='sm' onClick={selectNone}>
-        Select None
+        Select none
       </StyledButton>
       <br />
       <br />

--- a/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
@@ -29,7 +29,7 @@ exports[`NumberPicker renders a simple input 1`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 eJyyeU sc-ckRYGt kNLZPV"
+            class="StyledTextInput-sc-1x30a0s-0 eJyyeU sc-hKTJL jGnNlg"
             id="money"
             step="1"
             type="number"
@@ -37,18 +37,18 @@ exports[`NumberPicker renders a simple input 1`] = `
           />
         </div>
         <div
-          class="sc-kJpAAQ ePZWCM"
+          class="sc-gfqlmq iAquOw"
         >
           <div
             aria-label="Decrement"
-            class="sc-ciFPKr iWFETq"
+            class="sc-ckRYGt ixUnxL"
             role="button"
           >
             –
           </div>
           <div
             aria-label="Increment"
-            class="sc-ciFPKr iWFETq"
+            class="sc-ckRYGt ixUnxL"
             role="button"
           >
             +

--- a/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
@@ -8,7 +8,7 @@ exports[`RadioInput renders a disabled input 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-BHxdU gerjyR"
+      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
       tabindex="0"
     >
       <div
@@ -52,7 +52,7 @@ exports[`RadioInput renders a simple input 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-BHxdU gerjyR"
+      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
       tabindex="0"
     >
       <div
@@ -94,7 +94,7 @@ exports[`RadioInput renders an input with a form field label 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-BHxdU gerjyR"
+      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
       tabindex="0"
     >
       <label
@@ -144,7 +144,7 @@ exports[`RadioInput renders an input with a help message 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-BHxdU gerjyR"
+      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
       tabindex="0"
     >
       <span
@@ -191,7 +191,7 @@ exports[`RadioInput renders an input with a validation error 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-BHxdU gerjyR"
+      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
       tabindex="0"
     >
       <div
@@ -238,7 +238,7 @@ exports[`RadioInput renders an input with an info message 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-BHxdU gerjyR"
+      class="StyledBox-sc-13pk1d4-0 erPdoW FormField__FormFieldBox-m9hood-0 gWgpjB sc-hRMXGO fouCKV"
       tabindex="0"
     >
       <div

--- a/src/components/Users/DeleteUserModal.js
+++ b/src/components/Users/DeleteUserModal.js
@@ -4,7 +4,7 @@ import React from 'react';
 import UsersModal from './UsersModal';
 
 const DeleteUserModal = ({ forUser, isLoading, ...props }) => {
-  const confirmButtonText = isLoading ? 'Deleting User' : 'Delete User';
+  const confirmButtonText = isLoading ? 'Deleting user' : 'Delete user';
   const modalTitle = `Delete ${forUser}`;
 
   return (

--- a/src/components/Users/InviteUserModal/index.js
+++ b/src/components/Users/InviteUserModal/index.js
@@ -63,7 +63,7 @@ const InviteUserModal = ({
   const prevShow = usePrevious(show);
 
   const isInvited = Object.keys(invitationResult).length > 0;
-  const confirmButtonText = isLoading ? 'Inviting User' : 'Invite User';
+  const confirmButtonText = isLoading ? 'Inviting user' : 'Invite user';
   const cancelText = isInvited ? 'Close' : 'Cancel';
 
   let modalTitle = 'Invite a New User';

--- a/src/components/Users/UnexpireUserModal.js
+++ b/src/components/Users/UnexpireUserModal.js
@@ -5,8 +5,8 @@ import UsersModal from './UsersModal';
 
 const UnexpireUserModal = ({ forUser, isLoading, ...props }) => {
   const confirmButtonText = isLoading
-    ? 'Removing Expiration'
-    : 'Remove Expiration';
+    ? 'Removing expiration'
+    : 'Remove expiration';
   const modalTitle = `Remove Expiration Date from ${forUser}`;
 
   return (

--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -222,7 +222,7 @@ class Users extends React.Component {
               <>
                 <InvitesTable invitations={invitations} />
                 <Button onClick={this.inviteUser}>
-                  <i className='fa fa-add-circle' /> INVITE USER
+                  <i className='fa fa-add-circle' /> Invite user
                 </Button>
               </>
             </Section>


### PR DESCRIPTION
Towards [giantswarm/giantswarm#18139](https://github.com/giantswarm/giantswarm/issues/18139)

Buttons should use consistent casing - specifically, they should use sentence casing. This PR aligns all the buttons in the UI towards this goal.

Some examples:

![Screen Shot 2021-07-29 at 17 42 43](https://user-images.githubusercontent.com/62935115/127522838-1f95333e-f0ec-4661-9020-58f932d031aa.png)

![Screen Shot 2021-07-29 at 17 42 21](https://user-images.githubusercontent.com/62935115/127522841-0875b6cc-dcb9-4e83-8b29-8ce02e822a4e.png)

![Screen Shot 2021-07-29 at 17 42 09](https://user-images.githubusercontent.com/62935115/127522843-547c7a40-1dde-40d4-a312-206aee374378.png)

![Screen Shot 2021-07-29 at 17 41 55](https://user-images.githubusercontent.com/62935115/127522844-88ea2f9a-1f83-447c-9985-2db7bb02c284.png)
