### PR TITLE
Let renovate work during the night

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,5 +82,8 @@
     }
   ],
   "prConcurrentLimit": 5,
-  "schedule": ["every weekend"]
+  "schedule": [
+    "every weekend",
+    "after 6pm and before 6am every weekday"
+  ]
 }


### PR DESCRIPTION
With renovate working only on weekends and max 5 parallel PRs, we probably won't get through 57 PRs which are due _currently_.

This PR also activates it for every night.