### PR TITLE
Update cluster `spec.infrastructureRef.namespace` on release version selection

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -42,11 +42,6 @@ export function withClusterReleaseVersion(
     cluster.metadata.namespace = hasNonNamespacedResources
       ? defaultNamespace
       : orgNamespace;
-    if (cluster.spec?.infrastructureRef?.namespace) {
-      cluster.spec.infrastructureRef.namespace = hasNonNamespacedResources
-        ? defaultNamespace
-        : orgNamespace;
-    }
 
     if (providerCluster) {
       providerCluster.metadata.labels ??= {};
@@ -55,6 +50,10 @@ export function withClusterReleaseVersion(
       providerCluster.metadata.namespace = hasNonNamespacedResources
         ? defaultNamespace
         : orgNamespace;
+      if (cluster.spec?.infrastructureRef?.namespace) {
+        cluster.spec.infrastructureRef.namespace =
+          providerCluster.metadata.namespace;
+      }
     }
 
     for (const controlPlaneNode of controlPlaneNodes) {


### PR DESCRIPTION
When creating a cluster in the AWS MAPI UI, if the release version selected is less than v16.0.0, the cluster and provider cluster `metadata.namespace` will be set to `default`. We should also change the cluster's `spec.infrastrucutureRef.namespace` accordingly, and this resolves the bug for missing cluster conditions in happa-created AWS clusters.