### PR TITLE
Only display the `Users` page to admins, and only if customer SSO is disabled

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -60,7 +60,7 @@ class Layout extends React.Component {
     const showApps =
       supportsAppsViaMapi || Object.keys(this.props.catalogs.items).length > 0;
 
-    const showUsers = !featureFlags.flags.CustomerSSO.enabled;
+    const showUsers = !featureFlags.flags.CustomerSSO.enabled && user?.isAdmin;
 
     return (
       <DocumentTitle>


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18978

Just something I broke in a previous PR ✅ 