### PR TITLE
Add spacing between buttons in upgrade modal

### DIFF
--- a/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailUpgradeModal.tsx
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import GenericModal from 'Modals/GenericModal';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import React, { useMemo, useState } from 'react';
@@ -110,14 +111,14 @@ const ClusterDetailUpgradeModal: React.FC<IClusterDetailUpgradeModalProps> = ({
   return (
     <GenericModal
       footer={
-        <>
+        <Box direction='row' gap='small' justify='end'>
           {primaryButtonText && (
             <Button primary={true} onClick={handlePrimaryButtonClick}>
               {primaryButtonText}
             </Button>
           )}
           <Button onClick={onClose}>Cancel</Button>
-        </>
+        </Box>
       }
       onClose={onClose}
       title={title}


### PR DESCRIPTION
Closes [giantswarm/giantswarm#18671](https://github.com/giantswarm/giantswarm/issues/18671).

A small change to add spacing between the "Inspect changes" and "Cancel" button in the cluster upgrade modal.

<img width="612" alt="Screen Shot 2021-08-30 at 11 31 24" src="https://user-images.githubusercontent.com/62935115/131320798-09131346-1b2d-4901-bb1d-4a09d4c8b722.png">
