### PR TITLE
Remove "What's changed" headline from release notes template

### DIFF
--- a/.github/release-template.yml
+++ b/.github/release-template.yml
@@ -28,6 +28,4 @@ exclude-labels:
 
 change-template: '- $TITLE (#$NUMBER)'
 template: |
-  ## What's changed
-
   $CHANGES


### PR DESCRIPTION
This removes the `## What's changed` headline from the release notes template. I usually remove it manually anyway since it's not needed. Release notes are expected to talk about changes, and the sub headlines like `## Added` and `## Changed` give enough structure.