### PR TITLE
Add CLI guide for deleting a cluster

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -27,6 +27,7 @@ import ClusterDetailDeleteAction, {
   ClusterDetailDeleteActionNameVariant,
 } from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction';
 
+import DeleteClusterGuide from '../guides/DeleteClusterGuide';
 import { getWorkerNodesCount } from '../utils';
 import { deleteCluster } from './utils';
 
@@ -211,6 +212,17 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
               flex={{ grow: 1, shrink: 0 }}
             />
           </Box>
+          {cluster && (
+            <Box
+              margin={{ top: 'large' }}
+              direction='column'
+              gap='small'
+              basis='100%'
+              animation={{ type: 'fadeIn', duration: 300 }}
+            >
+              <DeleteClusterGuide clusterName={name} namespace={namespace!} />
+            </Box>
+          )}
         </Box>
       </Breadcrumb>
     </DocumentTitle>

--- a/src/components/MAPI/clusters/guides/DeleteClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/DeleteClusterGuide.tsx
@@ -1,0 +1,72 @@
+import { Text } from 'grommet';
+import * as docs from 'lib/docs';
+import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import CLIGuide from 'UI/Display/MAPI/CLIGuide';
+import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
+import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
+import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
+
+interface IDeleteClusterGuideProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
+  clusterName: string;
+  namespace: string;
+}
+
+const DeleteClusterGuide: React.FC<IDeleteClusterGuideProps> = ({
+  clusterName,
+  namespace,
+  ...props
+}) => {
+  const context = useSelector(getCurrentInstallationContextName);
+
+  return (
+    <CLIGuide
+      title='Delete this cluster via the Management API'
+      footer={
+        <CLIGuideAdditionalInfo
+          links={[
+            {
+              label: 'kubectl gs plugin installation',
+              href: docs.kubectlGSInstallationURL,
+              external: true,
+            },
+            {
+              label: 'Management API introduction',
+              href: docs.managementAPIIntroduction,
+              external: true,
+            },
+          ]}
+        />
+      }
+      {...props}
+    >
+      <CLIGuideStepList>
+        <LoginGuideStep />
+        <CLIGuideStep
+          title='2. Delete the cluster'
+          command={`
+          kubectl --context ${context} delete cluster ${clusterName} --namespace ${namespace}
+          `}
+        >
+          <Text>
+            <strong>Warning:</strong> This action terminates all workloads and
+            destroys all data stored on ephemeral storage. There is no undo.
+            Before you proceed, make sure you really want to delete this
+            cluster.
+          </Text>
+        </CLIGuideStep>
+      </CLIGuideStepList>
+    </CLIGuide>
+  );
+};
+
+DeleteClusterGuide.propTypes = {
+  clusterName: PropTypes.string.isRequired,
+  namespace: PropTypes.string.isRequired,
+};
+
+export default DeleteClusterGuide;


### PR DESCRIPTION
Towards [giantswarm/giantswarm#18343](https://github.com/giantswarm/giantswarm/issues/18343).

This PR adds a CLI guide to the Cluster Details > Actions tab, and provides information on how to delete a cluster using the Management API.

Collapsed:
<img width="1208" alt="Screen Shot 2021-08-19 at 16 30 25" src="https://user-images.githubusercontent.com/62935115/130087142-24a0f97b-d63f-41aa-93ad-00304784aaab.png">
Expanded:
<img width="1208" alt="Screen Shot 2021-08-19 at 16 30 47" src="https://user-images.githubusercontent.com/62935115/130087136-4ee33f99-36ea-41e9-ba2b-a1d10154b047.png">
