### PR TITLE
Hide Users page if the customer SSO feature flag is enabled

### DIFF
--- a/__tests__/Users.js
+++ b/__tests__/Users.js
@@ -6,6 +6,7 @@ import { getConfiguration } from 'model/services/metadata/configuration';
 import nock from 'nock';
 import { StatusCodes } from 'shared/constants';
 import { UsersRoutes } from 'shared/constants/routes';
+import * as featureFlags from 'shared/featureFlags';
 import {
   API_ENDPOINT,
   appCatalogsResponse,
@@ -28,6 +29,16 @@ import {
 import { renderRouteWithStore } from 'testUtils/renderUtils';
 
 describe('Users', () => {
+  const initialCustomerSSO = featureFlags.flags.CustomerSSO.enabled;
+
+  beforeAll(() => {
+    featureFlags.flags.CustomerSSO.enabled = false;
+  });
+
+  afterAll(() => {
+    featureFlags.flags.CustomerSSO.enabled = initialCustomerSSO;
+  });
+
   // Responses to requests
   beforeEach(() => {
     getInstallationInfo.mockResolvedValueOnce(AWSInfoResponse);

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -20,6 +20,7 @@ import {
   OrganizationsRoutes,
   UsersRoutes,
 } from 'shared/constants/routes';
+import * as featureFlags from 'shared/featureFlags';
 import { supportsMapiApps, supportsMapiClusters } from 'shared/featureSupport';
 import { batchedLayout, batchedOrganizationSelect } from 'stores/batchActions';
 import {
@@ -65,6 +66,8 @@ class Layout extends React.Component {
     const showApps =
       supportsAppsViaMapi || Object.keys(this.props.catalogs.items).length > 0;
 
+    const showUsers = !featureFlags.flags.CustomerSSO.enabled;
+
     return (
       <DocumentTitle>
         <LoadingOverlay loading={!this.props.firstLoadComplete}>
@@ -76,6 +79,7 @@ class Layout extends React.Component {
                 organizations={this.props.organizations}
                 selectedOrganization={this.props.selectedOrganization}
                 showApps={showApps}
+                showUsers={showUsers}
                 user={user}
               />
               <Breadcrumb data={{ title: 'HOME', pathname: MainRoutes.Home }}>
@@ -97,7 +101,9 @@ class Layout extends React.Component {
                       <Route component={Apps} path={AppsRoutes.Home} />
                     )}
 
-                    <Route component={Users} exact path={UsersRoutes.Home} />
+                    {showUsers && (
+                      <Route component={Users} exact path={UsersRoutes.Home} />
+                    )}
 
                     {user.type === LoggedInUserTypes.MAPI ? (
                       <Route

--- a/src/components/UI/Controls/Navigation/MainMenu.js
+++ b/src/components/UI/Controls/Navigation/MainMenu.js
@@ -91,7 +91,7 @@ const DropdownNavLink = styled(StyledNavLink)`
 
 const DropdownAnchor = DropdownNavLink.withComponent('a');
 
-function MainMenu({ showApps, isUserAdmin }) {
+function MainMenu({ showApps, showUsers }) {
   return (
     <>
       <NavDiv>
@@ -106,11 +106,11 @@ function MainMenu({ showApps, isUserAdmin }) {
             Apps
           </StyledNavLink>
         )}
-        {isUserAdmin ? (
+        {showUsers && (
           <StyledNavLink activeClassName='active' to={UsersRoutes.Home}>
             Users
           </StyledNavLink>
-        ) : undefined}
+        )}
         {monitoringURL && (
           <StyledExternalNavLink
             href={monitoringURL}
@@ -175,7 +175,7 @@ function MainMenu({ showApps, isUserAdmin }) {
                     </DropdownNavLink>
                   </li>
                 )}
-                {isUserAdmin ? (
+                {showUsers && (
                   <li>
                     <DropdownNavLink
                       activeClassName='active'
@@ -185,7 +185,7 @@ function MainMenu({ showApps, isUserAdmin }) {
                       Users
                     </DropdownNavLink>
                   </li>
-                ) : undefined}
+                )}
                 {monitoringURL && (
                   <li>
                     <DropdownAnchor
@@ -219,7 +219,7 @@ function MainMenu({ showApps, isUserAdmin }) {
 
 MainMenu.propTypes = {
   showApps: PropTypes.bool,
-  isUserAdmin: PropTypes.bool,
+  showUsers: PropTypes.bool,
 };
 
 export default MainMenu;

--- a/src/components/UI/Controls/Navigation/Navigation.js
+++ b/src/components/UI/Controls/Navigation/Navigation.js
@@ -120,7 +120,7 @@ class Navigation extends React.Component {
           </RUMActionTarget>
           <MainMenu
             showApps={this.props.showApps}
-            isUserAdmin={this.props.user.isAdmin}
+            showUsers={this.props.showUsers}
           />
 
           <Actions>
@@ -145,6 +145,7 @@ class Navigation extends React.Component {
 Navigation.propTypes = {
   user: PropTypes.object,
   showApps: PropTypes.bool,
+  showUsers: PropTypes.bool,
   organizations: PropTypes.object,
   onSelectOrganization: PropTypes.func,
   selectedOrganization: PropTypes.string,


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18597

Simply put, right now we have a `Users` page visible to GS staff. With the changes in this PR, if the customer SSO feature flag is on, the `Users` page is not displayed, and the `/users/` route is not accessible.