### PR TITLE
Activate renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:js-app"],
+  "dependencyDashboard": true,
   "labels": ["dependencies"],
   "reviewers": ["team:team-biscuit"],
   "packageRules": [


### PR DESCRIPTION
This activates Renovate's dependency dashboard feature, which will make it maintain an issue with an overview of the current PRs and some functions to re-trigger updates etc.