### PR TITLE
clusters: add code support for having multiple control plane nodes on cluster creation

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterControlPlaneNodeAZs.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterControlPlaneNodeAZs.tsx
@@ -24,7 +24,7 @@ interface ICreateClusterControlPlaneNodeAZsProps
     > {}
 
 const CreateClusterControlPlaneNodeAZs: React.FC<ICreateClusterControlPlaneNodeAZsProps> =
-  ({ id, cluster, controlPlaneNode, onChange, ...props }) => {
+  ({ id, cluster, controlPlaneNodes, onChange, ...props }) => {
     const [azSelector, setAzSelector] = useState(
       AvailabilityZoneSelection.Automatic
     );
@@ -33,9 +33,8 @@ const CreateClusterControlPlaneNodeAZs: React.FC<ICreateClusterControlPlaneNodeA
     const azStats = getSupportedAvailabilityZones();
 
     const value = useMemo(() => {
-      return computeControlPlaneNodesStats([controlPlaneNode])
-        .availabilityZones;
-    }, [controlPlaneNode]);
+      return computeControlPlaneNodesStats(controlPlaneNodes).availabilityZones;
+    }, [controlPlaneNodes]);
 
     const [manualZones, setManualZones] = useState<string[]>(value);
     const [manualZonesIsValid, setManualZonesIsValid] = useState(false);

--- a/src/components/MAPI/clusters/CreateCluster/__tests__/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/__tests__/index.tsx
@@ -90,7 +90,7 @@ describe('ClusterCreate', () => {
     createClusterMockFn.mockResolvedValue({
       cluster: capiv1alpha3Mocks.randomCluster1,
       providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
-      controlPlaneNode: capzv1alpha3Mocks.randomAzureMachine1,
+      controlPlaneNodes: [capzv1alpha3Mocks.randomAzureMachine1],
     });
 
     nock(window.config.mapiEndpoint)
@@ -137,7 +137,7 @@ describe('ClusterCreate', () => {
     createClusterMockFn.mockResolvedValue({
       cluster: capiv1alpha3Mocks.randomCluster1,
       providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
-      controlPlaneNode: capzv1alpha3Mocks.randomAzureMachine1,
+      controlPlaneNodes: [capzv1alpha3Mocks.randomAzureMachine1],
     });
 
     nock(window.config.mapiEndpoint)
@@ -180,13 +180,15 @@ describe('ClusterCreate', () => {
             }),
           }),
         }),
-        controlPlaneNode: expect.objectContaining({
-          metadata: expect.objectContaining({
-            labels: expect.objectContaining({
-              'release.giantswarm.io/version': '14.1.5',
+        controlPlaneNodes: expect.arrayContaining([
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              labels: expect.objectContaining({
+                'release.giantswarm.io/version': '14.1.5',
+              }),
             }),
           }),
-        }),
+        ]),
       })
     );
 
