### PR TITLE
Don't display tooltips with the full date on relative dates when they are not needed

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetCreated.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetCreated.tsx
@@ -1,5 +1,5 @@
 import { Text } from 'grommet';
-import { formatDate, relativeDate } from 'lib/helpers';
+import { formatDate, getRelativeDateFromNow } from 'lib/helpers';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -39,7 +39,7 @@ const ClusterDetailWidgetCreated: React.FC<IClusterDetailWidgetCreatedProps> = (
       {...props}
     >
       <ClusterDetailWidgetOptionalValue value={creationDate}>
-        {(value) => <Text>{relativeDate(value as string)}</Text>}
+        {(value) => <Text>{getRelativeDateFromNow(value as string)}</Text>}
       </ClusterDetailWidgetOptionalValue>
       <StyledDot />
       <ClusterDetailWidgetOptionalValue value={creationDate} loaderWidth={150}>

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairDetailsModal.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairDetailsModal.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'grommet';
-import { formatDate, relativeDate } from 'lib/helpers';
+import { formatDate, getRelativeDateFromNow } from 'lib/helpers';
 import GenericModal from 'Modals/GenericModal';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -84,7 +84,8 @@ const ClusterDetailKeyPairDetailsModal: React.FC<IClusterDetailKeyPairDetailsMod
           <Label>Created</Label>
           {creationDate ? (
             <Text>
-              {formatDate(creationDate)} &ndash; {relativeDate(creationDate)}
+              {formatDate(creationDate)} &ndash;{' '}
+              {getRelativeDateFromNow(creationDate)}
             </Text>
           ) : (
             <NotAvailable />
@@ -95,7 +96,7 @@ const ClusterDetailKeyPairDetailsModal: React.FC<IClusterDetailKeyPairDetailsMod
           {expirationDate ? (
             <Text color={isExpiringSoon ? 'status-warning' : undefined}>
               {formatDate(expirationDate)} &ndash;{' '}
-              {relativeDate(expirationDate)}
+              {getRelativeDateFromNow(expirationDate)}
             </Text>
           ) : (
             <NotAvailable />

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteActionClusterDetails.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteActionClusterDetails.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'grommet';
-import { formatDate, relativeDate } from 'lib/helpers';
+import { formatDate, getRelativeDateFromNow } from 'lib/helpers';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ClusterIDLabel, {
@@ -109,7 +109,8 @@ const ClusterDetailDeleteActionClusterDetails: React.FC<IClusterDetailDeleteActi
       </Box>
       <Box direction='row'>
         <Text>
-          Created: {relativeDate(creationDate)} ({formatDate(creationDate)})
+          Created: {getRelativeDateFromNow(creationDate)} (
+          {formatDate(creationDate)})
         </Text>
       </Box>
       <Box direction='row' gap='xsmall' align='baseline'>


### PR DESCRIPTION
As noticed by Sandy in https://github.com/giantswarm/happa/pull/2608#issuecomment-893451618, we always display a tooltip with the full date while hovering on relative dates, even when the full date is displayed near the relative one.

Turns out we actually have an utility that only formats the relative date, and does not return a React component.
So with this PR, we no longer display full date tooltips over relative dates, if the full date is already displayed in the UI.