### PR TITLE
Refactor the `<Button />` component to use `grommet`

### DIFF
--- a/__tests__/AppDetailPane.tsx
+++ b/__tests__/AppDetailPane.tsx
@@ -152,7 +152,8 @@ describe('Installed app detail pane', () => {
         findByText,
         findByTestId,
         getByText,
-        queryByText,
+        getByRole,
+        queryByRole,
       } = renderRouteWithStore(clusterDetailPath);
 
       const clusterDetailsView = await findByTestId('cluster-details-view');
@@ -167,18 +168,20 @@ describe('Installed app detail pane', () => {
       const fileInputPlaceholder = getByText(
         /User level config values have been set/i
       );
-      let deleteButton = fileInputPlaceholder.parentNode!.querySelector(
-        '.btn-danger'
-      )!;
+      let deleteButton = within(
+        fileInputPlaceholder.parentElement!
+      ).getByRole('button', { name: 'Delete' });
       fireEvent.click(deleteButton);
 
       // Confirm deletion
-      deleteButton = getByText(/^Delete user level config values$/i);
+      deleteButton = getByRole('button', {
+        name: /^Delete user level config values$/i,
+      }) as HTMLButtonElement;
       fireEvent.click(deleteButton);
 
       await waitFor(() => {
         expect(
-          queryByText(/Delete user level config values/i)
+          queryByRole('button', { name: /Delete user level config values/i })
         ).not.toBeInTheDocument();
       });
 
@@ -197,7 +200,7 @@ describe('Installed app detail pane', () => {
         findByText,
         findByTestId,
         getByText,
-        queryByText,
+        queryByRole,
       } = renderRouteWithStore(clusterDetailPath);
 
       const clusterDetailsView = await findByTestId('cluster-details-view');
@@ -236,7 +239,7 @@ describe('Installed app detail pane', () => {
 
       await waitFor(() => {
         expect(
-          queryByText(/delete user level secret values/i)
+          queryByRole('button', { name: /delete user level secret values/i })
         ).not.toBeInTheDocument();
       });
 
@@ -259,7 +262,8 @@ describe('Installed app detail pane', () => {
         findByText,
         findByTestId,
         getByText,
-        queryByText,
+        getByRole,
+        queryByRole,
       } = renderRouteWithStore(clusterDetailPath);
 
       const clusterDetailsView = await findByTestId('cluster-details-view');
@@ -274,18 +278,20 @@ describe('Installed app detail pane', () => {
       const fileInputPlaceholder = getByText(
         /user level secret values have been set/i
       );
-      let deleteButton = fileInputPlaceholder.parentNode!.querySelector(
-        '.btn-danger'
-      )!;
+      let deleteButton = within(
+        fileInputPlaceholder.parentElement!
+      ).getByRole('button', { name: 'Delete' });
       fireEvent.click(deleteButton);
 
       // Confirm deletion
-      deleteButton = getByText(/^delete user level secret values$/i);
+      deleteButton = getByRole('button', {
+        name: /^delete user level secret values$/i,
+      }) as HTMLButtonElement;
       fireEvent.click(deleteButton);
 
       await waitFor(() => {
         expect(
-          queryByText(/delete user level secret values/i)
+          queryByRole('button', { name: /delete user level secret values/i })
         ).not.toBeInTheDocument();
       });
 

--- a/__tests__/V5ClusterManagement.js
+++ b/__tests__/V5ClusterManagement.js
@@ -559,14 +559,16 @@ scales node pools correctly`, async () => {
       filterLabels(v5ClusterResponse.labels)
     );
 
-    const { findByText, getByRole } = renderRouteWithStore(clusterDetailPath);
+    const { findByText, getByRole, findByRole } = renderRouteWithStore(
+      clusterDetailPath
+    );
 
     await findByText('Labels:');
 
     fireEvent.click(
       getByRole('button', { name: `Delete '${visibleLabels[0][0]}' label` })
     );
-    fireEvent.click(await findByText('Delete', { selector: 'button' }));
+    fireEvent.click(await findByRole('button', { name: 'Delete' }));
 
     await findByText(/This cluster has no labels./);
   });
@@ -585,15 +587,15 @@ scales node pools correctly`, async () => {
       findByLabelText,
       findByText,
       getByLabelText,
-      getByText,
+      getByRole,
     } = renderRouteWithStore(clusterDetailPath);
 
     await findByText('Labels:');
-    fireEvent.click(getByText('Add label', { selector: 'button ' }));
+    fireEvent.click(getByRole('button', { name: 'Add label' }));
 
     const keyInput = await findByLabelText('Label key');
     const valueInput = getByLabelText('Label value');
-    const saveButton = getByText('Save', { selector: 'button' });
+    const saveButton = getByRole('button', { name: 'Save' });
 
     fireEvent.change(keyInput, { target: { value: '.invalid.' } });
     fireEvent.change(valueInput, { target: { value: 'valid' } });
@@ -635,14 +637,15 @@ scales node pools correctly`, async () => {
       findByText,
       getByLabelText,
       getByText,
+      getByRole,
     } = renderRouteWithStore(clusterDetailPath);
 
     await findByText('Labels:');
-    fireEvent.click(getByText('Add label', { selector: 'button ' }));
+    fireEvent.click(getByRole('button', { name: 'Add label' }));
 
     const keyInput = await findByLabelText('Label key');
     const valueInput = getByLabelText('Label value');
-    const saveButton = getByText('Save', { selector: 'button' });
+    const saveButton = getByRole('button', { name: 'Save' });
 
     fireEvent.change(keyInput, { target: { value: newLabelKey } });
     fireEvent.change(valueInput, {

--- a/src/components/AccountSettings/ChangeEmailForm.tsx
+++ b/src/components/AccountSettings/ChangeEmailForm.tsx
@@ -148,7 +148,7 @@ class ChangeEmailForm extends React.Component<
           <ButtonPlaceholder>
             <SlideTransition direction='left' in={this.state.isButtonVisible}>
               <Button
-                bsStyle='primary'
+                primary={true}
                 disabled={!this.state.isValid}
                 loading={this.state.isSubmitting}
                 type='submit'

--- a/src/components/AccountSettings/ChangePasswordForm.tsx
+++ b/src/components/AccountSettings/ChangePasswordForm.tsx
@@ -241,7 +241,7 @@ class ChangePassword extends React.Component<
             <div>
               <SlideTransition in={this.state.buttonVisible} direction='down'>
                 <Button
-                  bsStyle='primary'
+                  primary={true}
                   disabled={!this.state.formValid}
                   loading={this.state.submitting}
                   type='submit'

--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -1,6 +1,7 @@
 import { validateAppName } from 'Apps/AppDetail/InstallAppModal/utils';
 import GenericModal from 'components/Modals/GenericModal';
 import { push } from 'connected-react-router';
+import { Box } from 'grommet';
 import yaml from 'js-yaml';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import useDebounce from 'lib/hooks/useDebounce';
@@ -285,8 +286,11 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
 
   return (
     <>
-      <Button bsStyle='primary' onClick={openModal}>
-        <i className='fa fa-add-circle' />
+      <Button
+        primary={true}
+        onClick={openModal}
+        icon={<i className='fa fa-add-circle' />}
+      >
         Install in cluster
       </Button>
       {(() => {
@@ -296,7 +300,7 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
               <GenericModal
                 {...props}
                 footer={
-                  <Button bsStyle='link' onClick={onClose}>
+                  <Button link={true} onClick={onClose}>
                     Cancel
                   </Button>
                 }
@@ -319,22 +323,22 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
               <GenericModal
                 {...props}
                 footer={
-                  <>
+                  <Box direction='row' gap='small' justify='end'>
                     <Button
-                      bsStyle='primary'
+                      primary={true}
                       disabled={anyValidationErrors()}
                       loading={loading}
                       onClick={createApp}
                     >
                       Install app
                     </Button>
-                    <Button bsStyle='link' onClick={previous}>
+                    <Button link={true} onClick={previous}>
                       Pick a different cluster
                     </Button>
-                    <Button bsStyle='link' onClick={onClose}>
+                    <Button link={true} onClick={onClose}>
                       Cancel
                     </Button>
-                  </>
+                  </Box>
                 }
                 onClose={onClose}
                 title={

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -244,7 +244,6 @@ class Login extends React.Component<ILoginProps, ILoginState> {
                   <Button
                     bsStyle='default'
                     loading={authenticating}
-                    onClick={this.logIn}
                     type='submit'
                     disabled={mapiAuthenticating}
                   >

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -199,8 +199,8 @@ class Login extends React.Component<ILoginProps, ILoginState> {
             {featureFlags.flags.CustomerSSO.enabled && (
               <Box margin={{ bottom: 'medium' }}>
                 <Button
-                  bsStyle='primary'
-                  bsSize='lg'
+                  primary={true}
+                  size='large'
                   loading={mapiAuthenticating}
                   onClick={this.mapiLogin}
                   disabled={authenticating}
@@ -241,17 +241,18 @@ class Login extends React.Component<ILoginProps, ILoginState> {
                     />
                   </Box>
 
-                  <Button
-                    bsStyle='default'
-                    loading={authenticating}
-                    type='submit'
-                    disabled={mapiAuthenticating}
-                  >
-                    Log in
-                  </Button>
-                  <Link to={MainRoutes.ForgotPassword}>
-                    Forgot your password?
-                  </Link>
+                  <Box direction='row' gap='small' align='center'>
+                    <Button
+                      loading={authenticating}
+                      type='submit'
+                      disabled={mapiAuthenticating}
+                    >
+                      Log in
+                    </Button>
+                    <Link to={MainRoutes.ForgotPassword}>
+                      Forgot your password?
+                    </Link>
+                  </Box>
                 </form>
                 <div className='login_form--legal'>
                   By logging in you acknowledge that we track your activities in

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/AppDetailsModal.tsx
@@ -223,13 +223,13 @@ const AppDetailsModal: React.FC<IAppDetailsModalProps> = ({
           footer={
             <>
               <Button
-                bsStyle='primary'
+                primary={true}
                 onClick={editChartVersion}
                 loading={isLoading}
               >
                 Update chart version
               </Button>
-              <Button bsStyle='link' onClick={showPane(ModalPanes.Initial)}>
+              <Button link={true} onClick={showPane(ModalPanes.Initial)}>
                 Cancel
               </Button>
             </>

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/DeleteConfirmFooter.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/DeleteConfirmFooter.tsx
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Button from 'UI/Controls/Button';
@@ -14,20 +15,25 @@ const DeleteConfirmFooter: React.FC<IDeleteConfirmFooterProps> = ({
   onCancel,
 }) => {
   return (
-    <>
-      <Button bsStyle='danger' onClick={onConfirm}>
-        <i
-          className='fa fa-delete'
-          role='presentation'
-          aria-hidden='true'
-          aria-label={cta}
-        />
+    <Box direction='row' gap='small' justify='end'>
+      <Button
+        danger={true}
+        onClick={onConfirm}
+        icon={
+          <i
+            className='fa fa-delete'
+            role='presentation'
+            aria-hidden='true'
+            aria-label={cta}
+          />
+        }
+      >
         {cta}
       </Button>
-      <Button bsStyle='link' onClick={onCancel}>
+      <Button link={true} onClick={onCancel}>
         Cancel
       </Button>
-    </>
+    </Box>
   );
 };
 

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/InitialPane.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/InitialPane.tsx
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import { spinner } from 'images';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -113,27 +114,31 @@ const InitialPane: React.FC<IInitialPaneProps> = (props) => {
           <>
             <span>User level config values have been set</span>
 
-            <div className='actions'>
+            <Box direction='row' gap='small'>
               <YAMLFileUpload
                 buttonText='Replace values'
                 onInputChange={props.dispatchUpdateAppConfig}
               />
 
-              <Button bsStyle='danger' onClick={props.showDeleteAppConfigPane}>
-                <i className='fa fa-delete' /> Delete
+              <Button
+                danger={true}
+                onClick={props.showDeleteAppConfigPane}
+                icon={<i className='fa fa-delete' />}
+              >
+                Delete
               </Button>
-            </div>
+            </Box>
           </>
         ) : (
           <>
             <span>No user level config values</span>
 
-            <div className='actions'>
+            <Box direction='row' gap='small'>
               <YAMLFileUpload
                 buttonText='Upload user level config values'
                 onInputChange={props.dispatchCreateAppConfig}
               />
-            </div>
+            </Box>
           </>
         )}
       </DetailItem>
@@ -143,34 +148,41 @@ const InitialPane: React.FC<IInitialPaneProps> = (props) => {
           <>
             <span>User level secret values have been set</span>
 
-            <div className='actions'>
+            <Box direction='row' gap='small'>
               <YAMLFileUpload
                 buttonText='Replace user level secret values'
                 onInputChange={props.dispatchUpdateAppSecret}
               />
 
-              <Button bsStyle='danger' onClick={props.showDeleteAppSecretPane}>
-                <i className='fa fa-delete' /> Delete
+              <Button
+                danger={true}
+                onClick={props.showDeleteAppSecretPane}
+                icon={<i className='fa fa-delete' />}
+              >
+                Delete
               </Button>
-            </div>
+            </Box>
           </>
         ) : (
           <>
             <span>No user level secret values</span>
 
-            <div className='actions'>
+            <Box direction='row' gap='small'>
               <YAMLFileUpload
                 buttonText='Upload user level secret values'
                 onInputChange={props.dispatchCreateAppSecret}
               />
-            </div>
+            </Box>
           </>
         )}
       </DetailItem>
 
       <DetailItem title='Delete This App'>
-        <Button bsStyle='danger' onClick={props.showDeleteAppPane}>
-          <i className='fa fa-delete' />
+        <Button
+          danger={true}
+          onClick={props.showDeleteAppPane}
+          icon={<i className='fa fa-delete' />}
+        >
           Delete app
         </Button>
       </DetailItem>

--- a/src/components/Cluster/ClusterDetail/ClusterApps.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterApps.tsx
@@ -221,8 +221,9 @@ const ClusterApps: React.FC<IClusterAppsProps> = ({
             <BrowseButton
               onClick={openAppCatalog}
               disabled={isUpdatingOrCreating}
+              icon={<i className='fa fa-add-circle' />}
             >
-              <i className='fa fa-add-circle' /> Install app
+              Install app
             </BrowseButton>
 
             {isUpdatingOrCreating && (

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/DeleteLabelButton.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/DeleteLabelButton.tsx
@@ -88,7 +88,7 @@ const DeleteLabelButton: FC<IDeleteLabelButtonProps> = ({
             <DeleteLabelTooltipInner>
               <span>Are you sure you want to delete this label?</span>
               <Button
-                bsStyle='danger'
+                danger={true}
                 onClick={() => {
                   close();
                   onDelete();
@@ -97,7 +97,7 @@ const DeleteLabelButton: FC<IDeleteLabelButtonProps> = ({
                 Delete
               </Button>
               <Button
-                bsStyle='link'
+                link={true}
                 onClick={close}
                 ref={cancelButtonRef}
                 className='cancel-button'

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/DeleteLabelButton.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/DeleteLabelButton.tsx
@@ -25,7 +25,8 @@ const DeleteLabelTooltipInner = styled.div`
   }
 `;
 
-interface IDeleteLabelButtonProps extends ComponentPropsWithoutRef<'button'> {
+interface IDeleteLabelButtonProps
+  extends ComponentPropsWithoutRef<typeof Button> {
   onDelete(): void;
   onOpen(isOpen: boolean): void;
 
@@ -41,7 +42,7 @@ const DeleteLabelButton: FC<IDeleteLabelButtonProps> = ({
   const [isOpen, setIsOpen] = useState(false);
 
   const divElement = useRef<HTMLDivElement>(null);
-  const cancelButtonRef = useRef<HTMLElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
   const close = () => {
     setIsOpen(false);

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/EditLabelTooltip.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/EditLabelTooltip.tsx
@@ -1,4 +1,4 @@
-import { Keyboard, Text } from 'grommet';
+import { Box, Keyboard, Text } from 'grommet';
 import useValidatingInternalValue from 'lib/hooks/useValidatingInternalValue';
 import PropTypes from 'prop-types';
 import React, { FC, KeyboardEventHandler, useRef, useState } from 'react';
@@ -153,8 +153,10 @@ const EditLabelTooltip: FC<IEditLabelTooltip> = ({
           disabled={!allowInteraction || currentlyEditing}
           onClick={open}
           data-testid='add-label-button'
+          icon={<i className='fa fa-add-circle' />}
+          margin={{ left: 'small' }}
         >
-          <i className='fa fa-add-circle' /> Add label
+          Add label
         </Button>
       ) : (
         <Keyboard onSpace={handleLabelKeyDown} onEnter={handleLabelKeyDown}>
@@ -217,16 +219,18 @@ const EditLabelTooltip: FC<IEditLabelTooltip> = ({
                 />
               </ValueInputWrapper>
               <Buttons>
-                <Button
-                  bsStyle='primary'
-                  disabled={!keyIsValid || !valueIsValid}
-                  onClick={save}
-                >
-                  Save
-                </Button>
-                <Button bsStyle='link' onClick={onClose}>
-                  Cancel
-                </Button>
+                <Box gap='small' direction='row'>
+                  <Button
+                    primary={true}
+                    disabled={!keyIsValid || !valueIsValid}
+                    onClick={save}
+                  >
+                    Save
+                  </Button>
+                  <Button link={true} onClick={onClose}>
+                    Cancel
+                  </Button>
+                </Box>
               </Buttons>
             </FormWrapper>
           </Keyboard>

--- a/src/components/Cluster/ClusterDetail/Ingress/InstallIngressButton.tsx
+++ b/src/components/Cluster/ClusterDetail/Ingress/InstallIngressButton.tsx
@@ -152,7 +152,7 @@ const InstallIngressButton: React.FC<IInstallIngressButtonProps> = ({
       {!installedIngressApp && (
         <Button
           loading={isLoading}
-          bsStyle='primary'
+          primary={true}
           loadingTimeout={0}
           onClick={installIngressController}
         >

--- a/src/components/Cluster/ClusterDetail/KeyPairs.js
+++ b/src/components/Cluster/ClusterDetail/KeyPairs.js
@@ -187,7 +187,7 @@ class KeyPairs extends React.Component {
 
   actionsCellFormatter = (_cell, row) => {
     return (
-      <Button bsSize='sm' onClick={this.showKeyPairModal.bind(this, row)}>
+      <Button size='small' onClick={this.showKeyPairModal.bind(this, row)}>
         Details
       </Button>
     );

--- a/src/components/Cluster/ClusterDetail/KeypairCreateModal/DownloadKubeconfigButton.tsx
+++ b/src/components/Cluster/ClusterDetail/KeypairCreateModal/DownloadKubeconfigButton.tsx
@@ -23,7 +23,7 @@ const DownloadKubeconfigButton: React.FC<IDownloadKubeconfigButtonProps> = ({
       // Safe because of defaultProps.
       href={window.URL.createObjectURL(getBlob(content as string))}
     >
-      <Button bsStyle='default'>Download</Button>
+      <Button>Download</Button>
     </a>
   );
 };

--- a/src/components/Cluster/ClusterDetail/KeypairCreateModal/KeyPairCreateModal.tsx
+++ b/src/components/Cluster/ClusterDetail/KeypairCreateModal/KeyPairCreateModal.tsx
@@ -11,6 +11,7 @@ import {
   MODAL_CHANGE_TIMEOUT,
   VALIDATION_DEBOUNCE_RATE,
 } from 'Cluster/ClusterDetail/KeypairCreateModal/Utils';
+import { Box } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { makeKubeConfigTextFile } from 'lib/helpers';
 import useDebounce from 'lib/hooks/useDebounce';
@@ -184,8 +185,8 @@ const KeyPairCreateModal: React.FC<IKeyPairCreateModalProps> = (props) => {
 
   return (
     <>
-      <Button bsStyle='default' onClick={show}>
-        <i className='fa fa-add-circle' /> Create key pair and kubeconfig
+      <Button onClick={show} icon={<i className='fa fa-add-circle' />}>
+        Create key pair and kubeconfig
       </Button>
       <StyledModal
         data-testid='create-key-pair-modal'
@@ -223,24 +224,26 @@ const KeyPairCreateModal: React.FC<IKeyPairCreateModalProps> = (props) => {
             <AddKeyPairErrorTemplate>{modal.errorCode}</AddKeyPairErrorTemplate>
           </BootstrapModal.Body>
           <BootstrapModal.Footer data-testid='create-key-pair-modal-footer'>
-            {modal.status !== KeypairCreateModalStatus.Success && (
-              <Button
-                bsStyle='primary'
-                disabled={cnPrefixError !== null}
-                loading={modal.loading}
-                onClick={confirmAddKeyPair}
-                type='submit'
-                loadingTimeout={0}
-              >
-                {submitButtonText}
-              </Button>
-            )}
+            <Box direction='row' gap='small' justify='end'>
+              {modal.status !== KeypairCreateModalStatus.Success && (
+                <Button
+                  primary={true}
+                  disabled={cnPrefixError !== null}
+                  loading={modal.loading}
+                  onClick={confirmAddKeyPair}
+                  type='submit'
+                  loadingTimeout={0}
+                >
+                  {submitButtonText}
+                </Button>
+              )}
 
-            {!modal.loading && (
-              <Button bsStyle='link' onClick={close}>
-                {closeButtonText}
-              </Button>
-            )}
+              {!modal.loading && (
+                <Button link={true} onClick={close}>
+                  {closeButtonText}
+                </Button>
+              )}
+            </Box>
           </BootstrapModal.Footer>
         </form>
       </StyledModal>

--- a/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesConverter.tsx
+++ b/src/components/Cluster/ClusterDetail/MasterNodes/MasterNodesConverter.tsx
@@ -53,7 +53,7 @@ const MasterNodeConverter: React.FC<IMasterNodeConverterProps> = ({
       </p>
       <ButtonWrapper>
         <Button
-          bsStyle='primary'
+          primary={true}
           loading={isLoading}
           loadingTimeout={0}
           onClick={handleEventListener(onApply)}

--- a/src/components/Cluster/ClusterDetail/ScaleClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/ScaleClusterModal.js
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { compare } from 'lib/semver';
@@ -183,7 +184,7 @@ class ScaleClusterModal extends React.Component {
 
         return {
           title: `Increase minimum number of nodes by ${workerDelta}`,
-          style: 'primary',
+          primary: true,
           disabled: !this.state.scaling.minValid,
         };
       }
@@ -197,7 +198,7 @@ class ScaleClusterModal extends React.Component {
           title: `Remove ${workerDelta} worker node${this.pluralize(
             workerDelta
           )}`,
-          style: 'danger',
+          danger: true,
           disabled: !this.state.scaling.maxValid,
         };
       }
@@ -205,7 +206,7 @@ class ScaleClusterModal extends React.Component {
       if (this.state.scaling.min !== this.props.cluster.scaling.min) {
         return {
           title: 'Apply',
-          style: 'primary',
+          primary: true,
           disabled: !(
             this.state.scaling.minValid && this.state.scaling.maxValid
           ),
@@ -215,7 +216,7 @@ class ScaleClusterModal extends React.Component {
       if (this.state.scaling.max !== this.props.cluster.scaling.max) {
         return {
           title: 'Apply',
-          style: 'primary',
+          primary: true,
           disabled: !(
             this.state.scaling.minValid && this.state.scaling.maxValid
           ),
@@ -236,7 +237,7 @@ class ScaleClusterModal extends React.Component {
     if (workerDelta > 0) {
       return {
         title: `Add ${workerDelta} worker node${pluralizeWorkers}`,
-        style: 'primary',
+        primary: true,
         disabled: !(this.state.scaling.minValid && this.state.scaling.maxValid),
       };
     }
@@ -244,7 +245,7 @@ class ScaleClusterModal extends React.Component {
     if (workerDelta < 0) {
       return {
         title: `Remove ${Math.abs(workerDelta)} worker node${pluralizeWorkers}`,
-        style: 'danger',
+        danger: true,
         disabled: !(this.state.scaling.minValid && this.state.scaling.maxValid),
       };
     }
@@ -348,7 +349,8 @@ class ScaleClusterModal extends React.Component {
       <BootstrapModal.Footer>
         {this.buttonProperties().disabled ? undefined : (
           <Button
-            bsStyle={this.buttonProperties().style}
+            primary={this.buttonProperties().primary}
+            danger={this.buttonProperties().danger}
             disabled={this.buttonProperties().disabled}
             loading={this.state.loading}
             onClick={this.submit}
@@ -357,11 +359,7 @@ class ScaleClusterModal extends React.Component {
             {this.buttonProperties().title}
           </Button>
         )}
-        <Button
-          bsStyle='link'
-          disabled={this.state.loading}
-          onClick={this.close}
-        >
+        <Button link={true} disabled={this.state.loading} onClick={this.close}>
           Cancel
         </Button>
       </BootstrapModal.Footer>
@@ -380,20 +378,22 @@ class ScaleClusterModal extends React.Component {
       );
       footer = (
         <BootstrapModal.Footer>
-          <Button
-            bsStyle='link'
-            disabled={this.state.loading}
-            onClick={this.back}
-          >
-            Back
-          </Button>
-          <Button
-            bsStyle='link'
-            disabled={this.state.loading}
-            onClick={this.close}
-          >
-            Cancel
-          </Button>
+          <Box gap='small' direction='row' justify='end'>
+            <Button
+              link={true}
+              disabled={this.state.loading}
+              onClick={this.back}
+            >
+              Back
+            </Button>
+            <Button
+              link={true}
+              disabled={this.state.loading}
+              onClick={this.close}
+            >
+              Cancel
+            </Button>
+          </Box>
         </BootstrapModal.Footer>
       );
     }

--- a/src/components/Cluster/ClusterDetail/ScaleClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/ScaleClusterModal.js
@@ -351,7 +351,6 @@ class ScaleClusterModal extends React.Component {
             bsStyle={this.buttonProperties().style}
             disabled={this.buttonProperties().disabled}
             loading={this.state.loading}
-            loadingPosition='left'
             onClick={this.submit}
             type='submit'
           >

--- a/src/components/Cluster/ClusterDetail/ScaleNodePoolModal.tsx
+++ b/src/components/Cluster/ClusterDetail/ScaleNodePoolModal.tsx
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import PropTypes from 'prop-types';
@@ -215,7 +216,7 @@ class ScaleNodePoolModal extends React.Component<
 
         return {
           title: `Increase minimum number of nodes by ${workerDelta}`,
-          style: 'primary' as const,
+          primary: true,
           disabled: !minValid,
         };
       }
@@ -227,7 +228,7 @@ class ScaleNodePoolModal extends React.Component<
           title: `Remove ${workerDelta} worker node${this.pluralize(
             workerDelta
           )}`,
-          style: 'danger' as const,
+          danger: true,
           disabled: !maxValid,
         };
       }
@@ -235,7 +236,7 @@ class ScaleNodePoolModal extends React.Component<
       if (min !== nodePool.scaling!.min) {
         return {
           title: 'Apply',
-          style: 'primary' as const,
+          primary: true,
           disabled: !(minValid && maxValid),
         };
       }
@@ -243,7 +244,7 @@ class ScaleNodePoolModal extends React.Component<
       if (max !== nodePool.scaling!.max) {
         return {
           title: 'Apply',
-          style: 'primary' as const,
+          primary: true,
           disabled: !(minValid && maxValid),
         };
       }
@@ -256,7 +257,7 @@ class ScaleNodePoolModal extends React.Component<
     if (workerDelta > 0) {
       return {
         title: `Add ${workerDelta} worker node${pluralizeWorkers}`,
-        style: 'primary' as const,
+        primary: true,
         disabled: !(minValid && maxValid),
       };
     }
@@ -264,7 +265,7 @@ class ScaleNodePoolModal extends React.Component<
     if (workerDelta < 0) {
       return {
         title: `Remove ${Math.abs(workerDelta)} worker node${pluralizeWorkers}`,
-        style: 'danger' as const,
+        danger: true,
         disabled: !(minValid && maxValid),
       };
     }
@@ -338,20 +339,23 @@ class ScaleNodePoolModal extends React.Component<
     );
     let footer = (
       <BootstrapModal.Footer>
-        {this.buttonProperties().disabled ? undefined : (
-          <Button
-            bsStyle={this.buttonProperties().style}
-            disabled={this.buttonProperties().disabled}
-            loading={loading}
-            onClick={this.submit}
-            type='submit'
-          >
-            {this.buttonProperties().title}
+        <Box gap='small' direction='row' justify='end'>
+          {this.buttonProperties().disabled ? undefined : (
+            <Button
+              primary={this.buttonProperties().primary}
+              danger={this.buttonProperties().danger}
+              disabled={this.buttonProperties().disabled}
+              loading={loading}
+              onClick={this.submit}
+              type='submit'
+            >
+              {this.buttonProperties().title}
+            </Button>
+          )}
+          <Button link={true} disabled={loading} onClick={this.close}>
+            Cancel
           </Button>
-        )}
-        <Button bsStyle='link' disabled={loading} onClick={this.close}>
-          Cancel
-        </Button>
+        </Box>
       </BootstrapModal.Footer>
     );
 
@@ -366,10 +370,10 @@ class ScaleNodePoolModal extends React.Component<
       );
       footer = (
         <BootstrapModal.Footer>
-          <Button bsStyle='link' disabled={loading} onClick={this.back}>
+          <Button link={true} disabled={loading} onClick={this.back}>
             Back
           </Button>
-          <Button bsStyle='link' disabled={loading} onClick={this.close}>
+          <Button link={true} disabled={loading} onClick={this.close}>
             Cancel
           </Button>
         </BootstrapModal.Footer>

--- a/src/components/Cluster/ClusterDetail/ScaleNodePoolModal.tsx
+++ b/src/components/Cluster/ClusterDetail/ScaleNodePoolModal.tsx
@@ -343,7 +343,6 @@ class ScaleNodePoolModal extends React.Component<
             bsStyle={this.buttonProperties().style}
             disabled={this.buttonProperties().disabled}
             loading={loading}
-            loadingPosition='left'
             onClick={this.submit}
             type='submit'
           >

--- a/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
+++ b/src/components/Cluster/ClusterDetail/UpgradeClusterModal.js
@@ -1,4 +1,5 @@
 import diff from 'deep-diff';
+import { Box } from 'grommet';
 import { clusterUpgradeChecklistURL } from 'lib/docs';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
@@ -199,15 +200,17 @@ class UpgradeClusterModal extends React.Component {
           {UpgradeClusterModal.getMasterNodesInfo(this.props.cluster)}
         </BootstrapModal.Body>
         <BootstrapModal.Footer>
-          <Button
-            bsStyle='primary'
-            onClick={() => this.goToPage(Pages.InspectChanges)}
-          >
-            Inspect changes
-          </Button>
-          <Button bsStyle='link' onClick={this.close}>
-            Cancel
-          </Button>
+          <Box gap='small' direction='row' justify='end'>
+            <Button
+              primary={true}
+              onClick={() => this.goToPage(Pages.InspectChanges)}
+            >
+              Inspect changes
+            </Button>
+            <Button link={true} onClick={this.close}>
+              Cancel
+            </Button>
+          </Box>
         </BootstrapModal.Footer>
       </div>
     );
@@ -227,7 +230,7 @@ class UpgradeClusterModal extends React.Component {
         <BootstrapModal.Body>{this.changedComponents()}</BootstrapModal.Body>
         <BootstrapModal.Footer>
           <Button
-            bsStyle='primary'
+            primary={true}
             loading={loading}
             onClick={this.submit}
             loadingTimeout={0}
@@ -236,7 +239,7 @@ class UpgradeClusterModal extends React.Component {
           </Button>
 
           {!loading && (
-            <Button bsStyle='link' onClick={this.close}>
+            <Button link={true} onClick={this.close}>
               Cancel
             </Button>
           )}

--- a/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V4ClusterDetailTable.js
@@ -57,10 +57,6 @@ const KubernetesURIWrapper = styled(FlexRowWithTwoBlocksOnEdges)`
       }
     }
   }
-
-  i {
-    padding: 0 8px;
-  }
 `;
 
 const GetStartedWrapper = styled.div`
@@ -144,8 +140,11 @@ class V4ClusterDetailTable extends React.Component {
             {api_endpoint}
           </StyledURIBlock>
           <GetStartedWrapper>
-            <Button onClick={this.props.accessCluster}>
-              <i className='fa fa-start' /> Get started
+            <Button
+              onClick={this.props.accessCluster}
+              icon={<i className='fa fa-start' />}
+            >
+              Get started
             </Button>
           </GetStartedWrapper>
         </KubernetesURIWrapper>

--- a/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
+++ b/src/components/Cluster/ClusterDetail/V5ClusterDetailTable.js
@@ -1,6 +1,7 @@
 import MasterNodes from 'Cluster/ClusterDetail/MasterNodes/MasterNodes';
 import V5ClusterDetailTableNodePoolScaling from 'Cluster/ClusterDetail/V5ClusterDetailTableNodePoolScaling';
 import formatDistance from 'date-fns/fp/formatDistance';
+import { Box } from 'grommet';
 import produce from 'immer';
 import { nodePoolsURL } from 'lib/docs';
 import ErrorReporter from 'lib/errors/ErrorReporter';
@@ -246,10 +247,6 @@ const KubernetesURIWrapper = styled(FlexRowWithTwoBlocksOnEdges)`
       }
     }
   }
-
-  i {
-    padding: 0 8px;
-  }
 `;
 
 const GetStartedWrapper = styled.div`
@@ -457,8 +454,11 @@ class V5ClusterDetailTable extends React.Component {
             {api_endpoint}
           </StyledURIBlock>
           <GetStartedWrapper>
-            <Button onClick={accessCluster}>
-              <i className='fa fa-start' /> Get started
+            <Button
+              onClick={accessCluster}
+              icon={<i className='fa fa-start' />}
+            >
+              Get started
             </Button>
           </GetStartedWrapper>
         </KubernetesURIWrapper>
@@ -550,26 +550,27 @@ class V5ClusterDetailTable extends React.Component {
                   capabilities={cluster.capabilities}
                 />
                 <FlexWrapperDiv>
-                  <Button
-                    bsStyle='primary'
-                    disabled={!nodePoolForm.isValid}
-                    loading={nodePoolForm.isSubmitting}
-                    onClick={this.createNodePool}
-                    type='button'
-                  >
-                    Create node pool
-                  </Button>
-                  {/* We want to hide cancel button when the Create NP button has been clicked */}
-                  {!nodePoolForm.isSubmitting && (
+                  <Box gap='small' direction='row'>
                     <Button
-                      bsStyle='default'
+                      primary={true}
+                      disabled={!nodePoolForm.isValid}
                       loading={nodePoolForm.isSubmitting}
-                      onClick={this.toggleAddNodePoolForm}
+                      onClick={this.createNodePool}
                       type='button'
                     >
-                      Cancel
+                      Create node pool
                     </Button>
-                  )}
+                    {/* We want to hide cancel button when the Create NP button has been clicked */}
+                    {!nodePoolForm.isSubmitting && (
+                      <Button
+                        loading={nodePoolForm.isSubmitting}
+                        onClick={this.toggleAddNodePoolForm}
+                        type='button'
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                  </Box>
                 </FlexWrapperDiv>
               </AddNodePoolFlexColumnDiv>
             </AddNodePoolWrapperDiv>
@@ -586,8 +587,11 @@ class V5ClusterDetailTable extends React.Component {
               </p>
             )}
             <RUMActionTarget name={RUMActions.AddNodePool}>
-              <Button onClick={this.toggleAddNodePoolForm}>
-                <i className='fa fa-add-circle' /> Add node pool
+              <Button
+                onClick={this.toggleAddNodePoolForm}
+                icon={<i className='fa fa-add-circle' />}
+              >
+                Add node pool
               </Button>
             </RUMActionTarget>
             {nodePools && nodePools.length === 1 && (

--- a/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
+++ b/src/components/Cluster/NewCluster/CreateNodePoolsCluster.js
@@ -296,37 +296,41 @@ class CreateNodePoolsCluster extends Component {
             })}
           </NodePoolsTransitionGroup>
           <RUMActionTarget name={RUMActions.AddNodePool}>
-            <Button onClick={this.addNodePoolForm}>
-              <i className='fa fa-add-circle' /> Add node pool
+            <Button
+              onClick={this.addNodePoolForm}
+              icon={<i className='fa fa-add-circle' />}
+            >
+              Add node pool
             </Button>
           </RUMActionTarget>
           <HorizontalLine />
         </Box>
         <FlexRow>
-          <RUMActionTarget name={RUMActions.CreateClusterSubmit}>
-            <Button
-              bsStyle='primary'
-              disabled={!this.isValid()}
-              loading={isClusterCreating}
-              onClick={this.createCluster}
-              type='button'
-            >
-              Create cluster
-            </Button>
-          </RUMActionTarget>
-          {/* We want to hide cancel button when the Create NP button has been clicked */}
-          {!isClusterCreating && (
-            <RUMActionTarget name={RUMActions.CreateClusterCancel}>
+          <Box gap='small' direction='row'>
+            <RUMActionTarget name={RUMActions.CreateClusterSubmit}>
               <Button
-                bsStyle='default'
+                primary={true}
+                disabled={!this.isValid()}
                 loading={isClusterCreating}
-                onClick={this.props.closeForm}
+                onClick={this.createCluster}
                 type='button'
               >
-                Cancel
+                Create cluster
               </Button>
             </RUMActionTarget>
-          )}
+            {/* We want to hide cancel button when the Create NP button has been clicked */}
+            {!isClusterCreating && (
+              <RUMActionTarget name={RUMActions.CreateClusterCancel}>
+                <Button
+                  loading={isClusterCreating}
+                  onClick={this.props.closeForm}
+                  type='button'
+                >
+                  Cancel
+                </Button>
+              </RUMActionTarget>
+            )}
+          </Box>
         </FlexRow>
         <FlexRow>
           <ClusterCreationHint>

--- a/src/components/Cluster/NewCluster/CreateRegularCluster.js
+++ b/src/components/Cluster/NewCluster/CreateRegularCluster.js
@@ -343,29 +343,30 @@ class CreateRegularCluster extends React.Component {
         <HorizontalLine />
 
         <FlexRow>
-          <RUMActionTarget name={RUMActions.CreateClusterSubmit}>
-            <Button
-              bsStyle='primary'
-              disabled={!this.valid()}
-              loading={isClusterCreating}
-              onClick={this.createCluster}
-              type='submit'
-            >
-              Create cluster
-            </Button>
-          </RUMActionTarget>
-          {!isClusterCreating && (
-            <RUMActionTarget name={RUMActions.CreateClusterCancel}>
+          <Box gap='small' direction='row'>
+            <RUMActionTarget name={RUMActions.CreateClusterSubmit}>
               <Button
-                bsStyle='default'
+                primary={true}
+                disabled={!this.valid()}
                 loading={isClusterCreating}
-                onClick={this.props.closeForm}
-                type='button'
+                onClick={this.createCluster}
+                type='submit'
               >
-                Cancel
+                Create cluster
               </Button>
             </RUMActionTarget>
-          )}
+            {!isClusterCreating && (
+              <RUMActionTarget name={RUMActions.CreateClusterCancel}>
+                <Button
+                  loading={isClusterCreating}
+                  onClick={this.props.closeForm}
+                  type='button'
+                >
+                  Cancel
+                </Button>
+              </RUMActionTarget>
+            )}
+          </Box>
         </FlexRow>
         <FlexColumn>
           <ClusterCreationDuration stats={this.props.clusterCreationStats} />

--- a/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
+++ b/src/components/Cluster/NewCluster/ReleaseSelector/ReleaseRow.tsx
@@ -5,7 +5,7 @@ import React, { FC, useState } from 'react';
 import RUMActionTarget from 'RUM/RUMActionTarget';
 import { RUMActions } from 'shared/constants/realUserMonitoring';
 import styled from 'styled-components';
-import { TableButton } from 'UI/Controls/ExpandableSelector/Items';
+import Button from 'UI/Controls/Button';
 import KubernetesVersionLabel from 'UI/Display/Cluster/KubernetesVersionLabel';
 import ReleaseComponentLabel from 'UI/Display/Cluster/ReleaseComponentLabel';
 import { TableCell, TableRow } from 'UI/Display/Table';
@@ -14,10 +14,6 @@ import RadioInput from 'UI/Inputs/RadioInput';
 import { IRelease } from './ReleaseSelector';
 
 const INACTIVE_OPACITY = 0.4;
-
-const FixedWidthTableButton = styled(TableButton)`
-  width: 100px;
-`;
 
 const StyledTableRow = styled(TableRow)`
   cursor: pointer;
@@ -133,21 +129,23 @@ const ReleaseRow: FC<IReleaseRow> = ({
               onEnter={handleButtonKeyDown}
               onSpace={handleButtonKeyDown}
             >
-              <FixedWidthTableButton
+              <Button
                 data-testid={`show-components-${version}`}
                 onClick={(e: React.MouseEvent) => {
                   e.stopPropagation();
                   e.preventDefault();
                   setCollapsed(!collapsed);
                 }}
+                icon={
+                  <i
+                    role='presentation'
+                    aria-hidden={true}
+                    className={`fa fa-${collapsed ? 'eye' : 'eye-with-line'}`}
+                  />
+                }
               >
-                <i
-                  role='presentation'
-                  aria-hidden={true}
-                  className={`fa fa-${collapsed ? 'eye' : 'eye-with-line'}`}
-                />
                 {collapsed ? 'Show' : 'Hide'}
-              </FixedWidthTableButton>
+              </Button>
             </Keyboard>
           </RUMActionTarget>
         </TableCell>
@@ -159,21 +157,23 @@ const ReleaseRow: FC<IReleaseRow> = ({
           }
         >
           <Keyboard onEnter={handleButtonKeyDown} onSpace={handleButtonKeyDown}>
-            <TableButton
+            <Button
               data-testid={`open-changelog-${version}`}
               href={releaseNotesURL}
               target='_blank'
               rel='noopener noreferrer'
               onClick={(e: React.MouseEvent) => e.stopPropagation()}
               disabled={!releaseNotesURL}
+              icon={
+                <i
+                  className='fa fa-open-in-new'
+                  aria-hidden={true}
+                  role='presentation'
+                />
+              }
             >
-              <i
-                className='fa fa-open-in-new'
-                aria-hidden={true}
-                role='presentation'
-              />
               Open
-            </TableButton>
+            </Button>
           </Keyboard>
         </TableCell>
       </StyledTableRow>

--- a/src/components/Footer/FooterUpdateButton.tsx
+++ b/src/components/Footer/FooterUpdateButton.tsx
@@ -29,8 +29,8 @@ const FooterUpdateButton: React.FC<IFooterUpdateButtonProps> = ({
       <StyledButton
         disabled={isUpdating}
         loading={isUpdating}
-        bsStyle='warning'
-        bsSize='sm'
+        warning={true}
+        size='small'
         onClick={onClick}
         {...rest}
       >

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import {
   clearQueues,
@@ -137,15 +138,17 @@ class ForgotPassword extends React.Component {
             value={this.state.email}
             margin={{ bottom: 'medium' }}
           />
-          <Button
-            bsStyle='primary'
-            loading={this.state.submitting}
-            onClick={this.submit}
-            type='submit'
-          >
-            {this.state.submitting ? 'Submitting ...' : 'Submit'}
-          </Button>
-          <Link to={MainRoutes.Login}>Back to login form</Link>
+          <Box direction='row' gap='small' align='center'>
+            <Button
+              primary={true}
+              loading={this.state.submitting}
+              onClick={this.submit}
+              type='submit'
+            >
+              {this.state.submitting ? 'Submitting ...' : 'Submit'}
+            </Button>
+            <Link to={MainRoutes.Login}>Back to login form</Link>
+          </Box>
         </form>
       </>
     );

--- a/src/components/ForgotPassword/SetPassword.js
+++ b/src/components/ForgotPassword/SetPassword.js
@@ -1,4 +1,5 @@
 import { push } from 'connected-react-router';
+import { Box } from 'grommet';
 import { spinner } from 'images';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import {
@@ -257,16 +258,18 @@ class SetPassword extends React.Component {
             type='password'
           />
 
-          <Button
-            onClick={this.submit}
-            bsStyle='primary'
-            disabled={this.state.submitting || !this.formIsValid()}
-            loading={this.state.submitting}
-          >
-            {this.state.submitting ? 'Submitting ...' : 'Submit'}
-          </Button>
+          <Box direction='row' gap='small' align='center'>
+            <Button
+              onClick={this.submit}
+              primary={true}
+              disabled={this.state.submitting || !this.formIsValid()}
+              loading={this.state.submitting}
+            >
+              {this.state.submitting ? 'Submitting ...' : 'Submit'}
+            </Button>
 
-          <Link to={MainRoutes.Login}>Back to login form</Link>
+            <Link to={MainRoutes.Login}>Back to login form</Link>
+          </Box>
         </form>
       );
     }
@@ -306,15 +309,17 @@ class SetPassword extends React.Component {
           value={this.state.emailField}
         />
 
-        <Button
-          bsStyle='primary'
-          disabled={this.state.submitting}
-          onClick={this.setEmail}
-          loading={this.state.submitting}
-        >
-          {this.state.submitting ? 'Submitting ...' : 'Submit'}
-        </Button>
-        <Link to={MainRoutes.Login}>Back to login form</Link>
+        <Box direction='row' gap='small' align='center'>
+          <Button
+            primary={true}
+            disabled={this.state.submitting}
+            onClick={this.setEmail}
+            loading={this.state.submitting}
+          >
+            {this.state.submitting ? 'Submitting ...' : 'Submit'}
+          </Button>
+          <Link to={MainRoutes.Login}>Back to login form</Link>
+        </Box>
         <br />
         <br />
         <Link to={MainRoutes.ForgotPassword}>Request a new token</Link>

--- a/src/components/ForgotPassword/SetPassword.js
+++ b/src/components/ForgotPassword/SetPassword.js
@@ -262,7 +262,6 @@ class SetPassword extends React.Component {
             bsStyle='primary'
             disabled={this.state.submitting || !this.formIsValid()}
             loading={this.state.submitting}
-            loadingPosition='right'
           >
             {this.state.submitting ? 'Submitting ...' : 'Submit'}
           </Button>
@@ -312,7 +311,6 @@ class SetPassword extends React.Component {
           disabled={this.state.submitting}
           onClick={this.setEmail}
           loading={this.state.submitting}
-          loadingPosition='right'
         >
           {this.state.submitting ? 'Submitting ...' : 'Submit'}
         </Button>

--- a/src/components/GettingStarted/Steps/ConfigureKubectl.js
+++ b/src/components/GettingStarted/Steps/ConfigureKubectl.js
@@ -337,14 +337,16 @@ class ConfigKubeCtl extends React.Component {
 
           <GettingStartedBottomNav>
             <Link to={clusterGuideOverviewPath}>
-              <Button bsStyle='default'>
-                <i className='fa fa-chevron-left' /> Back
-              </Button>
+              <Button icon={<i className='fa fa-chevron-left' />}>Back</Button>
             </Link>
 
             <Link to={this.props.steps[this.props.stepIndex + 1].url}>
-              <Button bsStyle='primary'>
-                Continue <i className='fa fa-chevron-right' />
+              <Button
+                primary={true}
+                icon={<i className='fa fa-chevron-right' />}
+                reverse={true}
+              >
+                Continue
               </Button>
             </Link>
           </GettingStartedBottomNav>

--- a/src/components/GettingStarted/Steps/ConfigureKubectlAlternative.js
+++ b/src/components/GettingStarted/Steps/ConfigureKubectlAlternative.js
@@ -193,7 +193,7 @@ class ConfigKubeCtl extends React.Component {
               })
             )}
           >
-            <Button bsStyle='default'>CA CERTIFICATE</Button>
+            <Button>CA CERTIFICATE</Button>
           </a>
           <a
             download='client.crt'
@@ -203,7 +203,7 @@ class ConfigKubeCtl extends React.Component {
               })
             )}
           >
-            <Button bsStyle='default'>CLIENT CERTIFICATE</Button>
+            <Button>CLIENT CERTIFICATE</Button>
           </a>
           <a
             download='client.key'
@@ -213,7 +213,7 @@ class ConfigKubeCtl extends React.Component {
               })
             )}
           >
-            <Button bsStyle='default'>CLIENT KEY</Button>
+            <Button>CLIENT KEY</Button>
           </a>
         </div>
       </KubeconfigAndDownloadButtons>
@@ -248,7 +248,7 @@ class ConfigKubeCtl extends React.Component {
         ) : (
           <CreateKeyPairPlaceHolder>
             <Button
-              bsStyle='primary'
+              primary={true}
               loading={this.state.keyPair.generating}
               onClick={this.generateKeyPair}
             >

--- a/src/components/GettingStarted/Steps/InstallIngress.js
+++ b/src/components/GettingStarted/Steps/InstallIngress.js
@@ -82,14 +82,16 @@ const InstallIngress = (props) => {
 
         <GettingStartedBottomNav>
           <Link to={clusterGuideConfigurationPath}>
-            <Button bsStyle='default'>
-              <i className='fa fa-chevron-left' /> Back
-            </Button>
+            <Button icon={<i className='fa fa-chevron-left' />}>Back</Button>
           </Link>
 
           <Link to={clusterGuideExamplePath}>
-            <Button bsStyle='primary'>
-              Continue <i className='fa fa-chevron-right' />
+            <Button
+              primary={true}
+              icon={<i className='fa fa-chevron-right' />}
+              reverse={true}
+            >
+              Continue
             </Button>
           </Link>
         </GettingStartedBottomNav>

--- a/src/components/GettingStarted/Steps/NextSteps.js
+++ b/src/components/GettingStarted/Steps/NextSteps.js
@@ -94,9 +94,7 @@ const NextSteps = (props) => {
 
         <GettingStartedBottomNav>
           <Link to={clusterGuideExamplePath}>
-            <Button bsStyle='default'>
-              <i className='fa fa-chevron-left' /> Back
-            </Button>
+            <Button icon={<i className='fa fa-chevron-left' />}>Back</Button>
           </Link>
         </GettingStartedBottomNav>
       </>

--- a/src/components/GettingStarted/Steps/Overview.js
+++ b/src/components/GettingStarted/Steps/Overview.js
@@ -23,8 +23,12 @@ const Overview = (props) => (
 
     <GettingStartedBottomNav>
       <Link to={props.steps[0].url}>
-        <Button bsStyle='primary'>
-          Start <i className='fa fa-chevron-right' />
+        <Button
+          primary={true}
+          icon={<i className='fa fa-chevron-right' />}
+          reverse={true}
+        >
+          Start
         </Button>
       </Link>
     </GettingStartedBottomNav>

--- a/src/components/GettingStarted/Steps/SimpleExample.js
+++ b/src/components/GettingStarted/Steps/SimpleExample.js
@@ -298,14 +298,16 @@ class SimpleExample extends React.Component {
 
           <GettingStartedBottomNav>
             <Link to={this.props.steps[this.props.stepIndex - 1].url}>
-              <Button bsStyle='default'>
-                <i className='fa fa-chevron-left' /> Back
-              </Button>
+              <Button icon={<i className='fa fa-chevron-left' />}>Back</Button>
             </Link>
 
             <Link to={clusterGuideNextStepsPath}>
-              <Button bsStyle='primary'>
-                Finish <i className='fa fa-chevron-right' />
+              <Button
+                primary={true}
+                icon={<i className='fa fa-chevron-right' />}
+                reverse={true}
+              >
+                Finish
               </Button>
             </Link>
           </GettingStartedBottomNav>

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -5,7 +5,6 @@ import { relativeDate } from 'lib/helpers';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { CSSBreakpoints } from 'shared/constants';
@@ -284,12 +283,12 @@ function ClusterDashboardItem({
 
         <ButtonsWrapper>
           {clusterYoungerThan30Days() ? (
-            <ButtonGroup>
-              <Button onClick={accessCluster}>
-                <i className='fa fa-start' />
-                Get started
-              </Button>
-            </ButtonGroup>
+            <Button
+              onClick={accessCluster}
+              icon={<i className='fa fa-start' />}
+            >
+              Get started
+            </Button>
           ) : (
             ''
           )}

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,5 +1,6 @@
 import DocumentTitle from 'components/shared/DocumentTitle';
 import formatDistance from 'date-fns/fp/formatDistance';
+import { Box } from 'grommet';
 import PageVisibilityTracker from 'lib/pageVisibilityTracker';
 import RoutePath from 'lib/routePath';
 import PropTypes from 'prop-types';
@@ -124,15 +125,19 @@ class Home extends React.Component {
       <DocumentTitle title={this.title()}>
         <div data-testid='clusters-list'>
           {selectedOrganization && (
-            <div className='well launch-new-cluster'>
+            <Box className='well' gap='small' direction='row' align='center'>
               <Link to={this.newClusterPath()}>
-                <Button bsStyle='primary' type='button'>
-                  <i className='fa fa-add-circle' /> Launch new cluster
+                <Button
+                  primary={true}
+                  type='button'
+                  icon={<i className='fa fa-add-circle' />}
+                >
+                  Launch new cluster
                 </Button>
               </Link>
               {clusters.length === 0 &&
                 'Ready to launch your first cluster? Click the green button!'}
-            </div>
+            </Box>
           )}
           {clusters.length === 0 && (
             <ClusterEmptyState

--- a/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/AppDetailsModalInitialPane.tsx
@@ -1,4 +1,5 @@
 import YAMLFileUpload from 'Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload';
+import { Box } from 'grommet';
 import { spinner } from 'images';
 import { compare } from 'lib/semver';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
@@ -125,27 +126,31 @@ const AppDetailsModalInitialPane: React.FC<IAppDetailsModalInitialPaneProps> = (
           <>
             <span>User level config values have been set</span>
 
-            <div className='actions'>
+            <Box direction='row' gap='small'>
               <YAMLFileUpload
                 buttonText='Replace values'
                 onInputChange={props.dispatchUpdateAppConfig}
               />
 
-              <Button bsStyle='danger' onClick={props.showDeleteAppConfigPane}>
-                <i className='fa fa-delete' /> Delete
+              <Button
+                danger={true}
+                onClick={props.showDeleteAppConfigPane}
+                icon={<i className='fa fa-delete' />}
+              >
+                Delete
               </Button>
-            </div>
+            </Box>
           </>
         ) : (
           <>
             <span>No user level config values</span>
 
-            <div className='actions'>
+            <Box direction='row' gap='small'>
               <YAMLFileUpload
                 buttonText='Upload user level config values'
                 onInputChange={props.dispatchCreateAppConfig}
               />
-            </div>
+            </Box>
           </>
         )}
       </DetailItem>
@@ -155,34 +160,41 @@ const AppDetailsModalInitialPane: React.FC<IAppDetailsModalInitialPaneProps> = (
           <>
             <span>User level secret values have been set</span>
 
-            <div className='actions'>
+            <Box direction='row' gap='small'>
               <YAMLFileUpload
                 buttonText='Replace user level secret values'
                 onInputChange={props.dispatchUpdateAppSecret}
               />
 
-              <Button bsStyle='danger' onClick={props.showDeleteAppSecretPane}>
-                <i className='fa fa-delete' /> Delete
+              <Button
+                danger={true}
+                onClick={props.showDeleteAppSecretPane}
+                icon={<i className='fa fa-delete' />}
+              >
+                Delete
               </Button>
-            </div>
+            </Box>
           </>
         ) : (
           <>
             <span>No user level secret values</span>
 
-            <div className='actions'>
+            <Box direction='row' gap='small'>
               <YAMLFileUpload
                 buttonText='Upload user level secret values'
                 onInputChange={props.dispatchCreateAppSecret}
               />
-            </div>
+            </Box>
           </>
         )}
       </DetailItem>
 
       <DetailItem title='Delete This App'>
-        <Button bsStyle='danger' onClick={props.showDeleteAppPane}>
-          <i className='fa fa-delete' />
+        <Button
+          danger={true}
+          onClick={props.showDeleteAppPane}
+          icon={<i className='fa fa-delete' />}
+        >
           Delete app
         </Button>
       </DetailItem>

--- a/src/components/MAPI/apps/AppDetailsModal/index.tsx
+++ b/src/components/MAPI/apps/AppDetailsModal/index.tsx
@@ -497,13 +497,13 @@ const AppDetailsModal: React.FC<IAppDetailsModalProps> = ({
           footer={
             <>
               <Button
-                bsStyle='primary'
+                primary={true}
                 onClick={editChartVersion}
                 loading={appUpdateIsLoading}
               >
                 Update chart version
               </Button>
-              <Button bsStyle='link' onClick={showPane(ModalPanes.Initial)}>
+              <Button link={true} onClick={showPane(ModalPanes.Initial)}>
                 Cancel
               </Button>
             </>

--- a/src/components/MAPI/apps/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/AppInstallModal.tsx
@@ -4,6 +4,7 @@ import { validateAppName } from 'Apps/AppDetail/InstallAppModal/utils';
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import GenericModal from 'components/Modals/GenericModal';
 import { push } from 'connected-react-router';
+import { Box } from 'grommet';
 import yaml from 'js-yaml';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
@@ -310,8 +311,11 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
 
   return (
     <>
-      <Button bsStyle='primary' onClick={openModal}>
-        <i className='fa fa-add-circle' />
+      <Button
+        primary={true}
+        onClick={openModal}
+        icon={<i className='fa fa-add-circle' />}
+      >
         Install in cluster
       </Button>
       {(() => {
@@ -320,7 +324,7 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
             return (
               <GenericModal
                 footer={
-                  <Button bsStyle='link' onClick={onClose}>
+                  <Button link={true} onClick={onClose}>
                     Cancel
                   </Button>
                 }
@@ -342,22 +346,22 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
             return (
               <GenericModal
                 footer={
-                  <>
+                  <Box direction='row' gap='small' justify='end'>
                     <Button
-                      bsStyle='primary'
+                      primary={true}
                       disabled={anyValidationErrors()}
                       loading={loading}
                       onClick={installApp}
                     >
                       Install app
                     </Button>
-                    <Button bsStyle='link' onClick={previous}>
+                    <Button link={true} onClick={previous}>
                       Pick a different cluster
                     </Button>
-                    <Button bsStyle='link' onClick={onClose}>
+                    <Button link={true} onClick={onClose}>
                       Cancel
                     </Button>
-                  </>
+                  </Box>
                 }
                 onClose={onClose}
                 title={

--- a/src/components/MAPI/apps/AppList/__tests__/index.tsx
+++ b/src/components/MAPI/apps/AppList/__tests__/index.tsx
@@ -120,8 +120,7 @@ describe('AppList', () => {
 
     await waitForElementToBeRemoved(() => screen.queryAllByText('Loading...'));
 
-    const filterWrapperElement = screen.getByText('Filter by Catalog')
-      .parentElement!;
+    const filterWrapperElement = screen.getByLabelText('Filter by catalog');
 
     fireEvent.click(
       within(filterWrapperElement).getByLabelText('Default Catalog')
@@ -138,11 +137,7 @@ describe('AppList', () => {
       expect(screen.queryByLabelText(appName)).not.toBeInTheDocument();
     }
 
-    fireEvent.click(
-      within(filterWrapperElement).getByRole('button', {
-        name: 'Select none',
-      })
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Select none' }));
 
     for (const appName of [
       ...Object.keys(giantswarmAppCatalogIndex.entries),

--- a/src/components/MAPI/apps/ClusterDetailApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailApps.tsx
@@ -224,8 +224,9 @@ const ClusterDetailApps: React.FC<IClusterDetailApps> = ({
               <BrowseButton
                 onClick={openAppCatalog}
                 disabled={appListIsLoading}
+                icon={<i className='fa fa-add-circle' />}
               >
-                <i className='fa fa-add-circle' /> Install app
+                Install app
               </BrowseButton>
             </BrowseButtonContainer>
           </UserInstalledApps>

--- a/src/components/MAPI/apps/InstallIngressButton.tsx
+++ b/src/components/MAPI/apps/InstallIngressButton.tsx
@@ -184,7 +184,7 @@ const InstallIngressButton: React.FC<IInstallIngressButtonProps> = ({
       {!installedIngressApp && (
         <Button
           loading={isLoading}
-          bsStyle='primary'
+          primary={true}
           loadingTimeout={0}
           disabled={installationIsDisabled}
           onClick={handleClick}

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
@@ -61,8 +61,16 @@ const ClusterDetailWidgetKubernetesAPI: React.FC<IClusterDetailWidgetKubernetesA
 
       {typeof k8sApiURL !== 'undefined' && (
         <Link to={gettingStartedPath}>
-          <Button tabIndex={-1}>
-            <i className='fa fa-start' aria-hidden={true} role='presentation' />
+          <Button
+            tabIndex={-1}
+            icon={
+              <i
+                className='fa fa-start'
+                aria-hidden={true}
+                role='presentation'
+              />
+            }
+          >
             Get started
           </Button>
         </Link>

--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -231,7 +231,7 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
               )}
             </ClusterListItemOptionalValue>
           </Box>
-          <Box basis='82%'>
+          <Box basis='75%'>
             <Box direction='row' align='center' wrap={true} gap='small'>
               <ClusterListItemOptionalValue value={description}>
                 {(value) => (
@@ -284,13 +284,22 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
           </Box>
 
           {shouldDisplayGetStarted && (
-            <Box basis='8%'>
-              <Button onClick={handleGetStartedClick}>
-                <i
-                  className='fa fa-start'
-                  aria-hidden={true}
-                  role='presentation'
-                />
+            <Box
+              align='end'
+              basis='15%'
+              width={{ min: '120px' }}
+              flex={{ grow: 1 }}
+            >
+              <Button
+                onClick={handleGetStartedClick}
+                icon={
+                  <i
+                    className='fa fa-start'
+                    aria-hidden={true}
+                    role='presentation'
+                  />
+                }
+              >
                 Get started
               </Button>
             </Box>

--- a/src/components/MAPI/clusters/Clusters.tsx
+++ b/src/components/MAPI/clusters/Clusters.tsx
@@ -147,10 +147,15 @@ const Clusters: React.FC<{}> = () => {
             round='xsmall'
             direction='row'
             align='center'
+            gap='small'
           >
             <Link to={newClusterPath}>
-              <Button bsStyle='primary' tabIndex={-1}>
-                <i className='fa fa-add-circle' /> Launch new cluster
+              <Button
+                primary={true}
+                tabIndex={-1}
+                icon={<i className='fa fa-add-circle' />}
+              >
+                Launch new cluster
               </Button>
             </Link>
 

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -315,7 +315,7 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               onChange={handleChange(ClusterPropertyField.ControlPlaneNodeAZs)}
             />
             <Box margin={{ top: 'medium' }}>
-              <Box direction='row'>
+              <Box direction='row' gap='small'>
                 <Button
                   primary={true}
                   disabled={!isValid}

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -317,7 +317,7 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
             <Box margin={{ top: 'medium' }}>
               <Box direction='row'>
                 <Button
-                  bsStyle='primary'
+                  primary={true}
                   disabled={!isValid}
                   type='submit'
                   loading={state.isCreating}
@@ -326,9 +326,7 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
                 </Button>
 
                 {!state.isCreating && (
-                  <Button bsStyle='default' onClick={handleCancel}>
-                    Cancel
-                  </Button>
+                  <Button onClick={handleCancel}>Cancel</Button>
                 )}
               </Box>
               <Box margin={{ top: 'medium' }}>

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
@@ -192,7 +192,7 @@ const ClusterDetailKeyPairs: React.FC<IClusterDetailKeyPairsProps> = () => {
                     </TableCell>
                     <TableCell size='xsmall'>
                       <Button
-                        bsSize='sm'
+                        size='small'
                         onClick={handleOpenDetails(keyPair.serial_number)}
                       >
                         Details

--- a/src/components/MAPI/organizations/OrganizationDetailDelete.tsx
+++ b/src/components/MAPI/organizations/OrganizationDetailDelete.tsx
@@ -24,7 +24,7 @@ const OrganizationDetailDelete: React.FC<IOrganizationDetailDeleteProps> = ({
   clusterCount,
   ...props
 }) => {
-  const deleteButtonRef = useRef<HTMLElement>(null);
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
 
   const dispatch = useDispatch();
 

--- a/src/components/MAPI/organizations/OrganizationDetailDelete.tsx
+++ b/src/components/MAPI/organizations/OrganizationDetailDelete.tsx
@@ -119,7 +119,7 @@ const OrganizationDetailDelete: React.FC<IOrganizationDetailDeleteProps> = ({
             onConfirm={handleDelete}
             onCancel={hideConfirmation}
             confirmButton={
-              <Button bsStyle='danger' onClick={handleDelete}>
+              <Button danger={true} onClick={handleDelete}>
                 <i
                   className='fa fa-delete'
                   role='presentation'
@@ -141,7 +141,7 @@ const OrganizationDetailDelete: React.FC<IOrganizationDetailDeleteProps> = ({
             <Box animation={{ type: 'fadeIn', duration: 300 }}>
               <Button
                 ref={deleteButtonRef}
-                bsStyle='danger'
+                danger={true}
                 onClick={showConfirmation}
                 loading={isLoading}
               >

--- a/src/components/MAPI/organizations/OrganizationList.tsx
+++ b/src/components/MAPI/organizations/OrganizationList.tsx
@@ -115,7 +115,7 @@ const OrganizationIndex: React.FC = () => {
 
         {!isCreateFormOpen && (
           <Box animation={{ type: 'fadeIn', duration: 300 }}>
-            <Button bsStyle='default' onClick={handleOpenCreateForm}>
+            <Button onClick={handleOpenCreateForm}>
               <i
                 className='fa fa-add-circle'
                 role='presentation'

--- a/src/components/MAPI/organizations/OrganizationListCreateOrg.tsx
+++ b/src/components/MAPI/organizations/OrganizationListCreateOrg.tsx
@@ -166,9 +166,9 @@ const OrganizationListCreateOrg: React.FC<IOrganizationListCreateOrgProps> = ({
                 error={debouncedValidationMessage}
               />
             </Box>
-            <Box direction='row' margin={{ top: 'small' }}>
+            <Box direction='row' margin={{ top: 'small' }} gap='small'>
               <Button
-                bsStyle='primary'
+                primary={true}
                 type='submit'
                 loading={isCreating}
                 disabled={!hasTyped || !isValid}

--- a/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
@@ -113,7 +113,7 @@ const ClusterDetailUpgradeModal: React.FC<IClusterDetailUpgradeModalProps> = ({
       footer={
         <>
           {primaryButtonText && (
-            <Button bsStyle='primary' onClick={handlePrimaryButtonClick}>
+            <Button primary={true} onClick={handlePrimaryButtonClick}>
               {primaryButtonText}
             </Button>
           )}

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -411,7 +411,6 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> = () =>
               !isCreateFormOpen && (
                 <Box animation={{ type: 'fadeIn', duration: 300 }}>
                   <Button
-                    bsStyle='default'
                     onClick={handleOpenCreateForm}
                     disabled={!cluster || !providerCluster}
                   >

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -325,9 +325,9 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
                 providerNodePool={state.providerNodePool}
                 onChange={handleChange(NodePoolPropertyField.Scale)}
               />
-              <Box direction='row' margin={{ top: 'medium' }}>
+              <Box direction='row' margin={{ top: 'medium' }} gap='small'>
                 <Button
-                  bsStyle='primary'
+                  primary={true}
                   disabled={!isValid}
                   type='submit'
                   loading={state.isCreating}
@@ -336,9 +336,7 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
                 </Button>
 
                 {!state.isCreating && (
-                  <Button bsStyle='default' onClick={handleCancel}>
-                    Cancel
-                  </Button>
+                  <Button onClick={handleCancel}>Cancel</Button>
                 )}
               </Box>
             </Box>

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemDelete.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemDelete.tsx
@@ -21,7 +21,7 @@ const WorkerNodesNodePoolItemDelete: React.FC<IWorkerNodesNodePoolItemDeleteProp
     <ConfirmationPrompt
       onConfirm={onConfirm}
       confirmButton={
-        <Button bsStyle='danger' onClick={onConfirm} loading={isLoading}>
+        <Button danger={true} onClick={onConfirm} loading={isLoading}>
           <i
             className='fa fa-delete'
             role='presentation'

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemScale.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemScale.tsx
@@ -37,7 +37,7 @@ function getSubmitButtonAttributes(fromValue: {
   max: number;
   maxValid: boolean;
   initialScaling: ReturnType<typeof getNodePoolScaling>;
-}): { disabled: boolean; label: string; style?: 'primary' | 'danger' } {
+}): { disabled: boolean; label: string; primary?: boolean; danger?: boolean } {
   const { min, minValid, max, maxValid, initialScaling } = fromValue;
 
   const nodesDifference = getWorkerNodesDifference(
@@ -54,7 +54,7 @@ function getSubmitButtonAttributes(fromValue: {
   if (nodesDifference > 0 && initialScaling.desired > 0) {
     return {
       label: `Increase minimum number of nodes by ${nodesDifference}`,
-      style: 'primary',
+      primary: true,
       disabled: !isValid,
     };
   } else if (nodesDifference < 0 && initialScaling.desired > 0) {
@@ -62,14 +62,14 @@ function getSubmitButtonAttributes(fromValue: {
 
     return {
       label: `Remove ${Math.abs(nodesDifference)} ${nodesLabel}`,
-      style: 'danger',
+      danger: true,
       disabled: !isValid,
     };
   }
 
   return {
     label: 'Apply',
-    style: 'primary',
+    primary: true,
     disabled: !isValid,
   };
 }
@@ -196,7 +196,8 @@ const WorkerNodesNodePoolItemScale: React.FC<IWorkerNodesNodePoolItemScaleProps>
       onConfirm={handleScale}
       confirmButton={
         <Button
-          bsStyle={submitButtonAttributes.style}
+          primary={submitButtonAttributes.primary}
+          danger={submitButtonAttributes.danger}
           onClick={handleScale}
           loading={isLoading}
           disabled={submitButtonAttributes.disabled}

--- a/src/components/Modals/GenericModal.js
+++ b/src/components/Modals/GenericModal.js
@@ -20,7 +20,7 @@ const GenericModal = (props) => {
         {props.footer ? (
           props.footer
         ) : (
-          <Button bsStyle='link' onClick={props.onClose}>
+          <Button link={true} onClick={props.onClose}>
             Close
           </Button>
         )}

--- a/src/components/Modals/Modals.js
+++ b/src/components/Modals/Modals.js
@@ -155,7 +155,6 @@ class Modals extends React.Component {
               <Button
                 bsStyle='danger'
                 loading={this.props.modal.templateValues.loading}
-                loadingPosition='left'
                 onClick={() =>
                   this.props.dispatch(
                     batchedOrganizationDeleteConfirmed(
@@ -213,7 +212,6 @@ class Modals extends React.Component {
               <Button
                 bsStyle='primary'
                 loading={this.props.modal.templateValues.loading}
-                loadingPosition='left'
                 onClick={this.createOrganisation}
                 type='submit'
                 disabled={this.state.organizationNameValidationError.length > 0}
@@ -261,7 +259,6 @@ class Modals extends React.Component {
                 bsStyle='primary'
                 disabled={this.state.emailValidationError.length > 0}
                 loading={this.props.modal.templateValues.loading}
-                loadingPosition='left'
                 onClick={this.addMember}
                 type='submit'
               >
@@ -296,7 +293,6 @@ class Modals extends React.Component {
               <Button
                 bsStyle='danger'
                 loading={this.props.modal.templateValues.loading}
-                loadingPosition='left'
                 onClick={this.removeMember.bind(this)}
                 type='submit'
               >
@@ -362,7 +358,6 @@ class Modals extends React.Component {
               <Button
                 bsStyle='danger'
                 loading={this.props.modal.templateValues.loading}
-                loadingPosition='left'
                 onClick={() =>
                   this.props.dispatch(
                     nodePoolDeleteConfirmed(clusterId, nodePool)

--- a/src/components/Modals/Modals.js
+++ b/src/components/Modals/Modals.js
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
@@ -152,28 +153,30 @@ class Modals extends React.Component {
               <small>There is no undo</small>
             </BootstrapModal.Body>
             <BootstrapModal.Footer>
-              <Button
-                bsStyle='danger'
-                loading={this.props.modal.templateValues.loading}
-                onClick={() =>
-                  this.props.dispatch(
-                    batchedOrganizationDeleteConfirmed(
-                      this.props.modal.templateValues.orgId
+              <Box gap='small' direction='row' justify='end'>
+                <Button
+                  danger={true}
+                  loading={this.props.modal.templateValues.loading}
+                  onClick={() =>
+                    this.props.dispatch(
+                      batchedOrganizationDeleteConfirmed(
+                        this.props.modal.templateValues.orgId
+                      )
                     )
-                  )
-                }
-                type='submit'
-              >
-                {this.props.modal.templateValues.loading
-                  ? 'Deleting organization'
-                  : 'Delete organization'}
-              </Button>
-
-              {this.props.modal.templateValues.loading ? null : (
-                <Button bsStyle='link' onClick={this.close}>
-                  Cancel
+                  }
+                  type='submit'
+                >
+                  {this.props.modal.templateValues.loading
+                    ? 'Deleting organization'
+                    : 'Delete organization'}
                 </Button>
-              )}
+
+                {this.props.modal.templateValues.loading ? null : (
+                  <Button link={true} onClick={this.close}>
+                    Cancel
+                  </Button>
+                )}
+              </Box>
             </BootstrapModal.Footer>
           </BootstrapModal>
         );
@@ -209,23 +212,27 @@ class Modals extends React.Component {
               </form>
             </BootstrapModal.Body>
             <BootstrapModal.Footer>
-              <Button
-                bsStyle='primary'
-                loading={this.props.modal.templateValues.loading}
-                onClick={this.createOrganisation}
-                type='submit'
-                disabled={this.state.organizationNameValidationError.length > 0}
-              >
-                {this.props.modal.templateValues.loading
-                  ? 'Creating organization'
-                  : 'Create organization'}
-              </Button>
-
-              {this.props.modal.templateValues.loading ? null : (
-                <Button bsStyle='link' onClick={this.close}>
-                  Cancel
+              <Box gap='small' direction='row' justify='end'>
+                <Button
+                  primary={true}
+                  loading={this.props.modal.templateValues.loading}
+                  onClick={this.createOrganisation}
+                  type='submit'
+                  disabled={
+                    this.state.organizationNameValidationError.length > 0
+                  }
+                >
+                  {this.props.modal.templateValues.loading
+                    ? 'Creating organization'
+                    : 'Create organization'}
                 </Button>
-              )}
+
+                {this.props.modal.templateValues.loading ? null : (
+                  <Button link={true} onClick={this.close}>
+                    Cancel
+                  </Button>
+                )}
+              </Box>
             </BootstrapModal.Footer>
           </BootstrapModal>
         );
@@ -255,23 +262,25 @@ class Modals extends React.Component {
               </form>
             </BootstrapModal.Body>
             <BootstrapModal.Footer>
-              <Button
-                bsStyle='primary'
-                disabled={this.state.emailValidationError.length > 0}
-                loading={this.props.modal.templateValues.loading}
-                onClick={this.addMember}
-                type='submit'
-              >
-                {this.props.modal.templateValues.loading
-                  ? 'Adding member'
-                  : 'Add member to organization'}
-              </Button>
-
-              {this.props.modal.templateValues.loading ? null : (
-                <Button bsStyle='link' onClick={this.close}>
-                  Cancel
+              <Box gap='small' direction='row' justify='end'>
+                <Button
+                  primary={true}
+                  disabled={this.state.emailValidationError.length > 0}
+                  loading={this.props.modal.templateValues.loading}
+                  onClick={this.addMember}
+                  type='submit'
+                >
+                  {this.props.modal.templateValues.loading
+                    ? 'Adding member'
+                    : 'Add member to organization'}
                 </Button>
-              )}
+
+                {this.props.modal.templateValues.loading ? null : (
+                  <Button link={true} onClick={this.close}>
+                    Cancel
+                  </Button>
+                )}
+              </Box>
             </BootstrapModal.Footer>
           </BootstrapModal>
         );
@@ -290,22 +299,24 @@ class Modals extends React.Component {
               </p>
             </BootstrapModal.Body>
             <BootstrapModal.Footer>
-              <Button
-                bsStyle='danger'
-                loading={this.props.modal.templateValues.loading}
-                onClick={this.removeMember.bind(this)}
-                type='submit'
-              >
-                {this.props.modal.templateValues.loading
-                  ? 'Removing member'
-                  : 'Remove member from organization'}
-              </Button>
-
-              {this.props.modal.templateValues.loading ? null : (
-                <Button bsStyle='link' onClick={this.close}>
-                  Cancel
+              <Box gap='small' direction='row' justify='end'>
+                <Button
+                  danger={true}
+                  loading={this.props.modal.templateValues.loading}
+                  onClick={this.removeMember.bind(this)}
+                  type='submit'
+                >
+                  {this.props.modal.templateValues.loading
+                    ? 'Removing member'
+                    : 'Remove member from organization'}
                 </Button>
-              )}
+
+                {this.props.modal.templateValues.loading ? null : (
+                  <Button link={true} onClick={this.close}>
+                    Cancel
+                  </Button>
+                )}
+              </Box>
             </BootstrapModal.Footer>
           </BootstrapModal>
         );
@@ -355,26 +366,28 @@ class Modals extends React.Component {
             </BootstrapModal.Header>
             <BootstrapModal.Body>{bodyText}</BootstrapModal.Body>
             <BootstrapModal.Footer>
-              <Button
-                bsStyle='danger'
-                loading={this.props.modal.templateValues.loading}
-                onClick={() =>
-                  this.props.dispatch(
-                    nodePoolDeleteConfirmed(clusterId, nodePool)
-                  )
-                }
-                type='submit'
-              >
-                {this.props.modal.templateValues.loading
-                  ? 'Deleting node pool'
-                  : 'Delete node pool'}
-              </Button>
-
-              {this.props.modal.templateValues.loading ? null : (
-                <Button bsStyle='link' onClick={this.close}>
-                  Cancel
+              <Box gap='small' direction='row' justify='end'>
+                <Button
+                  danger={true}
+                  loading={this.props.modal.templateValues.loading}
+                  onClick={() =>
+                    this.props.dispatch(
+                      nodePoolDeleteConfirmed(clusterId, nodePool)
+                    )
+                  }
+                  type='submit'
+                >
+                  {this.props.modal.templateValues.loading
+                    ? 'Deleting node pool'
+                    : 'Delete node pool'}
                 </Button>
-              )}
+
+                {this.props.modal.templateValues.loading ? null : (
+                  <Button link={true} onClick={this.close}>
+                    Cancel
+                  </Button>
+                )}
+              </Box>
             </BootstrapModal.Footer>
           </BootstrapModal>
         );

--- a/src/components/Organizations/Detail/CredentialsDisplay.js
+++ b/src/components/Organizations/Detail/CredentialsDisplay.js
@@ -15,11 +15,7 @@ const CredentialsDisplay = (props) => {
     );
   }
   if (props.credentials.length === 0) {
-    const button = (
-      <Button bsStyle='default' onClick={props.onShowForm}>
-        Set credentials
-      </Button>
-    );
+    const button = <Button onClick={props.onShowForm}>Set credentials</Button>;
 
     if (props.provider === Providers.AZURE) {
       return (

--- a/src/components/Organizations/Detail/CredentialsForm.js
+++ b/src/components/Organizations/Detail/CredentialsForm.js
@@ -155,7 +155,7 @@ class CredentialsForm extends React.Component {
             margin={{ bottom: 'medium' }}
           />
           <Button
-            bsStyle='primary'
+            primary={true}
             disabled={!this.state.isValid}
             onClick={this.handleSubmit}
           >
@@ -203,7 +203,7 @@ class CredentialsForm extends React.Component {
             margin={{ bottom: 'medium' }}
           />
           <Button
-            bsStyle='primary'
+            primary={true}
             disabled={!this.state.isValid}
             onClick={this.handleSubmit}
           >

--- a/src/components/Organizations/Detail/View.js
+++ b/src/components/Organizations/Detail/View.js
@@ -213,8 +213,8 @@ class OrganizationDetail extends React.Component {
             />
           )}
           <Link to={newClusterPath}>
-            <Button bsStyle='default'>
-              <i className='fa fa-add-circle' /> Create cluster
+            <Button icon={<i className='fa fa-add-circle' />}>
+              Create cluster
             </Button>
           </Link>
         </Section>
@@ -233,8 +233,11 @@ class OrganizationDetail extends React.Component {
                 keyField='email'
               />
             )}
-            <Button bsStyle='default' onClick={this.addMember}>
-              <i className='fa fa-add-circle' /> Add member
+            <Button
+              onClick={this.addMember}
+              icon={<i className='fa fa-add-circle' />}
+            >
+              Add member
             </Button>
           </MembersTable>
         </Section>
@@ -254,12 +257,13 @@ class OrganizationDetail extends React.Component {
         <Section title='Delete this organization' flat>
           <Disclaimer>{supportsDeletion.message}</Disclaimer>
           <Button
-            bsStyle='danger'
+            danger={true}
             onClick={this.deleteOrganization}
             disabled={!supportsDeletion.status}
             aria-label='Delete organization'
+            icon={<i className='fa fa-delete' />}
           >
-            <i className='fa fa-delete' /> Delete organization
+            Delete organization
           </Button>
         </Section>
       </DocumentTitle>
@@ -321,7 +325,7 @@ function clusterActionsCellFormatter(_cell, row) {
 
   return (
     <Link to={clusterDetailPath}>
-      <Button bsStyle='default' bsSize='sm' type='button'>
+      <Button size='small' type='button'>
         Details
       </Button>
     </Link>
@@ -335,8 +339,7 @@ function memberActionsCellFormatter(_cell, row) {
       // eslint-disable-next-line react/no-this-in-sfc
       onClick={this.removeMember.bind(this, row.email)}
       type='button'
-      bsStyle='default'
-      bsSize='sm'
+      size='small'
       data-testid='organization-member-remove'
     >
       Remove

--- a/src/components/Organizations/List/List.js
+++ b/src/components/Organizations/List/List.js
@@ -43,8 +43,11 @@ class OrganizationListWrapper extends React.Component {
               organizations={this.props.organizations}
             />
           </EmptyStateDisplay>
-          <Button bsStyle='default' onClick={this.createOrganization}>
-            <i className='fa fa-add-circle' /> Create new organization
+          <Button
+            onClick={this.createOrganization}
+            icon={<i className='fa fa-add-circle' />}
+          >
+            Create new organization
           </Button>
         </>
       </DocumentTitle>

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -505,7 +505,7 @@ class SignUp extends React.Component<ISignUpProps, ISignUpState> {
           <StatusMessage status={this.state.statusMessage} />
           {this.state.buttonText[this.state.currentStep] !== '' ? (
             <Button
-              bsStyle='primary'
+              primary={true}
               disabled={!this.state.advancable || this.state.submitting}
               loading={this.state.submitting}
               type='submit'

--- a/src/components/UI/Controls/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Controls/Button/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,241 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button renders a button with a loading animation 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-iCoGMd hFJToB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
+    >
+      <button
+        class="StyledButtonKind-sc-1vhfpnt-0 duqESE"
+        disabled=""
+        type="button"
+      >
+        Hi friends
+      </button>
+      <div
+        aria-busy="true"
+        aria-hidden="false"
+        aria-live="assertive"
+        aria-valuetext="Loading\\\\u2026"
+        class="sc-gtsrHT cpCxxM sc-hKFxyN jWPeIx"
+        role="progressbar"
+      >
+        <img
+          alt="loading"
+          class="loader right"
+          src="[object Object]"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Button renders a danger button 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-iCoGMd hFJToB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
+    >
+      <button
+        class="StyledButtonKind-sc-1vhfpnt-0 fcQuyX"
+        type="button"
+      >
+        Hi friends
+      </button>
+      <div
+        aria-busy="true"
+        aria-hidden="true"
+        aria-live="assertive"
+        aria-valuetext="Loading\\\\u2026"
+        class="sc-gtsrHT cpCxxM sc-hKFxyN jWPeIx"
+        role="progressbar"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Button renders a disabled button 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-iCoGMd hFJToB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
+    >
+      <button
+        class="StyledButtonKind-sc-1vhfpnt-0 duqESE"
+        disabled=""
+        type="button"
+      >
+        Hi friends
+      </button>
+      <div
+        aria-busy="true"
+        aria-hidden="true"
+        aria-live="assertive"
+        aria-valuetext="Loading\\\\u2026"
+        class="sc-gtsrHT cpCxxM sc-hKFxyN jWPeIx"
+        role="progressbar"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Button renders a link button 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-iCoGMd hFJToB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
+    >
+      <button
+        class="StyledButtonKind-sc-1vhfpnt-0 ehJRIz"
+        type="button"
+      >
+        Hi friends
+      </button>
+      <div
+        aria-busy="true"
+        aria-hidden="true"
+        aria-live="assertive"
+        aria-valuetext="Loading\\\\u2026"
+        class="sc-gtsrHT cpCxxM sc-hKFxyN jWPeIx"
+        role="progressbar"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Button renders a primary button 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-iCoGMd hFJToB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
+    >
+      <button
+        class="StyledButtonKind-sc-1vhfpnt-0 dLRRvC"
+        type="button"
+      >
+        Hi friends
+      </button>
+      <div
+        aria-busy="true"
+        aria-hidden="true"
+        aria-live="assertive"
+        aria-valuetext="Loading\\\\u2026"
+        class="sc-gtsrHT cpCxxM sc-hKFxyN jWPeIx"
+        role="progressbar"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Button renders a secondary button 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-iCoGMd hFJToB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
+    >
+      <button
+        class="StyledButtonKind-sc-1vhfpnt-0 jSHbzi"
+        type="button"
+      >
+        Hi friends
+      </button>
+      <div
+        aria-busy="true"
+        aria-hidden="true"
+        aria-live="assertive"
+        aria-valuetext="Loading\\\\u2026"
+        class="sc-gtsrHT cpCxxM sc-hKFxyN jWPeIx"
+        role="progressbar"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Button renders a warning button 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-iCoGMd hFJToB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
+    >
+      <button
+        class="StyledButtonKind-sc-1vhfpnt-0 jaLtNn"
+        type="button"
+      >
+        Hi friends
+      </button>
+      <div
+        aria-busy="true"
+        aria-hidden="true"
+        aria-live="assertive"
+        aria-valuetext="Loading\\\\u2026"
+        class="sc-gtsrHT cpCxxM sc-hKFxyN jWPeIx"
+        role="progressbar"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Button renders without crashing 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-iCoGMd hFJToB"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
+    >
+      <button
+        class="StyledButtonKind-sc-1vhfpnt-0 jSHbzi"
+        type="button"
+      >
+        Hi friends
+      </button>
+      <div
+        aria-busy="true"
+        aria-hidden="true"
+        aria-live="assertive"
+        aria-valuetext="Loading\\\\u2026"
+        class="sc-gtsrHT cpCxxM sc-hKFxyN jWPeIx"
+        role="progressbar"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/UI/Controls/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Controls/Button/__tests__/__snapshots__/index.tsx.snap
@@ -47,7 +47,7 @@ exports[`Button renders a danger button 1`] = `
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
     >
       <button
-        class="StyledButtonKind-sc-1vhfpnt-0 fcQuyX"
+        class="StyledButtonKind-sc-1vhfpnt-0 fyIUWJ"
         type="button"
       >
         Hi friends
@@ -135,7 +135,7 @@ exports[`Button renders a primary button 1`] = `
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
     >
       <button
-        class="StyledButtonKind-sc-1vhfpnt-0 dLRRvC"
+        class="StyledButtonKind-sc-1vhfpnt-0 jMJXUD"
         type="button"
       >
         Hi friends
@@ -193,7 +193,7 @@ exports[`Button renders a warning button 1`] = `
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
     >
       <button
-        class="StyledButtonKind-sc-1vhfpnt-0 jaLtNn"
+        class="StyledButtonKind-sc-1vhfpnt-0 bkgFHr"
         type="button"
       >
         Hi friends

--- a/src/components/UI/Controls/Button/__tests__/index.tsx
+++ b/src/components/UI/Controls/Button/__tests__/index.tsx
@@ -1,0 +1,78 @@
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import Button from '..';
+
+type ComponentProps = React.ComponentPropsWithoutRef<typeof Button>;
+
+describe('Button', () => {
+  it('renders without crashing', () => {
+    const { container } = renderWithTheme(Button, {
+      children: 'Hi friends',
+    } as ComponentProps);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a primary button', () => {
+    const { container } = renderWithTheme(Button, {
+      children: 'Hi friends',
+      primary: true,
+    } as ComponentProps);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a secondary button', () => {
+    const { container } = renderWithTheme(Button, {
+      children: 'Hi friends',
+      secondary: true,
+    } as ComponentProps);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a danger button', () => {
+    const { container } = renderWithTheme(Button, {
+      children: 'Hi friends',
+      danger: true,
+    } as ComponentProps);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a warning button', () => {
+    const { container } = renderWithTheme(Button, {
+      children: 'Hi friends',
+      warning: true,
+    } as ComponentProps);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a link button', () => {
+    const { container } = renderWithTheme(Button, {
+      children: 'Hi friends',
+      link: true,
+    } as ComponentProps);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a button with a loading animation', () => {
+    const { container } = renderWithTheme(Button, {
+      children: 'Hi friends',
+      loading: true,
+    } as ComponentProps);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders a disabled button', () => {
+    const { container } = renderWithTheme(Button, {
+      children: 'Hi friends',
+      disabled: true,
+    } as ComponentProps);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/UI/Controls/Button/index.tsx
+++ b/src/components/UI/Controls/Button/index.tsx
@@ -167,7 +167,7 @@ const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
             }
             label={children}
             disabled={disabled || loading}
-            {...(props as React.ComponentPropsWithoutRef<typeof Control>)}
+            {...props}
             ref={ref}
           />
           <StyledLoadingIndicator

--- a/src/components/UI/Controls/Button/index.tsx
+++ b/src/components/UI/Controls/Button/index.tsx
@@ -1,3 +1,4 @@
+import { Button as Control } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import BsButton from 'react-bootstrap/lib/Button';
@@ -130,6 +131,16 @@ const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
     { loading, disabled, bsStyle, bsSize, children, loadingTimeout, ...props },
     ref
   ) => {
+    let grommetSize = 'medium';
+    switch (bsSize) {
+      case 'sm':
+        grommetSize = 'small';
+        break;
+      case 'lg':
+        grommetSize = 'large';
+        break;
+    }
+
     return (
       <Wrapper
         ref={ref as React.RefObject<HTMLDivElement>}
@@ -144,7 +155,14 @@ const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
         >
           {children}
         </BsButton>
-
+        <Control
+          primary={bsStyle === 'primary'}
+          secondary={bsStyle === 'default'}
+          size={grommetSize as never}
+          label={children}
+          disabled={disabled || loading}
+          {...(props as React.ComponentPropsWithoutRef<typeof Control>)}
+        />
         <LoadingIndicator
           loading={loading}
           loadingPosition='right'

--- a/src/components/UI/Controls/Button/index.tsx
+++ b/src/components/UI/Controls/Button/index.tsx
@@ -47,8 +47,8 @@ function makeCustomTheme(style: ButtonStyle): ThemeType {
 
       theme.button!.hover!.secondary = {
         background: {
-          color: 'status-danger',
-          opacity: 0.7,
+          color: '#c44e4b',
+          opacity: 1,
         },
         border: {
           width: '0',
@@ -58,7 +58,6 @@ function makeCustomTheme(style: ButtonStyle): ThemeType {
       theme.button!.active!.secondary = {
         background: {
           color: 'status-danger',
-          opacity: 0.5,
         },
         border: {
           width: '0',
@@ -78,8 +77,8 @@ function makeCustomTheme(style: ButtonStyle): ThemeType {
 
       theme.button!.hover!.secondary = {
         background: {
-          color: 'status-warning',
-          opacity: 0.7,
+          color: '#ffb83b',
+          opacity: 1,
         },
         border: {
           width: '0',
@@ -89,7 +88,6 @@ function makeCustomTheme(style: ButtonStyle): ThemeType {
       theme.button!.active!.secondary = {
         background: {
           color: 'status-warning',
-          opacity: 0.5,
         },
         border: {
           width: '0',

--- a/src/components/UI/Controls/Button/index.tsx
+++ b/src/components/UI/Controls/Button/index.tsx
@@ -1,191 +1,204 @@
-import { Button as Control } from 'grommet';
+import { Box, Button as Control, ThemeContext, ThemeType } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
-import BsButton from 'react-bootstrap/lib/Button';
 import styled from 'styled-components';
 import LoadingIndicator from 'UI/Display/Loading/LoadingIndicator';
 
-const Wrapper = styled.div`
-  .btn {
-    border: 0px;
-    border-radius: 3px;
-    color: #fff;
-    padding: 6px 12px;
-    font-weight: 400;
-    outline: none;
-    cursor: pointer;
-    transition: background-color 0.1s cubic-bezier(0, -0.41, 0.19, 1.44);
-  }
-  .btn.small {
-    font-size: 14px;
-    padding: 8px 18px;
-  }
+const StyledBox = styled(Box)`
+  display: inline-block;
+`;
 
-  .btn-secondary {
-    background-color: #52728a;
-    border: 1px #52728a solid;
-  }
-
-  .btn-primary {
-    background-color: #2d9a2c;
-    border: 1px #2d9a2c solid;
-  }
-
-  .btn-link {
-    color: #ccc;
-  }
-
-  .btn-link:hover {
-    color: #fff;
-  }
-
-  .btn:hover,
-  .btn:active,
-  .btn:active:focus,
-  .btn:focus {
-    background-color: #5c7f9a;
-    color: #fff;
-  }
-
-  .btn-primary.disabled.focus,
-  .btn-primary.disabled:focus,
-  .btn-primary.disabled:hover,
-  .btn-primary[disabled].focus,
-  .btn-primary[disabled]:focus,
-  .btn-primary[disabled]:hover,
-  fieldset[disabled] .btn-primary.focus,
-  fieldset[disabled] .btn-primary:focus,
-  fieldset[disabled] .btn-primary:hover {
-    background-color: #404040;
-  }
-
-  .btn-primary:hover,
-  .btn-primary:active:focus,
-  .btn-primary:focus,
-  .btn-primary:active:hover {
-    background-color: #278626;
-    border-color: #278626;
-  }
-
-  .btn-danger {
-    background-color: #d9534f;
-    border: 1px #d9534f solid;
-  }
-
-  .btn-danger:hover,
-  .btn-danger:active:hover {
-    background-color: #d43f3a;
-    border: 1px #d43f3a solid;
-  }
-
-  .btn:disabled,
-  .btn:disabled:hover,
-  .btn:disabled:active:hover {
-    background-color: #aaa;
-    border-color: #aaa;
-  }
-
-  .btn-default {
-    background-color: transparent;
-    color: #ccc;
-    border: 1px solid #d7d7d7;
-  }
-
-  .btn-default:focus,
-  .btn-default:active,
-  .btn-default:hover,
-  .btn-default:active:focus,
-  .btn-default:hover:focus,
-  .btn-default:hover:active {
-    background-color: rgba(255, 255, 255, 0.1);
-    color: #fff;
-    border: 1px solid #fff;
-  }
-
-  .btn {
-    i.fa {
-      padding-right: 0.3em;
-    }
-  }
-
-  .btn.btn-sm {
-    height: 24px;
-    padding: 0px 8px !important;
-    margin-left: 5px;
+const StyledLoadingIndicator = styled(LoadingIndicator)`
+  img {
+    width: 22px;
+    height: 22px;
+    position: relative;
+    margin: 0;
+    vertical-align: middle;
+    margin-left: 10px;
   }
 `;
 
-interface IButtonProps extends React.ComponentPropsWithoutRef<'button'> {
-  bsStyle?: 'primary' | 'danger' | 'default' | 'link' | 'warning';
-  bsSize?: 'sm' | 'lg';
+enum ButtonStyle {
+  Primary,
+  Secondary,
+  Danger,
+  Link,
+  Warning,
+}
+
+function makeCustomTheme(style: ButtonStyle): ThemeType {
+  const theme: ThemeType = {
+    button: {
+      hover: {},
+      active: {},
+    },
+  };
+
+  switch (style) {
+    case ButtonStyle.Danger:
+      theme.button!.secondary = {
+        background: 'status-danger',
+        border: {
+          width: '0',
+        },
+        color: 'text',
+      };
+
+      theme.button!.hover!.secondary = {
+        background: {
+          color: 'status-danger',
+          opacity: 0.7,
+        },
+        border: {
+          width: '0',
+        },
+      };
+
+      theme.button!.active!.secondary = {
+        background: {
+          color: 'status-danger',
+          opacity: 0.5,
+        },
+        border: {
+          width: '0',
+        },
+      };
+
+      break;
+
+    case ButtonStyle.Warning:
+      theme.button!.secondary = {
+        background: 'status-warning',
+        border: {
+          width: '0',
+        },
+        color: 'text',
+      };
+
+      theme.button!.hover!.secondary = {
+        background: {
+          color: 'status-warning',
+          opacity: 0.7,
+        },
+        border: {
+          width: '0',
+        },
+      };
+
+      theme.button!.active!.secondary = {
+        background: {
+          color: 'status-warning',
+          opacity: 0.5,
+        },
+        border: {
+          width: '0',
+        },
+      };
+
+      break;
+  }
+
+  return theme;
+}
+
+interface IButtonProps extends React.ComponentPropsWithoutRef<typeof Control> {
   loading?: boolean;
   loadingTimeout?: number;
   disabled?: boolean;
   href?: string;
   target?: '_self' | '_blank' | '_parent' | '_top' | string;
   rel?: string;
+  warning?: boolean;
+  danger?: boolean;
+  link?: boolean;
+  wrapperProps?: React.ComponentPropsWithoutRef<typeof StyledBox>;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
   (
-    { loading, disabled, bsStyle, bsSize, children, loadingTimeout, ...props },
+    {
+      loading,
+      disabled,
+      primary,
+      secondary,
+      warning,
+      danger,
+      link,
+      children,
+      loadingTimeout,
+      wrapperProps,
+      ...props
+    },
     ref
   ) => {
-    let grommetSize = 'medium';
-    switch (bsSize) {
-      case 'sm':
-        grommetSize = 'small';
+    let buttonStyle = ButtonStyle.Link;
+    switch (true) {
+      case primary:
+        buttonStyle = ButtonStyle.Primary;
         break;
-      case 'lg':
-        grommetSize = 'large';
+      case link:
+        buttonStyle = ButtonStyle.Link;
+        break;
+      case warning:
+        buttonStyle = ButtonStyle.Warning;
+        break;
+      case danger:
+        buttonStyle = ButtonStyle.Danger;
+        break;
+      case secondary:
+        buttonStyle = ButtonStyle.Secondary;
         break;
     }
 
     return (
-      <Wrapper
-        ref={ref as React.RefObject<HTMLDivElement>}
-        className='button-wrapper'
-      >
-        <BsButton
-          bsSize={bsSize}
-          bsStyle={bsStyle}
-          disabled={disabled || loading}
-          role='button'
-          {...(props as React.ComponentPropsWithoutRef<typeof BsButton>)}
+      <ThemeContext.Extend value={makeCustomTheme(buttonStyle)}>
+        <StyledBox
+          width={{
+            min: 'auto',
+          }}
+          {...wrapperProps}
         >
-          {children}
-        </BsButton>
-        <Control
-          primary={bsStyle === 'primary'}
-          secondary={bsStyle === 'default'}
-          size={grommetSize as never}
-          label={children}
-          disabled={disabled || loading}
-          {...(props as React.ComponentPropsWithoutRef<typeof Control>)}
-        />
-        <LoadingIndicator
-          loading={loading}
-          loadingPosition='right'
-          timeout={loadingTimeout}
-        />
-      </Wrapper>
+          <Control
+            primary={buttonStyle === ButtonStyle.Primary}
+            secondary={
+              buttonStyle !== ButtonStyle.Primary &&
+              buttonStyle !== ButtonStyle.Link
+            }
+            label={children}
+            disabled={disabled || loading}
+            {...(props as React.ComponentPropsWithoutRef<typeof Control>)}
+            ref={ref}
+          />
+          <StyledLoadingIndicator
+            loading={loading}
+            loadingPosition='right'
+            timeout={loadingTimeout}
+          />
+        </StyledBox>
+      </ThemeContext.Extend>
     );
   }
 );
 
 Button.propTypes = {
-  bsStyle: PropTypes.string as PropTypes.Requireable<IButtonProps['bsStyle']>,
-  bsSize: PropTypes.string as PropTypes.Requireable<IButtonProps['bsSize']>,
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
   loadingTimeout: PropTypes.number,
+  primary: PropTypes.bool,
+  secondary: PropTypes.bool,
+  warning: PropTypes.bool,
+  danger: PropTypes.bool,
+  link: PropTypes.bool,
+  wrapperProps: PropTypes.object,
 };
 
 Button.defaultProps = {
-  bsStyle: 'default',
+  secondary: true,
+  gap: 'xsmall',
 };
 
 export default Button;

--- a/src/components/UI/Controls/Button/index.tsx
+++ b/src/components/UI/Controls/Button/index.tsx
@@ -118,7 +118,6 @@ interface IButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   bsStyle?: 'primary' | 'danger' | 'default' | 'link' | 'warning';
   bsSize?: 'sm' | 'lg';
   loading?: boolean;
-  loadingPosition?: 'left' | 'right';
   loadingTimeout?: number;
   disabled?: boolean;
   href?: string;
@@ -128,16 +127,7 @@ interface IButtonProps extends React.ComponentPropsWithoutRef<'button'> {
 
 const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
   (
-    {
-      loadingPosition,
-      loading,
-      disabled,
-      bsStyle,
-      bsSize,
-      children,
-      loadingTimeout,
-      ...props
-    },
+    { loading, disabled, bsStyle, bsSize, children, loadingTimeout, ...props },
     ref
   ) => {
     return (
@@ -145,14 +135,6 @@ const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
         ref={ref as React.RefObject<HTMLDivElement>}
         className='button-wrapper'
       >
-        {loadingPosition === 'left' && (
-          <LoadingIndicator
-            loading={loading}
-            loadingPosition={loadingPosition}
-            timeout={loadingTimeout}
-          />
-        )}
-
         <BsButton
           bsSize={bsSize}
           bsStyle={bsStyle}
@@ -163,13 +145,11 @@ const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
           {children}
         </BsButton>
 
-        {loadingPosition === 'right' && (
-          <LoadingIndicator
-            loading={loading}
-            loadingPosition={loadingPosition}
-            timeout={loadingTimeout}
-          />
-        )}
+        <LoadingIndicator
+          loading={loading}
+          loadingPosition='right'
+          timeout={loadingTimeout}
+        />
       </Wrapper>
     );
   }
@@ -181,16 +161,12 @@ Button.propTypes = {
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
-  loadingPosition: PropTypes.string as PropTypes.Requireable<
-    IButtonProps['loadingPosition']
-  >,
   children: PropTypes.node,
   className: PropTypes.string,
   loadingTimeout: PropTypes.number,
 };
 
 Button.defaultProps = {
-  loadingPosition: 'right',
   bsStyle: 'default',
 };
 

--- a/src/components/UI/Controls/Button/index.tsx
+++ b/src/components/UI/Controls/Button/index.tsx
@@ -4,26 +4,6 @@ import BsButton from 'react-bootstrap/lib/Button';
 import styled from 'styled-components';
 import LoadingIndicator from 'UI/Display/Loading/LoadingIndicator';
 
-// Button
-//
-// <Button
-//   type='button|submit|reset'
-//   bsSize='sm'|undefined
-//   bsStyle='primary|danger|default|link'
-//   loading=true|false
-//   loadingPosition='left'|undefined
-//   disabled=true|false
-//   onClick=function>
-//
-//   Button Text
-// </Button>
-//
-// A basic button. Can go into a 'loading' state, which will disable the button
-// and show a spinner next to it.
-//
-// You can also disable the button by setting the disabled prop to true.
-//
-
 const Wrapper = styled.div`
   .btn {
     border: 0px;
@@ -134,82 +114,76 @@ const Wrapper = styled.div`
   }
 `;
 
-/**
- * @typedef {object} IButtonProps
- * @property {'button' | 'submit' | 'reset'} [type]
- * @property {'primary' | 'danger' | 'default' | 'link' | 'warning'} [bsStyle]
- * @property {'sm' | 'lg'} [bsSize]
- * @property {boolean} [disabled]
- * @property {boolean} [loading]
- * @property {'left'} [loadingPosition]
- * @property {React.ReactNode} [children]
- * @property {string} [className]
- * @property {number} [loadingTimeout]
- * @property {string} [href]
- * @property {'_blank'} [target]
- * @property {string} [rel]
- * @property {React.MouseEventHandler<HTMLElement>} [onClick]
- * @property {number | string} [tabIndex]
- */
+interface IButtonProps extends React.ComponentPropsWithoutRef<'button'> {
+  bsStyle?: 'primary' | 'danger' | 'default' | 'link' | 'warning';
+  bsSize?: 'sm' | 'lg';
+  loading?: boolean;
+  loadingPosition?: 'left' | 'right';
+  loadingTimeout?: number;
+  disabled?: boolean;
+  href?: string;
+  target?: '_self' | '_blank' | '_parent' | '_top' | string;
+  rel?: string;
+}
 
-/**
- * @type {React.ForwardRefExoticComponent<React.PropsWithoutRef<IButtonProps> & React.RefAttributes<HTMLElement>>}
- */
-const Button = React.forwardRef((props, ref) => {
-  const {
-    loadingPosition,
-    loading,
-    disabled,
-    bsStyle,
-    bsSize,
-    onClick,
-    type,
-    children,
-    loadingTimeout,
-    ...rest
-  } = props;
-
-  return (
-    <Wrapper ref={ref} className='button-wrapper'>
-      {loadingPosition === 'left' ? (
-        <LoadingIndicator
-          loading={loading}
-          loadingPosition={loadingPosition}
-          timeout={loadingTimeout}
-        />
-      ) : undefined}
-
-      <BsButton
-        bsSize={bsSize}
-        bsStyle={bsStyle || 'default'}
-        disabled={disabled || loading}
-        onClick={onClick}
-        type={type}
-        role='button'
-        {...rest}
+const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
+  (
+    {
+      loadingPosition,
+      loading,
+      disabled,
+      bsStyle,
+      bsSize,
+      children,
+      loadingTimeout,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <Wrapper
+        ref={ref as React.RefObject<HTMLDivElement>}
+        className='button-wrapper'
       >
-        {children}
-      </BsButton>
+        {loadingPosition === 'left' && (
+          <LoadingIndicator
+            loading={loading}
+            loadingPosition={loadingPosition}
+            timeout={loadingTimeout}
+          />
+        )}
 
-      {loadingPosition === 'right' ? (
-        <LoadingIndicator
-          loading={loading}
-          loadingPosition={loadingPosition}
-          timeout={loadingTimeout}
-        />
-      ) : undefined}
-    </Wrapper>
-  );
-});
+        <BsButton
+          bsSize={bsSize}
+          bsStyle={bsStyle}
+          disabled={disabled || loading}
+          role='button'
+          {...(props as React.ComponentPropsWithoutRef<typeof BsButton>)}
+        >
+          {children}
+        </BsButton>
+
+        {loadingPosition === 'right' && (
+          <LoadingIndicator
+            loading={loading}
+            loadingPosition={loadingPosition}
+            timeout={loadingTimeout}
+          />
+        )}
+      </Wrapper>
+    );
+  }
+);
 
 Button.propTypes = {
-  type: PropTypes.string,
-  bsStyle: PropTypes.string,
-  bsSize: PropTypes.string,
+  bsStyle: PropTypes.string as PropTypes.Requireable<IButtonProps['bsStyle']>,
+  bsSize: PropTypes.string as PropTypes.Requireable<IButtonProps['bsSize']>,
   onClick: PropTypes.func,
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
-  loadingPosition: PropTypes.string,
+  loadingPosition: PropTypes.string as PropTypes.Requireable<
+    IButtonProps['loadingPosition']
+  >,
   children: PropTypes.node,
   className: PropTypes.string,
   loadingTimeout: PropTypes.number,
@@ -217,6 +191,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   loadingPosition: 'right',
+  bsStyle: 'default',
 };
 
 export default Button;

--- a/src/components/UI/Controls/Button/stories/Button.stories.mdx
+++ b/src/components/UI/Controls/Button/stories/Button.stories.mdx
@@ -3,37 +3,13 @@ import { Box } from 'grommet';
 import Button from '../';
 
 <Meta
-  title="Inputs/Button"
+  title='Inputs/Button'
   component={Button}
-  parameters={{ actions: { argTypesRegex: '^onClick.\*' } }}
-  argTypes={{
-    bsStyle: {
-      name: 'Style',
-      description: 'Available options available to the Badge',
-      control: {
-        type: 'select',
-        options: [
-          'default',
-          'primary',
-          'danger',
-        ],
-      },
-      table: {
-        defaultValue: {
-          summary: 'default'
-        },
-        type: {
-          summary: 'Shows options to the Button',
-          detail: 'Listing of available options'
-        },
-      },
-    },
-  }}
+  parameters={{ actions: { argTypesRegex: '^onClick.*' } }}
+  argTypes={{}}
 />
 
 # Buttons
-
-**Note:** Buttons are currently not yet a Grommet component. They are still based on react-bootstrap.
 
 ## Parameters
 
@@ -44,12 +20,12 @@ What the styles mean and when to use them:
 - `primary` is used when there are multiple buttons, where one is the recommended action or the most important one. Example: a dialog with one conformation button (using the primary style) and one for cancelling (in link style).
 - `danger` is used to indicate that the click of the button triggers a destructive action.
 - `link` is used in a row with other buttons, in particular for the **Cancel** button in a model dialog.
-- `default` is for all other cases.
+- `secondary` is for all other cases.
 
 ### Size
 
 - The default size works for most contexts.
-- The small size (`sm`) is used especially in tables and space-constrained contexts.
+- The small size (`small`) is used especially in tables and space-constrained contexts.
 
 ### Loading indicator
 
@@ -57,7 +33,7 @@ Used to indicate activity, usually as a reaction to the button having been click
 
 ### Disabling
 
-The button can be disabled independent of other attributes. This shall not be combined with the *loading* parameter.
+The button can be disabled independent of other attributes. This shall not be combined with the _loading_ parameter.
 
 ## Examples
 
@@ -66,17 +42,11 @@ The button can be disabled independent of other attributes. This shall not be co
 ### Multiple buttons
 
 <Preview>
-  <Story name="Multiple">
-    <Box wrap={true} direction='row'>
-      <Button bsStyle="primary">
-        Primary
-      </Button>
-      <Button>
-        Default
-      </Button>
-      <Button bsStyle="link">
-        Link
-      </Button>
+  <Story name='Multiple'>
+    <Box wrap={true} direction='row' gap='small'>
+      <Button primary={true}>Primary</Button>
+      <Button>Secondary</Button>
+      <Button link={true}>Link</Button>
     </Box>
   </Story>
 </Preview>
@@ -84,49 +54,43 @@ The button can be disabled independent of other attributes. This shall not be co
 ### Icons and labels
 
 <Preview>
-  <Story name="IconAndLabel">
-    <Box wrap={true} direction='row'>
-      <Button bsStyle="primary">
-        <i className='fa fa-add-circle' /> Add
+  <Story name='IconAndLabel'>
+    <Box wrap={true} direction='row' gap='small'>
+      <Button primary={true} icon={<i className='fa fa-add-circle' />}>
+        Add
       </Button>
-      <Button bsStyle="danger">
-        <i className='fa fa-delete' /> Delete
+      <Button danger={true} icon={<i className='fa fa-delete' />}>
+        Delete
       </Button>
     </Box>
   </Story>
 </Preview>
 
-### Default
+### Secondary
 
 <Preview>
-  <Story name="Default">
-    <Button>
-      Default
-    </Button>
+  <Story name='Secondary'>
+    <Button>Secondary</Button>
   </Story>
 </Preview>
 
 <Preview>
-  <Story name="DefaultSmall">
-    <Button bsSize="sm">
-      Default small
-    </Button>
+  <Story name='SecondarySmall'>
+    <Button size='small'>Secondary small</Button>
   </Story>
 </Preview>
 
 ### Primary
 
 <Preview>
-  <Story name="Primary">
-    <Button bsStyle="primary">
-      Primary
-    </Button>
+  <Story name='Primary'>
+    <Button primary={true}>Primary</Button>
   </Story>
 </Preview>
 
 <Preview>
-  <Story name="PrimarySmall">
-    <Button bsStyle="primary" bsSize="sm">
+  <Story name='PrimarySmall'>
+    <Button primary={true} size='small'>
       Primary small
     </Button>
   </Story>
@@ -135,16 +99,14 @@ The button can be disabled independent of other attributes. This shall not be co
 ### Danger
 
 <Preview>
-  <Story name="Danger">
-    <Button bsStyle="danger">
-      Danger
-    </Button>
+  <Story name='Danger'>
+    <Button danger={true}>Danger</Button>
   </Story>
 </Preview>
 
 <Preview>
-  <Story name="DangerSmall">
-    <Button bsStyle="danger" bsSize="sm">
+  <Story name='DangerSmall'>
+    <Button danger={true} size='small'>
       Danger small
     </Button>
   </Story>
@@ -153,16 +115,14 @@ The button can be disabled independent of other attributes. This shall not be co
 ### Link
 
 <Preview>
-  <Story name="Link">
-    <Button bsStyle="link">
-      Link
-    </Button>
+  <Story name='Link'>
+    <Button link={true}>Link</Button>
   </Story>
 </Preview>
 
 <Preview>
-  <Story name="LinkSmall">
-    <Button bsStyle="link" bsSize="sm">
+  <Story name='LinkSmall'>
+    <Button link={true} size='small'>
       Link small
     </Button>
   </Story>
@@ -171,23 +131,21 @@ The button can be disabled independent of other attributes. This shall not be co
 ### Loading
 
 <Preview>
-  <Story name="Loading">
-    <Button loading={true}>
-      Loading
-    </Button>
+  <Story name='Loading'>
+    <Button loading={true}>Loading</Button>
   </Story>
 </Preview>
 
 <Preview>
-  <Story name="LoadingSmall">
-    <Button loading={true} bsSize="sm">
+  <Story name='LoadingSmall'>
+    <Button loading={true} size='small'>
       Loading small
     </Button>
   </Story>
 </Preview>
 
 <Preview>
-  <Story name="LoadingLeft">
+  <Story name='LoadingLeft'>
     <Button loading={true} loadignPosition='left'>
       Loading
     </Button>
@@ -195,8 +153,8 @@ The button can be disabled independent of other attributes. This shall not be co
 </Preview>
 
 <Preview>
-  <Story name="LoadingLeftSmall">
-    <Button loading={true} loadignPosition='left' bsSize="sm">
+  <Story name='LoadingLeftSmall'>
+    <Button loading={true} loadignPosition='left' size='small'>
       Loading small
     </Button>
   </Story>
@@ -205,16 +163,14 @@ The button can be disabled independent of other attributes. This shall not be co
 ### Disabled
 
 <Preview>
-  <Story name="Disabled">
-    <Button disabled={true}>
-      Disabled
-    </Button>
+  <Story name='Disabled'>
+    <Button disabled={true}>Disabled</Button>
   </Story>
 </Preview>
 
 <Preview>
-  <Story name="DisabledSmall">
-    <Button disabled={true} bsSize="sm">
+  <Story name='DisabledSmall'>
+    <Button disabled={true} size='small'>
       Disabled small
     </Button>
   </Story>

--- a/src/components/UI/Controls/ConfirmationPrompt/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Controls/ConfirmationPrompt/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`ConfirmationPrompt renders a component with a title 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       aria-hidden="true"
@@ -20,7 +20,7 @@ exports[`ConfirmationPrompt renders a component with buttons 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       aria-hidden="true"
@@ -35,7 +35,7 @@ exports[`ConfirmationPrompt renders a simple component 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       aria-hidden="true"

--- a/src/components/UI/Controls/ConfirmationPrompt/index.tsx
+++ b/src/components/UI/Controls/ConfirmationPrompt/index.tsx
@@ -88,10 +88,15 @@ const ConfirmationPrompt = React.forwardRef<
             {children}
 
             {(onConfirm || onCancel) && (
-              <Box direction='row' margin={{ top: 'medium' }} justify='center'>
+              <Box
+                direction='row'
+                margin={{ top: 'medium' }}
+                justify='center'
+                gap='small'
+              >
                 {onConfirm &&
                   (typeof confirmButton === 'string' ? (
-                    <Button bsStyle='danger' onClick={handleConfirm}>
+                    <Button danger={true} onClick={handleConfirm}>
                       {confirmButton}
                     </Button>
                   ) : (
@@ -101,7 +106,6 @@ const ConfirmationPrompt = React.forwardRef<
                 {onCancel &&
                   (typeof cancelButton === 'string' ? (
                     <Button
-                      bsStyle='default'
                       onClick={handleCancel}
                       ref={cancelButtonRef}
                       className='cancel-button'

--- a/src/components/UI/Controls/ExpandableSelector/Items.tsx
+++ b/src/components/UI/Controls/ExpandableSelector/Items.tsx
@@ -1,15 +1,4 @@
 import styled from 'styled-components';
-import Button from 'UI/Controls/Button';
-
-export const TableButton = styled(Button)`
-  position: relative;
-  margin-left: 0;
-  padding: 0px 15px;
-
-  i {
-    margin-right: 4px;
-  }
-`;
 
 export const Tr = styled.tr<{ isSelected: boolean; toneDown?: boolean }>`
   background-color: ${({ isSelected, theme }) =>

--- a/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
+++ b/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import { Link } from 'react-router-dom';
 import gfm from 'remark-gfm';
 import styled from 'styled-components';
+import Button from 'UI/Controls/Button';
 import VersionPicker from 'UI/Controls/VersionPicker/VersionPicker';
 import { IVersion } from 'UI/Controls/VersionPicker/VersionPickerUtils';
 import AppIcon from 'UI/Display/Apps/AppList/AppIcon';
@@ -37,6 +38,7 @@ const NonBreakingLink = styled.a`
 const Upper = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   border-bottom: 1px solid ${({ theme }) => theme.colors.darkBlueLighter3};
   margin-bottom: 20px;
 
@@ -205,8 +207,12 @@ const AppDetail: React.FC<IAppDetailPageProps> = (props) => {
   return (
     <Wrapper className={props.readmeURL ? '' : 'no-readme'}>
       <Link to='/apps'>
-        <i aria-hidden='true' className='fa fa-chevron-left' />
-        Back to Apps
+        <Button
+          icon={<i aria-hidden='true' className='fa fa-chevron-left' />}
+          plain={true}
+        >
+          Back to Apps
+        </Button>
       </Link>
 
       <Header>

--- a/src/components/UI/Display/Apps/AppList/AppsListPage.tsx
+++ b/src/components/UI/Display/Apps/AppList/AppsListPage.tsx
@@ -100,9 +100,7 @@ const AppsList: React.FC<IAppsListPageProps> = (props) => {
                 Please check your search term or check more catalogs to show
                 apps from
               </p>
-              <Button bsStyle='default' onClick={props.onResetSearch}>
-                Reset search
-              </Button>
+              <Button onClick={props.onResetSearch}>Reset search</Button>
             </div>
           </EmptyState>
         )}

--- a/src/components/UI/Display/Cluster/ClusterLabels/DeleteLabelButton.tsx
+++ b/src/components/UI/Display/Cluster/ClusterLabels/DeleteLabelButton.tsx
@@ -1,21 +1,10 @@
 import React, { ComponentPropsWithRef, FC } from 'react';
-import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
 
 interface IButtonProps extends ComponentPropsWithRef<typeof Button> {}
 
-const StyledButton = styled(Button)`
-  margin: 0;
-  padding: 0;
-  font-size: 1rem;
-
-  &.btn.btn-sm {
-    margin-left: 0;
-  }
-`;
-
 const DeleteLabelButton: FC<IButtonProps> = (props) => (
-  <StyledButton bsSize='sm' bsStyle='link' {...props} />
+  <Button size='small' link={true} {...props} />
 );
 
 export default DeleteLabelButton;

--- a/src/components/UI/Display/Cluster/ClusterLabels/DeleteLabelButton.tsx
+++ b/src/components/UI/Display/Cluster/ClusterLabels/DeleteLabelButton.tsx
@@ -2,7 +2,7 @@ import React, { ComponentPropsWithRef, FC } from 'react';
 import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
 
-interface IButtonProps extends ComponentPropsWithRef<'button'> {}
+interface IButtonProps extends ComponentPropsWithRef<typeof Button> {}
 
 const StyledButton = styled(Button)`
   margin: 0;

--- a/src/components/UI/Display/Documentation/GettingStartedBottomNav.tsx
+++ b/src/components/UI/Display/Documentation/GettingStartedBottomNav.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 // It centers the navigational buttons at the end of those docs.
 
 const GettingStartedBottomNav: React.FC = ({ children }) => (
-  <Box direction='row' margin={{ top: 'large' }} justify='center'>
+  <Box direction='row' margin={{ top: 'large' }} justify='center' gap='small'>
     {children}
   </Box>
 );

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm.tsx
@@ -15,27 +15,11 @@ import TextInput from 'UI/Inputs/TextInput';
 const VISIBLE_SUGGESTION_COUNT = 10;
 const FILTER_DEBOUNCE_RATE = 250;
 
-const StyledButton = styled(Button)`
-  &.btn {
-    height: 38px;
-    margin-left: 0;
-  }
-`;
-
-const StyledBox = styled(Box)`
-  .button-wrapper {
-    margin-right: 0;
-  }
-`;
-
 const SaveButton = styled(Button)`
-  &.btn {
-    height: 36px;
-    border: 0;
-    border-start-start-radius: 0;
-    border-end-start-radius: 0;
-    margin-left: 0;
-  }
+  border-start-start-radius: 0;
+  border-start-end-radius: 2px;
+  border-end-start-radius: 0;
+  border-end-end-radius: 2px;
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
@@ -132,7 +116,7 @@ const AccessControlSubjectAddForm: React.FC<IAccessControlSubjectAddFormProps> =
   return (
     <Box {...props}>
       {isAdding ? (
-        <StyledBox direction='row' gap='small' align='center'>
+        <Box direction='row' gap='small' align='center'>
           <Keyboard onEsc={handleOnEsc}>
             <form onSubmit={handleSubmit} aria-label='Subjects to add'>
               <TextInput
@@ -154,11 +138,7 @@ const AccessControlSubjectAddForm: React.FC<IAccessControlSubjectAddFormProps> =
                 onSuggestionSelect={handleSuggestionSelect}
                 suggestions={visibleSuggestions}
               >
-                <SaveButton
-                  type='submit'
-                  bsStyle='primary'
-                  disabled={isLoading}
-                >
+                <SaveButton type='submit' primary={true} disabled={isLoading}>
                   OK
                 </SaveButton>
               </TextInput>
@@ -171,12 +151,14 @@ const AccessControlSubjectAddForm: React.FC<IAccessControlSubjectAddFormProps> =
               timeout={0}
             />
           )}
-        </StyledBox>
+        </Box>
       ) : (
-        <StyledButton onClick={onToggleAdding}>
-          <i className='fa fa-add-circle' />
+        <Button
+          onClick={onToggleAdding}
+          icon={<i className='fa fa-add-circle' />}
+        >
           Add
-        </StyledButton>
+        </Button>
       )}
     </Box>
   );

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
@@ -159,10 +159,10 @@ const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> =
                 <Text>Are you sure?</Text>
               </Box>
               <Box direction='row'>
-                <Button bsStyle='danger' onClick={handleDelete}>
+                <Button danger={true} onClick={handleDelete}>
                   Yes, delete it
                 </Button>
-                <Button bsStyle='link' onClick={hideConfirmation}>
+                <Button link={true} onClick={hideConfirmation}>
                   Cancel
                 </Button>
               </Box>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
@@ -158,7 +158,7 @@ const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> =
               <Box>
                 <Text>Are you sure?</Text>
               </Box>
-              <Box direction='row'>
+              <Box direction='row' gap='small'>
                 <Button danger={true} onClick={handleDelete}>
                   Yes, delete it
                 </Button>

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
@@ -5,10 +5,10 @@ exports[`CLIGuide renders the contents when open 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hrJYol sc-kNnZrs iaZSkm"
+      class="StyledBox-sc-13pk1d4-0 hrJYol sc-jEWLvH kgGuXA"
       role="tablist"
     >
       <div
@@ -17,7 +17,7 @@ exports[`CLIGuide renders the contents when open 1`] = `
         <button
           aria-expanded="true"
           aria-selected="true"
-          class="StyledButton-sc-323bzc-0 eKfunH"
+          class="StyledButtonKind-sc-1vhfpnt-0 kjmWPw"
           role="tab"
           type="button"
         >
@@ -88,10 +88,10 @@ exports[`CLIGuide renders without crashing 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hrJYol sc-kNnZrs iaZSkm"
+      class="StyledBox-sc-13pk1d4-0 hrJYol sc-jEWLvH kgGuXA"
       role="tablist"
     >
       <div
@@ -100,7 +100,7 @@ exports[`CLIGuide renders without crashing 1`] = `
         <button
           aria-expanded="false"
           aria-selected="false"
-          class="StyledButton-sc-323bzc-0 eKfunH"
+          class="StyledButtonKind-sc-1vhfpnt-0 kjmWPw"
           role="tab"
           type="button"
         >

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 aYENS"
@@ -14,7 +14,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         class="StyledBox-sc-13pk1d4-0 jcMcey"
       >
         <div
-          class="sc-dFRpbK kJSiqA sc-cOohKt aynJd"
+          class="sc-bsatvv cYBmHJ sc-eEnULY hNVqzH"
         >
           <span
             aria-label="35 dogs"
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 fTVibh sc-bfmRie kXKjAQ"
+        class="StyledText-sc-1sadyjn-0 fTVibh sc-cdlubJ jPQraZ"
       >
         dogs
       </span>
@@ -39,7 +39,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 aYENS"
@@ -48,7 +48,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         class="StyledBox-sc-13pk1d4-0 jcMcey"
       >
         <div
-          class="sc-dFRpbK kJSiqA sc-cOohKt aynJd"
+          class="sc-bsatvv cYBmHJ sc-eEnULY hNVqzH"
         >
           <span
             aria-label="1 dog"
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 fTVibh sc-bfmRie kXKjAQ"
+        class="StyledText-sc-1sadyjn-0 fTVibh sc-cdlubJ jPQraZ"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction.tsx
@@ -123,7 +123,7 @@ const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
           onCancel={hideConfirmation}
           confirmButton={
             <Button
-              bsStyle='danger'
+              danger={true}
               onClick={handleContinue}
               disabled={isConfirmButtonDisabled}
             >
@@ -169,7 +169,6 @@ const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
         {!confirmationVisible && (
           <Box animation={{ type: 'fadeIn', duration: 300 }}>
             <Button
-              bsStyle='default'
               onClick={showConfirmation}
               loading={isLoading}
               disabled={disabled}

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       aria-label="Some widget"
@@ -15,7 +15,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 ihVIAm"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 biMlWM sc-eEihID crGluz"
+          class="StyledText-sc-1sadyjn-0 biMlWM sc-iazTlQ dhFNXQ"
         >
           Some widget
         </span>
@@ -39,7 +39,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       aria-label="Some widget"
@@ -49,7 +49,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 bbIfdU"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 biMlWM sc-eEihID crGluz"
+          class="StyledText-sc-1sadyjn-0 biMlWM sc-iazTlQ dhFNXQ"
         >
           Some widget
         </span>

--- a/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation.tsx
+++ b/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedNavigation.tsx
@@ -27,7 +27,7 @@ const GettingStartedNavigation: React.FC<IGettingStartedNavigationProps> = (
     <GettingStartedBottomNav {...props}>
       {!isFirstStep && prevStepPath && (
         <Link to={prevStepPath} key='prev-step'>
-          <Button bsStyle='default'>
+          <Button>
             <i
               className='fa fa-chevron-left'
               aria-hidden={true}
@@ -40,7 +40,7 @@ const GettingStartedNavigation: React.FC<IGettingStartedNavigationProps> = (
 
       {isFirstStep && !prevStepPath && (
         <Link to={homePath} key='prev-step'>
-          <Button bsStyle='default'>
+          <Button>
             <i
               className='fa fa-chevron-left'
               aria-hidden={true}
@@ -53,7 +53,7 @@ const GettingStartedNavigation: React.FC<IGettingStartedNavigationProps> = (
 
       {!isPenultimateStep && !isHome && nextStepPath && (
         <Link to={nextStepPath} key='next-step'>
-          <Button bsStyle='primary'>
+          <Button primary={true}>
             Continue{' '}
             <i
               className='fa fa-chevron-right'
@@ -66,7 +66,7 @@ const GettingStartedNavigation: React.FC<IGettingStartedNavigationProps> = (
 
       {isPenultimateStep && nextStepPath && (
         <Link to={nextStepPath} key='next-step'>
-          <Button bsStyle='primary'>
+          <Button primary={true}>
             Finish{' '}
             <i
               className='fa fa-chevron-right'
@@ -79,7 +79,7 @@ const GettingStartedNavigation: React.FC<IGettingStartedNavigationProps> = (
 
       {isHome && nextStepPath && (
         <Link to={nextStepPath} key='next-step'>
-          <Button bsStyle='primary'>
+          <Button primary={true}>
             Start{' '}
             <i
               className='fa fa-chevron-right'

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolListPlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolListPlaceholder.tsx
@@ -26,7 +26,7 @@ const WorkerNodesNodePoolListPlaceholder: React.FC<IWorkerNodesNodePoolListPlace
         </Text>
       </Box>
       <Box>
-        <Button bsStyle='default' onClick={onCreateButtonClick}>
+        <Button onClick={onCreateButtonClick}>
           <i
             className='fa fa-add-circle'
             role='presentation'

--- a/src/components/UI/Display/Table/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/Table/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`Table renders a simple table 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <table
       class="StyledTable-sc-1m3u5g-6 gnELFm"

--- a/src/components/UI/Inputs/CheckBoxInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/CheckBoxInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,10 +5,10 @@ exports[`CheckBoxInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
       tabindex="0"
     >
       <div
@@ -49,10 +49,10 @@ exports[`CheckBoxInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
       tabindex="0"
     >
       <div
@@ -89,10 +89,10 @@ exports[`CheckBoxInput renders a toggle input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
       tabindex="0"
     >
       <label
@@ -147,10 +147,10 @@ exports[`CheckBoxInput renders an input with a form field label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
       tabindex="0"
     >
       <label
@@ -192,10 +192,10 @@ exports[`CheckBoxInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
       tabindex="0"
     >
       <span
@@ -237,10 +237,10 @@ exports[`CheckBoxInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
       tabindex="0"
     >
       <div
@@ -282,10 +282,10 @@ exports[`CheckBoxInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
       tabindex="0"
     >
       <div

--- a/src/components/UI/Inputs/CurrencyInput/__tests__/__snapshots__/CurrencyInput.tsx.snap
+++ b/src/components/UI/Inputs/CurrencyInput/__tests__/__snapshots__/CurrencyInput.tsx.snap
@@ -5,7 +5,7 @@ exports[`CurrencyInput renders without crashing 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/DateInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/DateInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`DateInput renders a button that triggers the calendar 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -15,7 +15,7 @@ exports[`DateInput renders a button that triggers the calendar 1`] = `
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 kfaNv"
+          class="StyledButtonKind-sc-1vhfpnt-0 ehJRIz"
           id="dob"
           type="button"
         >
@@ -24,7 +24,7 @@ exports[`DateInput renders a button that triggers the calendar 1`] = `
           >
             <svg
               aria-label="Calendar"
-              class="StyledIcon-ofa7kd-0 dyOQNl"
+              class="StyledIcon-ofa7kd-0 jJugNl"
               viewBox="0 0 24 24"
             >
               <path
@@ -51,7 +51,7 @@ exports[`DateInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -104,7 +104,7 @@ exports[`DateInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -149,7 +149,7 @@ exports[`DateInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -206,7 +206,7 @@ exports[`DateInput renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -258,7 +258,7 @@ exports[`DateInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -315,7 +315,7 @@ exports[`DateInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/Facets.tsx
+++ b/src/components/UI/Inputs/Facets.tsx
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
@@ -15,10 +16,6 @@ const StyledButton = styled(Button)`
 const Wrapper = styled.div`
   width: 270px;
   flex-shrink: 0;
-
-  .btn.btn-sm {
-    margin-left: 0px;
-  }
 `;
 
 const CatalogList = styled.ul`
@@ -66,17 +63,18 @@ const Facets: React.FC<IFacetsProps> = (props) => {
 
   return (
     <Wrapper>
-      <label>Filter by Catalog</label>
-      <br />
-      <StyledButton bsSize='sm' onClick={selectAll}>
-        Select all
-      </StyledButton>{' '}
-      <StyledButton bsSize='sm' onClick={selectNone}>
-        Select none
-      </StyledButton>
-      <br />
-      <br />
-      <CatalogList>
+      <Box>
+        <label>Filter by Catalog</label>
+      </Box>
+      <Box direction='row' gap='xsmall' margin={{ bottom: 'medium' }}>
+        <StyledButton size='small' onClick={selectAll}>
+          Select all
+        </StyledButton>{' '}
+        <StyledButton size='small' onClick={selectNone}>
+          Select none
+        </StyledButton>
+      </Box>
+      <CatalogList aria-label='Filter by catalog'>
         {props.isLoading &&
           LOADING_COMPONENTS.map((_, i) => (
             <ListItem key={i}>

--- a/src/components/UI/Inputs/FileInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/FileInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`FileInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -35,7 +35,7 @@ exports[`FileInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -64,7 +64,7 @@ exports[`FileInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -98,7 +98,7 @@ exports[`FileInput renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -134,7 +134,7 @@ exports[`FileInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -168,7 +168,7 @@ exports[`FileInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/InputGroup/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/InputGroup/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`InputGroup renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 kfocQM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/MultiSelect/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/MultiSelect/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`MultiSelect renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -21,7 +21,7 @@ exports[`MultiSelect renders a simple input 1`] = `
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 csiCSO Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
+          class="StyledButtonKind-sc-1vhfpnt-0 eBvPtR Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
           id="pet"
           type="button"
         >

--- a/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`NumberPicker renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 cYwaIm"
@@ -29,7 +29,7 @@ exports[`NumberPicker renders a simple input 1`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 gHAWHi sc-hndLF kFbUOj"
+            class="StyledTextInput-sc-1x30a0s-0 gHAWHi sc-geBCVM guFsmP"
             id="money"
             step="1"
             type="number"
@@ -37,18 +37,18 @@ exports[`NumberPicker renders a simple input 1`] = `
           />
         </div>
         <div
-          class="sc-geBCVM kzDtOC"
+          class="sc-clGGWX dWXxSu"
         >
           <div
             aria-label="Decrement"
-            class="sc-clGGWX ifwCoB"
+            class="sc-kJNqyW Rrhmd"
             role="button"
           >
             –
           </div>
           <div
             aria-label="Increment"
-            class="sc-clGGWX ifwCoB"
+            class="sc-kJNqyW Rrhmd"
             role="button"
           >
             +

--- a/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,10 +5,10 @@ exports[`RadioInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hQYpqk eqojmW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
       tabindex="0"
     >
       <div
@@ -49,10 +49,10 @@ exports[`RadioInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hQYpqk eqojmW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
       tabindex="0"
     >
       <div
@@ -91,10 +91,10 @@ exports[`RadioInput renders an input with a form field label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hQYpqk eqojmW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
       tabindex="0"
     >
       <label
@@ -141,10 +141,10 @@ exports[`RadioInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hQYpqk eqojmW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
       tabindex="0"
     >
       <span
@@ -188,10 +188,10 @@ exports[`RadioInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hQYpqk eqojmW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
       tabindex="0"
     >
       <div
@@ -235,10 +235,10 @@ exports[`RadioInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hQYpqk eqojmW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
       tabindex="0"
     >
       <div

--- a/src/components/UI/Inputs/Select/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/Select/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`Select renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -21,7 +21,7 @@ exports[`Select renders a disabled input 1`] = `
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 cjpaII Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
+          class="StyledButtonKind-sc-1vhfpnt-0 kvbsMU Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
           disabled=""
           id="pet"
           type="button"
@@ -77,7 +77,7 @@ exports[`Select renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -87,7 +87,7 @@ exports[`Select renders a simple input 1`] = `
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 csiCSO Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
+          class="StyledButtonKind-sc-1vhfpnt-0 eBvPtR Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
           id="pet"
           type="button"
         >
@@ -142,7 +142,7 @@ exports[`Select renders an input inside the dropdown, that can search through th
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -152,7 +152,7 @@ exports[`Select renders an input inside the dropdown, that can search through th
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 cjpaII Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
+          class="StyledButtonKind-sc-1vhfpnt-0 kvbsMU Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
           disabled=""
           id="pet"
           type="button"
@@ -207,7 +207,7 @@ exports[`Select renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -228,7 +228,7 @@ exports[`Select renders an input with a help message 1`] = `
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 csiCSO Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
+          class="StyledButtonKind-sc-1vhfpnt-0 eBvPtR Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
           id="pet"
           type="button"
         >
@@ -283,7 +283,7 @@ exports[`Select renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -299,7 +299,7 @@ exports[`Select renders an input with a label 1`] = `
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 csiCSO Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
+          class="StyledButtonKind-sc-1vhfpnt-0 eBvPtR Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
           id="pet"
           type="button"
         >
@@ -354,7 +354,7 @@ exports[`Select renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -370,7 +370,7 @@ exports[`Select renders an input with a validation error 1`] = `
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 csiCSO Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
+          class="StyledButtonKind-sc-1vhfpnt-0 eBvPtR Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
           id="pet"
           type="button"
         >
@@ -430,7 +430,7 @@ exports[`Select renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -446,7 +446,7 @@ exports[`Select renders an input with an info message 1`] = `
       >
         <button
           aria-label="Open Drop"
-          class="StyledButton-sc-323bzc-0 csiCSO Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
+          class="StyledButtonKind-sc-1vhfpnt-0 eBvPtR Select__StyledSelectDropButton-sc-17idtfo-2 iEUOTR"
           id="pet"
           type="button"
         >

--- a/src/components/UI/Inputs/TextArea/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/TextArea/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`TextArea renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -31,7 +31,7 @@ exports[`TextArea renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -57,7 +57,7 @@ exports[`TextArea renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -87,7 +87,7 @@ exports[`TextArea renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -119,7 +119,7 @@ exports[`TextArea renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -149,7 +149,7 @@ exports[`TextArea renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/TextInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/TextInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`TextInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -39,7 +39,7 @@ exports[`TextInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -67,7 +67,7 @@ exports[`TextInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -105,7 +105,7 @@ exports[`TextInput renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -138,7 +138,7 @@ exports[`TextInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -176,7 +176,7 @@ exports[`TextInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-gKAaRy ezfMqp"
+    class="sc-iCoGMd hFJToB"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/ViewEditName.tsx
+++ b/src/components/UI/Inputs/ViewEditName.tsx
@@ -1,4 +1,4 @@
-import { Keyboard } from 'grommet';
+import { Box, Keyboard } from 'grommet';
 import { hasAppropriateLength } from 'lib/helpers';
 import PropTypes from 'prop-types';
 import React, { Component, FormEvent, GetDerivedStateFromProps } from 'react';
@@ -30,12 +30,6 @@ const FormWrapper = styled.span`
   form {
     display: flex;
     align-items: center;
-  }
-
-  .btn-group {
-    float: none;
-    margin-left: 4px;
-    top: -2px;
   }
 `;
 
@@ -222,12 +216,19 @@ class ViewAndEditName extends Component<
             >
               <Tooltip id='name-form-error'>{errorMessage}</Tooltip>
             </Overlay>
-            <div className='btn-group'>
-              <Button type='submit' bsStyle='primary' disabled={hasError}>
+            <Box direction='row' gap='small'>
+              <Button
+                type='submit'
+                primary={true}
+                disabled={hasError}
+                size='small'
+              >
                 OK
               </Button>
-              <Button onClick={this.handleCancel}>Cancel</Button>
-            </div>
+              <Button onClick={this.handleCancel} size='small'>
+                Cancel
+              </Button>
+            </Box>
           </form>
         </FormWrapper>
       );

--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -221,8 +221,11 @@ class Users extends React.Component {
             <Section title='Open invites'>
               <>
                 <InvitesTable invitations={invitations} />
-                <Button onClick={this.inviteUser}>
-                  <i className='fa fa-add-circle' /> Invite user
+                <Button
+                  onClick={this.inviteUser}
+                  icon={<i className='fa fa-add-circle' />}
+                >
+                  Invite user
                 </Button>
               </>
             </Section>

--- a/src/components/Users/UsersModal.js
+++ b/src/components/Users/UsersModal.js
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import BootstrapModal from 'react-bootstrap/lib/Modal';
@@ -29,23 +30,25 @@ const UsersModal = ({
 
       <BootstrapModal.Body>{children}</BootstrapModal.Body>
       <BootstrapModal.Footer>
-        {!confirmHidden && (
-          <Button
-            bsStyle='danger'
-            loading={isLoading}
-            onClick={onConfirm}
-            type='submit'
-            disabled={confirmDisabled}
-          >
-            {confirmText}
-          </Button>
-        )}
+        <Box gap='small' direction='row' justify='end'>
+          {!confirmHidden && (
+            <Button
+              danger={true}
+              loading={isLoading}
+              onClick={onConfirm}
+              type='submit'
+              disabled={confirmDisabled}
+            >
+              {confirmText}
+            </Button>
+          )}
 
-        {!isLoading && (
-          <Button bsStyle='link' onClick={onClose}>
-            {cancelText}
-          </Button>
-        )}
+          {!isLoading && (
+            <Button link={true} onClick={onClose}>
+              {cancelText}
+            </Button>
+          )}
+        </Box>
       </BootstrapModal.Footer>
     </BootstrapModal>
   );

--- a/src/components/Users/UsersTable.js
+++ b/src/components/Users/UsersTable.js
@@ -60,7 +60,7 @@ const getActionsCellFormatter = (_cell, row, deleteUser) => {
   const onDelete = () => deleteUser(row.email);
 
   return (
-    <Button bsStyle='default' bsSize='sm' onClick={onDelete} type='button'>
+    <Button size='small' onClick={onDelete} type='button'>
       Delete
     </Button>
   );

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -171,6 +171,7 @@ const theme = deepMerge(generate(16), {
       'selected-background': 'brand',
       'selected-text': 'text-strong',
       'status-critical': '#e49090',
+      'status-danger': '#bd3e3a',
       'status-warning': '#FFAA15',
       'status-ok': '#2a8b29',
       'status-unknown': '#CCCCCC',
@@ -296,10 +297,19 @@ const theme = deepMerge(generate(16), {
     border: {
       radius: '4px',
     },
+    extend: () => css`
+      white-space: nowrap;
+      user-select: none;
+      touch-action: manipulation;
+    `,
     size: {
       small: {
         border: {
           radius: '2px',
+        },
+        pad: {
+          vertical: '4px',
+          horizontal: '8px',
         },
       },
       medium: {
@@ -315,18 +325,25 @@ const theme = deepMerge(generate(16), {
         border: {
           radius: '4px',
         },
+        pad: {
+          vertical: '8px',
+          horizontal: '16px',
+        },
       },
     },
     default: {
       background: 'transparent',
+      color: 'text-weak',
+      font: {
+        weight: 'normal',
+      },
     },
     primary: {
       background: 'status-ok',
-      border: {
-        color: 'status-ok',
-        width: '1px',
-      },
       color: 'text',
+      font: {
+        weight: 'normal',
+      },
     },
     secondary: {
       background: 'transparent',
@@ -335,22 +352,28 @@ const theme = deepMerge(generate(16), {
         color: 'text-weak',
         width: '1px',
       },
+      font: {
+        weight: 'normal',
+      },
     },
     hover: {
       color: 'text',
       default: {
         background: {
           color: 'text',
-          opacity: 0.1,
+          opacity: 0.15,
         },
         border: {
           color: 'text',
         },
+        extend: () => css`
+          text-decoration: underline;
+        `,
       },
       secondary: {
         background: {
           color: 'text',
-          opacity: 0.1,
+          opacity: 0.15,
         },
         border: {
           color: 'text',
@@ -358,10 +381,6 @@ const theme = deepMerge(generate(16), {
       },
       primary: {
         background: {
-          color: 'status-ok',
-          opacity: 0.7,
-        },
-        border: {
           color: 'status-ok',
           opacity: 0.7,
         },
@@ -392,10 +411,14 @@ const theme = deepMerge(generate(16), {
           color: 'status-ok',
           opacity: 0.5,
         },
-        border: {
-          color: 'status-ok',
-          opacity: 0.5,
-        },
+      },
+    },
+    disabled: {
+      background: 'status-disabled',
+      color: 'text-weak',
+      opacity: 0.7,
+      border: {
+        width: '0',
       },
     },
   },

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -172,7 +172,7 @@ const theme = deepMerge(generate(16), {
       'selected-text': 'text-strong',
       'status-critical': '#e49090',
       'status-warning': '#FFAA15',
-      'status-ok': '#00C781',
+      'status-ok': '#2a8b29',
       'status-unknown': '#CCCCCC',
       'status-disabled': '#3a5f7b',
       'graph-0': 'brand',
@@ -294,12 +294,109 @@ const theme = deepMerge(generate(16), {
   meter: {},
   button: {
     border: {
-      width: '2px',
       radius: '4px',
     },
-    padding: {
-      vertical: '3px',
-      horizontal: '18px',
+    size: {
+      small: {
+        border: {
+          radius: '2px',
+        },
+      },
+      medium: {
+        border: {
+          radius: '4px',
+        },
+        pad: {
+          vertical: '8px',
+          horizontal: '16px',
+        },
+      },
+      large: {
+        border: {
+          radius: '4px',
+        },
+      },
+    },
+    default: {
+      background: 'transparent',
+    },
+    primary: {
+      background: 'status-ok',
+      border: {
+        color: 'status-ok',
+        width: '1px',
+      },
+      color: 'text',
+    },
+    secondary: {
+      background: 'transparent',
+      color: 'text-weak',
+      border: {
+        color: 'text-weak',
+        width: '1px',
+      },
+    },
+    hover: {
+      color: 'text',
+      default: {
+        background: {
+          color: 'text',
+          opacity: 0.1,
+        },
+        border: {
+          color: 'text',
+        },
+      },
+      secondary: {
+        background: {
+          color: 'text',
+          opacity: 0.1,
+        },
+        border: {
+          color: 'text',
+        },
+      },
+      primary: {
+        background: {
+          color: 'status-ok',
+          opacity: 0.7,
+        },
+        border: {
+          color: 'status-ok',
+          opacity: 0.7,
+        },
+      },
+    },
+    active: {
+      color: 'text',
+      default: {
+        background: {
+          color: 'text',
+          opacity: 0.3,
+        },
+        border: {
+          color: 'text',
+        },
+      },
+      secondary: {
+        background: {
+          color: 'text',
+          opacity: 0.3,
+        },
+        border: {
+          color: 'text',
+        },
+      },
+      primary: {
+        background: {
+          color: 'status-ok',
+          opacity: 0.5,
+        },
+        border: {
+          color: 'status-ok',
+          opacity: 0.5,
+        },
+      },
     },
   },
   calendar: {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -381,8 +381,8 @@ const theme = deepMerge(generate(16), {
       },
       primary: {
         background: {
-          color: 'status-ok',
-          opacity: 0.7,
+          color: '#3F963E',
+          opacity: 1,
         },
       },
     },
@@ -391,7 +391,6 @@ const theme = deepMerge(generate(16), {
       default: {
         background: {
           color: 'text',
-          opacity: 0.3,
         },
         border: {
           color: 'text',
@@ -400,7 +399,6 @@ const theme = deepMerge(generate(16), {
       secondary: {
         background: {
           color: 'text',
-          opacity: 0.3,
         },
         border: {
           color: 'text',
@@ -409,7 +407,6 @@ const theme = deepMerge(generate(16), {
       primary: {
         background: {
           color: 'status-ok',
-          opacity: 0.5,
         },
       },
     },


### PR DESCRIPTION
This PR refactors the `<Button />` component to use `grommet` as a base, instead of `bootstrap`. It also updates the component props to have the same interface as the original `grommet` one, while adding extra support for loading animations and `danger`/`warning` states.

All the components that used `<Button />` had to be updated, hence the large number of changes.

I tested all the buttons in the app and everything behaves the same as before.
The look is a bit different, because the new buttons are slightly larger, and have slightly different colors (for better contrast).

A code review would take too much effort, so please take the app for a spin, or build and run `fe-docs` locally, and check there.

## Preview

<details>
<summary>Primary</summary>

![image](https://user-images.githubusercontent.com/13508038/128551679-464c56f5-5b43-406e-ad58-9531ed65ffc1.png)

![image](https://user-images.githubusercontent.com/13508038/128687090-c34446b9-e3ac-4b7a-bb66-4329865b0531.png)

</details>

<details>
<summary>Secondary</summary>

![image](https://user-images.githubusercontent.com/13508038/128551889-54743906-037a-4358-9378-6c9210688910.png)

![image](https://user-images.githubusercontent.com/13508038/128551906-2b6dde66-7c93-41fa-8b79-69c54bedc39a.png)

</details>

<details>
<summary>Danger</summary>

![image](https://user-images.githubusercontent.com/13508038/128551928-cae97261-b525-4606-8d68-778ffab97d58.png)

![image](https://user-images.githubusercontent.com/13508038/128687116-0ce747b6-8f56-4b1d-8d8b-73ffffe9f6bb.png)

</details>

<details>
<summary>Link</summary>

![image](https://user-images.githubusercontent.com/13508038/128551963-c846e802-db52-46d4-a0c7-b58f820efbb0.png)

![image](https://user-images.githubusercontent.com/13508038/128551998-39d0d84a-ce28-4833-98b8-63adb8566f5a.png)

</details>

<details>
<summary>Disabled</summary>

![image](https://user-images.githubusercontent.com/13508038/128552089-0ed34b0a-27b9-4087-acb6-6ce97f9fbd36.png)

</details>

<details>
<summary>Loading</summary>

![image](https://user-images.githubusercontent.com/13508038/128552039-ba7a6569-1db2-493a-bddc-07c6d19e286d.png)

</details>


