### PR TITLE
node pools: add support for configuring similar instance types on AWS via MAPI

### DIFF
--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -610,17 +610,38 @@ export function getNodePoolDescription(
   }
 }
 
-export function getProviderNodePoolMachineType(
+export interface INodePoolMachineTypesAzure {
+  primary: string;
+}
+
+export interface INodePoolMachineTypesAWS {
+  primary: string;
+  all: string[];
+  similarInstances: boolean;
+}
+
+export type NodePoolMachineTypes =
+  | INodePoolMachineTypesAzure
+  | INodePoolMachineTypesAWS;
+
+export function getProviderNodePoolMachineTypes(
   providerNodePool: ProviderNodePool
-): string {
+): NodePoolMachineTypes | undefined {
   switch (providerNodePool?.apiVersion) {
     case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
     case 'infrastructure.cluster.x-k8s.io/v1alpha4':
-      return providerNodePool.spec?.template.vmSize ?? '';
+      return { primary: providerNodePool.spec?.template.vmSize ?? '' };
     case 'infrastructure.giantswarm.io/v1alpha3':
-      return providerNodePool.spec.provider.worker.instanceType;
+      return {
+        primary: providerNodePool.spec.provider.worker.instanceType,
+        all: providerNodePool.status?.provider?.worker?.instanceTypes ?? [
+          providerNodePool.spec.provider.worker.instanceType,
+        ],
+        similarInstances:
+          providerNodePool.spec.provider.worker.useAlikeInstanceTypes,
+      };
     default:
-      return '';
+      return undefined;
   }
 }
 

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -20,7 +20,7 @@ import {
   getNodePoolScaling,
   getProviderClusterLocation,
   getProviderNodePoolLocation,
-  getProviderNodePoolMachineType,
+  getProviderNodePoolMachineTypes,
   getProviderNodePoolSpotInstances,
   INodePoolSpotInstancesAWS,
   INodePoolSpotInstancesAzure,
@@ -276,7 +276,8 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
     state.nodePool,
     state.providerNodePool
   );
-  const machineType = getProviderNodePoolMachineType(state.providerNodePool);
+  const machineType =
+    getProviderNodePoolMachineTypes(state.providerNodePool)?.primary ?? '';
   const spotInstances = getProviderNodePoolSpotInstances(
     state.providerNodePool
   );

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePool.tsx
@@ -328,6 +328,7 @@ const WorkerNodesCreateNodePool: React.FC<IWorkerNodesCreateNodePoolProps> = ({
                 id={`node-pool-${id}-${NodePoolPropertyField.MachineType}`}
                 nodePool={state.nodePool}
                 providerNodePool={state.providerNodePool}
+                cluster={cluster}
                 onChange={handleChange(NodePoolPropertyField.MachineType)}
               />
               <WorkerNodesCreateNodePoolAvailabilityZones

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolMachineType.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolMachineType.tsx
@@ -1,5 +1,5 @@
 import AddNodePoolMachineType from 'Cluster/ClusterDetail/AddNodePool/AddNodePoolMachineType';
-import { getProviderNodePoolMachineType } from 'MAPI/utils';
+import { getProviderNodePoolMachineTypes } from 'MAPI/utils';
 import React from 'react';
 
 import { INodePoolPropertyProps, withNodePoolMachineType } from './patches';
@@ -28,7 +28,8 @@ const WorkerNodesCreateNodePoolMachineType: React.FC<IWorkerNodesCreateNodePoolM
       });
     };
 
