### PR TITLE
apps: display deleted cluster apps in a different way

### DIFF
--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppList.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppList.tsx
@@ -1,5 +1,7 @@
 import { screen } from '@testing-library/react';
+import sub from 'date-fns/fp/sub';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import { withMarkup } from 'testUtils/assertUtils';
 import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
 import { getComponentWithTheme, renderWithTheme } from 'testUtils/renderUtils';
 
@@ -152,5 +154,24 @@ describe('ClusterDetailAppList', () => {
 
     expect(screen.getByLabelText('App name: random-app')).toBeInTheDocument();
     expect(screen.getByLabelText('App version: 5.0.0')).toBeInTheDocument();
+  });
+
+  it('displays apps in a different state if they have been deleted', () => {
+    const deletedApp = generateApp('some-other-app', '2.3.1');
+
+    const deletionDate = sub({
+      hours: 1,
+    })(new Date());
+    deletedApp.metadata.deletionTimestamp = deletionDate.toISOString();
+
+    renderWithTheme(ClusterDetailAppList, {
+      apps: [deletedApp],
+      isLoading: false,
+    } as ComponentProps);
+
+    expect(screen.getByText('some-other-app')).toBeInTheDocument();
+    expect(
+      withMarkup(screen.getByText)('Deleted about 1 hour ago')
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -599,7 +599,7 @@ export function filterUserInstalledApps(
   apps: applicationv1alpha1.IApp[],
   supportsOptionalIngress: boolean
 ): applicationv1alpha1.IApp[] {
-  return apps.filter((app) => {
+  const userApps = apps.filter((app) => {
     switch (true) {
       case supportsOptionalIngress &&
         app.spec.name === Constants.INSTALL_INGRESS_TAB_APP_NAME:
@@ -613,6 +613,8 @@ export function filterUserInstalledApps(
         return true;
     }
   });
+
+  return userApps.sort(compareApps);
 }
 
 export function findIngressApp(
@@ -773,4 +775,21 @@ export function computeAppCatalogUITitle(
   }
 
   return catalog.spec.title;
+}
+
+export function compareApps(
+  a: applicationv1alpha1.IApp,
+  b: applicationv1alpha1.IApp
+) {
+  // Move apps that are currently deleting to the end of the list.
+  const aIsDeleting = typeof a.metadata.deletionTimestamp !== 'undefined';
+  const bIsDeleting = typeof b.metadata.deletionTimestamp !== 'undefined';
+
+  if (aIsDeleting && !bIsDeleting) {
+    return 1;
+  } else if (!aIsDeleting && bIsDeleting) {
+    return -1;
+  }
+
+  return a.metadata.name.localeCompare(b.metadata.name);
 }

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter/__tests__/__snapshots__/index.tsx.snap
@@ -25,7 +25,7 @@ exports[`ClusterDetailCounter renders a counter with a pluralized label 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 cQrzvg sc-bcmZex kzGrR"
+        class="StyledText-sc-1sadyjn-0 cQrzvg sc-eARyco ddVTFB"
       >
         dogs
       </span>
@@ -59,7 +59,7 @@ exports[`ClusterDetailCounter renders a simple counter 1`] = `
         </div>
       </div>
       <span
-        class="StyledText-sc-1sadyjn-0 cQrzvg sc-bcmZex kzGrR"
+        class="StyledText-sc-1sadyjn-0 cQrzvg sc-eARyco ddVTFB"
       >
         dog
       </span>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget/__tests__/__snapshots__/index.tsx.snap
@@ -15,7 +15,7 @@ exports[`ClusterDetailWidget renders a inline widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 fmJfdj"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 eTVfRR sc-eARyco ddVTFB"
+          class="StyledText-sc-1sadyjn-0 eTVfRR sc-hGbgdv dXlnhW"
         >
           Some widget
         </span>
@@ -49,7 +49,7 @@ exports[`ClusterDetailWidget renders a simple widget 1`] = `
         class="StyledBox-sc-13pk1d4-0 euFILx"
       >
         <span
-          class="StyledText-sc-1sadyjn-0 eTVfRR sc-eARyco ddVTFB"
+          class="StyledText-sc-1sadyjn-0 eTVfRR sc-hGbgdv dXlnhW"
         >
           Some widget
         </span>

--- a/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/NumberPicker/__tests__/__snapshots__/index.tsx.snap
@@ -29,7 +29,7 @@ exports[`NumberPicker renders a simple input 1`] = `
         >
           <input
             autocomplete="off"
-            class="StyledTextInput-sc-1x30a0s-0 iIgwzP sc-dHnuKO cvETGJ"
+            class="StyledTextInput-sc-1x30a0s-0 iIgwzP sc-Qpmqz kJGcll"
             id="money"
             step="1"
             type="number"
@@ -37,18 +37,18 @@ exports[`NumberPicker renders a simple input 1`] = `
           />
         </div>
         <div
-          class="sc-Qpmqz cWXijE"
+          class="sc-jfJyPD hlZPFc"
         >
           <div
             aria-label="Decrement"
-            class="sc-jfJyPD bbhoXf"
+            class="sc-fnlXEO eHZziu"
             role="button"
           >
             –
           </div>
           <div
             aria-label="Increment"
-            class="sc-jfJyPD bbhoXf"
+            class="sc-fnlXEO eHZziu"
             role="button"
           >
             +

--- a/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Inputs/RadioInput/__tests__/__snapshots__/index.tsx.snap
@@ -8,7 +8,7 @@ exports[`RadioInput renders a disabled input 1`] = `
     class="sc-gKseQn hEEPLy"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-kJFuxL iooZlr"
+      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-cipXqI hrTqzn"
       tabindex="0"
     >
       <div
@@ -52,7 +52,7 @@ exports[`RadioInput renders a simple input 1`] = `
     class="sc-gKseQn hEEPLy"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-kJFuxL iooZlr"
+      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-cipXqI hrTqzn"
       tabindex="0"
     >
       <div
@@ -94,7 +94,7 @@ exports[`RadioInput renders an input with a form field label 1`] = `
     class="sc-gKseQn hEEPLy"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-kJFuxL iooZlr"
+      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-cipXqI hrTqzn"
       tabindex="0"
     >
       <label
@@ -144,7 +144,7 @@ exports[`RadioInput renders an input with a help message 1`] = `
     class="sc-gKseQn hEEPLy"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-kJFuxL iooZlr"
+      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-cipXqI hrTqzn"
       tabindex="0"
     >
       <span
@@ -191,7 +191,7 @@ exports[`RadioInput renders an input with a validation error 1`] = `
     class="sc-gKseQn hEEPLy"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-kJFuxL iooZlr"
+      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-cipXqI hrTqzn"
       tabindex="0"
     >
       <div
@@ -238,7 +238,7 @@ exports[`RadioInput renders an input with an info message 1`] = `
     class="sc-gKseQn hEEPLy"
   >
     <div
-      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-kJFuxL iooZlr"
+      class="StyledBox-sc-13pk1d4-0 jPjcaB FormField__FormFieldBox-m9hood-0 cTSHiS sc-cipXqI hrTqzn"
       tabindex="0"
     >
       <div


### PR DESCRIPTION
Towards giantswarm/giantswarm#18522

This PR adds a different display style for apps that are currently deleted (have the `deletionTimestamp` set). It also introduces sorting to the list of cluster apps. The list is now sorted by the app name in an ascending order, leaving deleted apps at the end of the list (same as clusters on the home page).

## Preview

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/13508038/132222853-110bcaf1-a12f-4ebd-8603-9014c26615ab.png)


</details>