### PR TITLE
Add alpha support for node pools on CAPZ clusters

### DIFF
--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -13,7 +13,6 @@ import {
 import { fetchProviderClusterForClusterKey, IMachineType } from 'MAPI/utils';
 import { IHttpClient } from 'model/clients/HttpClient';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
-import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
 import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
 import * as corev1 from 'model/services/mapi/corev1';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
@@ -21,9 +20,7 @@ import { Constants, Providers } from 'shared/constants';
 import { PropertiesOf } from 'shared/types';
 import { mutate } from 'swr';
 
-export function getWorkerNodesCount(
-  nodePools?: capiv1alpha3.IMachineDeployment[] | capiexpv1alpha3.IMachinePool[]
-) {
+export function getWorkerNodesCount(nodePools?: NodePool[]) {
   if (!nodePools) return undefined;
 
   let count = 0;

--- a/src/components/MAPI/types.ts
+++ b/src/components/MAPI/types.ts
@@ -1,7 +1,9 @@
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
+import * as capiv1alpha4 from 'model/services/mapi/capiv1alpha4';
 import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
+import * as capzv1alpha4 from 'model/services/mapi/capzv1alpha4';
 import * as gscorev1alpha1 from 'model/services/mapi/gscorev1alpha1';
 
 export type ControlPlaneNode = capzv1alpha3.IAzureMachine;
@@ -18,14 +20,21 @@ export type ProviderClusterList = capzv1alpha3.IAzureClusterList;
 
 export type NodePool =
   | capiv1alpha3.IMachineDeployment
-  | capiexpv1alpha3.IMachinePool;
+  | capiexpv1alpha3.IMachinePool
+  | capiv1alpha4.IMachinePool;
 
 export type NodePoolList =
   | capiv1alpha3.IMachineDeploymentList
-  | capiexpv1alpha3.IMachinePoolList;
+  | capiexpv1alpha3.IMachinePoolList
+  | capiv1alpha4.IMachinePoolList;
 
-export type ProviderNodePool = capzexpv1alpha3.IAzureMachinePool | undefined;
+export type ProviderNodePool =
+  | capzexpv1alpha3.IAzureMachinePool
+  | capzv1alpha4.IAzureMachinePool
+  | undefined;
 
-export type ProviderNodePoolList = capzexpv1alpha3.IAzureMachinePoolList;
+export type ProviderNodePoolList =
+  | capzexpv1alpha3.IAzureMachinePoolList
+  | capzv1alpha4.IAzureMachinePoolList;
 
 export type BootstrapConfig = gscorev1alpha1.ISpark;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -491,7 +491,10 @@ interface INodesStatus {
   current: number;
 }
 
-export function getNodePoolScaling(nodePool: NodePool): INodesStatus {
+export function getNodePoolScaling(
+  nodePool: NodePool,
+  providerNodePool: ProviderNodePool
+): INodesStatus {
   switch (nodePool.apiVersion) {
     case 'exp.cluster.x-k8s.io/v1alpha3': {
       const status: INodesStatus = {
@@ -518,7 +521,11 @@ export function getNodePoolScaling(nodePool: NodePool): INodesStatus {
         current: -1,
       };
 
-      [status.min, status.max] = capiv1alpha4.getMachinePoolScaling(nodePool);
+      if (providerNodePool) {
+        [status.min, status.max] = capzv1alpha4.getAzureMachinePoolScaling(
+          providerNodePool as capzv1alpha4.IAzureMachinePool
+        );
+      }
 
       status.desired = nodePool.status?.replicas ?? -1;
       status.current = nodePool.status?.readyReplicas ?? -1;

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -12,6 +12,7 @@ import {
   fetchProviderClusterForClusterKey,
   fetchProviderNodePoolsForNodePools,
   fetchProviderNodePoolsForNodePoolsKey,
+  isNodePoolMngmtReadOnly,
 } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
@@ -305,6 +306,8 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
       setIsCreateFormOpen(false);
     };
 
+    const isReadOnly = cluster && isNodePoolMngmtReadOnly(cluster);
+
     return (
       <DocumentTitle title={`Worker Nodes | ${clusterId}`}>
         <Breadcrumb
@@ -389,6 +392,7 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
                         key={idx}
                         additionalColumns={additionalColumns}
                         margin={{ bottom: 'small' }}
+                        readOnly={isReadOnly}
                       />
                     ))}
 
@@ -410,6 +414,7 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
                               providerNodePool={providerNodePools?.[idx]}
                               additionalColumns={additionalColumns}
                               margin={{ bottom: 'small' }}
+                              readOnly={isReadOnly}
                             />
                           </BaseTransition>
                         ))}
@@ -437,7 +442,7 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
                   <Box animation={{ type: 'fadeIn', duration: 300 }}>
                     <Button
                       onClick={handleOpenCreateForm}
-                      disabled={!cluster || !providerCluster}
+                      disabled={!cluster || !providerCluster || isReadOnly}
                     >
                       <i
                         className='fa fa-add-circle'
@@ -471,12 +476,17 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
                     provider
                   )}
                 />
