### PR TITLE
Create feature flag value for mapiAuth (SSO)

### DIFF
--- a/helm/happa/Chart.yaml
+++ b/helm/happa/Chart.yaml
@@ -6,5 +6,5 @@ home: https://github.com/giantswarm/happa
 version: [[ .Version ]]
 appVersion: [[ .AppVersion ]]
 annotations:
-  #config.giantswarm.io/version: 1.x.x
+  # config.giantswarm.io/version: 1.x.x
   config.giantswarm.io/version: add-happa-mapiAuth

--- a/helm/happa/Chart.yaml
+++ b/helm/happa/Chart.yaml
@@ -6,4 +6,5 @@ home: https://github.com/giantswarm/happa
 version: [[ .Version ]]
 appVersion: [[ .AppVersion ]]
 annotations:
-  config.giantswarm.io/version: 1.x.x
+  #config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: add-happa-mapiAuth

--- a/helm/happa/templates/configmap.yaml
+++ b/helm/happa/templates/configmap.yaml
@@ -33,9 +33,5 @@ data:
   enable-rum: 'TRUE'
 
   # Feature flags
-  {{ if eq .Values.managementCluster.pipeline "testing" }}
-  feature-mapi-auth: 'TRUE'
-  {{ else }}
-  feature-mapi-auth: 'FALSE'
-  {{ end }}
+  feature-mapi-auth: {{ .Values.happa.featureFlags.mapiAuth | quote | upper }}
   feature-mapi-clusters: {{ .Values.happa.featureFlags.mapiClusters | quote | upper }}

--- a/helm/happa/values.yaml
+++ b/helm/happa/values.yaml
@@ -39,6 +39,7 @@ happa:
   host: ""
   letsencrypt: ""
   featureFlags:
+    mapiAuth: false
     mapiClusters: false
 
 happaapi:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17978

This PR

- removes the logic that all testing installations automatically have SSO auth enabled, while production ones don't.
- adds a feature flag configuration value `mapiAuth`

This requires a config change before releasing.