### PR TITLE
Fix version picker closing itself when ticking 'Use test versions'

### DIFF
--- a/src/components/UI/Controls/VersionPicker/VersionPicker.tsx
+++ b/src/components/UI/Controls/VersionPicker/VersionPicker.tsx
@@ -160,13 +160,6 @@ const VersionPicker: React.FC<IVersionPickerProps> = ({
     setIncludeTestVersions(event.target.checked);
   };
 
-  const handleBlur = (onBlurHandler: () => void) => () => {
-    setTimeout(() => {
-      onBlurHandler();
-      // eslint-disable-next-line no-magic-numbers
-    }, 300);
-  };
-
   const handleOnChange = (version: string) => (
     event: React.MouseEvent<HTMLAnchorElement>
   ) => {
@@ -185,7 +178,7 @@ const VersionPicker: React.FC<IVersionPickerProps> = ({
           onBlurHandler,
           onFocusHandler,
         }) => (
-          <div onBlur={handleBlur(onBlurHandler)} onFocus={onFocusHandler}>
+          <div onBlur={onBlurHandler} onFocus={onFocusHandler}>
             <VersionPickerDropdownTrigger
               aria-expanded={isOpen}
               aria-haspopup='true'


### PR DESCRIPTION
Quick and easy fix. Previously when ticking the `Use test versions` checkbox (which is only available to GS staff, hence the `kind/refactor` label), the dropdown would close itself before you could interact with any of the list items. This fixes that.