-                <ModifyNodePoolGuide
-                  clusterNamespace={cluster.metadata.namespace!}
-                />
-                <DeleteNodePoolGuide
-                  clusterNamespace={cluster.metadata.namespace!}
-                />
+
+                {!isReadOnly && (
+                  <>
+                    <ModifyNodePoolGuide
+                      clusterNamespace={cluster.metadata.namespace!}
+                    />
+                    <DeleteNodePoolGuide
+                      clusterNamespace={cluster.metadata.namespace!}
+                    />
+                  </>
+                )}
               </Box>
             )}
           </Box>

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -458,6 +458,7 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
                 <WorkerNodesNodePoolListPlaceholder
                   animation={{ type: 'fadeIn', duration: 300 }}
                   onCreateButtonClick={handleOpenCreateForm}
+                  disabled={isReadOnly}
                 />
               )}
             </Box>
@@ -478,14 +479,14 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
                 />
 
                 {!isReadOnly && (
-                  <>
-                    <ModifyNodePoolGuide
-                      clusterNamespace={cluster.metadata.namespace!}
-                    />
-                    <DeleteNodePoolGuide
-                      clusterNamespace={cluster.metadata.namespace!}
-                    />
-                  </>
+                  <ModifyNodePoolGuide
+                    clusterNamespace={cluster.metadata.namespace!}
+                  />
+                )}
+                {!isReadOnly && (
+                  <DeleteNodePoolGuide
+                    clusterNamespace={cluster.metadata.namespace!}
+                  />
                 )}
               </Box>
             )}

--- a/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesAzureMachinePoolSpotInstances.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from 'grommet';
+import { ProviderNodePool } from 'MAPI/types';
 import {
   getProviderNodePoolSpotInstances,
   INodePoolSpotInstancesAzure,
@@ -9,7 +10,7 @@ import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 
 interface IWorkerNodesAzureMachinePoolSpotInstancesProps {
-  providerNodePool?: capzexpv1alpha3.IAzureMachinePool;
+  providerNodePool?: ProviderNodePool;
 }
 
 const WorkerNodesAzureMachinePoolSpotInstances: React.FC<IWorkerNodesAzureMachinePoolSpotInstancesProps> =

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -267,7 +267,7 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
     state.providerNodePool
   ) as INodePoolSpotInstancesAzure;
   const nodePoolAZs = getNodePoolAvailabilityZones(state.nodePool);
-  const scaling = getNodePoolScaling(state.nodePool);
+  const scaling = getNodePoolScaling(state.nodePool, state.providerNodePool);
 
   return (
     <Collapsible {...props}>

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolScale.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolScale.tsx
@@ -13,7 +13,15 @@ interface IWorkerNodesCreateNodePoolScaleProps
     > {}
 
 const WorkerNodesCreateNodePoolScale: React.FC<IWorkerNodesCreateNodePoolScaleProps> =
-  ({ id, nodePool, onChange, readOnly, disabled, ...props }) => {
+  ({
+    id,
+    nodePool,
+    providerNodePool,
+    onChange,
+    readOnly,
+    disabled,
+    ...props
+  }) => {
     const isMinValid = useRef(false);
     const isMaxValid = useRef(false);
 
@@ -36,7 +44,7 @@ const WorkerNodesCreateNodePoolScale: React.FC<IWorkerNodesCreateNodePoolScalePr
       });
     };
 
-    const value = getNodePoolScaling(nodePool);
+    const value = getNodePoolScaling(nodePool, providerNodePool);
 
     return (
       <InputGroup htmlFor={id} label='Scaling range' {...props}>

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -97,8 +97,8 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
   const scaling = useMemo(() => {
     if (!nodePool) return undefined;
 
-    return getNodePoolScaling(nodePool);
-  }, [nodePool]);
+    return getNodePoolScaling(nodePool, providerNodePool);
+  }, [nodePool, providerNodePool]);
 
   const isScalingInProgress = scaling && scaling.desired !== scaling.current;
 
@@ -356,6 +356,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
         <Box margin={{ top: isScaleConfirmOpen ? 'small' : undefined }}>
           <WorkerNodesNodePoolItemScale
             nodePool={nodePool}
