### PR TITLE
apps: display error details when YAML validation fails

### DIFF
--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -7,6 +7,7 @@ import ErrorReporter from 'lib/errors/ErrorReporter';
 import useDebounce from 'lib/hooks/useDebounce';
 import RoutePath from 'lib/routePath';
 import lunr from 'lunr';
+import { formatYAMLError } from 'MAPI/apps/utils';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { OrganizationsRoutes } from 'shared/constants/routes';
@@ -201,7 +202,7 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
         setValuesYAML(parsedYAML);
         setValuesYAMLError('');
       } catch (err) {
-        setValuesYAMLError('Unable to parse valid YAML from this file.');
+        setValuesYAMLError(formatYAMLError(err));
       }
     };
 
@@ -225,7 +226,7 @@ const InstallAppModal: React.FC<IInstallAppModalProps> = (props) => {
         setSecretsYAML(parsedYAML);
         setSecretsYAMLError('');
       } catch (err) {
-        setSecretsYAMLError('Unable to parse valid YAML from this file.');
+        setSecretsYAMLError(formatYAMLError(err));
       }
     };
 

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload.tsx
@@ -1,5 +1,6 @@
 import yaml from 'js-yaml';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { formatYAMLError } from 'MAPI/apps/utils';
 import React, { useRef, useState } from 'react';
 import Button from 'UI/Controls/Button';
 
@@ -38,10 +39,13 @@ const YAMLFileUpload: React.FC<IYAMLFileUploadProps> = ({
           setFileUploading(false);
         });
       } catch (err) {
+        const errorMessage = formatYAMLError(err);
+
         new FlashMessage(
           'Unable to parse valid YAML from this file. Please validate that it is a valid YAML file and try again.',
           messageType.ERROR,
-          messageTTL.MEDIUM
+          messageTTL.MEDIUM,
+          errorMessage
         );
 
         setFileUploading(false);

--- a/src/components/MAPI/apps/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/AppInstallModal.tsx
@@ -27,7 +27,7 @@ import Button from 'UI/Controls/Button';
 import { IVersion } from 'UI/Controls/VersionPicker/VersionPickerUtils';
 import ClusterIDLabel from 'UI/Display/Cluster/ClusterIDLabel';
 
-import { createApp, filterClusters } from './utils';
+import { createApp, filterClusters, formatYAMLError } from './utils';
 
 function getOrganizationForCluster(
   cluster: Cluster,
@@ -206,7 +206,7 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
         setValuesYAML(yaml.dump(parsedYAML));
         setValuesYAMLError('');
       } catch (err) {
-        setValuesYAMLError('Unable to parse valid YAML from this file.');
+        setValuesYAMLError(formatYAMLError(err));
       }
     };
 
@@ -230,7 +230,7 @@ const AppInstallModal: React.FC<IAppInstallModalProps> = (props) => {
         setSecretsYAML(yaml.dump(parsedYAML));
         setSecretsYAMLError('');
       } catch (err) {
-        setSecretsYAMLError('Unable to parse valid YAML from this file.');
+        setSecretsYAMLError(formatYAMLError(err));
       }
     };
 

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -1,4 +1,5 @@
 import produce from 'immer';
+import { YAMLException } from 'js-yaml';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { HttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
@@ -802,4 +803,29 @@ export function compareApps(
   }
 
   return a.metadata.name.localeCompare(b.metadata.name);
+}
+
+export function formatYAMLError(err: unknown): string {
+  if (err instanceof YAMLException) {
+    interface IYAMLExceptionInternals extends YAMLException {
+      mark: {
+        line: number;
+        column: number;
+      };
+      reason: string;
+    }
+
+    const { reason, mark } = err as IYAMLExceptionInternals;
+    let { line, column } = mark;
+    /**
+     * Lines and columns are counted from 1, but the library
+     * counts from 0.
+     */
+    line++;
+    column++;
+
+    return `YAML parse error: ${reason} (${line}:${column})`;
+  }
+
+  return String(err);
 }


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/17553

This PR exposes the actual reasons for why YAML validation failed when uploading app values/secrets. This is handled on app installation and app updating. It is also implemented for the GS API UI, not because I wanted to, but because the `YAMLFileUpload` component is shared between the GS API and MAPI implementations, so it was actually easier to have everything consistent.

## Preview

#### Before

![image](https://user-images.githubusercontent.com/13508038/132847124-1128181e-5d60-45f2-9811-b3e14e83d28f.png)

#### After

![image](https://user-images.githubusercontent.com/13508038/132846727-54acc747-4c4c-4b9f-8116-a647c36a7c0e.png)
