### PR TITLE
Add CLI guide for listing a cluster's node pools

### DIFF
--- a/src/components/MAPI/guides/ListNodePoolsGuide.tsx
+++ b/src/components/MAPI/guides/ListNodePoolsGuide.tsx
@@ -1,0 +1,82 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface IListNodePoolsGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  clusterName: string;
+  clusterNamespace: string;
+  providerNodePoolResourceName: string;
+}
+
+const ListNodePoolsGuide: React.FC<IListNodePoolsGuideProps> = ({
+  clusterName,
+  clusterNamespace,
+  providerNodePoolResourceName,
+  ...props
+}) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
+  return (
+    <CLIGuide
+      title="List this cluster's node pools via the Management API"
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'kubectl gs get nodepools command',
+              href: docs.kubectlGSGetNodePoolsURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. List node pools.'
+          command={`
+          kubectl gs --context ${context} \\
+            get nodepools \\
+            --cluster-name ${clusterName} \\
+            --namespace ${clusterNamespace}
+          `}
+        >
+          <Text>
+            <strong>Note:</strong> Add <code>--output json</code> to include
+            full <code>{providerNodePoolResourceName}</code> resource details in
+            a machine-readable format.
+          </Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+ListNodePoolsGuide.propTypes = {
+  clusterName: PropTypes.string.isRequired,
+  clusterNamespace: PropTypes.string.isRequired,
+  providerNodePoolResourceName: PropTypes.string.isRequired,
+};
+
+export default ListNodePoolsGuide;

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -3,6 +3,7 @@ import { Box, Heading, Text } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
+import ListNodePoolsGuide from 'MAPI/guides/ListNodePoolsGuide';
 import { NodePool, ProviderCluster } from 'MAPI/types';
 import {
   extractErrorMessage,
@@ -71,6 +72,19 @@ function formatMachineTypeColumnTitle(
       return 'VM Size';
     default:
       return 'Machine type';
+  }
+}
+
+function getProviderNodePoolResourceName(
+  provider: PropertiesOf<typeof Providers>
+) {
+  switch (provider) {
+    case Providers.AWS:
+      return 'MachineDeployment';
+    case Providers.AZURE:
+      return 'MachinePool';
+    default:
+      return 'MachinePool';
   }
 }
 
@@ -156,6 +170,7 @@ const AnimationWrapper = styled.div`
 
 interface IClusterDetailWorkerNodesProps {}
 
+// eslint-disable-next-line complexity
 const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> = () => {
   const { pathname } = useLocation();
   const { clusterId, orgId } = useParams<{
@@ -431,6 +446,23 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> = () =>
               />
             )}
           </Box>
+          {cluster && providerCluster && (
+            <Box
+              margin={{ top: 'large' }}
+              direction='column'
+              gap='small'
+              basis='100%'
+              animation={{ type: 'fadeIn', duration: 300 }}
+            >
+              <ListNodePoolsGuide
+                clusterName={cluster.metadata.name}
+                clusterNamespace={cluster.metadata.namespace!}
+                providerNodePoolResourceName={getProviderNodePoolResourceName(
+                  provider
+                )}
+              />
+            </Box>
+          )}
         </Box>
       </Breadcrumb>
     </DocumentTitle>

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -45,6 +45,9 @@ export const kubernetesResourcesURL =
 // All information about node pools.
 export const nodePoolsURL = 'https://docs.giantswarm.io/advanced/node-pools/';
 
+export const kubectlGSGetNodePoolsURL =
+  'https://docs.giantswarm.io/ui-api/kubectl-gs/get-nodepools/';
+
 // Organization concept docs.
 export const organizationsExplainedURL =
   'https://docs.giantswarm.io/general/organizations/';


### PR DESCRIPTION
Towards [giantswarm/giantswarm#18343](https://github.com/giantswarm/giantswarm/issues/18343).

This PR adds a CLI guide to the Cluster Details > Worker Nodes tab, and provides information on how to node pools for a cluster using the Management API.

Collapsed:
<img width="1229" alt="Screen Shot 2021-08-17 at 12 37 22" src="https://user-images.githubusercontent.com/62935115/129711971-94a11c4c-0f22-4e2b-b79a-0b0d3ebdbca5.png">

Expanded:
<img width="1229" alt="Screen Shot 2021-08-17 at 12 37 43" src="https://user-images.githubusercontent.com/62935115/129712007-8178a343-fade-4fea-8d4d-0faabb8e267c.png">
