### PR TITLE
apps: display cluster app status next to app version in collapsed mode

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -4,6 +4,7 @@ import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
 import React, { useLayoutEffect, useRef } from 'react';
 import styled from 'styled-components';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
+import Truncated from 'UI/Util/Truncated';
 
 import ClusterDetailAppListItemStatus from './ClusterDetailAppListItemStatus';
 import ClusterDetailAppListWidgetCatalog from './ClusterDetailAppListWidgetCatalog';
@@ -114,12 +115,14 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
               <Box direction='row' wrap={true} gap='xsmall' align='center'>
                 <OptionalValue value={currentVersion} loaderWidth={100}>
                   {(value) => (
-                    <Text
-                      color='text-weak'
+                    <Truncated
+                      as={Text}
                       aria-label={`App version: ${value}`}
+                      numStart={10}
+                      color='text-weak'
                     >
-                      {value}
-                    </Text>
+                      {value as string}
+                    </Truncated>
                   )}
                 </OptionalValue>
 

--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -5,6 +5,7 @@ import React, { useLayoutEffect, useRef } from 'react';
 import styled from 'styled-components';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 
+import ClusterDetailAppListItemStatus from './ClusterDetailAppListItemStatus';
 import ClusterDetailAppListWidgetCatalog from './ClusterDetailAppListWidgetCatalog';
 import ClusterDetailAppListWidgetConfiguration from './ClusterDetailAppListWidgetConfiguration';
 import ClusterDetailAppListWidgetNamespace from './ClusterDetailAppListWidgetNamespace';
@@ -110,13 +111,20 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
                 Deleted {relativeDate(app.metadata.deletionTimestamp)}
               </Text>
             ) : (
-              <OptionalValue value={currentVersion} loaderWidth={100}>
-                {(value) => (
-                  <Text color='text-weak' aria-label={`App version: ${value}`}>
-                    {value}
-                  </Text>
-                )}
-              </OptionalValue>
+              <Box direction='row' wrap={true} gap='xsmall' align='center'>
+                <OptionalValue value={currentVersion} loaderWidth={100}>
+                  {(value) => (
+                    <Text
+                      color='text-weak'
+                      aria-label={`App version: ${value}`}
+                    >
+                      {value}
+                    </Text>
+                  )}
+                </OptionalValue>
+
+                {app && <ClusterDetailAppListItemStatus app={app} />}
+              </Box>
             )}
           </Box>
         </Header>

