### PR TITLE
Use CircleCI convenience image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 defaults: &defaults
   working_directory: ~/happa
   docker:
-    - image: circleci/node:16-buster
+    - image: cimg/node:16.8
 
 job_filters: &job_filters
   filters:


### PR DESCRIPTION
The legacy `circleci/node` images have been deprecated

https://circleci.com/developer/images/image/cimg/node