### PR TITLE
Block possibility to edit the `cluster.x-k8s.io/watch-filter` label.

### DIFF
--- a/src/utils/labelUtils.ts
+++ b/src/utils/labelUtils.ts
@@ -162,5 +162,15 @@ export const validateLabelKey: IValidationFunction = (key) => {
     };
   }
 
+  /**
+   * Hide CAPI watch-filter label, because we don't allow editing it at this time.
+   */
+  if (strKey.toLowerCase() === 'cluster.x-k8s.io/watch-filter') {
+    return {
+      isValid: false,
+      validationError: `Key cannot be 'cluster.x-k8s.io/watch-filter'`,
+    };
+  }
+
   return isQualifiedName(strKey);
 };


### PR DESCRIPTION

We don't want the user to edit the `cluster.x-k8s.io/watch-filter` as it will break functionality of CAPI clusters.