@@ -202,7 +204,7 @@ describe('ClusterCreate', () => {
     createClusterMockFn.mockResolvedValue({
       cluster: capiv1alpha3Mocks.randomCluster1,
       providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
-      controlPlaneNode: capzv1alpha3Mocks.randomAzureMachine1,
+      controlPlaneNodes: [capzv1alpha3Mocks.randomAzureMachine1],
     });
 
     nock(window.config.mapiEndpoint)
@@ -226,11 +228,13 @@ describe('ClusterCreate', () => {
       expect.any(Object),
       expect.any(Object),
       expect.objectContaining({
-        controlPlaneNode: expect.objectContaining({
-          spec: expect.objectContaining({
-            failureDomain: '3',
+        controlPlaneNodes: expect.arrayContaining([
+          expect.objectContaining({
+            spec: expect.objectContaining({
+              failureDomain: '3',
+            }),
           }),
-        }),
+        ]),
       })
     );
 

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -34,7 +34,7 @@ import CreateClusterGuide from '../guides/CreateClusterGuide';
 import {
   createCluster,
   createDefaultCluster,
-  createDefaultControlPlaneNode,
+  createDefaultControlPlaneNodes,
   createDefaultProviderCluster,
   findLatestReleaseVersion,
 } from '../utils';
@@ -91,7 +91,7 @@ interface IClusterState {
   provider: PropertiesOf<typeof Providers>;
   cluster: Cluster;
   providerCluster: ProviderCluster;
-  controlPlaneNode: ControlPlaneNode;
+  controlPlaneNodes: ControlPlaneNode[];
   validationResults: Record<ClusterPropertyField, boolean>;
   isCreating: boolean;
   latestRelease: string;
@@ -113,14 +113,14 @@ function makeInitialState(
     provider,
     resourceConfig
   );
-  const controlPlaneNode = createDefaultControlPlaneNode({ providerCluster });
+  const controlPlaneNodes = createDefaultControlPlaneNodes({ providerCluster });
   const cluster = createDefaultCluster({ providerCluster });
 
   return {
     provider,
     cluster,
     providerCluster,
-    controlPlaneNode,
+    controlPlaneNodes,
     validationResults: {
       [ClusterPropertyField.Name]: true,
       [ClusterPropertyField.Description]: true,
@@ -139,7 +139,7 @@ const reducer: React.Reducer<IClusterState, ClusterAction> = produce(
         action.value(
           draft.cluster,
           draft.providerCluster,
-          draft.controlPlaneNode
+          draft.controlPlaneNodes
         );
         break;
       case 'changeValidationStatus':
@@ -157,7 +157,7 @@ const reducer: React.Reducer<IClusterState, ClusterAction> = produce(
           withClusterReleaseVersion(action.value)(
             draft.cluster,
             draft.providerCluster,
-            draft.controlPlaneNode
+            draft.controlPlaneNodes
           );
         }
 
@@ -288,9 +288,9 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
   const releaseVersion = getClusterReleaseVersion(state.cluster);
   const description = getClusterDescription(state.cluster);
   const controlPlaneAZs = useMemo(() => {
-    return computeControlPlaneNodesStats([state.controlPlaneNode])
+    return computeControlPlaneNodesStats(state.controlPlaneNodes)
       .availabilityZones;
-  }, [state.controlPlaneNode]);
+  }, [state.controlPlaneNodes]);
   const labels = getVisibleLabels(state.cluster);
 
   return (
@@ -315,14 +315,14 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               id={`cluster-${ClusterPropertyField.Name}`}
               cluster={state.cluster}
               providerCluster={state.providerCluster}
-              controlPlaneNode={state.controlPlaneNode}
+              controlPlaneNodes={state.controlPlaneNodes}
               onChange={handleChange(ClusterPropertyField.Name)}
             />
             <CreateClusterDescription
               id={`cluster-${ClusterPropertyField.Description}`}
               cluster={state.cluster}
               providerCluster={state.providerCluster}
-              controlPlaneNode={state.controlPlaneNode}
+              controlPlaneNodes={state.controlPlaneNodes}
               onChange={handleChange(ClusterPropertyField.Description)}
               autoFocus={true}
             />
@@ -330,14 +330,14 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
               id={`cluster-${ClusterPropertyField.Release}`}
               cluster={state.cluster}
               providerCluster={state.providerCluster}
-              controlPlaneNode={state.controlPlaneNode}
+              controlPlaneNodes={state.controlPlaneNodes}
               onChange={handleChange(ClusterPropertyField.Release)}
             />
             <CreateClusterControlPlaneNodeAZs
               id={`cluster-${ClusterPropertyField.ControlPlaneNodeAZs}`}
               cluster={state.cluster}
               providerCluster={state.providerCluster}
-              controlPlaneNode={state.controlPlaneNode}
+              controlPlaneNodes={state.controlPlaneNodes}
               onChange={handleChange(ClusterPropertyField.ControlPlaneNodeAZs)}
             />
             <Box margin={{ top: 'medium' }}>

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -5,7 +5,7 @@ import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
 export type ClusterPatch = (
   cluster: Cluster,
   providerCluster: ProviderCluster,
-  controlPlaneNode: ControlPlaneNode
+  controlPlaneNodes: ControlPlaneNode[]
 ) => void;
 
 export interface IClusterPropertyValue {
@@ -17,14 +17,14 @@ export interface IClusterPropertyProps {
   id: string;
   cluster: Cluster;
   providerCluster: ProviderCluster;
-  controlPlaneNode: ControlPlaneNode;
+  controlPlaneNodes: ControlPlaneNode[];
   onChange: (value: IClusterPropertyValue) => void;
   disabled?: boolean;
   readOnly?: boolean;
 }
 
 export function withClusterReleaseVersion(newVersion: string): ClusterPatch {
-  return (cluster, providerCluster, controlPlaneNode) => {
+  return (cluster, providerCluster, controlPlaneNodes) => {
     cluster.metadata.labels ??= {};
     cluster.metadata.labels[capiv1alpha3.labelReleaseVersion] = newVersion;
 
@@ -32,9 +32,11 @@ export function withClusterReleaseVersion(newVersion: string): ClusterPatch {
     providerCluster.metadata.labels[capiv1alpha3.labelReleaseVersion] =
       newVersion;
 
-    controlPlaneNode.metadata.labels ??= {};
-    controlPlaneNode.metadata.labels[capiv1alpha3.labelReleaseVersion] =
-      newVersion;
+    for (const controlPlaneNode of controlPlaneNodes) {
+      controlPlaneNode.metadata.labels ??= {};
+      controlPlaneNode.metadata.labels[capiv1alpha3.labelReleaseVersion] =
+        newVersion;
+    }
   };
 }
 
@@ -47,8 +49,11 @@ export function withClusterDescription(newDescription: string): ClusterPatch {
 }
 
 export function withClusterControlPlaneNodeAZs(zones?: string[]): ClusterPatch {
-  return (_, _p, controlPlaneNode) => {
-    if (controlPlaneNode.kind === capzv1alpha3.AzureMachine)
-      controlPlaneNode.spec!.failureDomain = zones?.[0];
+  return (_, _p, controlPlaneNodes) => {
+    for (const controlPlaneNode of controlPlaneNodes) {
+      if (controlPlaneNode.kind === capzv1alpha3.AzureMachine) {
+        controlPlaneNode.spec!.failureDomain = zones?.[0];
+      }
+    }
   };
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/388

Cluster creation code was the only part of the MAPI UI that didn't support having multiple control plane nodes (all the other features do). Now it does, and we're ready for adding UI support for it with AWS cluster management.