### PR TITLE
Tweak renovate pings, simplify schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
   "labels": ["dependencies"],
   "reviewers": [
     "axbarsan",
-    "marians"
+    "marians",
+    "kuosandys"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Instead of pinging all of biscuit, this PR sets the individuals who want to deal with dependencies routine in happa.

Also simplified the schedule syntax a bit without changing it's meaning