-    const value = getProviderNodePoolMachineType(providerNodePool);
+    const value =
+      getProviderNodePoolMachineTypes(providerNodePool)?.primary ?? '';
 
     return (
       <AddNodePoolMachineType

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolMachineType.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolMachineType.tsx
@@ -1,15 +1,28 @@
 import AddNodePoolMachineType from 'Cluster/ClusterDetail/AddNodePool/AddNodePoolMachineType';
-import { getProviderNodePoolMachineTypes } from 'MAPI/utils';
+import { Cluster } from 'MAPI/types';
+import {
+  getClusterReleaseVersion,
+  getProviderNodePoolMachineTypes,
+  INodePoolMachineTypesAWS,
+} from 'MAPI/utils';
 import React from 'react';
+import { supportsAlikeInstances } from 'stores/nodepool/utils';
+import CheckBoxInput from 'UI/Inputs/CheckBoxInput';
 
-import { INodePoolPropertyProps, withNodePoolMachineType } from './patches';
+import {
+  INodePoolPropertyProps,
+  NodePoolMachineTypesConfig,
+  withNodePoolMachineType,
+} from './patches';
 
 interface IWorkerNodesCreateNodePoolMachineTypeProps
   extends INodePoolPropertyProps,
     Omit<
       React.ComponentPropsWithoutRef<typeof AddNodePoolMachineType>,
       'onChange' | 'id'
-    > {}
+    > {
+  cluster: Cluster;
+}
 
 const WorkerNodesCreateNodePoolMachineType: React.FC<IWorkerNodesCreateNodePoolMachineTypeProps> =
   ({
@@ -19,25 +32,63 @@ const WorkerNodesCreateNodePoolMachineType: React.FC<IWorkerNodesCreateNodePoolM
     readOnly,
     disabled,
     autoFocus,
+    cluster,
     ...props
   }) => {
-    const handleChange = (newValue: string) => {
+    const machineTypes = getProviderNodePoolMachineTypes(providerNodePool);
+
+    const appendChanges = (config: NodePoolMachineTypesConfig) => {
       onChange({
         isValid: true,
-        patch: withNodePoolMachineType(newValue),
+        patch: withNodePoolMachineType(config),
       });
     };
 
-    const value =
-      getProviderNodePoolMachineTypes(providerNodePool)?.primary ?? '';
+    const value = machineTypes?.primary ?? '';
+
+    const provider = window.config.info.general.provider;
+
+    const clusterReleaseVersion = getClusterReleaseVersion(cluster);
+    const supportsAlikeInstanceTypes = clusterReleaseVersion
+      ? supportsAlikeInstances(provider, clusterReleaseVersion)
+      : false;
+    const useAlikeInstanceTypes = (
+      machineTypes as INodePoolMachineTypesAWS | undefined
+    )?.similarInstances;
+
+    const handleChangePrimaryType = (newValue: string) => {
+      appendChanges({
+        primary: newValue,
+        similarInstances: useAlikeInstanceTypes,
+      });
+    };
+
+    const handleChangeAlikeInstances = (
+      e: React.ChangeEvent<HTMLInputElement>
+    ) => {
+      appendChanges({
+        primary: value,
+        similarInstances: e.target.checked,
+      });
+    };
 
     return (
-      <AddNodePoolMachineType
-        id={id}
-        onChange={handleChange}
-        machineType={value}
-        {...props}
-      />
+      <>
+        <AddNodePoolMachineType
+          id={id}
+          onChange={handleChangePrimaryType}
+          machineType={value}
+          {...props}
+        />
+        {supportsAlikeInstanceTypes && (
+          <CheckBoxInput
+            checked={useAlikeInstanceTypes}
+            onChange={handleChangeAlikeInstances}
+            label='Allow usage of similar instance types'
+            formFieldProps={{ margin: { top: 'small' } }}
+          />
+        )}
+      </>
     );
   };
 

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -10,10 +10,7 @@ import {
   getNodePoolAvailabilityZones,
   getNodePoolDescription,
   getNodePoolScaling,
-  getProviderNodePoolMachineType,
 } from 'MAPI/utils';
-import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
-import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
 import React, { useMemo, useRef, useState } from 'react';
 import Copyable from 'shared/Copyable';
 import styled from 'styled-components';
@@ -29,26 +26,8 @@ import ViewAndEditName, {
 import { IWorkerNodesAdditionalColumn } from './types';
 import { deleteNodePoolResources, updateNodePoolDescription } from './utils';
 import WorkerNodesNodePoolItemDelete from './WorkerNodesNodePoolItemDelete';
+import WorkerNodesNodePoolItemMachineType from './WorkerNodesNodePoolItemMachineType';
 import WorkerNodesNodePoolItemScale from './WorkerNodesNodePoolItemScale';
-
-function formatMachineTypeLabel(providerNodePool?: ProviderNodePool) {
-  switch (true) {
-    case providerNodePool?.kind === capzexpv1alpha3.AzureMachinePool &&
-      providerNodePool?.apiVersion ===
-        'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
-    case providerNodePool?.kind === capzexpv1alpha3.AzureMachinePool &&
-      providerNodePool?.apiVersion ===
-        'infrastructure.cluster.x-k8s.io/v1alpha4':
-      return `VM size: ${getProviderNodePoolMachineType(providerNodePool)}`;
-    case providerNodePool?.kind === infrav1alpha3.AWSMachineDeployment &&
-      providerNodePool?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3':
-      return `Instance type: ${getProviderNodePoolMachineType(
-        providerNodePool
-      )}`;
-    default:
-      return undefined;
-  }
-}
 
 function formatAvailabilityZonesLabel(zones: string[]) {
   if (zones.length < 1) {
@@ -103,9 +82,6 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
     : undefined;
   const availabilityZones = nodePool
     ? getNodePoolAvailabilityZones(nodePool, providerNodePool)
-    : undefined;
-  const machineType = nodePool
-    ? getProviderNodePoolMachineType(providerNodePool)
     : undefined;
   const scaling = useMemo(() => {
     if (!nodePool) return undefined;
@@ -265,15 +241,10 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
         </StyledDescriptionWrapper>
         {!isDeleting && !isEditingDescription && (
           <>
-            <Box align='center'>
-              <OptionalValue value={machineType} loaderWidth={130}>
-                {(value) => (
-                  <Code aria-label={formatMachineTypeLabel(providerNodePool)}>
-                    {value}
-                  </Code>
-                )}
-              </OptionalValue>
-            </Box>
+            <WorkerNodesNodePoolItemMachineType
+              nodePool={nodePool}
+              providerNodePool={providerNodePool}
+            />
             <Box align='center'>
               <OptionalValue value={availabilityZones} loaderHeight={26}>
                 {(value) => (

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemMachineType.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemMachineType.tsx
@@ -1,9 +1,17 @@
-import { Box } from 'grommet';
+import { Box, Text } from 'grommet';
 import { NodePool, ProviderNodePool } from 'MAPI/types';
 import { getProviderNodePoolMachineType } from 'MAPI/utils';
 import React from 'react';
+import styled from 'styled-components';
 import { Code } from 'styles';
+import NotAvailable from 'UI/Display/NotAvailable';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
+import { Tooltip, TooltipContainer } from 'UI/Display/Tooltip';
+
+const MixedInstanceType = styled(Code)`
+  background: ${({ theme }) => theme.global.colors['accent-strong'].dark};
+  color: ${({ theme }) => theme.global.colors.text.dark};
+`;
 
 function formatMachineTypeLabel(providerNodePool?: ProviderNodePool) {
   switch (providerNodePool?.apiVersion) {
@@ -33,14 +41,61 @@ const WorkerNodesNodePoolItemMachineType: React.FC<IWorkerNodesNodePoolItemMachi
       ? getProviderNodePoolMachineType(providerNodePool)
       : undefined;
 
+    const useAlikeInstanceTypes =
+      providerNodePool?.apiVersion ===
+        'infrastructure.giantswarm.io/v1alpha3' &&
+      providerNodePool.spec.provider.worker.useAlikeInstanceTypes;
+    const instanceTypes =
+      providerNodePool?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3'
+        ? providerNodePool.status?.provider?.worker?.instanceTypes
+        : undefined;
+
     return (
       <Box align='center' {...props}>
         <OptionalValue value={machineType} loaderWidth={130}>
-          {(value) => (
-            <Code aria-label={formatMachineTypeLabel(providerNodePool)}>
-              {value}
-            </Code>
-          )}
+          {(value) =>
+            useAlikeInstanceTypes ? (
+              <TooltipContainer
+                content={
+                  <Tooltip
+                    id={`${providerNodePool.metadata.name}-instance-types`}
+                  >
+                    <Box width='180px'>
+                      <Text size='xsmall' textAlign='center'>
+                        Similar instances enabled.
+                      </Text>
+                      <Text size='xsmall' textAlign='center'>
+                        Currently used:{' '}
+                        {instanceTypes?.join(', ') ?? <NotAvailable />}
+                      </Text>
+                    </Box>
+                  </Tooltip>
+                }
+              >
+                <div>
+                  <MixedInstanceType
+                    aria-label={formatMachineTypeLabel(providerNodePool)}
+                  >
+                    {value}
+                  </MixedInstanceType>
+                  {instanceTypes && instanceTypes.length > 1 && (
+                    <Text
+                      size='xsmall'
+                      margin={{ left: 'xsmall' }}
+                      color='text-weak'
+                    >
+                      +{instanceTypes.length - 1} more
+                    </Text>
+                  )}
+                </div>
+              </TooltipContainer>
+            ) : (
+              <Code aria-label={formatMachineTypeLabel(providerNodePool)}>
+                {' '}
+                {value}
+              </Code>
+            )
+          }
         </OptionalValue>
       </Box>
     );

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemMachineType.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemMachineType.tsx
@@ -1,0 +1,49 @@
+import { Box } from 'grommet';
+import { NodePool, ProviderNodePool } from 'MAPI/types';
+import { getProviderNodePoolMachineType } from 'MAPI/utils';
+import React from 'react';
+import { Code } from 'styles';
+import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
+
+function formatMachineTypeLabel(providerNodePool?: ProviderNodePool) {
+  switch (providerNodePool?.apiVersion) {
+    case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+      return `VM size: ${getProviderNodePoolMachineType(providerNodePool)}`;
+
+    case 'infrastructure.giantswarm.io/v1alpha3':
+      return `Instance type: ${getProviderNodePoolMachineType(
+        providerNodePool
+      )}`;
+
+    default:
+      return undefined;
+  }
+}
+
+interface IWorkerNodesNodePoolItemMachineTypeProps
+  extends React.ComponentPropsWithoutRef<typeof Box> {
+  nodePool?: NodePool;
+  providerNodePool?: ProviderNodePool;
+}
+
+const WorkerNodesNodePoolItemMachineType: React.FC<IWorkerNodesNodePoolItemMachineTypeProps> =
+  ({ nodePool, providerNodePool, ...props }) => {
+    const machineType = nodePool
+      ? getProviderNodePoolMachineType(providerNodePool)
+      : undefined;
+
+    return (
+      <Box align='center' {...props}>
+        <OptionalValue value={machineType} loaderWidth={130}>
+          {(value) => (
+            <Code aria-label={formatMachineTypeLabel(providerNodePool)}>
+              {value}
+            </Code>
+          )}
+        </OptionalValue>
+      </Box>
+    );
+  };
+
+export default WorkerNodesNodePoolItemMachineType;

--- a/src/components/MAPI/workernodes/patches.ts
+++ b/src/components/MAPI/workernodes/patches.ts
@@ -35,14 +35,32 @@ export function withNodePoolDescription(newDescription: string): NodePoolPatch {
   };
 }
 
-export function withNodePoolMachineType(newMachineType: string): NodePoolPatch {
+export interface INodePoolMachineTypesConfigAzure {
+  primary: string;
+}
+
+export interface INodePoolMachineTypesConfigAWS {
+  primary: string;
+  similarInstances: boolean;
+}
+
+export type NodePoolMachineTypesConfig =
+  | INodePoolMachineTypesConfigAzure
+  | INodePoolMachineTypesConfigAWS;
+
+export function withNodePoolMachineType(
+  config: NodePoolMachineTypesConfig
+): NodePoolPatch {
   return (_, providerNodePool) => {
     switch (providerNodePool?.apiVersion) {
       case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
-        providerNodePool.spec!.template.vmSize = newMachineType;
+        providerNodePool.spec!.template.vmSize = config.primary;
         break;
       case 'infrastructure.giantswarm.io/v1alpha3':
-        providerNodePool.spec.provider.worker.instanceType = newMachineType;
+        providerNodePool.spec.provider.worker.instanceType = config.primary;
+        providerNodePool.spec.provider.worker.useAlikeInstanceTypes = (
+          config as INodePoolMachineTypesConfigAWS
+        ).similarInstances;
         break;
     }
   };


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/388

This PR adds the option to enable similar instance types when creating an AWS node pool.

## Preview

<details>

<summary>NP creation form</summary>

![image](https://user-images.githubusercontent.com/13508038/139858382-8fe20383-cc54-4e76-99d5-e8dc60309a04.png)

</details>

<details>

<summary>NP uses similar instance types and 3 instance types</summary>

![image](https://user-images.githubusercontent.com/13508038/139858442-354f0ac4-697c-47a3-a8f5-d7fd3c887de3.png)

</details>

<details>

<summary>NP uses similar instance types and 3 instance types - hover</summary>

![image](https://user-images.githubusercontent.com/13508038/139858559-e9166947-8118-41ec-b5d0-855c980a47c5.png)

</details>