### PR TITLE
Align Access Control subject item's loading spinner width and margin with delete icon's

### DIFF
--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
@@ -8,9 +8,10 @@ import LoadingIndicator from 'UI/Display/Loading/LoadingIndicator';
 import { IAccessControlSubjectSetRenderer } from 'UI/Display/MAPI/AccessControl/AccessControlSubjectSet';
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
-  margin-left: 3px;
+  margin-left: 5px;
   display: block;
   height: 23px;
+  width: 18px;
 
   img {
     display: inline-block;


### PR DESCRIPTION
Closes [giantswarm/giantswarm#16822](https://github.com/giantswarm/giantswarm/issues/16822).

When clicking the "X" delete icon on a subject item, it is briefly replaced by a loading spinner before deletion is complete.

Aligning the loading spinner's width and margin to that of the delete icon's resolves the shift in layout when the subject item is being deleted.

Before deletion:
<img width="113" alt="Screen Shot 2021-08-03 at 14 31 17" src="https://user-images.githubusercontent.com/62935115/128018037-93551ed3-9d81-4cf5-b114-776ec29abff7.png">

After deletion is initiated:
<img width="113" alt="Screen Shot 2021-08-03 at 14 33 48" src="https://user-images.githubusercontent.com/62935115/128018033-6eab94db-3493-4501-8a8f-2f42178debda.png">