### PR TITLE
Add CLI guides for the cluster overview tab

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -21,6 +21,7 @@ import useSWR from 'swr';
 import ClusterDetailWidgetKeyPairs from '../../keypairs/ClusterDetailWidgetKeyPairs';
 import ClusterDetailWidgetWorkerNodes from '../../workernodes/ClusterDetailWidgetWorkerNodes';
 import InspectClusterGuide from '../guides/InspectClusterGuide';
+import InspectClusterReleaseGuide from '../guides/InspectClusterReleaseGuide';
 import ClusterDetailWidgetControlPlaneNodes from './ClusterDetailWidgetControlPlaneNodes';
 import ClusterDetailWidgetCreated from './ClusterDetailWidgetCreated';
 import ClusterDetailWidgetKubernetesAPI from './ClusterDetailWidgetKubernetesAPI';
@@ -85,6 +86,9 @@ const ClusterDetailOverview: React.FC<{}> = () => {
   }, [providerClusterError]);
 
   const provider = useSelector(getProvider);
+  const releaseVersion = cluster
+    ? capiv1alpha3.getReleaseVersion(cluster)
+    : undefined;
 
   return (
     <StyledBox wrap={true} direction='row'>
@@ -122,6 +126,14 @@ const ClusterDetailOverview: React.FC<{}> = () => {
             clusterName={cluster.metadata.name}
             clusterNamespace={cluster.metadata.namespace!}
           />
+
+          {releaseVersion && (
+            <InspectClusterReleaseGuide
+              clusterName={cluster.metadata.name}
+              clusterNamespace={cluster.metadata.namespace!}
+              releaseVersion={releaseVersion}
+            />
+          )}
         </Box>
       )}
     </StyledBox>

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -22,6 +22,7 @@ import ClusterDetailWidgetKeyPairs from '../../keypairs/ClusterDetailWidgetKeyPa
 import ClusterDetailWidgetWorkerNodes from '../../workernodes/ClusterDetailWidgetWorkerNodes';
 import InspectClusterGuide from '../guides/InspectClusterGuide';
 import InspectClusterReleaseGuide from '../guides/InspectClusterReleaseGuide';
+import SetClusterLabelsGuide from '../guides/SetClusterLabelsGuide';
 import ClusterDetailWidgetControlPlaneNodes from './ClusterDetailWidgetControlPlaneNodes';
 import ClusterDetailWidgetCreated from './ClusterDetailWidgetCreated';
 import ClusterDetailWidgetKubernetesAPI from './ClusterDetailWidgetKubernetesAPI';
@@ -134,6 +135,11 @@ const ClusterDetailOverview: React.FC<{}> = () => {
               releaseVersion={releaseVersion}
             />
           )}
+
+          <SetClusterLabelsGuide
+            clusterName={cluster.metadata.name}
+            clusterNamespace={cluster.metadata.namespace!}
+          />
         </Box>
       )}
     </StyledBox>

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -12,12 +12,15 @@ import { GenericResponseError } from 'model/clients/GenericResponseError';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as securityv1alpha1 from 'model/services/mapi/securityv1alpha1';
 import React, { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router';
+import { getProvider } from 'stores/main/selectors';
 import styled from 'styled-components';
 import useSWR from 'swr';
 
 import ClusterDetailWidgetKeyPairs from '../../keypairs/ClusterDetailWidgetKeyPairs';
 import ClusterDetailWidgetWorkerNodes from '../../workernodes/ClusterDetailWidgetWorkerNodes';
+import InspectClusterGuide from '../guides/InspectClusterGuide';
 import ClusterDetailWidgetControlPlaneNodes from './ClusterDetailWidgetControlPlaneNodes';
 import ClusterDetailWidgetCreated from './ClusterDetailWidgetCreated';
 import ClusterDetailWidgetKubernetesAPI from './ClusterDetailWidgetKubernetesAPI';
@@ -81,6 +84,8 @@ const ClusterDetailOverview: React.FC<{}> = () => {
     }
   }, [providerClusterError]);
 
