### PR TITLE
Use consistent labelling in the role listing CLI guide

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/guides/ListRolesGuide.tsx
+++ b/src/components/MAPI/organizations/AccessControl/guides/ListRolesGuide.tsx
@@ -69,7 +69,7 @@ const ListRolesGuide: React.FC<IListRolesGuideProps> = ({
               namespace
             </>
           }
-          command={`kubectl get roles -n ${namespace}`}
+          command={`kubectl get roles -n ${namespace} -l ui.giantswarm.io/display=true`}
         />
       </CLIGuideStepList>
     </CLIGuide>


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18361

We use the `ui.giantswarm.io/display=true` label selector to display Roles/ClusterRoles in the UI, so let's also include it in the command examples.