### PR TITLE
Prevent trying to select an app version when version loading fails

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
@@ -116,8 +116,12 @@ const ClusterDetailAppListWidgetVersionInspector: React.FC<IClusterDetailAppList
 
   useEffect(() => {
     // Select the current app version when everything is loaded.
-    if (!isLoading && typeof currentSelectedVersion === 'undefined') {
-      const entry = appCatalogEntryList!.items.find(
+    if (
+      typeof app !== 'undefined' &&
+      typeof appCatalogEntryList !== 'undefined' &&
+      typeof currentSelectedVersion === 'undefined'
+    ) {
+      const entry = appCatalogEntryList.items.find(
         (e) => e.spec.version === app.spec.version
       );
       if (!entry) {


### PR DESCRIPTION
Sentry issue: [HAPPA-5A](https://sentry.io/organizations/giantswarm/issues/2634389081/?referrer=github_integration)

🤦 