### PR TITLE
Access control: Improve deletion confirmation prompt for deleting service account subjects

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
@@ -405,6 +405,16 @@ const AccessControlRoleSubjects: React.FC<IAccessControlRoleSubjectsProps> = ({
               <AccessControlSubjectSetItem
                 aria-label={params.name}
                 deleteTooltipMessage="Remove this service account's binding to this role"
+                deleteConfirmationMessage={
+                  <Box gap='small' direction='column'>
+                    <Text>
+                      Remove the binding between service account{' '}
+                      <code>{params.name}</code> and role{' '}
+                      <code>{roleName}</code> ?
+                    </Text>
+                    <Text>The service account will stay.</Text>
+                  </Box>
+                }
                 {...params}
               />
             )}

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -364,7 +364,7 @@ describe('AccessControlRoleSubjects', () => {
     fireEvent.click(deleteButton);
 
     expect(screen.getByText('Are you sure?')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     await waitFor(() => {
       expect(within(subject).queryByRole('progressbar')).toBeInTheDocument();
@@ -520,7 +520,7 @@ describe('AccessControlRoleSubjects', () => {
     fireEvent.click(deleteButton);
 
     expect(screen.getByText('Are you sure?')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     expect(
       await screen.findByText(/Could not delete subject test-group1/)

--- a/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
@@ -741,7 +741,7 @@ describe('AccessControl', () => {
     const section = within(content).getByLabelText('Groups');
     const subject = within(section).getByLabelText('Admins');
     fireEvent.click(within(subject).getByTitle('Delete'));
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
     expect(
@@ -829,7 +829,7 @@ describe('AccessControl', () => {
     const section = within(content).getByLabelText('Groups');
     const subject = within(section).getByLabelText('Admins');
     fireEvent.click(within(subject).getByTitle('Delete'));
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
     expect(
@@ -933,7 +933,7 @@ describe('AccessControl', () => {
     const section = within(content).getByLabelText('Users');
     const subject = within(section).getByLabelText('test@test.com');
     fireEvent.click(within(subject).getByTitle('Delete'));
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
     expect(
@@ -1017,7 +1017,7 @@ describe('AccessControl', () => {
     const section = within(content).getByLabelText('Users');
     const subject = within(section).getByLabelText('test@test.com');
     fireEvent.click(within(subject).getByTitle('Delete'));
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     expect(
       await screen.findByText(/Could not delete subject test@test.com/)
@@ -1059,7 +1059,7 @@ describe('AccessControl', () => {
     const section = within(content).getByLabelText('Service accounts');
     const subject = within(section).getByLabelText('some-random-account');
     fireEvent.click(within(subject).getByTitle('Delete'));
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
     expect(
@@ -1535,7 +1535,7 @@ describe('AccessControl', () => {
     const section = within(content).getByLabelText('Service accounts');
     const subject = within(section).getByLabelText('el-toro');
     fireEvent.click(within(subject).getByTitle('Delete'));
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
     expect(
@@ -1622,7 +1622,7 @@ describe('AccessControl', () => {
     const section = within(content).getByLabelText('Service accounts');
     const subject = within(section).getByLabelText('el-toro');
     fireEvent.click(within(subject).getByTitle('Delete'));
-    fireEvent.click(screen.getByText('Yes, delete it'));
+    fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
     expect(

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
@@ -34,6 +34,10 @@ const StyledAnchor = styled(Anchor)`
   }
 `;
 
+const StyledDrop = styled(Drop)`
+  z-index: 1071; /* To appear above the Bootstrap Tooltip, which has a z-index of 1070 */
+`;
+
 interface IAccessControlSubjectSetItemProps
   extends Omit<IAccessControlSubjectSetRenderer, 'name'>,
     React.ComponentPropsWithoutRef<typeof Box> {
@@ -143,7 +147,7 @@ const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> =
 
       {confirmationVisible && deleteButtonRef.current && (
         <Keyboard onEsc={hideConfirmation}>
-          <Drop
+          <StyledDrop
             align={{ bottom: 'top', right: 'right' }}
             target={deleteButtonRef.current}
             plain={true}
@@ -167,7 +171,7 @@ const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> =
                 </Button>
               </Box>
             </Box>
-          </Drop>
+          </StyledDrop>
         </Keyboard>
       )}
     </Box>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
@@ -39,6 +39,7 @@ interface IAccessControlSubjectSetItemProps
     React.ComponentPropsWithoutRef<typeof Box> {
   name: React.ReactNode;
   deleteTooltipMessage?: string;
+  deleteConfirmationMessage?: React.ReactNode;
 }
 
 const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> = ({
@@ -47,6 +48,7 @@ const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> =
   isLoading,
   onDelete,
   deleteTooltipMessage,
+  deleteConfirmationMessage,
   ...props
 }) => {
   const deleteButtonRef = useRef<HTMLAnchorElement>(null);
@@ -155,9 +157,7 @@ const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> =
               gap='small'
               border={{ color: 'text-xweak' }}
             >
-              <Box>
-                <Text>Are you sure?</Text>
-              </Box>
+              <Box>{deleteConfirmationMessage}</Box>
               <Box direction='row' gap='small'>
                 <Button danger={true} onClick={handleDelete}>
                   Yes, delete it
@@ -174,12 +174,17 @@ const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> =
   );
 };
 
+AccessControlSubjectSetItem.defaultProps = {
+  deleteConfirmationMessage: <Text>Are you sure?</Text>,
+};
+
 AccessControlSubjectSetItem.propTypes = {
   name: PropTypes.node.isRequired,
   isLoading: PropTypes.bool.isRequired,
   isEditable: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
   deleteTooltipMessage: PropTypes.string,
+  deleteConfirmationMessage: PropTypes.node,
 };
 
 export default AccessControlSubjectSetItem;

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
@@ -154,13 +154,13 @@ const AccessControlSubjectSetItem: React.FC<IAccessControlSubjectSetItemProps> =
               pad='medium'
               round='small'
               direction='column'
-              gap='small'
+              gap='medium'
               border={{ color: 'text-xweak' }}
             >
               <Box>{deleteConfirmationMessage}</Box>
               <Box direction='row' gap='small'>
                 <Button danger={true} onClick={handleDelete}>
-                  Yes, delete it
+                  Remove
                 </Button>
                 <Button link={true} onClick={hideConfirmation}>
                   Cancel

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
@@ -8,7 +8,7 @@ exports[`CLIGuide renders the contents when open 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hrJYol sc-jTwxVy jRbBos"
+      class="StyledBox-sc-13pk1d4-0 hrJYol sc-jEWLvH kgGuXA"
       role="tablist"
     >
       <div
@@ -91,7 +91,7 @@ exports[`CLIGuide renders without crashing 1`] = `
     class="sc-iCoGMd hFJToB"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hrJYol sc-jTwxVy jRbBos"
+      class="StyledBox-sc-13pk1d4-0 hrJYol sc-jEWLvH kgGuXA"
       role="tablist"
     >
       <div


### PR DESCRIPTION
Closes [giantswarm/giantswarm#16790](https://github.com/giantswarm/giantswarm/issues/16790).

The confirmation prompt displayed when removing a binding between a service account subject and a role should be more specific, especially to clarify that removing the binding does not remove the service account that may have been created when the binding was created.

### Confirmation prompt
Replacing the text "Are you sure?" with a more specific message for removing bindings (service account subjects only):
<img width="530" alt="Screen Shot 2021-08-09 at 21 45 04" src="https://user-images.githubusercontent.com/62935115/128766278-ff24fa49-ca9a-4406-acc8-4cda3ec56cae.png">

### Confirmation buttons
The label for the delete button has also been changed from `Yes, delete it` to `Remove`.
The `Remove` and `Cancel` buttons should have the same height now after Adrian's button refactoring 👍 

### Z-index
Changing the z-index of the tooltip shown when hovering over the delete icon, so it appears behind the prompt:
<img width="660" alt="Screen Shot 2021-08-09 at 21 45 35" src="https://user-images.githubusercontent.com/62935115/128766273-95cbee2d-693f-48ca-859c-bfd8ae670016.png">
