### PR TITLE
Add CLI guides for listing and creating clusters

### DIFF
--- a/src/components/GettingStarted/Steps/SimpleExample.js
+++ b/src/components/GettingStarted/Steps/SimpleExample.js
@@ -175,10 +175,10 @@ class SimpleExample extends React.Component {
             </Prompt>
             <Output>
               {`
-                  service/helloworld created
-                  deployment.apps/helloworld created
-                  poddisruptionbudget.policy/helloworld-pdb created
-                  ingress.networking.k8s.io/helloworld created
+service/helloworld created
+deployment.apps/helloworld created
+poddisruptionbudget.policy/helloworld-pdb created
+ingress.networking.k8s.io/helloworld created
                 `}
             </Output>
           </CodeBlock>
@@ -208,8 +208,8 @@ class SimpleExample extends React.Component {
             <Prompt>kubectl get deployment -l app=helloworld</Prompt>
             <Output>
               {`
-                  NAME         READY   UP-TO-DATE   AVAILABLE   AGE
-                  helloworld   2/2     2            2           2m
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+helloworld   2/2     2            2           2m
                 `}
             </Output>
           </CodeBlock>
@@ -224,8 +224,8 @@ class SimpleExample extends React.Component {
             <Prompt>kubectl get svc -l app=helloworld</Prompt>
             <Output>
               {`
-                  NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
-                  helloworld   ClusterIP   172.31.144.55   <none>        8080/TCP   2m
+NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+helloworld   ClusterIP   172.31.144.55   <none>        8080/TCP   2m
                 `}
             </Output>
           </CodeBlock>
@@ -263,12 +263,12 @@ class SimpleExample extends React.Component {
             <Prompt>kubectl logs --selector app=helloworld</Prompt>
             <Output>
               {`
-                  2014/07/01 09:57:30 Starting up at :8080
-                  2014/07/01 09:57:40 GET /giant-swarm-logo.svg
-                  2014/07/01 09:57:41 GET /favicon32.ico
-                  2014/07/01 09:57:30 Starting up at :8080
-                  2014/07/01 09:57:40 GET /
-                  2014/07/01 09:57:40 GET /blue-bg.jpg
+2014/07/01 09:57:30 Starting up at :8080
+2014/07/01 09:57:40 GET /giant-swarm-logo.svg
+2014/07/01 09:57:41 GET /favicon32.ico
+2014/07/01 09:57:30 Starting up at :8080
+2014/07/01 09:57:40 GET /
+2014/07/01 09:57:40 GET /blue-bg.jpg
                 `}
             </Output>
           </CodeBlock>
@@ -288,10 +288,10 @@ class SimpleExample extends React.Component {
             <Prompt>kubectl delete -f helloworld-manifest.yaml</Prompt>
             <Output>
               {`
-                  service "helloworld" deleted
-                  deployment.apps "helloworld" deleted
-                  poddisruptionbudget.policy "helloworld-pdb" deleted
-                  ingress.networking.k8s.io "helloworld" deleted
+service "helloworld" deleted
+deployment.apps "helloworld" deleted
+poddisruptionbudget.policy "helloworld-pdb" deleted
+ingress.networking.k8s.io "helloworld" deleted
                 `}
             </Output>
           </CodeBlock>

--- a/src/components/MAPI/clusters/Clusters.tsx
+++ b/src/components/MAPI/clusters/Clusters.tsx
@@ -23,6 +23,7 @@ import ClusterListErrorPlaceholder from 'UI/Display/MAPI/clusters/ClusterList/Cl
 import ClusterListNoOrgsPlaceholder from 'UI/Display/MAPI/clusters/ClusterList/ClusterListNoOrgsPlaceholder';
 
 import ClusterListItem from './ClusterList/ClusterListItem';
+import ListClustersGuide from './guides/ListClustersGuide';
 import { compareClusters } from './utils';
 
 const LOADING_COMPONENTS = new Array(6).fill(0);
@@ -213,6 +214,9 @@ const Clusters: React.FC<{}> = () => {
               </TransitionGroup>
             </AnimationWrapper>
           </Keyboard>
+        </Box>
+        <Box margin={{ top: 'medium' }} direction='column' gap='small'>
+          <ListClustersGuide />
         </Box>
       </Box>
     </DocumentTitle>

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -7,9 +7,14 @@ import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import RoutePath from 'lib/routePath';
 import { Cluster, ControlPlaneNode, ProviderCluster } from 'MAPI/types';
-import { extractErrorMessage, generateUID } from 'MAPI/utils';
+import {
+  extractErrorMessage,
+  generateUID,
+  getClusterDescription,
+  getClusterReleaseVersion,
+} from 'MAPI/utils';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
-import React, { useEffect, useReducer, useRef } from 'react';
+import React, { useEffect, useMemo, useReducer, useRef } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router';
@@ -22,6 +27,10 @@ import { getNamespaceFromOrgName } from 'stores/main/utils';
 import useSWR from 'swr';
 import Button from 'UI/Controls/Button';
 
+import {
+  computeControlPlaneNodesStats,
+  getVisibleLabels,
+} from '../ClusterDetail/utils';
 import CreateClusterGuide from '../guides/CreateClusterGuide';
 import {
   createCluster,
@@ -268,6 +277,14 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
     }
   };
 
+  const releaseVersion = getClusterReleaseVersion(state.cluster);
+  const description = getClusterDescription(state.cluster);
+  const controlPlaneAZs = useMemo(() => {
+    return computeControlPlaneNodesStats([state.controlPlaneNode])
+      .availabilityZones;
+  }, [state.controlPlaneNode]);
+  const labels = getVisibleLabels(state.cluster);
+
   return (
     <Breadcrumb data={{ title: 'CREATE CLUSTER', pathname: match.url }}>
       <DocumentTitle title={`Create Cluster | ${orgId}`}>
@@ -343,6 +360,10 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               provider={state.provider}
               clusterName={state.cluster.metadata.name}
               organizationName={orgId}
+              releaseVersion={releaseVersion}
+              description={description}
+              labels={labels}
+              controlPlaneAZs={controlPlaneAZs}
             />
           </Box>
         </Box>

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -22,6 +22,7 @@ import { getNamespaceFromOrgName } from 'stores/main/utils';
 import useSWR from 'swr';
 import Button from 'UI/Controls/Button';
 
+import CreateClusterGuide from '../guides/CreateClusterGuide';
 import {
   createCluster,
   createDefaultCluster,
@@ -336,6 +337,13 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
                 </Text>
               </Box>
             </Box>
+          </Box>
+          <Box margin={{ top: 'large' }} direction='column' gap='small'>
+            <CreateClusterGuide
+              provider={state.provider}
+              clusterName={state.cluster.metadata.name}
+              organizationName={orgId}
+            />
           </Box>
         </Box>
       </DocumentTitle>

--- a/src/components/MAPI/clusters/guides/CreateClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/CreateClusterGuide.tsx
@@ -1,8 +1,16 @@
 import { Text } from 'grommet';
 import * as docs from 'lib/docs';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import {
+  getCurrentInstallationContextName,
+  makeKubectlGSCommand,
+  withContext,
+  withFormatting,
+  withTemplateCluster,
+} from 'MAPI/guides/utils';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
 import CLIGuide from 'UI/Display/MAPI/CLIGuide';
@@ -15,14 +23,24 @@ interface ICreateClusterGuideProps
   provider: PropertiesOf<typeof Providers>;
   clusterName: string;
   organizationName: string;
+  releaseVersion?: string;
+  description?: string;
+  labels?: Record<string, string>;
+  controlPlaneAZs?: string[];
 }
 
 const CreateClusterGuide: React.FC<ICreateClusterGuideProps> = ({
   provider,
   clusterName,
   organizationName,
+  releaseVersion,
+  description,
+  labels,
+  controlPlaneAZs,
   ...props
 }) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
   return (
     <CLIGuide
       title='Create a cluster via the Management API'
@@ -58,13 +76,20 @@ const CreateClusterGuide: React.FC<ICreateClusterGuideProps> = ({
         <LoginGuideStep />
         <CLIGuideStep
           title='2. Create a cluster manifest'
-          command={`
-              kubectl gs template cluster \\
-                --provider ${provider} \\
-                --owner ${organizationName} \\
-                --name ${clusterName} \\
-                --output cluster-${clusterName}.yaml
-          `}
+          command={makeKubectlGSCommand(
+            withContext(context),
+            withTemplateCluster({
+              provider,
+              owner: organizationName,
+              name: clusterName,
+              release: releaseVersion,
+              description,
+              controlPlaneAZs,
+              labels,
+              output: `cluster-${clusterName}.yaml`,
+            }),
+            withFormatting()
+          )}
         />
         <CLIGuideStep
           title='3. Apply the manifest'
@@ -85,6 +110,12 @@ CreateClusterGuide.propTypes = {
   provider: PropTypes.oneOf(Object.values(Providers)).isRequired,
   clusterName: PropTypes.string.isRequired,
   organizationName: PropTypes.string.isRequired,
+  releaseVersion: PropTypes.string,
+  description: PropTypes.string,
+  labels: PropTypes.object as PropTypes.Requireable<
+    ICreateClusterGuideProps['labels']
+  >,
+  controlPlaneAZs: PropTypes.arrayOf(PropTypes.string.isRequired),
 };
 
 export default CreateClusterGuide;

--- a/src/components/MAPI/clusters/guides/CreateClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/CreateClusterGuide.tsx
@@ -4,7 +4,6 @@ import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
 import {
   getCurrentInstallationContextName,
   makeKubectlGSCommand,
-  withContext,
   withFormatting,
   withTemplateCluster,
 } from 'MAPI/guides/utils';
@@ -77,7 +76,6 @@ const CreateClusterGuide: React.FC<ICreateClusterGuideProps> = ({
         <CLIGuideStep
           title='2. Create a cluster manifest'
           command={makeKubectlGSCommand(
-            withContext(context),
             withTemplateCluster({
               provider,
               owner: organizationName,
@@ -93,9 +91,7 @@ const CreateClusterGuide: React.FC<ICreateClusterGuideProps> = ({
         />
         <CLIGuideStep
           title='3. Apply the manifest'
-          command={`
-              kubectl apply -f cluster-${clusterName}.yaml
-          `}
+          command={`kubectl apply --context ${context} -f cluster-${clusterName}.yaml`}
         >
           <Text>
             As a result, a cluster without worker nodes will get created.

--- a/src/components/MAPI/clusters/guides/CreateClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/CreateClusterGuide.tsx
@@ -1,0 +1,90 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface ICreateClusterGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  provider: PropertiesOf<typeof Providers>;
+  clusterName: string;
+  organizationName: string;
+}
+
+const CreateClusterGuide: React.FC<ICreateClusterGuideProps> = ({
+  provider,
+  clusterName,
+  organizationName,
+  ...props
+}) => {
+  return (
+    <CLIGuide
+      title='Create a cluster via the Management API'
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'kubectl gs template cluster command',
+              href: docs.kubectlGSTemplateClusterURL,
+              external: true,
+            },
+            {
+              label: 'Cluster CRD schema',
+              href: docs.clusterCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. Create a cluster manifest'
+          command={`
+              kubectl gs template cluster \\
+                --provider ${provider} \\
+                --owner ${organizationName} \\
+                --name ${clusterName} \\
+                --output cluster-${clusterName}.yaml
+          `}
+        />
+        <CLIGuideStep
+          title='3. Apply the manifest'
+          command={`
+              kubectl apply -f cluster-${clusterName}.yaml
+          `}
+        >
+          <Text>
+            As a result, a cluster without worker nodes will get created.
+          </Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+CreateClusterGuide.propTypes = {
+  provider: PropTypes.oneOf(Object.values(Providers)).isRequired,
+  clusterName: PropTypes.string.isRequired,
+  organizationName: PropTypes.string.isRequired,
+};
+
+export default CreateClusterGuide;

--- a/src/components/MAPI/clusters/guides/ListClustersGuide.tsx
+++ b/src/components/MAPI/clusters/guides/ListClustersGuide.tsx
@@ -1,0 +1,63 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import React from 'react';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface IListClustersGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {}
+
+const ListClustersGuide: React.FC<IListClustersGuideProps> = (props) => {
+  return (
+    <CLIGuide
+      title='List clusters via the Management API'
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'kubectl gs get clusters command',
+              href: docs.kubectlGSGetClustersURL,
+              external: true,
+            },
+            {
+              label: 'Cluster CRD schema',
+              href: docs.clusterCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. List all clusters'
+          command='kubectl gs get clusters --all-namespaces'
+        >
+          <Text>
+            <strong>Note:</strong> The above command prints a user-friendly
+            table. Add <code>--output json</code> to create JSON output instead.
+          </Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+ListClustersGuide.propTypes = {};
+
+export default ListClustersGuide;

--- a/src/components/MAPI/clusters/guides/ListClustersGuide.tsx
+++ b/src/components/MAPI/clusters/guides/ListClustersGuide.tsx
@@ -1,7 +1,12 @@
 import { Text } from 'grommet';
 import * as docs from 'lib/docs';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
-import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
+import {
+  getCurrentInstallationContextName,
+  makeKubectlGSCommand,
+  withContext,
+  withGetClusters,
+} from 'MAPI/guides/utils';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import CLIGuide from 'UI/Display/MAPI/CLIGuide';
@@ -50,7 +55,12 @@ const ListClustersGuide: React.FC<IListClustersGuideProps> = (props) => {
         <LoginGuideStep />
         <CLIGuideStep
           title='2. List all clusters'
-          command={`kubectl --context ${context} gs get clusters --all-namespaces`}
+          command={makeKubectlGSCommand(
+            withContext(context),
+            withGetClusters({
+              allNamespaces: true,
+            })
+          )}
         >
           <Text>
             <strong>Note:</strong> The above command prints a user-friendly

--- a/src/components/MAPI/clusters/guides/ListClustersGuide.tsx
+++ b/src/components/MAPI/clusters/guides/ListClustersGuide.tsx
@@ -1,7 +1,9 @@
 import { Text } from 'grommet';
 import * as docs from 'lib/docs';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import CLIGuide from 'UI/Display/MAPI/CLIGuide';
 import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
 import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
@@ -11,6 +13,8 @@ interface IListClustersGuideProps
   extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {}
 
 const ListClustersGuide: React.FC<IListClustersGuideProps> = (props) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
   return (
     <CLIGuide
       title='List clusters via the Management API'
@@ -46,7 +50,7 @@ const ListClustersGuide: React.FC<IListClustersGuideProps> = (props) => {
         <LoginGuideStep />
         <CLIGuideStep
           title='2. List all clusters'
-          command='kubectl gs get clusters --all-namespaces'
+          command={`kubectl --context ${context} gs get clusters --all-namespaces`}
         >
           <Text>
             <strong>Note:</strong> The above command prints a user-friendly

--- a/src/components/MAPI/guides/__tests__/utils.ts
+++ b/src/components/MAPI/guides/__tests__/utils.ts
@@ -1,0 +1,269 @@
+import {
+  IKubectlGSTemplateClusterCommandConfig,
+  KubectlGSCommandModifier,
+  makeKubectlGSCommand,
+  withContext,
+  withFormatting,
+  withTemplateCluster,
+} from '../utils';
+
+describe('utils', () => {
+  describe('makeKubectlGSCommand', () => {
+    it('returns an empty command for no arguments', () => {
+      const output = makeKubectlGSCommand();
+      expect(output).toEqual('kubectl gs');
+    });
+
+    it('can be configured with modifiers', () => {
+      const modifierA: KubectlGSCommandModifier = (parts) => [
+        ...parts,
+        'some-arg',
+      ];
+
+      let output = makeKubectlGSCommand(modifierA);
+      expect(output).toEqual('kubectl gs some-arg');
+
+      const modifierB: KubectlGSCommandModifier = (parts) => [
+        ...parts,
+        '--some-flag',
+        ' ',
+        'test',
+      ];
+
+      output = makeKubectlGSCommand(modifierA, modifierB);
+      expect(output).toEqual('kubectl gs some-arg --some-flag test');
+
+      const modifierC: KubectlGSCommandModifier = (parts) => [
+        ...parts,
+        '--some-other-flag',
+        'value',
+      ];
+
+      output = makeKubectlGSCommand(modifierA, modifierB, modifierC);
+      expect(output).toEqual(
+        'kubectl gs some-arg --some-flag test --some-other-flag value'
+      );
+    });
+  });
+
+  describe('withContext', () => {
+    it('does not break if provided an empty value', () => {
+      const output = makeKubectlGSCommand(withContext(''));
+      expect(output).toEqual('kubectl gs --context');
+    });
+
+    it('can be configured with a value', () => {
+      const output = makeKubectlGSCommand(withContext('some-value'));
+      expect(output).toEqual('kubectl gs --context some-value');
+    });
+
+    it('always returns the value at the beginning of the output', () => {
+      const modifierA: KubectlGSCommandModifier = (parts) => [
+        ...parts,
+        'some-arg',
+      ];
+
+      const output = makeKubectlGSCommand(modifierA, withContext('some-value'));
+      expect(output).toEqual('kubectl gs --context some-value some-arg');
+    });
+  });
+
+  describe('withTemplateCluster', () => {
+    interface ITestCase {
+      name: string;
+      modifierConfig: IKubectlGSTemplateClusterCommandConfig;
+      expectedOutput: string;
+    }
+
+    const testCases: ITestCase[] = [
+      {
+        name: 'returns correct output with only required options',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner',
+      },
+      {
+        name: 'returns correct output with name',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+          name: 'some-resource',
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner --name some-resource',
+      },
+      {
+        name: 'returns correct output with description',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+          description: 'User friendliness',
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner --description "User friendliness"',
+      },
+      {
+        name: 'returns correct output with release',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+          release: '14.5.0',
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner --release 14.5.0',
+      },
+      {
+        name: 'returns correct output with label',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+          labels: { label1: 'value1' },
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner --label "label1=value1"',
+      },
+      {
+        name: 'returns correct output with multiple labels',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+          labels: { label1: 'value1', label2: 'value2' },
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner --label "label1=value1" --label "label2=value2"',
+      },
+      {
+        name: 'returns correct output with control plane AZ',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+          controlPlaneAZs: ['2'],
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner --control-plane-az 2',
+      },
+      {
+        name: 'returns correct output with multiple control plane AZs',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+          controlPlaneAZs: ['1', '2', '3'],
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner --control-plane-az 1 --control-plane-az 2 --control-plane-az 3',
+      },
+      {
+        name: 'returns correct output with output',
+        modifierConfig: {
+          owner: 'some-owner',
+          provider: 'some-provider',
+          output: 'test-file.yaml',
+        },
+        expectedOutput:
+          'kubectl gs template cluster --provider some-provider --owner some-owner --output "test-file.yaml"',
+      },
+    ];
+
+    for (const tc of testCases) {
+      it(tc.name, () => {
+        const output = makeKubectlGSCommand(
+          withTemplateCluster(tc.modifierConfig)
+        );
+
+        expect(output).toEqual(tc.expectedOutput);
+      });
+    }
+  });
+
+  describe('withFormatting', () => {
+    interface ITestCase {
+      name: string;
+      args: string[];
+      expectedOutput: string;
+    }
+
+    const testCases: ITestCase[] = [
+      {
+        name: 'returns correct output for no input',
+        args: [],
+        expectedOutput: 'kubectl gs',
+      },
+      {
+        name: 'returns correct output for a short command',
+        args: ['some-arg', 'some-other-arg'],
+        expectedOutput: 'kubectl gs some-arg some-other-arg',
+      },
+      {
+        name: 'returns correct output for a long command',
+        args: ['get', 'some', 'resources', 'from', 'somewhere'],
+        expectedOutput: `kubectl gs get some resources from somewhere`,
+      },
+      {
+        name: 'returns correct output for a long command and no arguments',
+        args: [
+          '--some-flag',
+          'super-value',
+          '--some-other-flag',
+          'other-value',
+          '--some-random-flag',
+          'the-value',
+        ],
+        expectedOutput: `kubectl gs \\
+    --some-flag super-value \\
+    --some-other-flag other-value \\
+    --some-random-flag the-value`,
+      },
+      {
+        name: 'returns correct output for a long command and some arguments',
+        args: [
+          'get',
+          'some',
+          'resources',
+          '--some-flag',
+          'super-value',
+          '--some-other-flag',
+          'other-value',
+          '--some-random-flag',
+          'the-value',
+        ],
+        expectedOutput: `kubectl gs get some resources \\
+    --some-flag super-value \\
+    --some-other-flag other-value \\
+    --some-random-flag the-value`,
+      },
+      {
+        name: 'returns correct output for a long command and a flag before it',
+        args: ['--some-flag', 'super-value', 'get', 'some', 'resources'],
+        expectedOutput: `kubectl gs --some-flag super-value \\
+    get some resources`,
+      },
+      {
+        name:
+          'returns correct output for a long command, a flag before it, and some more flags after it',
+        args: [
+          '--some-flag',
+          'super-value',
+          'get',
+          'some',
+          'resources',
+          '--some-other-flag',
+          'other-value',
+        ],
+        expectedOutput: `kubectl gs --some-flag super-value \\
+    get some resources \\
+    --some-other-flag other-value`,
+      },
+    ];
+
+    for (const tc of testCases) {
+      it(tc.name, () => {
+        const output = makeKubectlGSCommand(() => tc.args, withFormatting());
+
+        expect(output).toEqual(tc.expectedOutput);
+      });
+    }
+  });
+});

--- a/src/components/MAPI/guides/__tests__/utils.ts
+++ b/src/components/MAPI/guides/__tests__/utils.ts
@@ -1,9 +1,11 @@
 import {
+  IKubectlGSGetClustersCommandConfig,
   IKubectlGSTemplateClusterCommandConfig,
   KubectlGSCommandModifier,
   makeKubectlGSCommand,
   withContext,
   withFormatting,
+  withGetClusters,
   withTemplateCluster,
 } from '../utils';
 
@@ -172,6 +174,44 @@ describe('utils', () => {
         const output = makeKubectlGSCommand(
           withTemplateCluster(tc.modifierConfig)
         );
+
+        expect(output).toEqual(tc.expectedOutput);
+      });
+    }
+  });
+
+  describe('withGetClusters', () => {
+    interface ITestCase {
+      name: string;
+      modifierConfig: IKubectlGSGetClustersCommandConfig;
+      expectedOutput: string;
+    }
+
+    const testCases: ITestCase[] = [
+      {
+        name: 'returns correct output without options',
+        modifierConfig: {},
+        expectedOutput: 'kubectl gs get clusters',
+      },
+      {
+        name: 'returns correct output with namespace',
+        modifierConfig: {
+          namespace: 'the-namespace',
+        },
+        expectedOutput: 'kubectl gs get clusters --namespace the-namespace',
+      },
+      {
+        name: 'returns correct output with all namespaces',
+        modifierConfig: {
+          allNamespaces: true,
+        },
+        expectedOutput: 'kubectl gs get clusters --all-namespaces',
+      },
+    ];
+
+    for (const tc of testCases) {
+      it(tc.name, () => {
+        const output = makeKubectlGSCommand(withGetClusters(tc.modifierConfig));
 
         expect(output).toEqual(tc.expectedOutput);
       });

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -85,7 +85,7 @@ export function withTemplateCluster(
     }
 
     if (config.release) {
-      newParts.push('--release', `${config.release}`);
+      newParts.push('--release', config.release);
     }
 
     if (config.labels) {

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -5,3 +5,175 @@ export function getCurrentInstallationContextName(state: IState): string {
 
   return `gs-${codeName}`;
 }
+
+export type KubectlGSCommandModifier = (
+  parts: readonly string[]
+) => readonly string[];
+
+/**
+ * Construct a `kubectl gs` command example.
+ *
+ * You can use modifiers to add arguments or flags to the command.
+ * */
+export function makeKubectlGSCommand(
+  ...modifiers: KubectlGSCommandModifier[]
+): string {
+  let commandParts = ['kubectl', 'gs'];
+
+  // Compose a single function that applies all the modifiers.
+  const makeParts = modifiers.reduce<KubectlGSCommandModifier>(
+    (f, g) => (parts) => g(f(parts)),
+    (parts) => parts
+  );
+
+  commandParts.push(...makeParts([]));
+
+  // Filter out parts that only contain whitespace.
+  commandParts = commandParts.filter((part) => part.trim().length !== 0);
+
+  return commandParts.join(' ');
+}
+
+/**
+ * Apply a `kubectl` context to a command.
+ * */
+export function withContext(context: string): KubectlGSCommandModifier {
+  return (parts) => ['--context', context, ...parts];
+}
+
+/**
+ * All the configuration options supported by the
+ * `template cluster` command.
+ * Taken from:
+ * {@link https://github.com/giantswarm/kubectl-gs/blob/master/cmd/template/cluster/flag.go#L14}
+ * */
+export interface IKubectlGSTemplateClusterCommandConfig {
+  provider: string;
+  owner: string;
+  release?: string;
+  name?: string;
+  description?: string;
+  labels?: Record<string, string>;
+  controlPlaneAZs?: string[];
+  output?: string;
+}
+
+/**
+ * Generate modifier for constructing the
+ * `kubectl gs template cluster` command.
+ * */
+export function withTemplateCluster(
+  config: IKubectlGSTemplateClusterCommandConfig
+): KubectlGSCommandModifier {
+  return (parts) => {
+    const newParts = [
+      ...parts,
+      'template',
+      'cluster',
+      '--provider',
+      config.provider,
+      '--owner',
+      config.owner,
+    ];
+
+    if (config.name) {
+      newParts.push('--name', config.name);
+    }
+
+    if (config.description) {
+      newParts.push('--description', `"${config.description}"`);
+    }
+
+    if (config.release) {
+      newParts.push('--release', `${config.release}`);
+    }
+
+    if (config.labels) {
+      for (const [key, value] of Object.entries(config.labels)) {
+        newParts.push('--label', `"${key}=${value}"`);
+      }
+    }
+
+    if (config.controlPlaneAZs) {
+      for (const controlPlaneAZ of config.controlPlaneAZs) {
+        newParts.push('--control-plane-az', controlPlaneAZ);
+      }
+    }
+
+    if (config.output) {
+      newParts.push('--output', `"${config.output}"`);
+    }
+
+    return newParts;
+  };
+}
+
+function isFlag(value: string): boolean {
+  return value.startsWith('--');
+}
+
+// The delimiter used between each line of a multi-line command.
+const formattingLineBreak = ' \\\n    ';
+
+/**
+ * Format a command output in a more user-friendly way.
+ * Check out the tests for examples.
+ *
+ * Note: This should only be used as the last modifier in the list.
+ * */
+export function withFormatting(
+  // eslint-disable-next-line no-magic-numbers
+  lineBreakThreshold: number = 30
+): KubectlGSCommandModifier {
+  return (parts) => {
+    const totalLength = parts.join(' ').length;
+    if (totalLength <= lineBreakThreshold) return parts;
+
+    const newParts = [];
+
+    let hasFlags = false;
+    let hasArgs = false;
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const peekPart = parts[i + 1];
+      const peekNextPart = parts[i + 2];
+
+      if (isFlag(part)) {
+        hasFlags = true;
+
+        if (i > 0) {
+          newParts.push(formattingLineBreak);
+        }
+
+        newParts.push(part);
+
+        // If the flag has a value, add it to the output.
+        if (peekPart && !isFlag(peekPart)) {
+          newParts.push(' ', peekPart);
+          i++;
+        }
+
+        // If after the flag value we have an argument, add a line break.
+        if (peekNextPart && !isFlag(peekNextPart)) {
+          newParts.push(formattingLineBreak);
+        }
+
+        continue;
+      }
+
+      hasArgs = true;
+      newParts.push(part);
+      // If the next value is not a flag, add an argument delimiter.
+      if (peekPart && !isFlag(peekPart)) {
+        newParts.push(' ');
+      }
+    }
+
+    if (hasFlags && !hasArgs) {
+      newParts.unshift(formattingLineBreak);
+    }
+
+    return [newParts.join('').trim()];
+  };
+}

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -1,0 +1,7 @@
+import { IState } from 'stores/state';
+
+export function getCurrentInstallationContextName(state: IState): string {
+  const codeName = state.main.info.general.installation_name;
+
+  return `gs-${codeName}`;
+}

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -108,6 +108,39 @@ export function withTemplateCluster(
   };
 }
 
+/**
+ * All the configuration options supported by the
+ * `template cluster` command.
+ * Taken from:
+ * {@link https://github.com/giantswarm/kubectl-gs/blob/master/cmd/get/clusters/flag.go#L14}
+ * */
+export interface IKubectlGSGetClustersCommandConfig {
+  namespace?: string;
+  allNamespaces?: boolean;
+}
+
+/**
+ * Generate modifier for constructing the
+ * `kubectl gs get clusters` command.
+ * */
+export function withGetClusters(
+  config: IKubectlGSGetClustersCommandConfig
+): KubectlGSCommandModifier {
+  return (parts) => {
+    const newParts = [...parts, 'get', 'clusters'];
+
+    if (config.namespace) {
+      newParts.push('--namespace', config.namespace);
+    }
+
+    if (config.allNamespaces) {
+      newParts.push('--all-namespaces');
+    }
+
+    return newParts;
+  };
+}
+
 function isFlag(value: string): boolean {
   return value.startsWith('--');
 }

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
@@ -8,7 +8,7 @@ exports[`CLIGuide renders the contents when open 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hrJYol sc-jEWLvH kgGuXA"
+      class="StyledBox-sc-13pk1d4-0 hrJYol sc-WZYut qvxWH"
       role="tablist"
     >
       <div
@@ -91,7 +91,7 @@ exports[`CLIGuide renders without crashing 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hrJYol sc-jEWLvH kgGuXA"
+      class="StyledBox-sc-13pk1d4-0 hrJYol sc-WZYut qvxWH"
       role="tablist"
     >
       <div

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 fTVibh sc-lMZDC rhkUX"
+        class="StyledText-sc-1sadyjn-0 fTVibh sc-iazTlQ dhFNXQ"
       >
         dogs
       </span>
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 fTVibh sc-lMZDC rhkUX"
+        class="StyledText-sc-1sadyjn-0 fTVibh sc-iazTlQ dhFNXQ"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -15,7 +15,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 ihVIAm"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 biMlWM sc-cdlubJ jPQraZ"
+          class="StyledText-sc-1sadyjn-0 biMlWM sc-eSRwjH jBSQhy"
         >
           Some widget
         </span>
@@ -49,7 +49,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 bbIfdU"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 biMlWM sc-cdlubJ jPQraZ"
+          class="StyledText-sc-1sadyjn-0 biMlWM sc-eSRwjH jBSQhy"
         >
           Some widget
         </span>

--- a/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedSimpleExample.tsx
+++ b/src/components/UI/Display/MAPI/clusters/GettingStarted/GettingStartedSimpleExample.tsx
@@ -114,10 +114,10 @@ const GettingStartedSimpleExample: React.FC<IGettingStartedSimpleExampleProps> =
           </Prompt>
           <Output>
             {`
-                  service/helloworld created
-                  deployment.apps/helloworld created
-                  poddisruptionbudget.policy/helloworld-pdb created
-                  ingress.networking.k8s.io/helloworld created
+service/helloworld created
+deployment.apps/helloworld created
+poddisruptionbudget.policy/helloworld-pdb created
+ingress.networking.k8s.io/helloworld created
                 `}
           </Output>
         </CodeBlock>
@@ -146,8 +146,8 @@ const GettingStartedSimpleExample: React.FC<IGettingStartedSimpleExampleProps> =
           <Prompt>kubectl get deployment -l app=helloworld</Prompt>
           <Output>
             {`
-                  NAME         READY   UP-TO-DATE   AVAILABLE   AGE
-                  helloworld   2/2     2            2           2m
+NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+helloworld   2/2     2            2           2m
                 `}
           </Output>
         </CodeBlock>
@@ -159,8 +159,8 @@ const GettingStartedSimpleExample: React.FC<IGettingStartedSimpleExampleProps> =
           <Prompt>kubectl get svc -l app=helloworld</Prompt>
           <Output>
             {`
-                  NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
-                  helloworld   ClusterIP   172.31.144.55   <none>        8080/TCP   2m
+NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+helloworld   ClusterIP   172.31.144.55   <none>        8080/TCP   2m
                 `}
           </Output>
         </CodeBlock>
@@ -169,9 +169,9 @@ const GettingStartedSimpleExample: React.FC<IGettingStartedSimpleExampleProps> =
           <Prompt>kubectl get pods -l app=helloworld</Prompt>
           <Output>
             {`
-                  NAME                          READY     STATUS    RESTARTS   AGE
-                  helloworld-3495070191-0ynir   1/1       Running   0          3m
-                  helloworld-3495070191-onuik   1/1       Running   0          3m
+NAME                          READY     STATUS    RESTARTS   AGE
+helloworld-3495070191-0ynir   1/1       Running   0          3m
+helloworld-3495070191-onuik   1/1       Running   0          3m
                 `}
           </Output>
         </CodeBlock>
@@ -198,12 +198,12 @@ const GettingStartedSimpleExample: React.FC<IGettingStartedSimpleExampleProps> =
           <Prompt>kubectl logs --selector app=helloworld</Prompt>
           <Output>
             {`
-                  2014/07/01 09:57:30 Starting up at :8080
-                  2014/07/01 09:57:40 GET /giant-swarm-logo.svg
-                  2014/07/01 09:57:41 GET /favicon32.ico
-                  2014/07/01 09:57:30 Starting up at :8080
-                  2014/07/01 09:57:40 GET /
-                  2014/07/01 09:57:40 GET /blue-bg.jpg
+2014/07/01 09:57:30 Starting up at :8080
+2014/07/01 09:57:40 GET /giant-swarm-logo.svg
+2014/07/01 09:57:41 GET /favicon32.ico
+2014/07/01 09:57:30 Starting up at :8080
+2014/07/01 09:57:40 GET /
+2014/07/01 09:57:40 GET /blue-bg.jpg
                 `}
           </Output>
         </CodeBlock>
@@ -221,10 +221,10 @@ const GettingStartedSimpleExample: React.FC<IGettingStartedSimpleExampleProps> =
           <Prompt>kubectl delete -f helloworld-manifest.yaml</Prompt>
           <Output>
             {`
-                  service "helloworld" deleted
-                  deployment.apps "helloworld" deleted
-                  poddisruptionbudget.policy "helloworld-pdb" deleted
-                  ingress.networking.k8s.io "helloworld" deleted
+service "helloworld" deleted
+deployment.apps "helloworld" deleted
+poddisruptionbudget.policy "helloworld-pdb" deleted
+ingress.networking.k8s.io "helloworld" deleted
                 `}
           </Output>
         </CodeBlock>

--- a/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
@@ -29,7 +29,7 @@ exports[`NumberPicker renders a simple input 1`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 gHAWHi sc-geBCVM guFsmP"
+            class="StyledTextInput-sc-1x30a0s-0 gHAWHi sc-kJNqyW kDNiVL"
             id="money"
             step="1"
             type="number"
@@ -37,18 +37,18 @@ exports[`NumberPicker renders a simple input 1`] = `
           />
         </div>
         <div
-          class="sc-clGGWX dWXxSu"
+          class="sc-ciOKUB jUWQIf"
         >
           <div
             aria-label="Decrement"
-            class="sc-kJNqyW Rrhmd"
+            class="sc-kGVuwA dVoObw"
             role="button"
           >
             –
           </div>
           <div
             aria-label="Increment"
-            class="sc-kJNqyW Rrhmd"
+            class="sc-kGVuwA dVoObw"
             role="button"
           >
             +

--- a/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
@@ -8,7 +8,7 @@ exports[`RadioInput renders a disabled input 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-biHcxt ecaunY"
       tabindex="0"
     >
       <div
@@ -52,7 +52,7 @@ exports[`RadioInput renders a simple input 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-biHcxt ecaunY"
       tabindex="0"
     >
       <div
@@ -94,7 +94,7 @@ exports[`RadioInput renders an input with a form field label 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-biHcxt ecaunY"
       tabindex="0"
     >
       <label
@@ -144,7 +144,7 @@ exports[`RadioInput renders an input with a help message 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-biHcxt ecaunY"
       tabindex="0"
     >
       <span
@@ -191,7 +191,7 @@ exports[`RadioInput renders an input with a validation error 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-biHcxt ecaunY"
       tabindex="0"
     >
       <div
@@ -238,7 +238,7 @@ exports[`RadioInput renders an input with an info message 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fTFMiz dToSGW"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-biHcxt ecaunY"
       tabindex="0"
     >
       <div

--- a/src/lib/__tests__/helpers.ts
+++ b/src/lib/__tests__/helpers.ts
@@ -30,8 +30,8 @@ describe('helpers', () => {
       const result = dedent(input);
 
       expect(result).toEqual(`somecommand execute \\
-go-home \\
-cool`);
+      go-home \\
+      cool`);
     });
   });
 

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -61,8 +61,14 @@ export const kubectlGSInstallationURL =
 export const kubectlGSLoginURL =
   'https://docs.giantswarm.io/ui-api/kubectl-gs/login/';
 
+export const kubectlGSGetClustersURL =
+  'https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/';
+
 export const organizationCRDSchema =
   'https://docs.giantswarm.io/ui-api/management-api/crd/organizations.security.giantswarm.io/';
+
+export const clusterCRDSchemaURL =
+  'https://docs.giantswarm.io/ui-api/management-api/crd/clusters.cluster.x-k8s.io/';
 
 export const managementAPIIntroduction =
   'https://docs.giantswarm.io/ui-api/management-api/overview/';

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -64,6 +64,9 @@ export const kubectlGSLoginURL =
 export const kubectlGSGetClustersURL =
   'https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/';
 
+export const kubectlGSTemplateClusterURL =
+  'https://docs.giantswarm.io/ui-api/kubectl-gs/template-cluster/';
+
 export const organizationCRDSchema =
   'https://docs.giantswarm.io/ui-api/management-api/crd/organizations.security.giantswarm.io/';
 

--- a/src/lib/helpers.tsx
+++ b/src/lib/helpers.tsx
@@ -33,6 +33,7 @@ export function dedent(str: string): string {
   const lines = result.split('\n');
   const spacesRegexp = /^(\s+)\S+/;
   let minIndent: number | null = null;
+  let maxIndent: number | null = null;
   for (const line of lines) {
     const m = spacesRegexp.exec(line);
     if (!m) continue;
@@ -44,9 +45,17 @@ export function dedent(str: string): string {
     } else {
       minIndent = Math.min(minIndent, indent);
     }
+
+    if (!maxIndent) {
+      maxIndent = indent;
+    } else {
+      maxIndent = Math.max(maxIndent, indent);
+    }
   }
 
-  if (minIndent !== null) {
+  if (minIndent !== null && minIndent === maxIndent) {
+    result = lines.join('\n');
+  } else if (minIndent !== null) {
     result = lines
       .map((l) => (l.startsWith(' ') ? l.slice(minIndent as number) : l))
       .join('\n');


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18343

Nothing too crazy, following the spec. The cluster creation guide gets data such as the provider, organization and cluster name from the state (so when you refresh the page, you see that you get the same UID in the guide as you do in the form)

## Preview

<details>
<summary>List clusters</summary>

![image](https://user-images.githubusercontent.com/13508038/128737310-cabdc1cf-919b-43de-af10-cf895739164c.png)

</details>

<details>
<summary>Create cluster</summary>

![image](https://user-images.githubusercontent.com/13508038/128737384-014cbb0a-2fe9-417b-bc40-e235e96ee2db.png)

</details>