### PR TITLE
Fix organization usage when SSO is used but MAPI cluster management is disabled

### DIFF
--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -14,7 +14,6 @@ import { installApp } from 'stores/appcatalog/actions';
 import { IAsynchronousDispatch } from 'stores/asynchronousAction';
 import { selectIsClusterAwaitingUpgrade } from 'stores/cluster/selectors';
 import { isClusterCreating, isClusterUpdating } from 'stores/cluster/utils';
-import { selectOrganizationByID } from 'stores/organization/selectors';
 import { IState } from 'stores/state';
 import Button from 'UI/Controls/Button';
 import { IVersion } from 'UI/Controls/VersionPicker/VersionPickerUtils';
@@ -37,13 +36,10 @@ function selectClusters(state: IState) {
       selectIsClusterAwaitingUpgrade(cluster.id)(state);
     const isCreatingOrUpdating = isClusterCreating(cluster) || isUpdating;
 
-    const organizationID =
-      selectOrganizationByID(cluster.owner)(state)?.id ?? cluster.owner;
-
     clusters[cluster.id] = {
       id: cluster.id,
       name: cluster.name!,
-      owner: organizationID,
+      owner: cluster.owner,
       isAvailable: !isCreatingOrUpdating,
     };
   }

--- a/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
+++ b/src/components/Cluster/NewCluster/NewClusterWrapper.tsx
@@ -15,6 +15,7 @@ import {
   getFirstNodePoolsRelease,
   getUserIsAdmin,
 } from 'stores/main/selectors';
+import { selectOrganizationByID } from 'stores/organization/selectors';
 import {
   getReleases,
   getReleasesError,
@@ -94,6 +95,10 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = () => {
 
   const isAdmin = useSelector(getUserIsAdmin);
 
+  const selectedOrganization = useSelector(selectOrganizationByID(orgId));
+  const selectedOrganizationName =
+    selectedOrganization?.name ?? selectedOrganization?.id ?? '';
+
   return (
     <Breadcrumb
       data={{
@@ -129,7 +134,7 @@ const NewClusterWrapper: FC<INewClusterWrapperProps> = () => {
           </FlexColumn>
           <CreationForm
             allowSubmit={clusterNameIsValid}
-            selectedOrganization={orgId}
+            selectedOrganization={selectedOrganizationName}
             selectedRelease={selectedRelease}
             clusterName={clusterName}
             capabilities={creationCapabilities}

--- a/src/components/Home/ClusterDashboardItem.js
+++ b/src/components/Home/ClusterDashboardItem.js
@@ -14,7 +14,6 @@ import { isClusterCreating } from 'stores/cluster/utils';
 import { selectErrorByIdAndAction } from 'stores/entityerror/selectors';
 import { CLUSTER_NODEPOOLS_LOAD_REQUEST } from 'stores/nodepool/constants';
 import { selectClusterNodePools } from 'stores/nodepool/selectors';
-import { selectOrganizationByID } from 'stores/organization/selectors';
 import { getAllReleases } from 'stores/releases/selectors';
 import { css } from 'styled-components';
 import styled from 'styled-components';
@@ -301,8 +300,7 @@ function mapStateToProps(state, props) {
   const cluster = selectClusterById(state, props.clusterId);
   let organizationID = '';
   if (cluster) {
-    organizationID =
-      selectOrganizationByID(cluster.owner)(state)?.id ?? cluster.owner;
+    organizationID = cluster.owner;
   }
 
   return {

--- a/src/lib/helpers.tsx
+++ b/src/lib/helpers.tsx
@@ -331,7 +331,10 @@ export function clustersForOrg(
 ): Cluster[] {
   if (!allClusters) return [];
 
-  const organizationID = getOrganizationByID(orgId, organizations)?.id;
+  const organization = getOrganizationByID(orgId, organizations);
+  if (!organization) return [];
+
+  const organizationID = organization.name ?? organization?.id;
 
   return Object.values(allClusters).filter(
     (cluster) => cluster.owner === organizationID

--- a/src/stores/cluster/actions.ts
+++ b/src/stores/cluster/actions.ts
@@ -136,11 +136,15 @@ export function clustersDetails(opts: {
       dispatch({ type: CLUSTERS_DETAILS_REQUEST });
     }
 
-    const selectedOrganization =
-      getState().main.selectedOrganization?.toLowerCase() ?? '';
-    const organizationID =
-      selectOrganizationByID(selectedOrganization)(getState())?.id ??
-      selectedOrganization;
+    const state = getState();
+    if (!state.main.selectedOrganization) return;
+
+    const selectedOrganization = selectOrganizationByID(
+      state.main.selectedOrganization
+    )(state);
+    if (!selectedOrganization) return;
+
+    const organizationID = selectedOrganization.name ?? selectedOrganization.id;
 
     const allClusters = getState().entities.clusters.items;
     // Remove deleted clusters from clusters array.
@@ -347,7 +351,7 @@ export function clusterCreate(
   void,
   ClusterActions
 > {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     try {
       dispatch({ type: CLUSTER_CREATE_REQUEST });
 
@@ -381,8 +385,7 @@ export function clusterCreate(
         clusterId,
       });
 
-      const organizationID =
-        selectOrganizationByID(cluster.owner)(getState())?.id ?? cluster.owner;
+      const organizationID = cluster.owner;
 
       return { clusterId, owner: organizationID };
     } catch (error) {

--- a/src/stores/cluster/selectors.ts
+++ b/src/stores/cluster/selectors.ts
@@ -29,11 +29,14 @@ export function selectClusterById(
 function selectOrganizationClusterNames(state: IState): string[] {
   const clusters = state.entities.clusters.items;
   const clusterIds = Object.keys(clusters);
-  const selectedOrganization =
-    state.main.selectedOrganization?.toLowerCase() ?? '';
-  const organizationID =
-    selectOrganizationByID(selectedOrganization)(state)?.id ??
-    selectedOrganization;
+
+  if (!state.main.selectedOrganization) return [];
+  const selectedOrganization = selectOrganizationByID(
+    state.main.selectedOrganization
+  )(state);
+  if (!selectedOrganization) return [];
+
+  const organizationID = selectedOrganization.name ?? selectedOrganization.id;
 
   return clusterIds
     .filter((id) => clusters[id].owner === organizationID)

--- a/src/stores/nodepool/actions.ts
+++ b/src/stores/nodepool/actions.ts
@@ -105,11 +105,15 @@ export function nodePoolsLoad(opts?: {
     if (opts?.withLoadingFlags)
       dispatch({ type: NODEPOOL_MULTIPLE_LOAD_REQUEST });
 
-    const selectedOrganization =
-      getState().main.selectedOrganization?.toLowerCase() ?? '';
-    const organizationID =
-      selectOrganizationByID(selectedOrganization)(getState())?.id ??
-      selectedOrganization;
+    const state = getState();
+    if (!state.main.selectedOrganization) return;
+
+    const selectedOrganization = selectOrganizationByID(
+      state.main.selectedOrganization
+    )(state);
+    if (!selectedOrganization) return;
+
+    const organizationID = selectedOrganization.name ?? selectedOrganization.id;
 
     const allClusters = getState().entities.clusters.items;
     const v5ClusterIDs: string[] =


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C13MG9F0W/p1630578781011000

Turns out that while working on https://github.com/giantswarm/happa/pull/2683 I didn't take into account happa hybrid mode (SSO enabled, but MAPI cluster management disabled -> currently only used by GS staff, on AWS and KVM).

For migrated organizations, that used to have names that didn't adhere to the DNS standard, there were no clusters showing up. Also, cluster creation was not happening in the right organization. This PR fixes those issues.