### PR TITLE
Access Control: Sort roles list by (cluster) role name

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -84,7 +84,7 @@ export function mapResourcesToUiRoles(
     }
   }
 
-  return Object.values(roleMap);
+  return Object.values(roleMap).sort((a, b) => (a.name > b.name ? 1 : -1));
 }
 
 /**


### PR DESCRIPTION
Closes [giantswarm/giantswarm#16835](https://github.com/giantswarm/giantswarm/issues/16835).

The roles list was previously unordered - it is now sorted by (cluster) role name in alphabetical order:
<img width="273" alt="Screen Shot 2021-08-16 at 12 08 11" src="https://user-images.githubusercontent.com/62935115/129560864-bf53ca78-a079-4560-ac93-6611d70afb93.png">