--- a/src/components/MAPI/apps/ClusterDetailAppListItemStatus.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItemStatus.tsx
@@ -1,0 +1,102 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { Box, Text } from 'grommet';
+import ErrorReporter from 'lib/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { useHttpClient } from 'lib/hooks/useHttpClient';
+import { extractErrorMessage } from 'MAPI/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import React, { useEffect, useMemo } from 'react';
+import useSWR from 'swr';
+
+import { getLatestVersionForApp, isAppChangingVersion } from './utils';
+
+interface IClusterDetailAppListItemStatusProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  app: applicationv1alpha1.IApp;
+}
+
+const ClusterDetailAppListItemStatus: React.FC<IClusterDetailAppListItemStatusProps> = ({
+  app,
+  ...props
+}) => {
+  const auth = useAuthProvider();
+  const appCatalogEntryListClient = useHttpClient();
+
+  const appCatalogEntryListGetOptions: applicationv1alpha1.IGetAppCatalogEntryListOptions = useMemo(() => {
+    return {
+      labelSelector: {
+        matchingLabels: {
+          [applicationv1alpha1.labelAppName]: app.spec.name,
+          [applicationv1alpha1.labelAppCatalog]: app.spec.catalog,
+        },
+      },
+    };
+  }, [app]);
+
+  const { data: appCatalogEntryList, error: appCatalogEntryListError } = useSWR<
+    applicationv1alpha1.IAppCatalogEntryList,
+    GenericResponseError
+  >(
+    applicationv1alpha1.getAppCatalogEntryListKey(
+      appCatalogEntryListGetOptions
+    ),
+    () =>
+      applicationv1alpha1.getAppCatalogEntryList(
+        appCatalogEntryListClient,
+        auth,
+        appCatalogEntryListGetOptions
+      )
+  );
+
+  useEffect(() => {
+    if (appCatalogEntryListError) {
+      const errorMessage = extractErrorMessage(appCatalogEntryListError);
+
+      new FlashMessage(
+        'There was a problem loading app versions.',
+        messageType.ERROR,
+        messageTTL.FOREVER,
+        errorMessage
+      );
+
+      ErrorReporter.getInstance().notify(appCatalogEntryListError);
+    }
+  }, [appCatalogEntryListError]);
+
+  const isChangingVersion = isAppChangingVersion(app);
+  const hasNewVersion = useMemo(() => {
+    if (!appCatalogEntryList || isChangingVersion) return false;
+
+    const latestVersion = getLatestVersionForApp(
+      appCatalogEntryList.items,
+      app.spec.name
+    );
+
+    return latestVersion && latestVersion !== app.spec.version;
+  }, [app, appCatalogEntryList, isChangingVersion]);
+
+  return (
+    <Box {...props}>
+      {isChangingVersion && (
+        <Text color='status-warning' size='small'>
+          <i
+            className='fa fa-version-upgrade'
+            role='presentation'
+            aria-hidden='true'
+          />{' '}
+          Switching to {app.spec.version}
+        </Text>
+      )}
+
+      {hasNewVersion && (
+        <Text color='status-warning' size='small'>
+          <i className='fa fa-warning' role='presentation' aria-hidden='true' />{' '}
+          Upgrade available
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+export default ClusterDetailAppListItemStatus;

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListItemStatus.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListItemStatus.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import TestOAuth2 from 'lib/OAuth2/TestOAuth2';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import nock from 'nock';
+import React from 'react';
+import { StatusCodes } from 'shared/constants';
+import { cache, SWRConfig } from 'swr';
+import * as applicationv1alpha1Mocks from 'testUtils/mockHttpCalls/applicationv1alpha1';
+import * as capiv1alpha3Mocks from 'testUtils/mockHttpCalls/capiv1alpha3';
+import { getComponentWithStore } from 'testUtils/renderUtils';
+
+import ClusterDetailAppListItemStatus from '../ClusterDetailAppListItemStatus';
+
+function generateApp(
+  name: string = 'some-app',
+  version: string = '1.2.1'
+): applicationv1alpha1.IApp {
+  const namespace = capiv1alpha3Mocks.randomCluster1.metadata.name;
+
+  return {
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'App',
+    metadata: {
+      annotations: {
+        'chart-operator.giantswarm.io/force-helm-upgrade': 'true',
+      },
+      creationTimestamp: new Date().toISOString(),
+      finalizers: ['operatorkit.giantswarm.io/app-operator-app'],
+      generation: 1,
+      labels: {
+        app: name,
+        'app-operator.giantswarm.io/version': '3.2.1',
+        'giantswarm.io/cluster': namespace,
+        'giantswarm.io/managed-by': 'Helm',
+        'giantswarm.io/organization': 'org1',
+        'giantswarm.io/service-type': 'managed',
+      },
+      name,
+      namespace,
+      resourceVersion: '294675096',
+      selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${name}`,
+      uid: '859c4eb1-ece4-4eca-85b2-a4a456b6ae81',
+    },
+    spec: {
+      catalog: 'default',
+      config: {
+        configMap: {
+          name: `${namespace}-cluster-values`,
+          namespace,
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      kubeConfig: {
+        context: {
+          name: `${namespace}-kubeconfig`,
+        },
+        inCluster: false,
+        secret: {
+          name: `${namespace}-kubeconfig`,
+          namespace,
+        },
+      },
+      name,
+      namespace: 'giantswarm',
+      userConfig: {
+        configMap: {
+          name: '',
+          namespace: '',
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      version,
+    },
+    status: {
+      appVersion: '0.4.1',
+      release: {
+        lastDeployed: '2021-04-27T16:21:37Z',
+        status,
+      },
+      version,
+    },
+  };
+}
+
+function getComponent(
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailAppListItemStatus>
+) {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = (p: typeof props) => (
+    <SWRConfig value={{ dedupingInterval: 0 }}>
+      <ClusterDetailAppListItemStatus {...p} />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    props,
+    undefined,
+    undefined,
+    history,
+    auth
+  );
+}
+
+describe('ClusterDetailAppListItemStatus', () => {
+  afterEach(() => {
+    cache.clear();
+  });
+
+  it('renders without crashing', () => {
+    render(getComponent({ app: generateApp() }));
+  });
+
+  it('displays if the app is switching versions', () => {
+    const app = generateApp('some-app', '1.2.3');
+    app.spec.version = '1.3.0';
+
+    render(getComponent({ app }));
+
+    expect(screen.getByText('Switching to 1.3.0')).toBeInTheDocument();
+  });
+
+  it('displays a warning if a newer version is available', async () => {
+    nock(window.config.mapiEndpoint)
+      .get(
+        '/apis/application.giantswarm.io/v1alpha1/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
+      )
+      .reply(
+        StatusCodes.Ok,
+        applicationv1alpha1Mocks.defaultCatalogAppCatalogEntryList
+      );
+
+    const app = generateApp('coredns', '1.1.0');
+    delete app.status;
+
+    render(getComponent({ app }));
+
+    expect(await screen.findByText('Upgrade available')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18826

This PR adds the app version status next to the version in collapsed mode, so you don't have to open each app to see if they need to be updated or if they are updating.

The PR also adds truncation for long pre-release versions displayed in collapsed mode, because with the version status, the text would be too long.

## Preview

![image](https://user-images.githubusercontent.com/13508038/132505241-f471e9a0-1226-430c-911f-6b8afe470411.png)