### PR TITLE
Add CLI Guide UI components

### DIFF
--- a/src/components/UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo.tsx
@@ -1,0 +1,60 @@
+import { Box, Heading, Text } from 'grommet';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledLink = styled.a`
+  color: ${({ theme }) => theme.global.colors['input-highlight']};
+`;
+
+interface ICLIGuideAdditionalInfoLink {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+interface ICLIGuideAdditionalInfoProps
+  extends React.ComponentPropsWithoutRef<'div'> {
+  links?: ICLIGuideAdditionalInfoLink[];
+}
+
+const CLIGuideAdditionalInfo: React.FC<ICLIGuideAdditionalInfoProps> = ({
+  links,
+  ...props
+}) => {
+  return (
+    <Box {...props}>
+      <Box>
+        <Heading level={5}>Additional information</Heading>
+      </Box>
+      <Box>
+        {links?.map((link) => (
+          // eslint-disable-next-line react/jsx-no-target-blank
+          <StyledLink
+            key={`${link.label}-${link.href}`}
+            href={link.href}
+            rel={link.external ? 'noopener noreferrer' : undefined}
+            target={link.external ? '_blank' : undefined}
+          >
+            {link.external && (
+              <Text
+                className='fa fa-open-in-new'
+                aria-hidden={true}
+                role='presentation'
+                aria-label='Opens in a new tab'
+                margin={{ right: 'xsmall' }}
+              />
+            )}
+            {link.label}
+          </StyledLink>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+CLIGuideAdditionalInfo.propTypes = {
+  links: PropTypes.array,
+};
+
+export default CLIGuideAdditionalInfo;

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
@@ -8,7 +8,7 @@ exports[`CLIGuide renders the contents when open 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bkbNEX"
+      class="StyledBox-sc-13pk1d4-0 AHCYz"
       role="tablist"
     >
       <div
@@ -91,7 +91,7 @@ exports[`CLIGuide renders without crashing 1`] = `
     class="sc-gKckTs izRacH"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 bkbNEX"
+      class="StyledBox-sc-13pk1d4-0 AHCYz"
       role="tablist"
     >
       <div

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLIGuide renders the contents when open 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 hSiATR"
+>
+  <div
+    class="sc-gKckTs izRacH"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 bkbNEX"
+      role="tablist"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 iuBOfw"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="StyledButton-sc-323bzc-0 gUjxTZ"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 hoBZOR"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 jrFayi"
+            >
+              <span
+                aria-hidden="true"
+                class="StyledText-sc-1sadyjn-0 cORcyl fa fa-shell"
+                role="presentation"
+              />
+              <div
+                class="StyledBox__StyledBoxGap-sc-13pk1d4-1 FkBck"
+              />
+              <span
+                class="StyledText-sc-1sadyjn-0 FLjzT"
+              >
+                Get something from somewhere
+              </span>
+            </div>
+            <div
+              class="StyledBox-sc-13pk1d4-0 ibrxYb"
+            >
+              <svg
+                aria-label="FormUp"
+                class="StyledIcon-ofa7kd-0 cVihZy"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                  transform="matrix(1 0 0 -1 0 24)"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="StyledBox-sc-13pk1d4-0 hvUCKZ"
+          style=""
+        >
+          <div
+            aria-hidden="false"
+            class="StyledBox-sc-13pk1d4-0 hvUCKZ Collapsible__AnimatedBox-sc-15kniua-0 bRxhUn"
+            open=""
+            style="max-height: 0;"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 ieolrg"
+            >
+              Just some content
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CLIGuide renders without crashing 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 hSiATR"
+>
+  <div
+    class="sc-gKckTs izRacH"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 bkbNEX"
+      role="tablist"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 iuBOfw"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="StyledButton-sc-323bzc-0 gUjxTZ"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 hoBZOR"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 jrFayi"
+            >
+              <span
+                aria-hidden="true"
+                class="StyledText-sc-1sadyjn-0 cORcyl fa fa-shell"
+                role="presentation"
+              />
+              <div
+                class="StyledBox__StyledBoxGap-sc-13pk1d4-1 FkBck"
+              />
+              <span
+                class="StyledText-sc-1sadyjn-0 FLjzT"
+              >
+                Get something from somewhere
+              </span>
+            </div>
+            <div
+              class="StyledBox-sc-13pk1d4-0 ibrxYb"
+            >
+              <svg
+                aria-label="FormDown"
+                class="StyledIcon-ofa7kd-0 cVihZy"
+                viewBox="0 0 24 24"
+              >
+                <polyline
+                  fill="none"
+                  points="18 9 12 15 6 9"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="StyledBox-sc-13pk1d4-0 hvUCKZ"
+        >
+          <div
+            aria-hidden="true"
+            class="StyledBox-sc-13pk1d4-0 hvUCKZ Collapsible__AnimatedBox-sc-15kniua-0 gxzVjq"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/index.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/index.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import CLIGuide from '..';
+
+describe('CLIGuide', () => {
+  it('renders without crashing', () => {
+    const { container } = renderWithTheme(CLIGuide, {
+      title: 'Get something from somewhere',
+      children: '',
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders the contents when open', async () => {
+    const { container } = renderWithTheme(CLIGuide, {
+      title: 'Get something from somewhere',
+      children: 'Just some content',
+    });
+
+    fireEvent.click(
+      screen.getByRole('tab', { name: /Get something from somewhere/ })
+    );
+
+    expect(await screen.findByText('Just some content')).toBeInTheDocument();
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/UI/Display/MAPI/CLIGuide/index.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/index.tsx
@@ -31,9 +31,15 @@ const customTheme: ThemeType = {
 interface ICLIGuideProps
   extends React.ComponentPropsWithoutRef<typeof Accordion> {
   title: string;
+  footer?: React.ReactNode;
 }
 
-const CLIGuide: React.FC<ICLIGuideProps> = ({ children, title, ...props }) => {
+const CLIGuide: React.FC<ICLIGuideProps> = ({
+  children,
+  title,
+  footer,
+  ...props
+}) => {
   return (
     <ThemeContext.Extend value={customTheme}>
       <Accordion background='background-contrast' round='xsmall' {...props}>
@@ -59,6 +65,16 @@ const CLIGuide: React.FC<ICLIGuideProps> = ({ children, title, ...props }) => {
             width={{ max: 'xlarge' }}
           >
             {children}
+
+            {footer && (
+              <Box
+                border={{ side: 'top' }}
+                pad={{ vertical: 'small' }}
+                margin={{ top: 'medium' }}
+              >
+                {footer}
+              </Box>
+            )}
           </Box>
         </AccordionPanel>
       </Accordion>
@@ -69,6 +85,7 @@ const CLIGuide: React.FC<ICLIGuideProps> = ({ children, title, ...props }) => {
 CLIGuide.propTypes = {
   children: PropTypes.node.isRequired,
   title: PropTypes.string.isRequired,
+  footer: PropTypes.node,
 };
 
 export default CLIGuide;

--- a/src/components/UI/Display/MAPI/CLIGuide/index.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/index.tsx
@@ -1,0 +1,74 @@
+import {
+  Accordion,
+  AccordionPanel,
+  Box,
+  Text,
+  ThemeContext,
+  ThemeType,
+} from 'grommet';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { css } from 'styled-components';
+
+const customTheme: ThemeType = {
+  global: {
+    colors: {
+      text: 'text-weak',
+    },
+  },
+  accordion: {
+    border: false,
+  },
+  icon: {
+    // @ts-expect-error
+    extend: css`
+      fill: ${({ theme }) => theme.global.colors['text-weak'].dark};
+      stroke: ${({ theme }) => theme.global.colors['text-weak'].dark};
+    `,
+  },
+};
+
+interface ICLIGuideProps
+  extends React.ComponentPropsWithoutRef<typeof Accordion> {
+  title: string;
+}
+
+const CLIGuide: React.FC<ICLIGuideProps> = ({ children, title, ...props }) => {
+  return (
+    <ThemeContext.Extend value={customTheme}>
+      <Accordion background='background-contrast' round='xsmall' {...props}>
+        <AccordionPanel
+          label={
+            <Box
+              direction='row'
+              gap='xsmall'
+              align='center'
+              pad={{ vertical: 'small', horizontal: 'small' }}
+            >
+              <Text
+                className='fa fa-shell'
+                role='presentation'
+                aria-hidden={true}
+              />
+              <Text weight='bold'>{title}</Text>
+            </Box>
+          }
+        >
+          <Box
+            pad={{ vertical: 'medium', horizontal: 'large' }}
+            width={{ max: 'xlarge' }}
+          >
+            {children}
+          </Box>
+        </AccordionPanel>
+      </Accordion>
+    </ThemeContext.Extend>
+  );
+};
+
+CLIGuide.propTypes = {
+  children: PropTypes.node.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+export default CLIGuide;

--- a/src/components/UI/Display/MAPI/CLIGuide/index.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/index.tsx
@@ -42,7 +42,7 @@ const CLIGuide: React.FC<ICLIGuideProps> = ({
 }) => {
   return (
     <ThemeContext.Extend value={customTheme}>
-      <Accordion background='background-contrast' round='xsmall' {...props}>
+      <Accordion background='background-strong' round='xsmall' {...props}>
         <AccordionPanel
           label={
             <Box

--- a/src/components/UI/Display/MAPI/CLIGuide/stories/AdditionalInfo.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/stories/AdditionalInfo.tsx
@@ -1,0 +1,52 @@
+import { Story } from '@storybook/react';
+import { Box, Text } from 'grommet';
+import React from 'react';
+import { CodeBlock, Prompt } from 'UI/Display/Documentation/CodeBlock';
+
+import CLIGuide from '..';
+import CLIGuideAdditionalInfo from '../CLIGuideAdditionalInfo';
+
+export const AdditionalInfo: Story<
+  React.ComponentPropsWithoutRef<typeof CLIGuide>
+> = (args) => {
+  return <CLIGuide {...args} />;
+};
+
+AdditionalInfo.args = {
+  title: 'Get some data from the somewhere',
+  children: (
+    <Box direction='column' gap='small'>
+      <Box direction='column' gap='small'>
+        <Text>1. Make sure you are a boss</Text>
+        <CodeBlock>
+          <Prompt>some command --some-flag</Prompt>
+        </CodeBlock>
+      </Box>
+      <Box direction='column' gap='small'>
+        <Text>2. Maybe check again if you are still a boss</Text>
+        <CodeBlock>
+          <Prompt>some-other-cli checkboss</Prompt>
+        </CodeBlock>
+      </Box>
+    </Box>
+  ),
+  footer: (
+    <CLIGuideAdditionalInfo
+      links={[
+        {
+          label: 'Giant Swarm Home',
+          href: 'https://giantswarm.io',
+          external: true,
+        },
+        {
+          label: 'Some page',
+          href: '/some-page/',
+        },
+      ]}
+    />
+  ),
+};
+
+AdditionalInfo.argTypes = {
+  title: { control: { type: 'text' } },
+};

--- a/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuide.stories.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuide.stories.tsx
@@ -3,6 +3,7 @@ import { Meta } from '@storybook/react';
 import CLIGuide from '..';
 
 export { Simple } from './Simple';
+export { AdditionalInfo } from './AdditionalInfo';
 
 export default {
   title: 'Display/MAPI/CLIGuide',

--- a/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuide.stories.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuide.stories.tsx
@@ -1,0 +1,10 @@
+import { Meta } from '@storybook/react';
+
+import CLIGuide from '..';
+
+export { Simple } from './Simple';
+
+export default {
+  title: 'Display/MAPI/CLIGuide',
+  component: CLIGuide,
+} as Meta;

--- a/src/components/UI/Display/MAPI/CLIGuide/stories/Simple.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/stories/Simple.tsx
@@ -1,0 +1,36 @@
+import { Story } from '@storybook/react';
+import { Box, Text } from 'grommet';
+import React from 'react';
+import { CodeBlock, Prompt } from 'UI/Display/Documentation/CodeBlock';
+
+import CLIGuide from '..';
+
+export const Simple: Story<React.ComponentPropsWithoutRef<typeof CLIGuide>> = (
+  args
+) => {
+  return <CLIGuide {...args} />;
+};
+
+Simple.args = {
+  title: 'Get some data from the somewhere',
+  children: (
+    <Box direction='column' gap='small'>
+      <Box direction='column' gap='small'>
+        <Text>1. Make sure you are a boss</Text>
+        <CodeBlock>
+          <Prompt>some command --some-flag</Prompt>
+        </CodeBlock>
+      </Box>
+      <Box direction='column' gap='small'>
+        <Text>2. Maybe check again if you are still a boss</Text>
+        <CodeBlock>
+          <Prompt>some-other-cli checkboss</Prompt>
+        </CodeBlock>
+      </Box>
+    </Box>
+  ),
+};
+
+Simple.argTypes = {
+  title: { control: { type: 'text' } },
+};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -599,23 +599,23 @@ const theme = deepMerge(generate(16), {
       },
       '5': {
         small: {
-          size: '13px',
-          height: '18px',
+          size: '15px',
+          height: '20px',
           maxWidth: '267px',
         },
         medium: {
-          size: '13px',
-          height: '18px',
+          size: '15px',
+          height: '20px',
           maxWidth: '267px',
         },
         large: {
-          size: '13px',
-          height: '18px',
+          size: '15px',
+          height: '20px',
           maxWidth: '267px',
         },
         xlarge: {
-          size: '13px',
-          height: '18px',
+          size: '15px',
+          height: '20px',
           maxWidth: '267px',
         },
       },

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -134,6 +134,10 @@ const theme = deepMerge(generate(16), {
         dark: '#15253150',
         light: '#15253150',
       },
+      'background-strong': {
+        dark: '#10212c',
+        light: '#10212c',
+      },
       text: {
         dark: '#EEEEEE',
         light: '#EEEEEE',

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -131,8 +131,8 @@ const theme = deepMerge(generate(16), {
         light: '#375b70',
       },
       'background-contrast': {
-        dark: '#15253111',
-        light: '#15253111',
+        dark: '#15253150',
+        light: '#15253150',
       },
       text: {
         dark: '#EEEEEE',


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16564

This PR adds the UI components necessary for creating CLI Guides (see issue for more info). The actual CLI guides will be implemented in a separate PR.

## Preview

<details>
<summary>Closed</summary>

![image](https://user-images.githubusercontent.com/13508038/127870330-6f88dd1b-8daa-4bd7-a30c-e4a12cef90d8.png)

</details>

<details>
<summary>Open</summary>

![image](https://user-images.githubusercontent.com/13508038/127870365-da87e90c-fd35-4edf-bcb1-414dddba5f96.png)

</details>

<details>
<summary>Open (with additional information)</summary>

![image](https://user-images.githubusercontent.com/13508038/127870401-a0701cf3-aa80-4b28-b40a-e71f536e130d.png)

</details>
