### PR TITLE
Prevent pasting and dropping text into the cluster deletion name confirmation input

### DIFF
--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteActionClusterName.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteActionClusterName.tsx
@@ -24,6 +24,8 @@ const ClusterDetailDeleteActionClusterName: React.FC<IClusterDetailDeleteActionC
       onChange(e.target.value);
     };
 
+    const blockEvent = (e: React.SyntheticEvent) => e.preventDefault();
+
     return (
       <Box direction='row' gap='small' align='baseline' {...props}>
         <Text>If yes, please enter the cluster {variant}:</Text>
@@ -37,6 +39,8 @@ const ClusterDetailDeleteActionClusterName: React.FC<IClusterDetailDeleteActionC
             autoCorrect='false'
             autoCapitalize='false'
             aria-label={`Cluster ${variant}`}
+            onPaste={blockEvent}
+            onDrop={blockEvent}
           />
         </Keyboard>
       </Box>


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/19162

This PR addresses both the MAPI and GS API implementations. We now prevent pasting and dragging and dropping text in the confirmation input.