### PR TITLE
Compute namespace if the Organization CR does not have the required status field

### DIFF
--- a/src/stores/main/actions.ts
+++ b/src/stores/main/actions.ts
@@ -53,7 +53,7 @@ import {
 } from 'utils/localStorageUtils';
 
 import { LoggedInUserTypes } from './types';
-import { computePermissions } from './utils';
+import { computePermissions, getNamespaceFromOrgName } from './utils';
 
 export function selectCluster(clusterID: string): MainActions {
   return {
@@ -417,7 +417,9 @@ export function fetchPermissions(
   return async (dispatch, getState) => {
     const orgs = Object.values(selectOrganizations()(getState()));
 
-    const namespaces = orgs.map((o) => o.namespace ?? '');
+    const namespaces = orgs.map(
+      (o) => o.namespace ?? getNamespaceFromOrgName(o.id)
+    );
     // Also get permissions for the default namespace.
     namespaces.push('default');
 

--- a/src/stores/main/actions.ts
+++ b/src/stores/main/actions.ts
@@ -443,7 +443,17 @@ export function fetchPermissions(
       return [namespace, review] as [typeof namespace, typeof review];
     });
 
-    const reviews = await Promise.all(requests);
+    const reviewRequests = await Promise.allSettled(requests);
+    const reviews: [
+      namespace: string,
+      review: authorizationv1.ISelfSubjectRulesReview
+    ][] = [];
+    for (const reviewRequest of reviewRequests) {
+      if (reviewRequest.status === 'fulfilled') {
+        reviews.push(reviewRequest.value);
+      }
+    }
+
     const permissions = computePermissions(reviews);
 
     dispatch(setPermissions(permissions));


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C02MS174K/p1630671483018400

The problem was that we weren't taking into account that `Organization` CRs might not have the `status.namespace` field populated. Which meant that we were creating `SelfSubjectRulesReviews` using empty namespaces (which resulted in errors).

This PR addresses that, by computing the organization name manually if the CR does not provide it. Also, now if one of the `SelfSubjectRulesReview` request fails, we still compute permissions for other namespaces. One failure does no longer mean that we block access to the whole app.