### PR TITLE
Change Node Pools table header font size in MAPI UI to align with Key Pairs table

### DIFF
--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -295,40 +295,49 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> = () =>
             margin={{ top: 'xsmall' }}
           >
             <NodesInfo>
-              <NodesInfoText color='text-weak' textAlign='center' size='small'>
+              <NodesInfoText color='text-weak' textAlign='center' size='xsmall'>
                 Nodes
               </NodesInfoText>
             </NodesInfo>
           </ColumnInfo>
-          <Header additionalColumnsCount={additionalColumns.length}>
+          <Header
+            additionalColumnsCount={additionalColumns.length}
+            height='xxsmall'
+          >
             <Box align='center' margin={{ left: '-12px' }}>
-              <Text>Name</Text>
+              <Text size='xsmall'>Name</Text>
             </Box>
             <Box>
-              <Text>Description</Text>
+              <Text size='xsmall'>Description</Text>
             </Box>
             <Box align='center'>
-              <Text>{formatMachineTypeColumnTitle(provider)}</Text>
+              <Text size='xsmall'>
+                {formatMachineTypeColumnTitle(provider)}
+              </Text>
             </Box>
             <Box align='center'>
-              <Text textAlign='center'>Availability zones</Text>
+              <Text textAlign='center' size='xsmall'>
+                Availability zones
+              </Text>
             </Box>
             <Box align='center'>
-              <Text>Min</Text>
+              <Text size='xsmall'>Min</Text>
             </Box>
             <Box align='center'>
-              <Text>Max</Text>
+              <Text size='xsmall'>Max</Text>
             </Box>
             <Box align='center'>
-              <Text>Desired</Text>
+              <Text size='xsmall'>Desired</Text>
             </Box>
             <Box align='center'>
-              <Text>Current</Text>
+              <Text size='xsmall'>Current</Text>
             </Box>
 
             {additionalColumns.map((column) => (
               <Box align='center' key={column.title}>
-                <Text textAlign='center'>{column.title}</Text>
+                <Text textAlign='center' size='xsmall'>
+                  {column.title}
+                </Text>
               </Box>
             ))}
 


### PR DESCRIPTION
Closes [giantswarm/giantswarm#18275](https://github.com/giantswarm/giantswarm/issues/18275).

This PR aligns the node pools header style with the key pairs table to have the same font size of 12px.

![Screen Shot 2021-08-03 at 12 18 51](https://user-images.githubusercontent.com/62935115/127999840-f1cb6539-b048-4345-82d8-3a05807eea4e.png)

![Screen Shot 2021-08-03 at 12 19 09](https://user-images.githubusercontent.com/62935115/127999853-8a7d8ed1-adc7-482a-814a-895aed249f20.png)
