### PR TITLE
Align flash messages for updating installed apps

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
@@ -218,7 +218,7 @@ const ClusterDetailAppListWidgetVersionInspector: React.FC<IClusterDetailAppList
         new FlashMessage(
           `<code>${app.metadata.name}</code> on cluster <code>${app.metadata.namespace}</code> will be ${updateAction} to version <code>${truncatedVersion}</code>.`,
           messageType.SUCCESS,
-          messageTTL.SHORT
+          messageTTL.LONG
         );
       } catch (err) {
         setAppUpdateIsLoading(false);

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
@@ -2,6 +2,7 @@ import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { Box, Text } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { truncate } from 'lib/helpers';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
 import RoutePath from 'lib/routePath';
 import { compare } from 'lib/semver';
@@ -37,6 +38,9 @@ interface IClusterDetailAppListWidgetVersionInspectorProps
   > {
   app?: applicationv1alpha1.IApp;
 }
+
+const TRUNCATE_START_CHARS = 10;
+const TRUNCATE_END_CHARS = 5;
 
 const ClusterDetailAppListWidgetVersionInspector: React.FC<IClusterDetailAppListWidgetVersionInspectorProps> =
   ({ app, ...props }) => {
@@ -202,8 +206,17 @@ const ClusterDetailAppListWidgetVersionInspector: React.FC<IClusterDetailAppList
         setAppUpdateIsLoading(false);
         handleCancelSwitchingVersion();
 
+        const truncatedVersion = truncate(
+          currentSelectedVersion,
+          '…',
+          TRUNCATE_START_CHARS,
+          TRUNCATE_END_CHARS
+        );
+
+        const updateAction = isUpgrading ? 'upgraded' : 'downgraded';
+
         new FlashMessage(
-          `App <code>${app.metadata.name}</code> on <code>${app.metadata.namespace}</code> has been updated. Changes might take some time to take effect.`,
+          `<code>${app.metadata.name}</code> on cluster <code>${app.metadata.namespace}</code> will be ${updateAction} to version <code>${truncatedVersion}</code>.`,
           messageType.SUCCESS,
           messageTTL.SHORT
         );
@@ -291,11 +304,11 @@ const ClusterDetailAppListWidgetVersionInspector: React.FC<IClusterDetailAppList
                   variant={ClusterIDLabelType.Name}
                 />{' '}
                 from version{' '}
-                <Truncated as='code' numStart={10}>
+                <Truncated as='code' numStart={TRUNCATE_START_CHARS}>
                   {app?.spec.version ?? ''}
                 </Truncated>{' '}
                 to{' '}
-                <Truncated as='code' numStart={10}>
+                <Truncated as='code' numStart={TRUNCATE_START_CHARS}>
                   {currentSelectedVersion ?? ''}
                 </Truncated>
                 ?

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetVersionInspector.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetVersionInspector.tsx
@@ -279,7 +279,7 @@ describe('ClusterDetailAppListWidgetVersionInspector', () => {
     );
 
     await withMarkup(screen.findByText)(
-      `App ${app.metadata.name} on ${app.metadata.namespace} has been updated. Changes might take some time to take effect.`
+      `${app.metadata.name} on cluster ${app.metadata.namespace} will be upgraded to version ${newVersion}.`
     );
   });
 
@@ -342,7 +342,7 @@ describe('ClusterDetailAppListWidgetVersionInspector', () => {
     );
 
     await withMarkup(screen.findByText)(
-      `App ${app.metadata.name} on ${app.metadata.namespace} has been updated. Changes might take some time to take effect.`
+      `${app.metadata.name} on cluster ${app.metadata.namespace} will be downgraded to version ${newVersion}.`
     );
   });
 });


### PR DESCRIPTION
Closes [giantswarm/giantswarm#18967](https://github.com/giantswarm/giantswarm/issues/18967).

The messages for successfully updating an installed app are aligned with other information shown in the UI. The length of time for which the flash messages are displayed is also increased, and they are visible for the same amount of time as an unsuccessful update message.

The messages can still be pinned by pointing the cursor on the message (no changes needed here).

Successful upgrade:
<img width="336" alt="Screen Shot 2021-09-17 at 12 08 28" src="https://user-images.githubusercontent.com/62935115/133768552-c7c86c98-c83e-48e4-b172-a4c811c8f547.png">

Successful downgrade:
<img width="336" alt="Screen Shot 2021-09-17 at 12 08 44" src="https://user-images.githubusercontent.com/62935115/133768547-aed3993e-7efb-4b6d-869a-29b3871d4cec.png">