+            providerNodePool={providerNodePool}
             onConfirm={onCancelScale}
             onCancel={onCancelScale}
             open={isScaleConfirmOpen}

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -74,12 +74,14 @@ interface IWorkerNodesNodePoolItemProps
   nodePool?: NodePool;
   providerNodePool?: ProviderNodePool;
   additionalColumns?: IWorkerNodesAdditionalColumn[];
+  readOnly?: boolean;
 }
 
 const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
   nodePool,
   providerNodePool,
   additionalColumns,
+  readOnly,
   ...props
 }) => {
   const clientFactory = useHttpClientFactory();
@@ -234,6 +236,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
                   onSave={updateDescription}
                   ref={viewAndEditNameRef}
                   variant={ViewAndEditNameVariant.Description}
+                  readOnly={readOnly}
                 />
               )
             }
@@ -330,6 +333,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
               <WorkerNodesNodePoolActions
                 onDeleteClick={onDelete}
                 onScaleClick={onScale}
+                disabled={readOnly}
               />
             </Box>
           </>

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemScale.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemScale.tsx
@@ -3,7 +3,7 @@ import { Box, Text } from 'grommet';
 import ErrorReporter from 'lib/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { useHttpClientFactory } from 'lib/hooks/useHttpClientFactory';
-import { NodePool } from 'MAPI/types';
+import { NodePool, ProviderNodePool } from 'MAPI/types';
 import { extractErrorMessage, getNodePoolScaling } from 'MAPI/utils';
 import React, { useMemo, useState } from 'react';
 import NodeCountSelector from 'shared/NodeCountSelector';