+  const provider = useSelector(getProvider);
+
   return (
     <StyledBox wrap={true} direction='row'>
       <ClusterDetailWidgetWorkerNodes
@@ -103,6 +108,22 @@ const ClusterDetailOverview: React.FC<{}> = () => {
         basis='100%'
       />
       <ClusterDetailWidgetCreated cluster={cluster} basis='100%' />
+
+      {cluster && (
+        <Box
+          margin={{ top: 'large' }}
+          direction='column'
+          gap='small'
+          basis='100%'
+          animation={{ type: 'fadeIn', duration: 300 }}
+        >
+          <InspectClusterGuide
+            provider={provider}
+            clusterName={cluster.metadata.name}
+            clusterNamespace={cluster.metadata.namespace!}
+          />
+        </Box>
+      )}
     </StyledBox>
   );
 };

--- a/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
@@ -1,0 +1,126 @@
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import {
+  getCurrentInstallationContextName,
+  makeKubectlGSCommand,
+  withContext,
+  withFormatting,
+  withGetClusters,
+} from 'MAPI/guides/utils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface IInspectClusterGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  provider: PropertiesOf<typeof Providers>;
+  clusterName: string;
+  clusterNamespace: string;
+}
+
+const InspectClusterGuide: React.FC<IInspectClusterGuideProps> = ({
+  provider,
+  clusterName,
+  clusterNamespace,
+  ...props
+}) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
+  return (
+    <CLIGuide
+      title='Inspect this cluster via the Management API'
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'Cluster CRD schema',
+              href: docs.clusterCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'AzureCluster CRD schema',
+              href: docs.azureClusterCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'AzureMachine CRD schema',
+              href: docs.azureMachineCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. Show main details'
+          command={makeKubectlGSCommand(
+            withContext(context),
+            withGetClusters({
+              name: clusterName,
+              namespace: clusterNamespace,
+            }),
+            withFormatting()
+          )}
+        />
+
+        {provider === Providers.AZURE && (
+          <>
+            <CLIGuideStep
+              title={
+                <>
+                  3. Show the <code>AzureCluster</code> resource
+                </>
+              }
+              command={`
+              kubectl --context ${context} \\
+                get azureclusters.infrastructure.cluster.x-k8s.io ${clusterName} \\
+                --namespace ${clusterNamespace} --output json
+              `}
+            />
+            <CLIGuideStep
+              title={
+                <>
+                  4. Show the <code>AzureMachine</code> resources representing
+                  the control plane nodes
+                </>
+              }
+              command={`
+              kubectl --context ${context} \\
+                get azuremachines.infrastructure.cluster.x-k8s.io \\
+                -l cluster.x-k8s.io/cluster-name=${clusterName} \\
+                --namespace ${clusterNamespace}
+              `}
+            />
+          </>
+        )}
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+InspectClusterGuide.propTypes = {
+  provider: PropTypes.oneOf(Object.values(Providers)).isRequired,
+  clusterName: PropTypes.string.isRequired,
+  clusterNamespace: PropTypes.string.isRequired,
+};
+
+export default InspectClusterGuide;

--- a/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
@@ -106,7 +106,7 @@ const InspectClusterGuide: React.FC<IInspectClusterGuideProps> = ({
               command={`
               kubectl --context ${context} \\
                 get azuremachines.infrastructure.cluster.x-k8s.io \\
-                -l cluster.x-k8s.io/cluster-name=${clusterName} \\
+                --selector cluster.x-k8s.io/cluster-name=${clusterName} \\
                 --namespace ${clusterNamespace}
               `}
             />

--- a/src/components/MAPI/clusters/guides/InspectClusterReleaseGuide.tsx
+++ b/src/components/MAPI/clusters/guides/InspectClusterReleaseGuide.tsx
@@ -1,0 +1,103 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import {
+  getCurrentInstallationContextName,
+  makeKubectlGSCommand,
+  withContext,
+  withFormatting,
+  withGetClusters,
+} from 'MAPI/guides/utils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface IInspectClusterReleaseGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  clusterName: string;
+  clusterNamespace: string;
+  releaseVersion: string;
+}
+
+const InspectClusterReleaseGuide: React.FC<IInspectClusterReleaseGuideProps> = ({
+  clusterName,
+  clusterNamespace,
+  releaseVersion,
+  ...props
+}) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
+  return (
+    <CLIGuide
+      title={`Inspect this cluster's release via the Management API`}
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'Cluster CRD schema',
+              href: docs.clusterCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'Release CRD schema',
+              href: docs.releaseCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. Find out which release version is used by this cluster'
+          command={makeKubectlGSCommand(
+            withContext(context),
+            withGetClusters({
+              name: clusterName,
+              namespace: clusterNamespace,
+              output: `jsonpath={.metadata.labels.release\\.giantswarm\\.io/version}`,
+            }),
+            withFormatting()
+          )}
+        >
+          <Text>
+            This should print out <code>{releaseVersion}</code>.
+          </Text>
+        </CLIGuideStep>
+        <CLIGuideStep
+          title='3. Get release details'
+          command={`kubectl --context ${context} describe release v${releaseVersion}`}
+        >
+          <Text>
+            <strong>Note:</strong> You will need the <code>v</code> prefix
+            appended to the version number.
+          </Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+InspectClusterReleaseGuide.propTypes = {
+  clusterName: PropTypes.string.isRequired,
+  clusterNamespace: PropTypes.string.isRequired,
+  releaseVersion: PropTypes.string.isRequired,
+};
+
+export default InspectClusterReleaseGuide;

--- a/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
+++ b/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
@@ -1,0 +1,74 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import PropTypes from 'prop-types';
+import React from 'react';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface ISetClusterLabelsGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  clusterName: string;
+  clusterNamespace: string;
+}
+
+const SetClusterLabelsGuide: React.FC<ISetClusterLabelsGuideProps> = ({
+  clusterName,
+  clusterNamespace,
+  ...props
+}) => {
+  return (
+    <CLIGuide
+      title='Set cluster labels via the Management API'
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'Cluster CRD schema',
+              href: docs.clusterCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'Labelling workload clusters',
+              href: docs.labellingWorkloadClustersURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. Add a label to this cluster'
+          command={`kubectl patch cluster ${clusterName} -n ${clusterNamespace} --type merge -p '{"metadata": {"labels": {"foo": "bar"}}}'`}
+        >
+          <Text>
+            The above command would add the label <code>foo</code> with the
+            value <code>bar</code>.
+          </Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+SetClusterLabelsGuide.propTypes = {
+  clusterName: PropTypes.string.isRequired,
+  clusterNamespace: PropTypes.string.isRequired,
+};
+
+export default SetClusterLabelsGuide;

--- a/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
+++ b/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
@@ -62,7 +62,8 @@ const SetClusterLabelsGuide: React.FC<ISetClusterLabelsGuideProps> = ({
           kubectl --context ${context} \\
             patch cluster ${clusterName} \\
             -n ${clusterNamespace} \\
-            --type merge -p '{"metadata": {"labels": {"foo": "bar"}}}'
+            --type merge \\
+            --patch '{"metadata": {"labels": {"foo": "bar"}}}'
           `}
         >
           <Text>

--- a/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
+++ b/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
@@ -1,8 +1,10 @@
 import { Text } from 'grommet';
 import * as docs from 'lib/docs';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import CLIGuide from 'UI/Display/MAPI/CLIGuide';
 import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
 import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
@@ -19,6 +21,8 @@ const SetClusterLabelsGuide: React.FC<ISetClusterLabelsGuideProps> = ({
   clusterNamespace,
   ...props
 }) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
   return (
     <CLIGuide
       title='Set cluster labels via the Management API'
@@ -54,7 +58,12 @@ const SetClusterLabelsGuide: React.FC<ISetClusterLabelsGuideProps> = ({
         <LoginGuideStep />
         <CLIGuideStep
           title='2. Add a label to this cluster'
-          command={`kubectl patch cluster ${clusterName} -n ${clusterNamespace} --type merge -p '{"metadata": {"labels": {"foo": "bar"}}}'`}
+          command={`
+          kubectl --context ${context} \\
+            patch cluster ${clusterName} \\
+            -n ${clusterNamespace} \\
+            --type merge -p '{"metadata": {"labels": {"foo": "bar"}}}'
+          `}
         >
           <Text>
             The above command would add the label <code>foo</code> with the

--- a/src/components/MAPI/guides/__tests__/utils.ts
+++ b/src/components/MAPI/guides/__tests__/utils.ts
@@ -207,6 +207,13 @@ describe('utils', () => {
         },
         expectedOutput: 'kubectl gs get clusters --all-namespaces',
       },
+      {
+        name: 'returns correct output with name',
+        modifierConfig: {
+          name: 'some-cluster',
+        },
+        expectedOutput: 'kubectl gs get clusters some-cluster',
+      },
     ];
 
     for (const tc of testCases) {
@@ -252,9 +259,9 @@ describe('utils', () => {
           'the-value',
         ],
         expectedOutput: `kubectl gs \\
-    --some-flag super-value \\
-    --some-other-flag other-value \\
-    --some-random-flag the-value`,
+  --some-flag super-value \\
+  --some-other-flag other-value \\
+  --some-random-flag the-value`,
       },
       {
         name: 'returns correct output for a long command and some arguments',
@@ -270,15 +277,15 @@ describe('utils', () => {
           'the-value',
         ],
         expectedOutput: `kubectl gs get some resources \\
-    --some-flag super-value \\
-    --some-other-flag other-value \\
-    --some-random-flag the-value`,
+  --some-flag super-value \\
+  --some-other-flag other-value \\
+  --some-random-flag the-value`,
       },
       {
         name: 'returns correct output for a long command and a flag before it',
         args: ['--some-flag', 'super-value', 'get', 'some', 'resources'],
         expectedOutput: `kubectl gs --some-flag super-value \\
-    get some resources`,
+  get some resources`,
       },
       {
         name:
@@ -293,8 +300,8 @@ describe('utils', () => {
           'other-value',
         ],
         expectedOutput: `kubectl gs --some-flag super-value \\
-    get some resources \\
-    --some-other-flag other-value`,
+  get some resources \\
+  --some-other-flag other-value`,
       },
     ];
 

--- a/src/components/MAPI/guides/__tests__/utils.ts
+++ b/src/components/MAPI/guides/__tests__/utils.ts
@@ -214,6 +214,13 @@ describe('utils', () => {
         },
         expectedOutput: 'kubectl gs get clusters some-cluster',
       },
+      {
+        name: 'returns correct output with output',
+        modifierConfig: {
+          output: 'json',
+        },
+        expectedOutput: 'kubectl gs get clusters -o "json"',
+      },
     ];
 
     for (const tc of testCases) {

--- a/src/components/MAPI/guides/__tests__/utils.ts
+++ b/src/components/MAPI/guides/__tests__/utils.ts
@@ -219,7 +219,7 @@ describe('utils', () => {
         modifierConfig: {
           output: 'json',
         },
-        expectedOutput: 'kubectl gs get clusters -o "json"',
+        expectedOutput: 'kubectl gs get clusters --output "json"',
       },
     ];
 

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -144,7 +144,7 @@ export function withGetClusters(
     }
 
     if (config.output) {
-      newParts.push('-o', `"${config.output}"`);
+      newParts.push('--output', `"${config.output}"`);
     }
 
     return newParts;

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -117,6 +117,7 @@ export function withTemplateCluster(
 export interface IKubectlGSGetClustersCommandConfig {
   namespace?: string;
   allNamespaces?: boolean;
+  name?: string;
 }
 
 /**
@@ -128,6 +129,10 @@ export function withGetClusters(
 ): KubectlGSCommandModifier {
   return (parts) => {
     const newParts = [...parts, 'get', 'clusters'];
+
+    if (config.name) {
+      newParts.push(config.name);
+    }
 
     if (config.namespace) {
       newParts.push('--namespace', config.namespace);
@@ -146,7 +151,7 @@ function isFlag(value: string): boolean {
 }
 
 // The delimiter used between each line of a multi-line command.
-const formattingLineBreak = ' \\\n    ';
+const formattingLineBreak = ' \\\n  ';
 
 /**
  * Format a command output in a more user-friendly way.

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -118,6 +118,7 @@ export interface IKubectlGSGetClustersCommandConfig {
   namespace?: string;
   allNamespaces?: boolean;
   name?: string;
+  output?: string;
 }
 
 /**
@@ -140,6 +141,10 @@ export function withGetClusters(
 
     if (config.allNamespaces) {
       newParts.push('--all-namespaces');
+    }
+
+    if (config.output) {
+      newParts.push('-o', `"${config.output}"`);
     }
 
     return newParts;

--- a/src/components/UI/Display/MAPI/CLIGuide/CLIGuideStep.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/CLIGuideStep.tsx
@@ -27,8 +27,8 @@ const CLIGuideStep: React.FC<ICLIGuideStepProps> = ({
 };
 
 CLIGuideStep.propTypes = {
-  title: PropTypes.string.isRequired,
-  command: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
+  command: PropTypes.node.isRequired,
   children: PropTypes.node,
 };
 

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -90,3 +90,6 @@ export const kubectlCreateRoleBindingURL =
 
 export const kubectlCreateClusterRoleBindingURL =
   'https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-clusterrolebinding-em-';
+
+export const labellingWorkloadClustersURL =
+  'https://docs.giantswarm.io/advanced/labelling-workload-clusters/';

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -73,6 +73,12 @@ export const organizationCRDSchema =
 export const clusterCRDSchemaURL =
   'https://docs.giantswarm.io/ui-api/management-api/crd/clusters.cluster.x-k8s.io/';
 
+export const azureClusterCRDSchemaURL =
+  'https://docs.giantswarm.io/ui-api/management-api/crd/azureclusters.infrastructure.cluster.x-k8s.io/';
+
+export const azureMachineCRDSchemaURL =
+  'https://docs.giantswarm.io/ui-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io/';
+
 export const managementAPIIntroduction =
   'https://docs.giantswarm.io/ui-api/management-api/overview/';
 

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -79,6 +79,9 @@ export const azureClusterCRDSchemaURL =
 export const azureMachineCRDSchemaURL =
   'https://docs.giantswarm.io/ui-api/management-api/crd/azuremachines.infrastructure.cluster.x-k8s.io/';
 
+export const releaseCRDSchemaURL =
+  'https://docs.giantswarm.io/ui-api/management-api/crd/releases.release.giantswarm.io/';
+
 export const managementAPIIntroduction =
   'https://docs.giantswarm.io/ui-api/management-api/overview/';
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18343

## Preview

<details>
<summary>Chilling</summary>

![image](https://user-images.githubusercontent.com/13508038/128850477-e8b4cf09-1235-4cec-b282-a95152e4db74.png)

</details>

<details>
<summary>Inspect cluster</summary>

![image](https://user-images.githubusercontent.com/13508038/129213684-7b4f7975-02ed-49a4-9913-057b9c5d8504.png)

</details>

<details>
<summary>Inspect cluster's release version</summary>

![image](https://user-images.githubusercontent.com/13508038/129213719-301cfa58-0fe9-4299-b6be-6fcd728eb855.png)

</details>

<details>
<summary>Set cluster labels</summary>

![image](https://user-images.githubusercontent.com/13508038/129213754-5ae998fd-6665-4467-9403-4db3f2250aca.png)

</details>