### PR TITLE
Create generic app list widget component for displaying app info

### DIFF
--- a/src/components/MAPI/apps/AppList/utils.tsx
+++ b/src/components/MAPI/apps/AppList/utils.tsx
@@ -10,14 +10,7 @@ import AppsList from 'UI/Display/Apps/AppList/AppsListPage';
 import CatalogLabel from 'UI/Display/Apps/AppList/CatalogLabel';
 import { IFacetOption } from 'UI/Inputs/Facets';
 
-function isAppCatalogVisibleToUsers(
-  appCatalog: applicationv1alpha1.IAppCatalog
-) {
-  return (
-    applicationv1alpha1.isAppCatalogPublic(appCatalog) &&
-    applicationv1alpha1.isAppCatalogStable(appCatalog)
-  );
-}
+import { computeAppCatalogUITitle, isAppCatalogVisibleToUsers } from '../utils';
 
 function compareAppCatalogEntriesByName(
   a: applicationv1alpha1.IAppCatalogEntry,
@@ -61,26 +54,6 @@ export const compareAppCatalogEntriesFns: Record<
   catalog: compareAppCatalogEntriesByAppCatalog,
   latest: compareAppCatalogEntriesByLatest,
 };
-
-/**
- * Remove the `Giant Swarm` prefix from
- * internal catalogs, to ease cognitive load.
- * @param catalog
- */
-export function computeAppCatalogUITitle(
-  catalog: applicationv1alpha1.IAppCatalog
-): string {
-  const prefix = 'Giant Swarm ';
-
-  if (
-    !isAppCatalogVisibleToUsers(catalog) &&
-    catalog.spec.title.startsWith(prefix)
-  ) {
-    return catalog.spec.title.slice(prefix.length);
-  }
-
-  return catalog.spec.title;
-}
 
 /**
  * Sort catalogs in an alphabetical order, but group

--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 
+import ClusterDetailAppListWidgetStatus from './ClusterDetailAppListWidgetStatus';
 import ClusterDetailAppListWidgetVersion from './ClusterDetailAppListWidgetVersion';
 
 const Icon = styled(Text)<{ isActive?: boolean }>`
@@ -80,7 +81,16 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
         pad={{ horizontal: 'small', top: 'xsmall', bottom: 'small' }}
       >
         <StyledBox wrap={true} direction='row'>
-          <ClusterDetailAppListWidgetVersion app={app} />
+          <ClusterDetailAppListWidgetVersion
+            app={app}
+            basis='200px'
+            flex={{ grow: 1, shrink: 1 }}
+          />
+          <ClusterDetailAppListWidgetStatus
+            app={app}
+            basis='200px'
+            flex={{ grow: 1, shrink: 1 }}
+          />
         </StyledBox>
       </Box>
     </AccordionPanel>

--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -85,22 +85,22 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
         <StyledBox wrap={true} direction='row'>
           <ClusterDetailAppListWidgetVersion
             app={app}
-            basis='200px'
+            basis='250px'
             flex={{ grow: 1, shrink: 1 }}
           />
           <ClusterDetailAppListWidgetStatus
             app={app}
-            basis='200px'
+            basis='250px'
             flex={{ grow: 1, shrink: 1 }}
           />
           <ClusterDetailAppListWidgetCatalog
             app={app}
-            basis='200px'
+            basis='250px'
             flex={{ grow: 1, shrink: 1 }}
           />
           <ClusterDetailAppListWidgetNamespace
             app={app}
-            basis='200px'
+            basis='250px'
             flex={{ grow: 1, shrink: 1 }}
           />
         </StyledBox>

--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 
 import ClusterDetailAppListWidgetCatalog from './ClusterDetailAppListWidgetCatalog';
+import ClusterDetailAppListWidgetNamespace from './ClusterDetailAppListWidgetNamespace';
 import ClusterDetailAppListWidgetStatus from './ClusterDetailAppListWidgetStatus';
 import ClusterDetailAppListWidgetVersion from './ClusterDetailAppListWidgetVersion';
 
@@ -93,6 +94,11 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
             flex={{ grow: 1, shrink: 1 }}
           />
           <ClusterDetailAppListWidgetCatalog
+            app={app}
+            basis='200px'
+            flex={{ grow: 1, shrink: 1 }}
+          />
+          <ClusterDetailAppListWidgetNamespace
             app={app}
             basis='200px'
             flex={{ grow: 1, shrink: 1 }}

--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 
+import ClusterDetailAppListWidgetCatalog from './ClusterDetailAppListWidgetCatalog';
 import ClusterDetailAppListWidgetStatus from './ClusterDetailAppListWidgetStatus';
 import ClusterDetailAppListWidgetVersion from './ClusterDetailAppListWidgetVersion';
 
@@ -87,6 +88,11 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
             flex={{ grow: 1, shrink: 1 }}
           />
           <ClusterDetailAppListWidgetStatus
+            app={app}
+            basis='200px'
+            flex={{ grow: 1, shrink: 1 }}
+          />
+          <ClusterDetailAppListWidgetCatalog
             app={app}
             basis='200px'
             flex={{ grow: 1, shrink: 1 }}

--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -4,10 +4,16 @@ import React from 'react';
 import styled from 'styled-components';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 
+import ClusterDetailAppListWidgetVersion from './ClusterDetailAppListWidgetVersion';
+
 const Icon = styled(Text)<{ isActive?: boolean }>`
   transform: rotate(${({ isActive }) => (isActive ? '0deg' : '-90deg')});
   transform-origin: center center;
   transition: 0.15s ease-out;
+`;
+
+const StyledBox = styled(Box)`
+  gap: ${({ theme }) => theme.global.edgeSize.small};
 `;
 
 interface IClusterDetailAppListItemProps
@@ -71,9 +77,11 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
         round={{ corner: 'bottom', size: 'xsmall' }}
         background='background-front'
         fill='horizontal'
-        pad='medium'
+        pad={{ horizontal: 'small', top: 'xsmall', bottom: 'small' }}
       >
-        hi friends
+        <StyledBox wrap={true} direction='row'>
+          <ClusterDetailAppListWidgetVersion app={app} />
+        </StyledBox>
       </Box>
     </AccordionPanel>
   );

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetCatalog.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetCatalog.tsx
@@ -1,0 +1,104 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { Box, Text } from 'grommet';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { useHttpClient } from 'lib/hooks/useHttpClient';
+import {
+  computeAppCatalogUITitle,
+  isAppCatalogVisibleToUsers,
+} from 'MAPI/apps/utils';
+import { extractErrorMessage } from 'MAPI/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import useSWR from 'swr';
+import ClusterDetailAppListWidget from 'UI/Display/MAPI/apps/ClusterDetailAppListWidget';
+import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
+
+const CatalogType = styled(Text)`
+  text-transform: uppercase;
+`;
+
+interface IClusterDetailAppListWidgetCatalogProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof ClusterDetailAppListWidget>,
+    'title'
+  > {
+  app?: applicationv1alpha1.IApp;
+}
+
+const ClusterDetailAppListWidgetCatalog: React.FC<IClusterDetailAppListWidgetCatalogProps> = ({
+  app,
+  ...props
+}) => {
+  const auth = useAuthProvider();
+  const appCatalogClient = useHttpClient();
+
+  const appCatalogKey = app
+    ? applicationv1alpha1.getAppCatalogKey('', app.spec.catalog)
+    : null;
+
+  const { data: appCatalog, error: appCatalogError } = useSWR<
+    applicationv1alpha1.IAppCatalog,
+    GenericResponseError
+  >(appCatalogKey, () =>
+    applicationv1alpha1.getAppCatalog(
+      appCatalogClient,
+      auth,
+      '',
+      app!.spec.catalog
+    )
+  );
+
+  useEffect(() => {
+    if (appCatalogError) {
+      const errorMessage = extractErrorMessage(appCatalogError);
+
+      new FlashMessage(
+        `There was a problem loading the app's catalog.`,
+        messageType.ERROR,
+        messageTTL.FOREVER,
+        errorMessage
+      );
+
+      ErrorReporter.getInstance().notify(appCatalogError);
+    }
+  }, [appCatalogError]);
+
+  const appCatalogTitle = appCatalog
+    ? computeAppCatalogUITitle(appCatalog)
+    : undefined;
+  const isManaged = appCatalog ? isAppCatalogVisibleToUsers(appCatalog) : false;
+
+  return (
+    <ClusterDetailAppListWidget
+      title='Catalog'
+      contentProps={{
+        direction: 'row',
+        gap: 'small',
+        wrap: true,
+        align: 'baseline',
+      }}
+      {...props}
+    >
+      <OptionalValue value={appCatalogTitle} loaderWidth={150}>
+        {(value) => <Text aria-label={`App catalog: ${value}`}>{value}</Text>}
+      </OptionalValue>
+
+      {isManaged && (
+        <Box
+          pad={{ horizontal: 'xsmall', vertical: 'none' }}
+          round='xxsmall'
+          background='#8dc163'
+        >
+          <CatalogType size='xsmall' color='background' weight='bold'>
+            managed
+          </CatalogType>
+        </Box>
+      )}
+    </ClusterDetailAppListWidget>
+  );
+};
+
+export default ClusterDetailAppListWidgetCatalog;

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetNamespace.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetNamespace.tsx
@@ -1,0 +1,30 @@
+import { Text } from 'grommet';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import React from 'react';
+import ClusterDetailAppListWidget from 'UI/Display/MAPI/apps/ClusterDetailAppListWidget';
+import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
+
+interface IClusterDetailAppListWidgetNamespaceProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof ClusterDetailAppListWidget>,
+    'title'
+  > {
+  app?: applicationv1alpha1.IApp;
+}
+
+const ClusterDetailAppListWidgetNamespace: React.FC<IClusterDetailAppListWidgetNamespaceProps> = ({
+  app,
+  ...props
+}) => {
+  return (
+    <ClusterDetailAppListWidget title='Target namespace' {...props}>
+      <OptionalValue value={app?.spec.namespace} loaderWidth={100}>
+        {(value) => (
+          <Text aria-label={`App target namespace: ${value}`}>{value}</Text>
+        )}
+      </OptionalValue>
+    </ClusterDetailAppListWidget>
+  );
+};
+
+export default ClusterDetailAppListWidgetNamespace;

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetStatus.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetStatus.tsx
@@ -1,0 +1,32 @@
+import { Text } from 'grommet';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import React from 'react';
+import ClusterDetailAppListWidget from 'UI/Display/MAPI/apps/ClusterDetailAppListWidget';
+import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
+
+interface IClusterDetailAppListWidgetStatusProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof ClusterDetailAppListWidget>,
+    'title'
+  > {
+  app?: applicationv1alpha1.IApp;
+}
+
+const ClusterDetailAppListWidgetStatus: React.FC<IClusterDetailAppListWidgetStatusProps> = ({
+  app,
+  ...props
+}) => {
+  let status: string | undefined = '';
+  if (!app) status = undefined;
+  if (app?.status?.release.status) status = app.status.release.status;
+
+  return (
+    <ClusterDetailAppListWidget title='Status' {...props}>
+      <OptionalValue value={status} loaderWidth={100}>
+        {(value) => <Text aria-label={`App status: ${value}`}>{value}</Text>}
+      </OptionalValue>
+    </ClusterDetailAppListWidget>
+  );
+};
+
+export default ClusterDetailAppListWidgetStatus;

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersion.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersion.tsx
@@ -128,7 +128,7 @@ const ClusterDetailAppListWidgetVersion: React.FC<IClusterDetailAppListWidgetVer
       {hasNewVersion && (
         <Text color='status-warning'>
           <i className='fa fa-warning' role='presentation' aria-hidden='true' />{' '}
-          Newer version available
+          Upgrade available
         </Text>
       )}
     </ClusterDetailAppListWidget>

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersion.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersion.tsx
@@ -1,0 +1,138 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { Text } from 'grommet';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { useHttpClient } from 'lib/hooks/useHttpClient';
+import { extractErrorMessage } from 'MAPI/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import React, { useEffect, useMemo } from 'react';
+import useSWR from 'swr';
+import ClusterDetailAppListWidget from 'UI/Display/MAPI/apps/ClusterDetailAppListWidget';
+import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
+import Truncated from 'UI/Util/Truncated';
+
+import { getLatestVersionForApp, isAppChangingVersion } from './utils';
+
+interface IClusterDetailAppListWidgetVersionProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof ClusterDetailAppListWidget>,
+    'title'
+  > {
+  app?: applicationv1alpha1.IApp;
+}
+
+const ClusterDetailAppListWidgetVersion: React.FC<IClusterDetailAppListWidgetVersionProps> = ({
+  app,
+  ...props
+}) => {
+  const auth = useAuthProvider();
+  const appCatalogEntryListClient = useHttpClient();
+
+  const appCatalogEntryListGetOptions: applicationv1alpha1.IGetAppCatalogEntryListOptions = useMemo(() => {
+    if (!app) return {};
+
+    return {
+      labelSelector: {
+        matchingLabels: {
+          [applicationv1alpha1.labelAppName]: app.spec.name,
+          [applicationv1alpha1.labelAppCatalog]: app.spec.catalog,
+        },
+      },
+    };
+  }, [app]);
+  const appCatalogEntryListKey = useMemo(() => {
+    if (!app) return null;
+
+    return applicationv1alpha1.getAppCatalogEntryListKey(
+      appCatalogEntryListGetOptions
+    );
+  }, [app, appCatalogEntryListGetOptions]);
+
+  const { data: appCatalogEntryList, error: appCatalogEntryListError } = useSWR<
+    applicationv1alpha1.IAppCatalogEntryList,
+    GenericResponseError
+  >(appCatalogEntryListKey, () =>
+    applicationv1alpha1.getAppCatalogEntryList(
+      appCatalogEntryListClient,
+      auth,
+      appCatalogEntryListGetOptions
+    )
+  );
+
+  useEffect(() => {
+    if (appCatalogEntryListError) {
+      const errorMessage = extractErrorMessage(appCatalogEntryListError);
+
+      new FlashMessage(
+        'There was a problem loading app versions.',
+        messageType.ERROR,
+        messageTTL.FOREVER,
+        errorMessage
+      );
+
+      ErrorReporter.getInstance().notify(appCatalogEntryListError);
+    }
+  }, [appCatalogEntryListError]);
+
+  const currentVersion = app
+    ? applicationv1alpha1.getAppCurrentVersion(app)
+    : undefined;
+
+  const isChangingVersion = app ? isAppChangingVersion(app) : false;
+  const hasNewVersion = useMemo(() => {
+    if (!appCatalogEntryList || !app || isChangingVersion) return false;
+
+    const latestVersion = getLatestVersionForApp(
+      appCatalogEntryList.items,
+      app.spec.name
+    );
+
+    return latestVersion && latestVersion !== app.spec.version;
+  }, [app, appCatalogEntryList, isChangingVersion]);
+
+  return (
+    <ClusterDetailAppListWidget
+      title='Version'
+      contentProps={{
+        direction: 'row',
+        gap: 'small',
+        wrap: true,
+        align: 'baseline',
+      }}
+      {...props}
+    >
+      <OptionalValue value={currentVersion} loaderWidth={100}>
+        {(value) => (
+          <Truncated
+            as={Text}
+            aria-label={`App version: ${value}`}
+            numStart={10}
+          >
+            {value as string}
+          </Truncated>
+        )}
+      </OptionalValue>
+
+      {isChangingVersion && (
+        <Text color='status-warning'>
+          <i
+            className='fa fa-version-upgrade'
+            role='presentation'
+            aria-hidden='true'
+          />{' '}
+          Switching to {app?.spec.version}
+        </Text>
+      )}
+
+      {hasNewVersion && (
+        <Text color='status-warning'>
+          <i className='fa fa-warning' role='presentation' aria-hidden='true' />{' '}
+          Newer version available
+        </Text>
+      )}
+    </ClusterDetailAppListWidget>
+  );
+};
+
+export default ClusterDetailAppListWidgetVersion;

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetCatalog.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetCatalog.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as applicationv1alpha1Mocks from 'testUtils/mockHttpCalls/applicationv1alpha1';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailAppListWidgetCatalog from '../ClusterDetailAppListWidgetCatalog';
+
+function generateApp(
+  name: string = 'some-app',
+  version: string = '1.2.1'
+): applicationv1alpha1.IApp {
+  const namespace = capiv1alpha3Mocks.randomCluster1.metadata.name;
+
+  return {
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'App',
+    metadata: {
+      annotations: {
+        'chart-operator.giantswarm.io/force-helm-upgrade': 'true',
+      },
+      creationTimestamp: new Date().toISOString(),
+      finalizers: ['operatorkit.giantswarm.io/app-operator-app'],
+      generation: 1,
+      labels: {
+        app: name,
+        'app-operator.giantswarm.io/version': '3.2.1',
+        'giantswarm.io/cluster': namespace,
+        'giantswarm.io/managed-by': 'Helm',
+        'giantswarm.io/organization': 'org1',
+        'giantswarm.io/service-type': 'managed',
+      },
+      name,
+      namespace,
+      resourceVersion: '294675096',
+      selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${name}`,
+      uid: '859c4eb1-ece4-4eca-85b2-a4a456b6ae81',
+    },
+    spec: {
+      catalog: 'default',
+      config: {
+        configMap: {
+          name: `${namespace}-cluster-values`,
+          namespace,
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      kubeConfig: {
+        context: {
+          name: `${namespace}-kubeconfig`,
+        },
+        inCluster: false,
+        secret: {
+          name: `${namespace}-kubeconfig`,
+          namespace,
+        },
+      },
+      name,
+      namespace: 'giantswarm',
+      userConfig: {
+        configMap: {
+          name: '',
+          namespace: '',
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      version,
+    },
+    status: {
+      appVersion: '0.4.1',
+      release: {
+        lastDeployed: '2021-04-27T16:21:37Z',
+        status,
+      },
+      version,
+    },
+  };
+}
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<
+    typeof ClusterDetailAppListWidgetCatalog
+  >
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailAppListWidgetCatalog {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+describe('ClusterDetailAppListWidgetCatalog', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays the current app catalog', async () => {
+    const catalog = applicationv1alpha1Mocks.defaultAppCatalog;
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/application.giantswarm.io/v1alpha1/appcatalogs/${catalog.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, catalog);
+
+    const app = generateApp('some-app', '1.2.3');
+
+    render(getComponent({ app }));
+
+    expect(
+      await screen.findByLabelText('App catalog: Default Catalog')
+    ).toBeInTheDocument();
+  });
+
+  it('displays if the catalog is managed or not', async () => {
+    const catalog = applicationv1alpha1Mocks.giantswarmAppCatalog;
+
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/application.giantswarm.io/v1alpha1/appcatalogs/${catalog.metadata.name}/`
+      )
+      .reply(StatusCodes.Ok, catalog);
+
+    const app = generateApp('some-app', '1.2.3');
+    app.spec.catalog = 'giantswarm';
+
+    render(getComponent({ app }));
+
+    expect(
+      await screen.findByLabelText('App catalog: Giant Swarm Catalog')
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/managed/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetNamespace.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetNamespace.tsx
@@ -1,0 +1,105 @@
+import { screen } from '@testing-library/react';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import ClusterDetailAppListWidgetNamespace from '../ClusterDetailAppListWidgetNamespace';
+
+function generateApp(
+  name: string = 'some-app',
+  version: string = '1.2.1'
+): applicationv1alpha1.IApp {
+  const namespace = capiv1alpha3Mocks.randomCluster1.metadata.name;
+
+  return {
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'App',
+    metadata: {
+      annotations: {
+        'chart-operator.giantswarm.io/force-helm-upgrade': 'true',
+      },
+      creationTimestamp: new Date().toISOString(),
+      finalizers: ['operatorkit.giantswarm.io/app-operator-app'],
+      generation: 1,
+      labels: {
+        app: name,
+        'app-operator.giantswarm.io/version': '3.2.1',
+        'giantswarm.io/cluster': namespace,
+        'giantswarm.io/managed-by': 'Helm',
+        'giantswarm.io/organization': 'org1',
+        'giantswarm.io/service-type': 'managed',
+      },
+      name,
+      namespace,
+      resourceVersion: '294675096',
+      selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${name}`,
+      uid: '859c4eb1-ece4-4eca-85b2-a4a456b6ae81',
+    },
+    spec: {
+      catalog: 'default',
+      config: {
+        configMap: {
+          name: `${namespace}-cluster-values`,
+          namespace,
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      kubeConfig: {
+        context: {
+          name: `${namespace}-kubeconfig`,
+        },
+        inCluster: false,
+        secret: {
+          name: `${namespace}-kubeconfig`,
+          namespace,
+        },
+      },
+      name,
+      namespace: 'giantswarm',
+      userConfig: {
+        configMap: {
+          name: '',
+          namespace: '',
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      version,
+    },
+    status: {
+      appVersion: '0.4.1',
+      release: {
+        lastDeployed: '2021-04-27T16:21:37Z',
+        status,
+      },
+      version,
+    },
+  };
+}
+
+type ComponentProps = React.ComponentPropsWithoutRef<
+  typeof ClusterDetailAppListWidgetNamespace
+>;
+
+describe('ClusterDetailAppListWidgetNamespace', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(ClusterDetailAppListWidgetNamespace, {} as ComponentProps);
+  });
+
+  it('displays the app target namespace', () => {
+    const app = generateApp();
+
+    renderWithTheme(ClusterDetailAppListWidgetNamespace, {
+      app,
+    } as ComponentProps);
+
+    expect(
+      screen.getByLabelText('App target namespace: giantswarm')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetStatus.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetStatus.tsx
@@ -1,0 +1,117 @@
+import { screen } from '@testing-library/react';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import ClusterDetailAppListWidgetStatus from '../ClusterDetailAppListWidgetStatus';
+
+function generateApp(
+  name: string = 'some-app',
+  version: string = '1.2.1'
+): applicationv1alpha1.IApp {
+  const namespace = capiv1alpha3Mocks.randomCluster1.metadata.name;
+
+  return {
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'App',
+    metadata: {
+      annotations: {
+        'chart-operator.giantswarm.io/force-helm-upgrade': 'true',
+      },
+      creationTimestamp: new Date().toISOString(),
+      finalizers: ['operatorkit.giantswarm.io/app-operator-app'],
+      generation: 1,
+      labels: {
+        app: name,
+        'app-operator.giantswarm.io/version': '3.2.1',
+        'giantswarm.io/cluster': namespace,
+        'giantswarm.io/managed-by': 'Helm',
+        'giantswarm.io/organization': 'org1',
+        'giantswarm.io/service-type': 'managed',
+      },
+      name,
+      namespace,
+      resourceVersion: '294675096',
+      selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${name}`,
+      uid: '859c4eb1-ece4-4eca-85b2-a4a456b6ae81',
+    },
+    spec: {
+      catalog: 'default',
+      config: {
+        configMap: {
+          name: `${namespace}-cluster-values`,
+          namespace,
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      kubeConfig: {
+        context: {
+          name: `${namespace}-kubeconfig`,
+        },
+        inCluster: false,
+        secret: {
+          name: `${namespace}-kubeconfig`,
+          namespace,
+        },
+      },
+      name,
+      namespace: 'giantswarm',
+      userConfig: {
+        configMap: {
+          name: '',
+          namespace: '',
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      version,
+    },
+    status: {
+      appVersion: '0.4.1',
+      release: {
+        lastDeployed: '2021-04-27T16:21:37Z',
+        status,
+      },
+      version,
+    },
+  };
+}
+
+type ComponentProps = React.ComponentPropsWithoutRef<
+  typeof ClusterDetailAppListWidgetStatus
+>;
+
+describe('ClusterDetailAppListWidgetStatus', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(ClusterDetailAppListWidgetStatus, {} as ComponentProps);
+  });
+
+  it('displays the app status', () => {
+    const app = generateApp();
+    app.status!.release.status = 'deployed';
+
+    renderWithTheme(ClusterDetailAppListWidgetStatus, {
+      app,
+    } as ComponentProps);
+
+    expect(screen.getByLabelText('App status: deployed')).toBeInTheDocument();
+  });
+
+  it(`displays a 'n/a' label if the app status is not there`, () => {
+    const app = generateApp();
+    delete app.status!.release.status;
+
+    renderWithTheme(ClusterDetailAppListWidgetStatus, {
+      app,
+    } as ComponentProps);
+
+    expect(
+      screen.getByLabelText('no information available')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetVersion.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetVersion.tsx
@@ -1,0 +1,182 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as applicationv1alpha1Mocks from 'testUtils/mockHttpCalls/applicationv1alpha1';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailAppListWidgetVersion from '../ClusterDetailAppListWidgetVersion';
+
+function generateApp(
+  name: string = 'some-app',
+  version: string = '1.2.1'
+): applicationv1alpha1.IApp {
+  const namespace = capiv1alpha3Mocks.randomCluster1.metadata.name;
+
+  return {
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'App',
+    metadata: {
+      annotations: {
+        'chart-operator.giantswarm.io/force-helm-upgrade': 'true',
+      },
+      creationTimestamp: new Date().toISOString(),
+      finalizers: ['operatorkit.giantswarm.io/app-operator-app'],
+      generation: 1,
+      labels: {
+        app: name,
+        'app-operator.giantswarm.io/version': '3.2.1',
+        'giantswarm.io/cluster': namespace,
+        'giantswarm.io/managed-by': 'Helm',
+        'giantswarm.io/organization': 'org1',
+        'giantswarm.io/service-type': 'managed',
+      },
+      name,
+      namespace,
+      resourceVersion: '294675096',
+      selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${name}`,
+      uid: '859c4eb1-ece4-4eca-85b2-a4a456b6ae81',
+    },
+    spec: {
+      catalog: 'default',
+      config: {
+        configMap: {
+          name: `${namespace}-cluster-values`,
+          namespace,
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      kubeConfig: {
+        context: {
+          name: `${namespace}-kubeconfig`,
+        },
+        inCluster: false,
+        secret: {
+          name: `${namespace}-kubeconfig`,
+          namespace,
+        },
+      },
+      name,
+      namespace: 'giantswarm',
+      userConfig: {
+        configMap: {
+          name: '',
+          namespace: '',
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      version,
+    },
+    status: {
+      appVersion: '0.4.1',
+      release: {
+        lastDeployed: '2021-04-27T16:21:37Z',
+        status,
+      },
+      version,
+    },
+  };
+}
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<
+    typeof ClusterDetailAppListWidgetVersion
+  >
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailAppListWidgetVersion {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+describe('ClusterDetailAppListWidgetVersion', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({}));
+  });
+
+  it('displays the current app version', () => {
+    const app = generateApp('some-app', '1.2.3');
+
+    render(getComponent({ app }));
+
+    expect(screen.getByLabelText('App version: 1.2.3')).toBeInTheDocument();
+  });
+
+  it('displays if the app is switching versions', () => {
+    const app = generateApp('some-app', '1.2.3');
+    app.spec.version = '1.3.0';
+
+    render(getComponent({ app }));
+
+    expect(screen.getByLabelText('App version: 1.2.3')).toBeInTheDocument();
+    expect(screen.getByText('Switching to 1.3.0')).toBeInTheDocument();
+  });
+
+  it('displays the spec version if there is no status', () => {
+    const app = generateApp('some-app', '1.2.3');
+    delete app.status;
+
+    render(getComponent({ app }));
+
+    expect(screen.getByLabelText('App version: 1.2.3')).toBeInTheDocument();
+  });
+
+  it('displays the spec version if there is no status', () => {
+    const app = generateApp('some-app', '1.2.3');
+    delete app.status;
+
+    render(getComponent({ app }));
+
+    expect(screen.getByLabelText('App version: 1.2.3')).toBeInTheDocument();
+  });
+
+  it('displays a warning if a newer version is available', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        '/apis/application.giantswarm.io/v1alpha1/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
+      )
+      .reply(
+        StatusCodes.Ok,
+        applicationv1alpha1Mocks.defaultCatalogAppCatalogEntryList
+      );
+
+    const app = generateApp('coredns', '1.1.0');
+    delete app.status;
+
+    render(getComponent({ app }));
+
+    expect(screen.getByLabelText('App version: 1.1.0')).toBeInTheDocument();
+
+    expect(
+      await screen.findByText('Newer version available')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetVersion.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetVersion.tsx
@@ -175,8 +175,6 @@ describe('ClusterDetailAppListWidgetVersion', () => {
 
     expect(screen.getByLabelText('App version: 1.1.0')).toBeInTheDocument();
 
-    expect(
-      await screen.findByText('Newer version available')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Upgrade available')).toBeInTheDocument();
   });
 });

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -1,6 +1,7 @@
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { HttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { compare } from 'lib/semver';
 import { VersionImpl } from 'lib/Version';
 import * as releasesUtils from 'MAPI/releases/utils';
 import { GenericResponse } from 'model/clients/GenericResponse';
@@ -645,4 +646,26 @@ export function computeAppsCategorizedCounters(
     uniqueApps: Object.values(apps).length,
     deployed: deployedAppCount,
   };
+}
+
+export function isAppChangingVersion(app: applicationv1alpha1.IApp): boolean {
+  if (!app.status) return false;
+
+  return (
+    app.status.version.length > 0 && app.spec.version !== app.status.version
+  );
+}
+
+export function getLatestVersionForApp(
+  apps: applicationv1alpha1.IAppCatalogEntry[],
+  appName: string
+): string | undefined {
+  const versions: string[] = [];
+  for (const app of apps) {
+    if (app.spec.appName === appName) {
+      versions.push(app.spec.version);
+    }
+  }
+
+  return versions.sort((a, b) => compare(b, a))[0];
 }

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -669,3 +669,32 @@ export function getLatestVersionForApp(
 
   return versions.sort((a, b) => compare(b, a))[0];
 }
+
+export function isAppCatalogVisibleToUsers(
+  appCatalog: applicationv1alpha1.IAppCatalog
+) {
+  return (
+    applicationv1alpha1.isAppCatalogPublic(appCatalog) &&
+    applicationv1alpha1.isAppCatalogStable(appCatalog)
+  );
+}
+
+/**
+ * Remove the `Giant Swarm` prefix from
+ * internal catalogs, to ease cognitive load.
+ * @param catalog
+ */
+export function computeAppCatalogUITitle(
+  catalog: applicationv1alpha1.IAppCatalog
+): string {
+  const prefix = 'Giant Swarm ';
+
+  if (
+    !isAppCatalogVisibleToUsers(catalog) &&
+    catalog.spec.title.startsWith(prefix)
+  ) {
+    return catalog.spec.title.slice(prefix.length);
+  }
+
+  return catalog.spec.title;
+}

