### PR TITLE
apps: use normalized app versions for comparisons

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
@@ -28,7 +28,7 @@ import ClusterDetailAppListWidget from 'UI/Display/MAPI/apps/ClusterDetailAppLis
 import Select from 'UI/Inputs/Select';
 import Truncated from 'UI/Util/Truncated';
 
-import { updateAppVersion } from './utils';
+import { normalizeAppVersion, updateAppVersion } from './utils';
 
 interface IClusterDetailAppListWidgetVersionInspectorProps
   extends Omit<
@@ -144,7 +144,12 @@ const ClusterDetailAppListWidgetVersionInspector: React.FC<IClusterDetailAppList
     // Sort in a descending order, showing newest versions first.
     return appCatalogEntryList.items
       .slice()
-      .sort((a, b) => compare(b.spec.version, a.spec.version));
+      .sort((a, b) =>
+        compare(
+          normalizeAppVersion(b.spec.version),
+          normalizeAppVersion(a.spec.version)
+        )
+      );
   }, [appCatalogEntryList]);
 
   const isCurrentVersionSelected = currentSelectedVersion === app?.spec.version;

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -734,6 +734,14 @@ export function isAppChangingVersion(app: applicationv1alpha1.IApp): boolean {
   );
 }
 
+export function normalizeAppVersion(version: string): string {
+  if (version.toLowerCase().startsWith('v')) {
+    return version.substring(1);
+  }
+
+  return version;
+}
+
 export function getLatestVersionForApp(
   apps: applicationv1alpha1.IAppCatalogEntry[],
   appName: string
@@ -745,7 +753,9 @@ export function getLatestVersionForApp(
     }
   }
 
-  return versions.sort((a, b) => compare(b, a))[0];
+  return versions.sort((a, b) =>
+    compare(normalizeAppVersion(b), normalizeAppVersion(a))
+  )[0];
 }
 
 export function isAppCatalogVisibleToUsers(


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18827

The problem: Some versions have a `v` prefix, while others don't.
Solution: Always remove the `v` prefix before doing semver comparisons ✅ 