### PR TITLE
Add CLI guide for creating a node pool

### DIFF
--- a/src/components/MAPI/guides/__tests__/utils.ts
+++ b/src/components/MAPI/guides/__tests__/utils.ts
@@ -372,13 +372,25 @@ describe('utils', () => {
           clusterName: 'a1b2c',
           owner: 'some-owner',
           provider: 'some-provider',
-          nodesMin: 4,
+          nodesMin: 0,
         },
         expectedOutput:
-          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --nodes-min 4',
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --nodes-min 0',
       },
       {
-        name: 'returns correct output with minimum number of nodes',
+        name:
+          'returns correct output if the minimum number of nodes equals the recommended default',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          nodesMin: 3,
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c',
+      },
+      {
+        name: 'returns correct output with maximum number of nodes',
         modifierConfig: {
           clusterName: 'a1b2c',
           owner: 'some-owner',
@@ -387,6 +399,18 @@ describe('utils', () => {
         },
         expectedOutput:
           'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --nodes-max 8',
+      },
+      {
+        name:
+          'returns correct output if the maximum number of nodes equals the recommended default',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          nodesMax: 10,
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c',
       },
     ];
 

--- a/src/components/MAPI/guides/__tests__/utils.ts
+++ b/src/components/MAPI/guides/__tests__/utils.ts
@@ -2,6 +2,7 @@ import {
   IKubectlGSGetAppsCommandConfig,
   IKubectlGSGetClustersCommandConfig,
   IKubectlGSTemplateClusterCommandConfig,
+  IKubectlGSTemplateNodePoolCommandConfig,
   KubectlGSCommandModifier,
   makeKubectlGSCommand,
   withContext,
@@ -9,6 +10,7 @@ import {
   withGetApps,
   withGetClusters,
   withTemplateCluster,
+  withTemplateNodePool,
 } from '../utils';
 
 describe('utils', () => {
@@ -273,6 +275,126 @@ describe('utils', () => {
     for (const tc of testCases) {
       it(tc.name, () => {
         const output = makeKubectlGSCommand(withGetClusters(tc.modifierConfig));
+
+        expect(output).toEqual(tc.expectedOutput);
+      });
+    }
+  });
+
+  describe('withTemplateNodePool', () => {
+    interface ITestCase {
+      name: string;
+      modifierConfig: IKubectlGSTemplateNodePoolCommandConfig;
+      expectedOutput: string;
+    }
+
+    const testCases: ITestCase[] = [
+      {
+        name: 'returns correct output with required options',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c',
+      },
+      {
+        name: 'returns correct output with description',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          description: 'Describe me',
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --description "Describe me"',
+      },
+      {
+        name: 'returns correct output with Azure VM size',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          azureVMSize: 'some_standard_size',
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --azure-vm-size some_standard_size',
+      },
+      {
+        name: 'returns correct output with one node pool AZ',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          nodePoolAZs: ['1'],
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --availability-zones 1',
+      },
+      {
+        name: 'returns correct output with multiple node pool AZs',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          nodePoolAZs: ['1', '2'],
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --availability-zones 1,2',
+      },
+      {
+        name: 'returns correct output with use Azure spot VMs',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          azureUseSpotVMs: true,
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --azure-spot-vms',
+      },
+      {
+        name: 'returns correct output with Azure spot VMs max price',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          azureUseSpotVMs: true,
+          azureSpotVMsMaxPrice: 0.00001,
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --azure-spot-vms --azure-spot-vms-max-price 0.00001',
+      },
+      {
+        name: 'returns correct output with minimum number of nodes',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          nodesMin: 4,
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --nodes-min 4',
+      },
+      {
+        name: 'returns correct output with minimum number of nodes',
+        modifierConfig: {
+          clusterName: 'a1b2c',
+          owner: 'some-owner',
+          provider: 'some-provider',
+          nodesMax: 8,
+        },
+        expectedOutput:
+          'kubectl gs template nodepool --provider some-provider --owner some-owner --cluster-name a1b2c --nodes-max 8',
+      },
+    ];
+
+    for (const tc of testCases) {
+      it(tc.name, () => {
+        const output = makeKubectlGSCommand(
+          withTemplateNodePool(tc.modifierConfig)
+        );
 
         expect(output).toEqual(tc.expectedOutput);
       });

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -187,6 +187,83 @@ export function withGetClusters(
   };
 }
 
+/**
+ * Configuration options supported by the `template nodepool` command.
+ * {@link https://github.com/giantswarm/kubectl-gs/blob/master/cmd/template/nodepool/flag.go#L13}
+ * */
+export interface IKubectlGSTemplateNodePoolCommandConfig {
+  provider: string;
+  owner: string;
+  clusterName: string;
+  description?: string;
+  azureVMSize?: string;
+  nodePoolAZs?: string[];
+  azureUseSpotVMs?: boolean;
+  azureSpotVMsMaxPrice?: number;
+  nodesMin?: number;
+  nodesMax?: number;
+  output?: string;
+}
+
+/**
+ * Generate a modifier for constructing the
+ * `kubectl gs template nodepool` command.
+ * */
+export function withTemplateNodePool(
+  config: IKubectlGSTemplateNodePoolCommandConfig
+): KubectlGSCommandModifier {
+  return (parts) => {
+    const newParts = [
+      ...parts,
+      'template',
+      'nodepool',
+      '--provider',
+      config.provider,
+      '--owner',
+      config.owner,
+      '--cluster-name',
+      config.clusterName,
+    ];
+
+    if (config.description) {
+      newParts.push('--description', `"${config.description}"`);
+    }
+
+    if (config.azureVMSize) {
+      newParts.push('--azure-vm-size', config.azureVMSize);
+    }
+
+    if (config.nodePoolAZs && config.nodePoolAZs.length > 0) {
+      newParts.push('--availability-zones', config.nodePoolAZs.join(','));
+    }
+
+    if (config.azureUseSpotVMs) {
+      newParts.push('--azure-spot-vms', '');
+    }
+
+    if (config.azureSpotVMsMaxPrice && config.azureSpotVMsMaxPrice > -1) {
+      newParts.push(
+        '--azure-spot-vms-max-price',
+        `${config.azureSpotVMsMaxPrice}`
+      );
+    }
+
+    if (config.nodesMin) {
+      newParts.push('--nodes-min', `${config.nodesMin}`);
+    }
+
+    if (config.nodesMax) {
+      newParts.push('--nodes-max', `${config.nodesMax}`);
+    }
+
+    if (config.output) {
+      newParts.push('--output', `"${config.output}"`);
+    }
+
+    return newParts;
+  };
+}
+
 function isFlag(value: string): boolean {
   return value.startsWith('--');
 }

--- a/src/components/MAPI/guides/utils.ts
+++ b/src/components/MAPI/guides/utils.ts
@@ -1,3 +1,4 @@
+import { Constants } from 'shared/constants';
 import { IState } from 'stores/state';
 
 export function getCurrentInstallationContextName(state: IState): string {
@@ -248,11 +249,17 @@ export function withTemplateNodePool(
       );
     }
 
-    if (config.nodesMin) {
+    if (
+      typeof config.nodesMin !== 'undefined' &&
+      config.nodesMin !== Constants.NP_DEFAULT_MIN_SCALING
+    ) {
       newParts.push('--nodes-min', `${config.nodesMin}`);
     }
 
-    if (config.nodesMax) {
+    if (
+      typeof config.nodesMax !== 'undefined' &&
+      config.nodesMax !== Constants.NP_DEFAULT_MAX_SCALING
+    ) {
       newParts.push('--nodes-max', `${config.nodesMax}`);
     }
 

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -264,7 +264,9 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
   const supportsSpotInstances = clusterReleaseVersion
     ? supportsNodePoolSpotInstances(provider, clusterReleaseVersion)
     : false;
-  const orgName = cluster.metadata.labels![capiv1alpha3.labelOrganization];
+  const orgName = state.nodePool.metadata.labels![
+    capiv1alpha3.labelOrganization
+  ];
   const description = getNodePoolDescription(state.nodePool);
   const machineType = getProviderNodePoolMachineType(state.providerNodePool);
   const spotInstances = getProviderNodePoolSpotInstances(

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -15,8 +15,14 @@ import {
   extractErrorMessage,
   generateUID,
   getClusterReleaseVersion,
+  getNodePoolAvailabilityZones,
+  getNodePoolDescription,
+  getNodePoolScaling,
   getProviderClusterLocation,
   getProviderNodePoolLocation,
+  getProviderNodePoolMachineType,
+  getProviderNodePoolSpotInstances,
+  INodePoolSpotInstancesAzure,
 } from 'MAPI/utils';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import PropTypes from 'prop-types';
@@ -28,6 +34,7 @@ import { getProvider } from 'stores/main/selectors';
 import { supportsNodePoolSpotInstances } from 'stores/nodepool/utils';
 import Button from 'UI/Controls/Button';
 
+import CreateNodePoolGuide from './guides/CreateNodePoolGuide';
 import { INodePoolPropertyValue, NodePoolPatch } from './patches';
 import {
   createDefaultBootstrapConfig,
@@ -257,6 +264,14 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
   const supportsSpotInstances = clusterReleaseVersion
     ? supportsNodePoolSpotInstances(provider, clusterReleaseVersion)
     : false;
+  const orgName = cluster.metadata.labels![capiv1alpha3.labelOrganization];
+  const description = getNodePoolDescription(state.nodePool);
+  const machineType = getProviderNodePoolMachineType(state.providerNodePool);
+  const spotInstances = getProviderNodePoolSpotInstances(
+    state.providerNodePool
+  ) as INodePoolSpotInstancesAzure;
+  const nodePoolAZs = getNodePoolAvailabilityZones(state.nodePool);
+  const scaling = getNodePoolScaling(state.nodePool);
 
   return (
     <Collapsible {...props}>
@@ -339,6 +354,26 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
                   <Button onClick={handleCancel}>Cancel</Button>
                 )}
               </Box>
+            </Box>
+            <Box
+              margin={{ top: 'large' }}
+              direction='column'
+              gap='small'
+              basis='100%'
+              animation={{ type: 'fadeIn', duration: 300 }}
+            >
+              <CreateNodePoolGuide
+                provider={provider}
+                organizationName={orgName}
+                clusterName={cluster.metadata.name}
+                description={description}
+                azureVMSize={machineType}
+                nodePoolAZs={nodePoolAZs}
+                azureUseSpotVMs={spotInstances.enabled}
+                azureSpotVMsMaxPrice={spotInstances.maxPrice}
+                nodesMin={scaling.min}
+                nodesMax={scaling.max}
+              />
             </Box>
           </Box>
         </form>

--- a/src/components/MAPI/workernodes/guides/CreateNodePoolGuide.tsx
+++ b/src/components/MAPI/workernodes/guides/CreateNodePoolGuide.tsx
@@ -95,7 +95,7 @@ const CreateNodePoolGuide: React.FC<ICreateNodePoolGuide> = ({
         />
         <CLIGuideStep
           title='3. Apply the manifest'
-          command={`kubectl apply --context ${context} -f cluster-${clusterName}-nodepool.yaml`}
+          command={`kubectl --context ${context} apply -f cluster-${clusterName}-nodepool.yaml`}
         >
           <Text>As a result, a node pool will get created.</Text>
         </CLIGuideStep>

--- a/src/components/MAPI/workernodes/guides/CreateNodePoolGuide.tsx
+++ b/src/components/MAPI/workernodes/guides/CreateNodePoolGuide.tsx
@@ -1,0 +1,120 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import {
+  getCurrentInstallationContextName,
+  makeKubectlGSCommand,
+  withFormatting,
+  withTemplateNodePool,
+} from 'MAPI/guides/utils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface ICreateNodePoolGuide
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  provider: PropertiesOf<typeof Providers>;
+  organizationName: string;
+  clusterName: string;
+  description?: string;
+  azureVMSize?: string;
+  nodePoolAZs?: string[];
+  azureUseSpotVMs?: boolean;
+  azureSpotVMsMaxPrice?: number;
+  nodesMin?: number;
+  nodesMax?: number;
+}
+
+const CreateNodePoolGuide: React.FC<ICreateNodePoolGuide> = ({
+  provider,
+  organizationName,
+  clusterName,
+  description,
+  azureVMSize,
+  nodePoolAZs,
+  azureUseSpotVMs,
+  azureSpotVMsMaxPrice,
+  nodesMin,
+  nodesMax,
+  ...props
+}) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
+  return (
+    <CLIGuide
+      title='Create a node pool via the Management API'
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'kubectl gs template nodepool command',
+              href: docs.kubectlGSTemplateNodePoolURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. Create a node pool manifest'
+          command={makeKubectlGSCommand(
+            withTemplateNodePool({
+              provider,
+              owner: organizationName,
+              clusterName,
+              description,
+              azureVMSize,
+              nodePoolAZs,
+              azureUseSpotVMs,
+              azureSpotVMsMaxPrice,
+              nodesMin,
+              nodesMax,
+              output: `cluster-${clusterName}-nodepool.yaml`,
+            }),
+            withFormatting()
+          )}
+        />
+        <CLIGuideStep
+          title='3. Apply the manifest'
+          command={`kubectl apply --context ${context} -f cluster-${clusterName}-nodepool.yaml`}
+        >
+          <Text>As a result, a node pool will get created.</Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+CreateNodePoolGuide.propTypes = {
+  provider: PropTypes.oneOf(Object.values(Providers)).isRequired,
+  organizationName: PropTypes.string.isRequired,
+  clusterName: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  azureVMSize: PropTypes.string,
+  nodePoolAZs: PropTypes.arrayOf(PropTypes.string.isRequired),
+  azureUseSpotVMs: PropTypes.bool,
+  azureSpotVMsMaxPrice: PropTypes.number,
+  nodesMin: PropTypes.number,
+  nodesMax: PropTypes.number,
+};
+
+export default CreateNodePoolGuide;

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -70,6 +70,9 @@ export const kubectlGSTemplateClusterURL =
 export const kubectlGSGetNodePoolsURL =
   'https://docs.giantswarm.io/ui-api/kubectl-gs/get-nodepools/';
 
+export const kubectlGSTemplateNodePoolURL =
+  'https://docs.giantswarm.io/ui-api/kubectl-gs/template-nodepool/';
+
 // Management API introduction page
 export const managementAPIIntroduction =
   'https://docs.giantswarm.io/ui-api/management-api/overview/';


### PR DESCRIPTION
Towards [giantswarm/giantswarm#18343](giantswarm/giantswarm#18343).

This PR adds a CLI guide to the Cluster Details > Worker Nodes tab > Add Node Pool form, and provides information on how to template and create a node pool using the Management API.

The contents of the node pool manifest aligns with user input from the Add Node Pool form.

Collapsed:
<img width="1208" alt="Screen Shot 2021-08-19 at 10 23 18" src="https://user-images.githubusercontent.com/62935115/130035410-4ce1476b-eca1-4b6d-ae24-b3ef320a5e14.png">

Expanded:
<img width="1208" alt="Screen Shot 2021-08-19 at 16 38 26" src="https://user-images.githubusercontent.com/62935115/130088393-5b563016-8a1e-42bc-9787-cb107a703157.png">
<img width="1208" alt="Screen Shot 2021-08-19 at 16 38 46" src="https://user-images.githubusercontent.com/62935115/130088383-598c4f41-e31d-48a1-a9da-cc439d6d641c.png">
