### PR TITLE
Keep footer button padding consistent while hovering and increase color contrast

### DIFF
--- a/src/components/Footer/FooterUpdateButton.tsx
+++ b/src/components/Footer/FooterUpdateButton.tsx
@@ -1,12 +1,7 @@
 import { getUpdateButtonMessage } from 'Footer/FooterUtils';
 import PropTypes from 'prop-types';
 import React from 'react';
-import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
-
-const StyledButton = styled(Button)`
-  padding: 0 5px;
-`;
 
 interface IFooterUpdateButtonProps {
   hasUpdateReady: boolean;
@@ -26,7 +21,7 @@ const FooterUpdateButton: React.FC<IFooterUpdateButtonProps> = ({
 
   if (hasUpdateReady) {
     return (
-      <StyledButton
+      <Button
         disabled={isUpdating}
         loading={isUpdating}
         warning={true}
@@ -35,7 +30,7 @@ const FooterUpdateButton: React.FC<IFooterUpdateButtonProps> = ({
         {...rest}
       >
         {label}
-      </StyledButton>
+      </Button>
     );
   }
 

--- a/src/components/UI/Controls/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Controls/Button/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`Button renders a button with a loading animation 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
@@ -41,7 +41,7 @@ exports[`Button renders a danger button 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
@@ -70,7 +70,7 @@ exports[`Button renders a disabled button 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
@@ -100,7 +100,7 @@ exports[`Button renders a link button 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
@@ -129,7 +129,7 @@ exports[`Button renders a primary button 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
@@ -158,7 +158,7 @@ exports[`Button renders a secondary button 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
@@ -187,13 +187,13 @@ exports[`Button renders a warning button 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"
     >
       <button
-        class="StyledButtonKind-sc-1vhfpnt-0 bkgFHr"
+        class="StyledButtonKind-sc-1vhfpnt-0 FXAWq"
         type="button"
       >
         Hi friends
@@ -216,7 +216,7 @@ exports[`Button renders without crashing 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 XLeeE sc-dlnjwi clPEKk"

--- a/src/components/UI/Controls/Button/index.tsx
+++ b/src/components/UI/Controls/Button/index.tsx
@@ -68,7 +68,7 @@ function makeCustomTheme(style: ButtonStyle): ThemeType {
 
     case ButtonStyle.Warning:
       theme.button!.secondary = {
-        background: 'status-warning',
+        background: '#d4982f',
         border: {
           width: '0',
         },
@@ -77,7 +77,7 @@ function makeCustomTheme(style: ButtonStyle): ThemeType {
 
       theme.button!.hover!.secondary = {
         background: {
-          color: '#ffb83b',
+          color: '#ffaa15',
           opacity: 1,
         },
         border: {
@@ -87,7 +87,7 @@ function makeCustomTheme(style: ButtonStyle): ThemeType {
 
       theme.button!.active!.secondary = {
         background: {
-          color: 'status-warning',
+          color: '#d4982f',
         },
         border: {
           width: '0',

--- a/src/components/UI/Controls/ConfirmationPrompt/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Controls/ConfirmationPrompt/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`ConfirmationPrompt renders a component with a title 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       aria-hidden="true"
@@ -20,7 +20,7 @@ exports[`ConfirmationPrompt renders a component with buttons 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       aria-hidden="true"
@@ -35,7 +35,7 @@ exports[`ConfirmationPrompt renders a simple component 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       aria-hidden="true"

--- a/src/components/UI/DataTable/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/DataTable/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`DataTable renders a simple table 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <table
       class="StyledTable-sc-1m3u5g-6 gnELFm StyledDataTable-xrlyjm-0 efGflZ"

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
@@ -5,10 +5,10 @@ exports[`CLIGuide renders the contents when open 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hrJYol sc-WZYut qvxWH"
+      class="StyledBox-sc-13pk1d4-0 hrJYol sc-dkQUaI fkbCbt"
       role="tablist"
     >
       <div
@@ -88,10 +88,10 @@ exports[`CLIGuide renders without crashing 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hrJYol sc-WZYut qvxWH"
+      class="StyledBox-sc-13pk1d4-0 hrJYol sc-dkQUaI fkbCbt"
       role="tablist"
     >
       <div

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 aYENS"
@@ -14,7 +14,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         class="StyledBox-sc-13pk1d4-0 jcMcey"
       >
         <div
-          class="sc-TtZnY dDiQmU sc-jHNicF dneNot"
+          class="sc-dvXYtj cRgYCU sc-TtZnY iYGJoU"
         >
           <span
             aria-label="35 dogs"
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 fTVibh sc-kQfVtO fxJeOe"
+        class="StyledText-sc-1sadyjn-0 fTVibh sc-eSRwjH jBSQhy"
       >
         dogs
       </span>
@@ -39,7 +39,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 aYENS"
@@ -48,7 +48,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         class="StyledBox-sc-13pk1d4-0 jcMcey"
       >
         <div
-          class="sc-TtZnY dDiQmU sc-jHNicF dneNot"
+          class="sc-dvXYtj cRgYCU sc-TtZnY iYGJoU"
         >
           <span
             aria-label="1 dog"
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 fTVibh sc-kQfVtO fxJeOe"
+        class="StyledText-sc-1sadyjn-0 fTVibh sc-eSRwjH jBSQhy"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       aria-label="Some widget"
@@ -15,7 +15,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 ihVIAm"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 biMlWM sc-ektJcd hwJBHE"
+          class="StyledText-sc-1sadyjn-0 biMlWM sc-kQfVtO fxJeOe"
         >
           Some widget
         </span>
@@ -39,7 +39,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       aria-label="Some widget"
@@ -49,7 +49,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 bbIfdU"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 biMlWM sc-ektJcd hwJBHE"
+          class="StyledText-sc-1sadyjn-0 biMlWM sc-kQfVtO fxJeOe"
         >
           Some widget
         </span>

--- a/src/components/UI/Display/Table/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/Table/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`Table renders a simple table 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <table
       class="StyledTable-sc-1m3u5g-6 gnELFm"

--- a/src/components/UI/Display/Tabs/__tests__/__snapshots__/Tabs.tsx.snap
+++ b/src/components/UI/Display/Tabs/__tests__/__snapshots__/Tabs.tsx.snap
@@ -5,7 +5,7 @@ exports[`Tabs renders a basic tab layout 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 kUTqHn StyledTabs-a4fwxl-2 bpLJQL"

--- a/src/components/UI/Inputs/CheckBoxInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/CheckBoxInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,10 +5,10 @@ exports[`CheckBoxInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
       tabindex="0"
     >
       <div
@@ -49,10 +49,10 @@ exports[`CheckBoxInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
       tabindex="0"
     >
       <div
@@ -89,10 +89,10 @@ exports[`CheckBoxInput renders a toggle input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
       tabindex="0"
     >
       <label
@@ -147,10 +147,10 @@ exports[`CheckBoxInput renders an input with a form field label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
       tabindex="0"
     >
       <label
@@ -192,10 +192,10 @@ exports[`CheckBoxInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
       tabindex="0"
     >
       <span
@@ -237,10 +237,10 @@ exports[`CheckBoxInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
       tabindex="0"
     >
       <div
@@ -282,10 +282,10 @@ exports[`CheckBoxInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-bCwfaz jcofer"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fKgJPI hfiqMR"
       tabindex="0"
     >
       <div

--- a/src/components/UI/Inputs/CurrencyInput/__tests__/__snapshots__/CurrencyInput.tsx.snap
+++ b/src/components/UI/Inputs/CurrencyInput/__tests__/__snapshots__/CurrencyInput.tsx.snap
@@ -5,7 +5,7 @@ exports[`CurrencyInput renders without crashing 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/DateInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/DateInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`DateInput renders a button that triggers the calendar 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -51,7 +51,7 @@ exports[`DateInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -104,7 +104,7 @@ exports[`DateInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -149,7 +149,7 @@ exports[`DateInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -206,7 +206,7 @@ exports[`DateInput renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -258,7 +258,7 @@ exports[`DateInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -315,7 +315,7 @@ exports[`DateInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/FileInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/FileInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`FileInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -35,7 +35,7 @@ exports[`FileInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -64,7 +64,7 @@ exports[`FileInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -98,7 +98,7 @@ exports[`FileInput renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -134,7 +134,7 @@ exports[`FileInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -168,7 +168,7 @@ exports[`FileInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/InputGroup/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/InputGroup/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`InputGroup renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 kfocQM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/MultiSelect/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/MultiSelect/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`MultiSelect renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`NumberPicker renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 cYwaIm"
@@ -29,7 +29,7 @@ exports[`NumberPicker renders a simple input 1`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 gHAWHi sc-kGVuwA gKkVlS"
+            class="StyledTextInput-sc-1x30a0s-0 gHAWHi sc-ciOKUB hvszOO"
             id="money"
             step="1"
             type="number"
@@ -37,18 +37,18 @@ exports[`NumberPicker renders a simple input 1`] = `
           />
         </div>
         <div
-          class="sc-bA-DTon jdgQSB"
+          class="sc-kGVuwA kVWBtb"
         >
           <div
             aria-label="Decrement"
-            class="sc-jYKCQm eUTjom"
+            class="sc-bA-DTon dNOjvy"
             role="button"
           >
             –
           </div>
           <div
             aria-label="Increment"
-            class="sc-jYKCQm eUTjom"
+            class="sc-bA-DTon dNOjvy"
             role="button"
           >
             +

--- a/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,10 +5,10 @@ exports[`RadioInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fiCYzP guNYpz"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hfVBHA jHXnFT"
       tabindex="0"
     >
       <div
@@ -49,10 +49,10 @@ exports[`RadioInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fiCYzP guNYpz"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hfVBHA jHXnFT"
       tabindex="0"
     >
       <div
@@ -91,10 +91,10 @@ exports[`RadioInput renders an input with a form field label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fiCYzP guNYpz"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hfVBHA jHXnFT"
       tabindex="0"
     >
       <label
@@ -141,10 +141,10 @@ exports[`RadioInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fiCYzP guNYpz"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hfVBHA jHXnFT"
       tabindex="0"
     >
       <span
@@ -188,10 +188,10 @@ exports[`RadioInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fiCYzP guNYpz"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hfVBHA jHXnFT"
       tabindex="0"
     >
       <div
@@ -235,10 +235,10 @@ exports[`RadioInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-fiCYzP guNYpz"
+      class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz sc-hfVBHA jHXnFT"
       tabindex="0"
     >
       <div

--- a/src/components/UI/Inputs/Select/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/Select/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`Select renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -77,7 +77,7 @@ exports[`Select renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -142,7 +142,7 @@ exports[`Select renders an input inside the dropdown, that can search through th
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -207,7 +207,7 @@ exports[`Select renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -283,7 +283,7 @@ exports[`Select renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -354,7 +354,7 @@ exports[`Select renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -430,7 +430,7 @@ exports[`Select renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/TextArea/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/TextArea/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`TextArea renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -31,7 +31,7 @@ exports[`TextArea renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -57,7 +57,7 @@ exports[`TextArea renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -87,7 +87,7 @@ exports[`TextArea renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -119,7 +119,7 @@ exports[`TextArea renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -149,7 +149,7 @@ exports[`TextArea renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"

--- a/src/components/UI/Inputs/TextInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/TextInput/__tests__/__snapshots__/index.tsx.snap
@@ -5,7 +5,7 @@ exports[`TextInput renders a disabled input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -39,7 +39,7 @@ exports[`TextInput renders a simple input 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -67,7 +67,7 @@ exports[`TextInput renders an input with a help message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -105,7 +105,7 @@ exports[`TextInput renders an input with a label 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -138,7 +138,7 @@ exports[`TextInput renders an input with a validation error 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"
@@ -176,7 +176,7 @@ exports[`TextInput renders an input with an info message 1`] = `
   class="StyledGrommet-sc-19lkkz7-0 iUQqn"
 >
   <div
-    class="sc-iCoGMd hFJToB"
+    class="sc-gKAaRy ezfMqp"
   >
     <div
       class="StyledBox-sc-13pk1d4-0 hcMLLM FormField__FormFieldBox-m9hood-0 ofKvz"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18607

This PR removes the custom styling from the `Update the web interface now` button in the footer. It is now using the default `small` padding that all buttons use. Also, I played with the `warning`'s button colors for a bit, to increase color contrast.

## Preview

<details>
<summary>Chill</summary>

![image](https://user-images.githubusercontent.com/13508038/130482518-2278b8e4-f538-4f12-ae76-4a22025ec755.png)

</details>

<details>
<summary>Hover</summary>

![image](https://user-images.githubusercontent.com/13508038/130482555-08d0e7ab-defe-44d3-b4ad-8cc3f3f4adad.png)

</details>