### PR TITLE
Add CLI guide for deleting a node pool

### DIFF
--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -33,6 +33,7 @@ import Button from 'UI/Controls/Button';
 import { NodePoolGridRow } from 'UI/Display/MAPI/workernodes/styles';
 import WorkerNodesNodePoolListPlaceholder from 'UI/Display/MAPI/workernodes/WorkerNodesNodePoolListPlaceholder';
 
+import DeleteNodePoolGuide from './guides/DeleteNodePoolGuide';
 import ListNodePoolsGuide from './guides/ListNodePoolsGuide';
 import ModifyNodePoolGuide from './guides/ModifyNodePoolGuide';
 import { IWorkerNodesAdditionalColumn } from './types';
@@ -463,6 +464,9 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> = () =>
                 )}
               />
               <ModifyNodePoolGuide
+                clusterNamespace={cluster.metadata.namespace!}
+              />
+              <DeleteNodePoolGuide
                 clusterNamespace={cluster.metadata.namespace!}
               />
             </Box>

--- a/src/components/MAPI/workernodes/guides/DeleteNodePoolGuide.tsx
+++ b/src/components/MAPI/workernodes/guides/DeleteNodePoolGuide.tsx
@@ -1,0 +1,74 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface IDeleteNodePoolGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  clusterNamespace: string;
+}
+
+const DeleteNodePoolGuide: React.FC<IDeleteNodePoolGuideProps> = ({
+  clusterNamespace,
+  ...props
+}) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
+  return (
+    <CLIGuide
+      title='Delete a node pool via the Management API'
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. Delete a node pool'
+          command={`
+          kubectl --context ${context} \\
+            delete machinepools.exp.cluster.x-k8s.io my-np \\
+            --namespace ${clusterNamespace}
+          `}
+        >
+          <Text>
+            Replace <code>my-np</code> with the name of the node pool to delete.
+          </Text>
+          <Text>
+            <strong>Note:</strong> This will result in the deletion of worker
+            nodes. Data stored on worker nodes or in ephemeral volumes will be
+            lost. There is no way to undo this. To allow scheduling of workloads
+            to other worker nodes, make sure to have other node pools available.
+          </Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+DeleteNodePoolGuide.propTypes = {
+  clusterNamespace: PropTypes.string.isRequired,
+};
+
+export default DeleteNodePoolGuide;


### PR DESCRIPTION
Towards [giantswarm/giantswarm#18343](https://github.com/giantswarm/giantswarm/issues/18343).

This PR adds a CLI guide to the Cluster Details > Worker Nodes tab, and provides information on how to delete a node pool using the Management API.

Collapsed:
<img width="1198" alt="Screen Shot 2021-08-18 at 13 13 05" src="https://user-images.githubusercontent.com/62935115/129888556-a94bcaee-cc97-4e12-b6cd-32beb72e6d70.png">

Expanded:
<img width="1198" alt="Screen Shot 2021-08-18 at 13 13 17" src="https://user-images.githubusercontent.com/62935115/129888548-1cd4694a-4a08-47dd-9f0a-3d9dd3cdfe65.png">

