### PR TITLE
Use utility function for extracting error message from org error

### DIFF
--- a/src/components/MAPI/organizations/OrganizationDetail.tsx
+++ b/src/components/MAPI/organizations/OrganizationDetail.tsx
@@ -6,6 +6,7 @@ import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import RoutePath from 'lib/routePath';
 import AccessControlPage from 'MAPI/organizations/AccessControl';
+import { extractErrorMessage } from 'MAPI/utils';
 import { GenericResponse } from 'model/clients/GenericResponse';
 import * as metav1 from 'model/services/mapi/metav1';
 import * as securityv1alpha1 from 'model/services/mapi/securityv1alpha1';
@@ -76,10 +77,13 @@ const OrganizationDetail: React.FC<IOrganizationDetailProps> = () => {
 
       dispatch(push(OrganizationsRoutes.Home));
     } else if (error) {
+      const errorMessage = extractErrorMessage(error);
+
       new FlashMessage(
         `There was a problem loading organization <code>${orgId}</code>`,
         messageType.ERROR,
-        messageTTL.FOREVER
+        messageTTL.FOREVER,
+        errorMessage
       );
 
       if (!data) {


### PR DESCRIPTION
Closes [giantswarm/giantswarm#16569](https://github.com/giantswarm/giantswarm/issues/16569).

Throughout the MAPI UI, a utility function for extracting error messages from Kubernetes API responses is used to return more meaningful error messages to the user. This function is now also used for errors related to loading organization details.

Example:
<img width="366" alt="Screen Shot 2021-08-10 at 13 33 00" src="https://user-images.githubusercontent.com/62935115/128864132-8d7feb89-8327-4f3b-b622-07797a863f2e.png">