### PR TITLE
Add Management API guide to list installed apps

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailApps.tsx
@@ -1,11 +1,13 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import UserInstalledApps from 'Cluster/ClusterDetail/UserInstalledApps/UserInstalledApps';
 import { push } from 'connected-react-router';
+import { Box } from 'grommet';
 import { ingressControllerInstallationURL } from 'lib/docs';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import AppDetailsModalMAPI from 'MAPI/apps/AppDetailsModal';
+import ListAppsGuide from 'MAPI/clusters/guides/ListAppsGuide';
 import { extractErrorMessage } from 'MAPI/utils';
 import { GenericResponse } from 'model/clients/GenericResponse';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
@@ -229,6 +231,10 @@ const ClusterDetailApps: React.FC<IClusterDetailApps> = ({
                 Install app
               </BrowseButton>
             </BrowseButtonContainer>
+
+            <Box margin={{ top: 'large' }} direction='column' gap='small'>
+              <ListAppsGuide namespace={clusterId} />
+            </Box>
           </UserInstalledApps>
 
           <div>

--- a/src/components/MAPI/clusters/guides/ListAppsGuide.tsx
+++ b/src/components/MAPI/clusters/guides/ListAppsGuide.tsx
@@ -1,0 +1,83 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import {
+  getCurrentInstallationContextName,
+  makeKubectlGSCommand,
+  withContext,
+  withFormatting,
+  withGetApps,
+} from 'MAPI/guides/utils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface IListAppsGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  namespace: string;
+}
+
+const ListAppsGuide: React.FC<IListAppsGuideProps> = ({
+  namespace,
+  ...props
+}) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
+  return (
+    <CLIGuide
+      title='List installed apps via the Management API'
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'App CRD schema',
+              href: docs.appCRDSchemaURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. List installed apps'
+          command={makeKubectlGSCommand(
+            withContext(context),
+            withGetApps({
+              namespace: namespace,
+            }),
+            withFormatting()
+          )}
+        >
+          <Text>
+            As a result, you will get a list of all <code>App</code> resources
+            representing apps installed in this cluster. You can append the flag{' '}
+            <code>--output json</code> for full, machine-readable information.
+          </Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+ListAppsGuide.propTypes = {
+  namespace: PropTypes.string.isRequired,
+};
+
+export default ListAppsGuide;

--- a/src/components/MAPI/guides/__tests__/utils.ts
+++ b/src/components/MAPI/guides/__tests__/utils.ts
@@ -1,10 +1,12 @@
 import {
+  IKubectlGSGetAppsCommandConfig,
   IKubectlGSGetClustersCommandConfig,
   IKubectlGSTemplateClusterCommandConfig,
   KubectlGSCommandModifier,
   makeKubectlGSCommand,
   withContext,
   withFormatting,
+  withGetApps,
   withGetClusters,
   withTemplateCluster,
 } from '../utils';
@@ -174,6 +176,51 @@ describe('utils', () => {
         const output = makeKubectlGSCommand(
           withTemplateCluster(tc.modifierConfig)
         );
+
+        expect(output).toEqual(tc.expectedOutput);
+      });
+    }
+  });
+
+  describe('withGetApps', () => {
+    interface ITestCase {
+      name: string;
+      modifierConfig: IKubectlGSGetAppsCommandConfig;
+      expectedOutput: string;
+    }
+
+    const testCases: ITestCase[] = [
+      {
+        name: 'returns correct output without options',
+        modifierConfig: {},
+        expectedOutput: 'kubectl gs get apps',
+      },
+      {
+        name: 'returns correct output with namespace',
+        modifierConfig: {
+          namespace: 'the-namespace',
+        },
+        expectedOutput: 'kubectl gs get apps --namespace the-namespace',
+      },
+      {
+        name: 'returns correct output with all namespaces',
+        modifierConfig: {
+          allNamespaces: true,
+        },
+        expectedOutput: 'kubectl gs get apps --all-namespaces',
+      },
+      {
+        name: 'returns correct output with output',
+        modifierConfig: {
+          output: 'json',
+        },
+        expectedOutput: 'kubectl gs get apps --output "json"',
+      },
+    ];
+
+    for (const tc of testCases) {
+      it(tc.name, () => {
+        const output = makeKubectlGSCommand(withGetApps(tc.modifierConfig));
 
         expect(output).toEqual(tc.expectedOutput);
       });

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -109,8 +109,44 @@ export function withTemplateCluster(
 }
 
 /**
+ * Relevant configuration options supported by the
+ * `get apps` command.
+ * */
+export interface IKubectlGSGetAppsCommandConfig {
+  namespace?: string;
+  allNamespaces?: boolean;
+  output?: string;
+}
+
+/**
+ * Generate modifier for constructing the
+ * `kubectl gs get apps` command.
+ * */
+export function withGetApps(
+  config: IKubectlGSGetAppsCommandConfig
+): KubectlGSCommandModifier {
+  return (parts) => {
+    const newParts = [...parts, 'get', 'apps'];
+
+    if (config.namespace) {
+      newParts.push('--namespace', config.namespace);
+    }
+
+    if (config.allNamespaces) {
+      newParts.push('--all-namespaces');
+    }
+
+    if (config.output) {
+      newParts.push('--output', `"${config.output}"`);
+    }
+
+    return newParts;
+  };
+}
+
+/**
  * All the configuration options supported by the
- * `template cluster` command.
+ * `get clusters` command.
  * Taken from:
  * {@link https://github.com/giantswarm/kubectl-gs/blob/master/cmd/get/clusters/flag.go#L14}
  * */

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -82,6 +82,10 @@ export const azureMachineCRDSchemaURL =
 export const releaseCRDSchemaURL =
   'https://docs.giantswarm.io/ui-api/management-api/crd/releases.release.giantswarm.io/';
 
+export const appCRDSchemaURL =
+  'https://docs.giantswarm.io/ui-api/management-api/crd/apps.application.giantswarm.io/';
+
+// Management API introduction page
 export const managementAPIIntroduction =
   'https://docs.giantswarm.io/ui-api/management-api/overview/';
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18343

This PR adds a MAPI guide for listing apps installed in a cluster.

## Preview

![image](https://user-images.githubusercontent.com/273727/129707700-b82913d7-750d-49d4-aac5-058bca1e875b.png)

![image](https://user-images.githubusercontent.com/273727/129707738-6f2b9e8a-8138-419f-95b6-2a47aaa4215d.png)