@@ -76,13 +76,14 @@ function getSubmitButtonAttributes(fromValue: {
 interface IWorkerNodesNodePoolItemScaleProps
   extends React.ComponentPropsWithoutRef<typeof ConfirmationPrompt> {
   nodePool: NodePool;
+  providerNodePool: ProviderNodePool;
 }
 
 const WorkerNodesNodePoolItemScale: React.FC<IWorkerNodesNodePoolItemScaleProps> =
-  ({ nodePool, onConfirm, onCancel, open, ...props }) => {
+  ({ nodePool, providerNodePool, onConfirm, onCancel, open, ...props }) => {
     const initialScaling = useMemo(
-      () => getNodePoolScaling(nodePool),
-      [nodePool]
+      () => getNodePoolScaling(nodePool, providerNodePool),
+      [nodePool, providerNodePool]
     );
 
     const [scalingMin, setScalingMin] = useState(initialScaling.min);

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -19,7 +19,7 @@ export async function updateNodePoolDescription(
   nodePool: NodePool,
   newDescription: string
 ) {
-  if (nodePool.kind === capiexpv1alpha3.MachinePool) {
+  if (nodePool.apiVersion === 'exp.cluster.x-k8s.io/v1alpha3') {
     let machinePool = await capiexpv1alpha3.getMachinePool(
       httpClient,
       auth,
@@ -72,7 +72,7 @@ export async function deleteNodePool(
   auth: IOAuth2Provider,
   nodePool: NodePool
 ) {
-  if (nodePool.kind === capiexpv1alpha3.MachinePool) {
+  if (nodePool.apiVersion === 'exp.cluster.x-k8s.io/v1alpha3') {
     const machinePool = await capiexpv1alpha3.getMachinePool(
       httpClient,
       auth,
@@ -130,7 +130,7 @@ export async function updateNodePoolScaling(
   min: number,
   max: number
 ) {
-  if (nodePool.kind === capiexpv1alpha3.MachinePool) {
+  if (nodePool.apiVersion === 'exp.cluster.x-k8s.io/v1alpha3') {
     let machinePool = await capiexpv1alpha3.getMachinePool(
       httpClient,
       auth,
@@ -295,7 +295,10 @@ export function createDefaultNodePool(config: {
   providerNodePool: ProviderNodePool;
   bootstrapConfig: BootstrapConfig;
 }) {
-  if (config.providerNodePool?.kind === capzexpv1alpha3.AzureMachinePool) {
+  if (
+    config.providerNodePool?.apiVersion ===
+    'exp.infrastructure.cluster.x-k8s.io/v1alpha3'
+  ) {
     return createDefaultMachinePool(config);
   }
 
@@ -366,7 +369,10 @@ export async function createNodePool(
   providerNodePool: ProviderNodePool;
   bootstrapConfig: BootstrapConfig;
 }> {
-  if (config.providerNodePool?.kind === capzexpv1alpha3.AzureMachinePool) {
+  if (
+    config.providerNodePool?.apiVersion ===
+    'exp.infrastructure.cluster.x-k8s.io/v1alpha3'
+  ) {
     const bootstrapConfig = await gscorev1alpha1.createSpark(
       httpClient,
       auth,

--- a/src/components/UI/Controls/DropdownMenu.tsx
+++ b/src/components/UI/Controls/DropdownMenu.tsx
@@ -51,10 +51,14 @@ export const DropdownTrigger = styled.button`
   &:focus {
     outline: 5px auto -webkit-focus-ring-color;
   }
-  &:hover,
+  &:hover:not(:disabled),
   &:focus,
   &:focus-within {
     background: ${(props) => props.theme.colors.shade8};
+  }
+
+  &:disabled {
+    color: ${({ theme }) => theme.global.colors['text-xweak'].dark};
   }
 `;
 

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolActions.tsx
@@ -15,10 +15,11 @@ interface IWorkerNodesNodePoolActionsProps
   extends React.ComponentPropsWithoutRef<'div'> {
   onDeleteClick?: () => void;
   onScaleClick?: () => void;
+  disabled?: boolean;
 }
 
 const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> =
-  ({ onDeleteClick, onScaleClick, ...props }) => {
+  ({ onDeleteClick, onScaleClick, disabled, ...props }) => {
     const handleListKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
       e.stopPropagation();
       e.preventDefault();
@@ -44,6 +45,7 @@ const WorkerNodesNodePoolActions: React.FC<IWorkerNodesNodePoolActionsProps> =
               onKeyDown={onKeyDownHandler}
               type='button'
               aria-label='Actions'
+              disabled={disabled}
             >
               &bull;&bull;&bull;
             </StyledDropdownTrigger>

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolListPlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolListPlaceholder.tsx
@@ -5,10 +5,11 @@ import Button from 'UI/Controls/Button';
 interface IWorkerNodesNodePoolListPlaceholderProps
   extends React.ComponentPropsWithoutRef<typeof Box> {
   onCreateButtonClick?: () => void;
+  disabled?: boolean;
 }
 
 const WorkerNodesNodePoolListPlaceholder: React.FC<IWorkerNodesNodePoolListPlaceholderProps> =
-  ({ onCreateButtonClick, ...props }) => {
+  ({ onCreateButtonClick, disabled, ...props }) => {
     return (
       <Box
         background='background-back'
@@ -23,7 +24,7 @@ const WorkerNodesNodePoolListPlaceholder: React.FC<IWorkerNodesNodePoolListPlace
           </Text>
         </Box>
         <Box>
-          <Button onClick={onCreateButtonClick}>
+          <Button onClick={onCreateButtonClick} disabled={disabled}>
             <i
               className='fa fa-add-circle'
               role='presentation'

--- a/src/components/UI/Inputs/ViewEditName.tsx
+++ b/src/components/UI/Inputs/ViewEditName.tsx
@@ -20,6 +20,7 @@ interface IViewAndEditNameProps extends React.ComponentPropsWithRef<'span'> {
   onSave(value: string): void;
   onToggleEditingState?(editing: boolean): void;
   variant?: ViewAndEditNameVariant;
+  readOnly?: boolean;
 }
 
 interface IViewAndEditNameState {
@@ -187,8 +188,15 @@ class ViewAndEditName extends Component<
   };
 
   render() {
-    const { typeLabel, value, onSave, onToggleEditingState, variant, ...rest } =
-      this.props;
+    const {
+      typeLabel,
+      value,
+      onSave,
+      onToggleEditingState,
+      variant,
+      readOnly,
+      ...rest
+    } = this.props;
     const { errorMessage } = this.state;
     const hasError = errorMessage !== '';
 
@@ -246,18 +254,22 @@ class ViewAndEditName extends Component<
         onEnter={this.handleFocusKeyDown}
       >
         <span tabIndex={0} {...rest}>
-          <OverlayTrigger
-            overlay={
-              <Tooltip id='tooltip'>
-                Click to edit {typeLabel} {variant}
-              </Tooltip>
-            }
-            placement='top'
-          >
-            <NameLabel onClick={this.activateEditMode}>
-              {this.state.value}
-            </NameLabel>
-          </OverlayTrigger>
+          {readOnly && this.state.value}
+
+          {!readOnly && (
+            <OverlayTrigger
+              overlay={
+                <Tooltip id='tooltip'>
+                  Click to edit {typeLabel} {variant}
+                </Tooltip>
+              }
+              placement='top'
+            >
+              <NameLabel onClick={this.activateEditMode}>
+                {this.state.value}
+              </NameLabel>
+            </OverlayTrigger>
+          )}
         </span>
       </Keyboard>
     );

--- a/src/model/services/mapi/capiv1alpha4/createMachinePool.ts
+++ b/src/model/services/mapi/capiv1alpha4/createMachinePool.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { createResource } from '../generic/createResource';
+import { IMachinePool } from './';
+
+export function createMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  machinePool: IMachinePool
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha4',
+    kind: 'machinepools',
+    namespace: machinePool.metadata.namespace!,
+    name: machinePool.metadata.name,
+  } as k8sUrl.IK8sUpdateOptions);
+
+  return createResource<IMachinePool>(
+    client,
+    auth,
+    url.toString(),
+    machinePool
+  );
+}

--- a/src/model/services/mapi/capiv1alpha4/deleteMachinePool.ts
+++ b/src/model/services/mapi/capiv1alpha4/deleteMachinePool.ts
@@ -1,0 +1,22 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { deleteResource } from '../generic/deleteResource';
+import { IMachinePool } from './types';
+
+export function deleteMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  cluster: IMachinePool
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha4',
+    kind: 'machinepools',
+    namespace: cluster.metadata.namespace,
+    name: cluster.metadata.name,
+  } as k8sUrl.IK8sDeleteOptions);
+
+  return deleteResource(client, auth, url.toString());
+}

--- a/src/model/services/mapi/capiv1alpha4/getMachinePool.ts
+++ b/src/model/services/mapi/capiv1alpha4/getMachinePool.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { getResource } from '../generic/getResource';
+import { IMachinePool } from './types';
+
+export function getMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  name: string
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha4',
+    kind: 'machinepools',
+    namespace,
+    name,
+  });
+
+  return getResource<IMachinePool>(client, auth, url.toString());
+}
+
+export function getMachinePoolKey(namespace: string, name: string) {
+  return `getMachinePool/capiv1alpha4/${namespace}/${name}`;
+}

--- a/src/model/services/mapi/capiv1alpha4/getMachinePoolList.ts
+++ b/src/model/services/mapi/capiv1alpha4/getMachinePoolList.ts
@@ -1,0 +1,37 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { getResource } from '../generic/getResource';
+import { IMachinePoolList } from './types';
+
+export interface IGetMachinePoolListOptions {
+  namespace?: string;
+  labelSelector?: k8sUrl.IK8sLabelSelector;
+}
+
+export function getMachinePoolList(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  options?: IGetMachinePoolListOptions
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha4',
+    kind: 'machinepools',
+    ...options,
+  });
+
+  return getResource<IMachinePoolList>(client, auth, url.toString());
+}
+
+export function getMachinePoolListKey(options?: IGetMachinePoolListOptions) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha4',
+    kind: 'machinepools',
+    ...options,
+  });
+
+  return url.toString();
+}

--- a/src/model/services/mapi/capiv1alpha4/index.ts
+++ b/src/model/services/mapi/capiv1alpha4/index.ts
@@ -1,0 +1,7 @@
+export * from './types';
+export * from './key';
+export * from './getMachinePoolList';
+export * from './getMachinePool';
+export * from './updateMachinePool';
+export * from './deleteMachinePool';
+export * from './createMachinePool';

--- a/src/model/services/mapi/capiv1alpha4/key.ts
+++ b/src/model/services/mapi/capiv1alpha4/key.ts
@@ -1,0 +1,38 @@
+import { Constants } from 'shared/constants';
+
+import { IMachinePool } from './types';
+
+export const labelClusterName = 'cluster.x-k8s.io/cluster-name';
+export const labelMachinePool = 'giantswarm.io/machine-pool';
+
+export const annotationMachinePoolDescription =
+  'machine-pool.giantswarm.io/name';
+export const annotationMachinePoolMinSize =
+  'cluster.k8s.io/cluster-api-autoscaler-node-group-min-size';
+export const annotationMachinePoolMaxSize =
+  'cluster.k8s.io/cluster-api-autoscaler-node-group-max-size';
+
+export function getMachinePoolDescription(machinePool: IMachinePool): string {
+  let name =
+    machinePool.metadata.annotations?.[annotationMachinePoolDescription];
+  name ??= Constants.DEFAULT_NODEPOOL_DESCRIPTION;
+
+  return name;
+}
+
+export function getMachinePoolScaling(
+  machinePool: IMachinePool
+): readonly [number, number] {
+  const annotations = machinePool.metadata.annotations;
+  if (!annotations) return [-1, -1];
+
+  const minScaling = annotations[annotationMachinePoolMinSize];
+  const maxScaling = annotations[annotationMachinePoolMaxSize];
+  if (!minScaling || !maxScaling) return [-1, -1];
+
+  try {
+    return [parseInt(minScaling, 10), parseInt(maxScaling, 10)];
+  } catch {
+    return [-1, -1];
+  }
+}

--- a/src/model/services/mapi/capiv1alpha4/key.ts
+++ b/src/model/services/mapi/capiv1alpha4/key.ts
@@ -7,10 +7,6 @@ export const labelMachinePool = 'giantswarm.io/machine-pool';
 
 export const annotationMachinePoolDescription =
   'machine-pool.giantswarm.io/name';
-export const annotationMachinePoolMinSize =
-  'cluster.k8s.io/cluster-api-autoscaler-node-group-min-size';
-export const annotationMachinePoolMaxSize =
-  'cluster.k8s.io/cluster-api-autoscaler-node-group-max-size';
 
 export function getMachinePoolDescription(machinePool: IMachinePool): string {
   let name =
@@ -18,21 +14,4 @@ export function getMachinePoolDescription(machinePool: IMachinePool): string {
   name ??= Constants.DEFAULT_NODEPOOL_DESCRIPTION;
 
   return name;
-}
-
-export function getMachinePoolScaling(
-  machinePool: IMachinePool
-): readonly [number, number] {
-  const annotations = machinePool.metadata.annotations;
-  if (!annotations) return [-1, -1];
-
-  const minScaling = annotations[annotationMachinePoolMinSize];
-  const maxScaling = annotations[annotationMachinePoolMaxSize];
-  if (!minScaling || !maxScaling) return [-1, -1];
-
-  try {
-    return [parseInt(minScaling, 10), parseInt(maxScaling, 10)];
-  } catch {
-    return [-1, -1];
-  }
 }

--- a/src/model/services/mapi/capiv1alpha4/types.ts
+++ b/src/model/services/mapi/capiv1alpha4/types.ts
@@ -1,0 +1,75 @@
+import * as corev1 from '../corev1';
+import * as metav1 from '../metav1';
+
+export interface ICondition {
+  type: string;
+  status:
+    | typeof corev1.conditionTrue
+    | typeof corev1.conditionFalse
+    | typeof corev1.conditionUnknown;
+  severity?: 'Error' | 'Warning' | 'Info' | '';
+  lastTransitionTime?: string;
+  reason?: string;
+  message?: string;
+}
+
+export interface IMachineSpecBootstrap {
+  configRef?: corev1.IObjectReference;
+  dataSecretName?: string;
+}
+
+export interface IMachineSpec {
+  clusterName: string;
+  bootstrap: IMachineSpecBootstrap;
+  infrastructureRef: corev1.IObjectReference;
+  version?: string;
+  providerID?: string;
+  failureDomain?: string;
+  nodeDrainTimeout?: number;
+}
+
+export interface IMachineTemplateSpec {
+  metadata?: metav1.IObjectMeta;
+  spec?: IMachineSpec;
+}
+
+export interface IMachinePoolSpec {
+  clusterName: string;
+  template: IMachineTemplateSpec;
+  replicas?: number;
+  minReadySeconds?: number;
+  providerIDList?: string[];
+  failureDomains?: string[];
+}
+
+export interface IMachinePoolStatus {
+  nodeRefs?: corev1.IObjectReference[];
+  replicas?: number;
+  readyReplicas?: number;
+  availableReplicas?: number;
+  unavailableReplicas?: number;
+  failureReason?: string;
+  failureMessage?: string;
+  phase?: string;
+  bootstrapReady?: boolean;
+  infrastructureReady?: boolean;
+  observedGeneration?: number;
+  conditions?: ICondition[];
+}
+
+export const MachinePool = 'MachinePool';
+
+export interface IMachinePool {
+  apiVersion: 'cluster.x-k8s.io/v1alpha4';
+  kind: typeof MachinePool;
+  metadata: metav1.IObjectMeta;
+  spec?: IMachinePoolSpec;
+  status?: IMachinePoolStatus;
+}
+
+export const MachinePoolList = 'MachinePoolList';
+
+export interface IMachinePoolList extends metav1.IList<IMachinePool> {
+  apiVersion: 'cluster.x-k8s.io/v1alpha4';
+  kind: typeof MachinePoolList;
+}

--- a/src/model/services/mapi/capiv1alpha4/updateMachinePool.ts
+++ b/src/model/services/mapi/capiv1alpha4/updateMachinePool.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { updateResource } from '../generic/updateResource';
+import { IMachinePool } from './';
+
+export function updateMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  machinePool: IMachinePool
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'cluster.x-k8s.io/v1alpha4',
+    kind: 'machinepools',
+    namespace: machinePool.metadata.namespace!,
+    name: machinePool.metadata.name,
+  } as k8sUrl.IK8sUpdateOptions);
+
+  return updateResource<IMachinePool>(
+    client,
+    auth,
+    url.toString(),
+    machinePool
+  );
+}

--- a/src/model/services/mapi/capzv1alpha4/createAzureMachinePool.ts
+++ b/src/model/services/mapi/capzv1alpha4/createAzureMachinePool.ts
@@ -1,0 +1,27 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { createResource } from '../generic/createResource';
+import { IAzureMachinePool } from '.';
+
+export function createAzureMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  azureMachinePool: IAzureMachinePool
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha4',
+    kind: 'azuremachinepools',
+    namespace: azureMachinePool.metadata.namespace!,
+    name: azureMachinePool.metadata.name,
+  } as k8sUrl.IK8sUpdateOptions);
+
+  return createResource<IAzureMachinePool>(
+    client,
+    auth,
+    url.toString(),
+    azureMachinePool
+  );
+}

--- a/src/model/services/mapi/capzv1alpha4/getAzureMachinePool.ts
+++ b/src/model/services/mapi/capzv1alpha4/getAzureMachinePool.ts
@@ -1,0 +1,32 @@
+import { IOAuth2Provider } from 'lib/OAuth2/OAuth2';
+import { IHttpClient } from 'model/clients/HttpClient';
+import * as k8sUrl from 'model/services/mapi/k8sUrl';
+
+import { getResource } from '../generic/getResource';
+import { IAzureMachinePool } from '.';
+
+export interface IGetAzureMachinePoolOptions {
+  namespace?: string;
+  labelSelector?: k8sUrl.IK8sLabelSelector;
+}
+
+export function getAzureMachinePool(
+  client: IHttpClient,
+  auth: IOAuth2Provider,
+  namespace: string,
+  name: string
+) {
+  const url = k8sUrl.create({
+    baseUrl: window.config.mapiEndpoint,
+    apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha4',
+    kind: 'azuremachinepools',
+    namespace,
+    name,
+  });
+
+  return getResource<IAzureMachinePool>(client, auth, url.toString());
+}
+
+export function getAzureMachinePoolKey(namespace: string, name: string) {
+  return `getAzureMachinePool/v1alpha4/${namespace}/${name}`;
+}

--- a/src/model/services/mapi/capzv1alpha4/index.ts
+++ b/src/model/services/mapi/capzv1alpha4/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
+export * from './key';
 export * from './getAzureMachinePool';
 export * from './createAzureMachinePool';

--- a/src/model/services/mapi/capzv1alpha4/index.ts
+++ b/src/model/services/mapi/capzv1alpha4/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './getAzureMachinePool';
+export * from './createAzureMachinePool';

--- a/src/model/services/mapi/capzv1alpha4/key.ts
+++ b/src/model/services/mapi/capzv1alpha4/key.ts
@@ -1,0 +1,21 @@
+import { IAzureMachinePool } from './';
+
+export const tagAutoscalerMinSize = 'min';
+export const tagAutoscalerMaxSize = 'max';
+
+export function getAzureMachinePoolScaling(
+  azureMachinePool: IAzureMachinePool
+): readonly [number, number] {
+  const tags = azureMachinePool.spec?.additionalTags;
+  if (!tags) return [-1, -1];
+
+  const minScaling = tags[tagAutoscalerMinSize];
+  const maxScaling = tags[tagAutoscalerMaxSize];
+  if (!minScaling || !maxScaling) return [-1, -1];
+
+  try {
+    return [parseInt(minScaling, 10), parseInt(maxScaling, 10)];
+  } catch {
+    return [-1, -1];
+  }
+}

--- a/src/model/services/mapi/capzv1alpha4/types.ts
+++ b/src/model/services/mapi/capzv1alpha4/types.ts
@@ -1,0 +1,154 @@
+import * as capiv1alpha4 from '../capiv1alpha4';
+import * as metav1 from '../metav1';
+
+export type Tags = Record<string, string>;
+
+export interface IImageSharedGalleryImage {
+  subscriptionID: string;
+  resourceGroup: string;
+  gallery: string;
+  name: string;
+  version: string;
+  publisher?: string;
+  offer?: string;
+  sku?: string;
+}
+
+export interface IImageMarketplaceImage {
+  publisher: string;
+  offer: string;
+  sku: string;
+  version: string;
+  thirdPartyImage: boolean;
+}
+
+export interface IImage {
+  id?: string;
+  sharedGallery?: IImageSharedGalleryImage;
+  marketplace?: IImageMarketplaceImage;
+}
+
+export interface IOSDiskManagedDiskEncryptionSetParameters {
+  id?: string;
+}
+
+export interface IManagedDiskParameters {
+  storageAccountType?: string;
+  diskEncryptionSet?: IOSDiskManagedDiskEncryptionSetParameters;
+}
+
+export interface IOSDiskDiffDiskSettings {
+  option: string;
+}
+
+export interface IOSDisk {
+  osType: string;
+  diskSizeGB?: number;
+  managedDisk?: IManagedDiskParameters;
+  diffDiskSettings?: IOSDiskDiffDiskSettings;
+  cachingType?: string;
+}
+
+export interface IDataDisk {
+  nameSuffix: string;
+  diskSizeGB: number;
+  managedDisk?: IManagedDiskParameters;
+  lun?: number;
+  cachingType?: string;
+}
+
+export interface IUserAssignedIdentity {
+  providerID: string;
+}
+
+export interface ISpotVMOptions {
+  maxPrice?: metav1.Quantity;
+}
+
+export interface ISecurityProfile {
+  encryptionAtHost?: boolean;
+}
+
+export interface IFuture {
+  type: string;
+  name: string;
+  serviceName: string;
+  resourceGroup?: string;
+  data?: string;
+}
+
+export interface IAzureMachinePoolMachineTemplate {
+  vmSize: string;
+  osDisk: IOSDisk;
+  image?: IImage;
+  dataDisks?: IDataDisk[];
+  sshPublicKey?: string;
+  acceleratedNetworking?: boolean;
+  terminateNotificationTimeout?: number;
+  securityProfile?: ISecurityProfile;
+  spotVMOptions?: ISpotVMOptions;
+  subnetName?: string;
+}
+
+export interface IAzureMachinePoolDeploymentStrategyRollingUpdate {
+  maxUnavailable?: number | string;
+  maxSurge?: number | string;
+  deletePolicy?: string;
+}
+
+export interface IAzureMachinePoolDeploymentStrategy {
+  type?: string;
+  rollingUpdate?: IAzureMachinePoolDeploymentStrategyRollingUpdate;
+}
+
+export interface IAzureMachinePoolSpec {
+  location: string;
+  template: IAzureMachinePoolMachineTemplate;
+  additionalTags?: Tags;
+  providerID?: string;
+  providerIDList?: string[];
+  identity?: string;
+  roleAssignmentName?: string;
+  userAssignedIdentities?: IUserAssignedIdentity[];
+  strategy?: IAzureMachinePoolDeploymentStrategy;
+  nodeDrainTimeout?: number;
+}
+
+export interface IAzureMachinePoolInstanceStatus {
+  version?: string;
+  provisioningState?: string;
+  providerID?: string;
+  instanceID?: string;
+  instanceName?: string;
+  latestModelApplied?: boolean;
+}
+
+export interface IAzureMachinePoolStatus {
+  ready?: boolean;
+  replicas?: number;
+  instances?: IAzureMachinePoolInstanceStatus[];
+  image?: IImage;
+  version?: string;
+  provisioningState?: string;
+  failureReason?: string;
+  failureMessage?: string;
+  conditions?: capiv1alpha4.ICondition[];
+  longRunningOperationState?: IFuture;
+}
+
+export const AzureMachinePool = 'AzureMachinePool';
+
+export interface IAzureMachinePool {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha4';
+  kind: typeof AzureMachinePool;
+  metadata: metav1.IObjectMeta;
+  spec?: IAzureMachinePoolSpec;
+  status?: IAzureMachinePoolStatus;
+}
+
+export const AzureMachinePoolList = 'AzureMachinePoolList';
+
+export interface IAzureMachinePoolList extends metav1.IList<IAzureMachinePool> {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1alpha4';
+  kind: typeof AzureMachinePoolList;
+}

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -38,6 +38,8 @@ export const Constants = {
   AWS_HA_MASTERS_VERSION: '11.4.0',
   AWS_HA_MASTERS_MAX_NODES: 3,
 
+  AZURE_CAPZ_VERSION: '20.0.0',
+
   // UI labels
   CURRENT_NODES_INPOOL_EXPLANATION:
     'Current number of worker nodes in the node pool',


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18770

Starting with the Giant Swarm Azure alpha release `v20.0.0`, we support full blown CAPZ clusters and node pools, and since these use `v1alpha4` `MachinePool` and `AzureMachinePool` CRs, which are now part of a different API group, we need to make some changes to support them.

This PR adds the new `v1alpha4` types and utility functions, and adapts the logic so the new types would also work.

> ⚠️ Note: CAPZ node pools are in read only mode for the alpha release: you can't create/update/delete node pools from the UI, and the CLI guides for those operations are also hidden.