--- a/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/__tests__/__snapshots__/index.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClusterDetailAppListWidget renders a simple widget 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 iUQqn"
+>
+  <div
+    class="sc-gKAaRy ezfMqp"
+  >
+    <div
+      aria-label="Some widget"
+      class="StyledBox-sc-13pk1d4-0 erippm"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 kUTqHn"
+      >
+        <span
+          class="StyledText-sc-1sadyjn-0 fTVibh sc-tsGVs iEFaxe"
+        >
+          Some widget
+        </span>
+      </div>
+      <div
+        class="StyledBox-sc-13pk1d4-0 kUTqHn"
+      >
+        <span
+          class="StyledText-sc-1sadyjn-0 giPNPf"
+        >
+          Some content
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/__tests__/index.tsx
+++ b/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/__tests__/index.tsx
@@ -1,0 +1,15 @@
+import { Text } from 'grommet';
+import * as React from 'react';
+import { renderWithTheme } from 'testUtils/renderUtils';
+
+import ClusterDetailAppListWidget from '..';
+
+describe('ClusterDetailAppListWidget', () => {
+  it('renders a simple widget', () => {
+    const { container } = renderWithTheme(ClusterDetailAppListWidget, {
+      title: 'Some widget',
+      children: <Text>Some content</Text>,
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/index.tsx
+++ b/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/index.tsx
@@ -1,0 +1,33 @@
+import { Box, Text } from 'grommet';
+import React from 'react';
+import styled from 'styled-components';
+
+const Title = styled(Text)`
+  text-transform: uppercase;
+`;
+
+interface IClusterDetailAppListWidgetProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  title: string;
+  contentProps?: React.ComponentPropsWithoutRef<typeof Box>;
+}
+
+const ClusterDetailAppListWidget: React.FC<IClusterDetailAppListWidgetProps> = ({
+  title,
+  children,
+  contentProps,
+  ...props
+}) => {
+  return (
+    <Box pad='xsmall' direction='column' aria-label={title} {...props}>
+      <Box>
+        <Title color='text-weak' size='small'>
+          {title}
+        </Title>
+      </Box>
+      <Box {...contentProps}>{children}</Box>
+    </Box>
+  );
+};
+
+export default ClusterDetailAppListWidget;

--- a/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/stories/ClusterDetailAppListWidget.stories.tsx
+++ b/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/stories/ClusterDetailAppListWidget.stories.tsx
@@ -1,0 +1,10 @@
+import { Meta } from '@storybook/react/types-6-0';
+
+import ClusterDetailAppListWidget from '..';
+
+export { Simple } from './Simple';
+
+export default {
+  title: 'Display/MAPI/Apps/ClusterDetailAppListWidget',
+  component: ClusterDetailAppListWidget,
+} as Meta;

--- a/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/stories/Simple.tsx
+++ b/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/stories/Simple.tsx
@@ -1,0 +1,43 @@
+import { Story } from '@storybook/react';
+import { Box, Heading, Text } from 'grommet';
+import React, { ComponentPropsWithoutRef } from 'react';
+
+import ClusterDetailAppListWidget from '..';
+
+export const Simple: Story<
+  ComponentPropsWithoutRef<typeof ClusterDetailAppListWidget>
+> = (args) => {
+  return (
+    <ClusterDetailAppListWidget {...args}>
+      <Text>Hi everyone. This is a widget that you can customize</Text>
+      <Box direction='row' pad='small' gap='small' margin={{ top: 'medium' }}>
+        <Box align='center'>
+          <Heading level={3} margin='none'>
+            50
+          </Heading>
+          <Text>shades of happa</Text>
+        </Box>
+        <Box align='center'>
+          <Heading level={3} margin='none'>
+            50
+          </Heading>
+          <Text>shades of happa</Text>
+        </Box>
+        <Box align='center'>
+          <Heading level={3} margin='none'>
+            50
+          </Heading>
+          <Text>shades of happa</Text>
+        </Box>
+      </Box>
+    </ClusterDetailAppListWidget>
+  );
+};
+
+Simple.args = {
+  title: 'Some widget',
+};
+
+Simple.argTypes = {
+  title: { control: { type: 'text' } },
+};


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18522

This PR adds the building blocks for all the app widgets. It also includes 4 basic widgets:
- version
- status
- catalog
- target namespace

Note: In the spec, the label for an app that can be upgraded is `Newer version available`. That is too big, and makes the label span to the next line for pre-release versions. I changed it to `Upgrade available`, so it fits properly, and is consistent with the cluster status.

## Preview

<details>
<summary>Upgrade available, app without status, managed catalog</summary>

![image](https://user-images.githubusercontent.com/13508038/131719202-ad220d5e-0e91-4c93-bad5-10744ebc8b3a.png)

</details>

<details>
<summary>App without status</summary>

![image](https://user-images.githubusercontent.com/13508038/131719263-5fb78a6b-72ca-4d42-9531-07afb5526fb6.png)

</details>

<details>
<summary>App deployed</summary>

![image](https://user-images.githubusercontent.com/13508038/131719305-5a363a6c-fb13-4683-8591-adf7b7beba02.png)

</details>

<details>
<summary>Upgrade available, pre-release version, app without status</summary>

![image](https://user-images.githubusercontent.com/13508038/131719374-846dd36d-bdb6-4afc-bae9-ee2508286ede.png)

</details>


