### PR TITLE
Fix semver comparison

### DIFF
--- a/src/lib/__tests__/semver.ts
+++ b/src/lib/__tests__/semver.ts
@@ -54,5 +54,21 @@ describe('semver', () => {
         '47.48.11.2',
       ]);
     });
+
+    it('compares versions with the same version number and different labels', () => {
+      const versionA = '1.2.0-alpha';
+      const versionB = '1.2.0-beta';
+
+      expect(compare(versionA, versionB)).toEqual(-1);
+      expect(compare(versionB, versionA)).toEqual(1);
+    });
+
+    it('compares versions with the same version number, one without a label', () => {
+      const versionA = '1.2.0-alpha';
+      const versionB = '1.2.0';
+
+      expect(compare(versionA, versionB)).toEqual(-1);
+      expect(compare(versionB, versionA)).toEqual(1);
+    });
   });
 });

--- a/src/lib/semver.ts
+++ b/src/lib/semver.ts
@@ -37,7 +37,7 @@ export function compare(a: string, b: string): -1 | 0 | 1 {
    */
   switch (true) {
     case aParts[1] && bParts[1] && aParts[1] > bParts[1]:
-    case !aParts[1] && bParts[1]:
+    case bParts[1] && !aParts[1]:
       return 1;
 
     case aParts[1] && bParts[1] && aParts[1] < bParts[1]:


### PR DESCRIPTION
When comparing a version without labels (e.g. `12.0.0`) to a version of the same number with labels (e.g. `12.0.0-something`), the `compare` function is returning "0", indicating that the versions are equal. This creates a bug where it is not possible to downgrade an app's version:

<img width="1168" alt="Screen Shot 2021-09-28 at 09 30 22" src="https://user-images.githubusercontent.com/62935115/135044730-ebf75904-bf5f-4bd7-836e-207151d57051.png">

This is fixed by changing the order of operands in the logical operation so that the last value returned is a boolean.

