### PR TITLE
Reference the correct command for creating a client certificate

### DIFF
--- a/src/components/MAPI/keypairs/ClusterDetailWidgetKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailWidgetKeyPairs.tsx
@@ -72,10 +72,10 @@ const ClusterDetailWidgetKeyPairs: React.FC<IClusterDetailWidgetKeyPairsProps> =
               Use{' '}
               <StyledLink
                 target='_blank'
-                href={docs.gsctlCreateKubeconfigURL}
+                href={docs.kubectlGSLoginURL}
                 rel='noopener noreferrer'
               >
-                gsctl create kubeconfig
+                kubectl gs login
               </StyledLink>{' '}
               to create one.
             </Text>

--- a/src/components/MAPI/keypairs/__tests__/ClusterDetailWidgetKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/__tests__/ClusterDetailWidgetKeyPairs.tsx
@@ -78,9 +78,7 @@ describe('ClusterDetailWidgetKeyPairs', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText((_, node) => {
-        return (
-          node?.textContent === 'Use gsctl create kubeconfig to create one.'
-        );
+        return node?.textContent === 'Use kubectl gs login to create one.';
       })
     ).toBeInTheDocument();
   });


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C13MG9F0W/p1635416289014800

Creating a client certificate using `gsctl create kubeconfig` is no longer possible