### PR TITLE
Fix: truncate long names in User dropdown UI

### DIFF
--- a/__tests__/Login.tsx
+++ b/__tests__/Login.tsx
@@ -87,7 +87,7 @@ describe('Login', () => {
     // Then I should be logged in and see the home page with no orgs or clusters.
     await waitFor(() => {
       // Verify we are now on the layout page and I can see my username
-      expect(getByText(/developer@giantswarm.io/i)).toBeInTheDocument();
+      expect(getByLabelText(/developer@giantswarm.io/i)).toBeInTheDocument();
       expect(getByText(/Welcome to Giant Swarm!/i)).toBeInTheDocument();
       expect(
         getByText(/There are no organizations yet in your installation./i)

--- a/__tests__/Logout.js
+++ b/__tests__/Logout.js
@@ -33,7 +33,7 @@ it('logging out redirects to the login page', async () => {
   nock(API_ENDPOINT).delete('/v4/auth-tokens/').reply(StatusCodes.Ok);
 
   // Given I am logged in and on the home page.
-  const { getByText } = renderRouteWithStore(MainRoutes.Home);
+  const { getByText, getByLabelText } = renderRouteWithStore(MainRoutes.Home);
 
   // Wait till the app is ready and we're on the home page.
   await waitFor(() => {
@@ -41,7 +41,7 @@ it('logging out redirects to the login page', async () => {
   });
 
   // When I click logout in the user dropdown.
-  const userDropdown = getByText('developer@giantswarm.io');
+  const userDropdown = getByLabelText('developer@giantswarm.io');
   fireEvent.click(userDropdown);
 
   const logoutButton = getByText('Logout');

--- a/__tests__/Users.js
+++ b/__tests__/Users.js
@@ -90,12 +90,8 @@ describe('Users', () => {
         status: 'READY',
       });
 
-    const {
-      findByText,
-      getByText,
-      getByLabelText,
-      getAllByText,
-    } = renderRouteWithStore(UsersRoutes.Home);
+    const { findByText, getByText, getByLabelText, getAllByText } =
+      renderRouteWithStore(UsersRoutes.Home);
 
     let inviteButton = await findByText(/invite user/i);
     expect(inviteButton).toBeInTheDocument();
@@ -110,7 +106,7 @@ describe('Users', () => {
     fireEvent.click(getByLabelText(/organizations/i));
 
     // Select `giantswarm` organizatio
-    fireEvent.click(getByLabelText(/giantswarm/i));
+    fireEvent.click(getByLabelText('giantswarm'));
 
     // Email input validation
 
@@ -200,9 +196,8 @@ describe('Users', () => {
     const expiryDate = within(selectedEmailCell).getByText(/in about 1 year/i);
     expect(expiryDate).toBeInTheDocument();
 
-    let unexpireButton = within(selectedEmailCell).getByTitle(
-      /remove expiration/i
-    );
+    let unexpireButton =
+      within(selectedEmailCell).getByTitle(/remove expiration/i);
     fireEvent.click(unexpireButton);
 
     expect(

--- a/src/components/UI/Controls/Navigation/UserDropdown.tsx
+++ b/src/components/UI/Controls/Navigation/UserDropdown.tsx
@@ -93,7 +93,9 @@ const UserDropdown: React.FC<IUserDropdownProps> = ({ user }) => {
               type='button'
             >
               <StyledGravatar default='mm' email={user.email} size={100} />
-              <Truncated tooltipPlacement='bottom'>{user.email}</Truncated>
+              <Truncated tooltipPlacement='bottom' aria-label={user.email}>
+                {user.email}
+              </Truncated>
               <span className='caret' />
             </StyledDropdownTrigger>
             {isOpen && (

--- a/src/components/UI/Controls/Navigation/UserDropdown.tsx
+++ b/src/components/UI/Controls/Navigation/UserDropdown.tsx
@@ -5,6 +5,7 @@ import { AuthorizationTypes } from 'shared/constants';
 import { AccountSettingsRoutes, MainRoutes } from 'shared/constants/routes';
 import styled from 'styled-components';
 import DropdownMenu, { DropdownTrigger, List } from 'UI/Controls/DropdownMenu';
+import Truncated from 'UI/Util/Truncated';
 
 const Wrapper = styled.div`
   display: flex;
@@ -92,7 +93,7 @@ const UserDropdown: React.FC<IUserDropdownProps> = ({ user }) => {
               type='button'
             >
               <StyledGravatar default='mm' email={user.email} size={100} />
-              <span>{user.email}</span>
+              <Truncated tooltipPlacement='bottom'>{user.email}</Truncated>
               <span className='caret' />
             </StyledDropdownTrigger>
             {isOpen && (


### PR DESCRIPTION
Closes [giantswarm/giantswarm#18874](https://github.com/giantswarm/giantswarm/issues/18874).

Long names in the User dropdown menu are truncated so they don't break the UI.

<img width="411" alt="Screen Shot 2021-09-10 at 10 50 10" src="https://user-images.githubusercontent.com/62935115/132834741-a07c8f3d-f788-453f-a9b6-369165786858.png">
Tooltip shows the full name on hover:
<img width="453" alt="Screen Shot 2021-09-10 at 10 50 33" src="https://user-images.githubusercontent.com/62935115/132834694-e1b88923-186e-4718-9dda-088dae6fce8c.png">

