### PR TITLE
Fix not being able to display any information about CAPZ clusters

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
@@ -30,6 +30,7 @@ export function getClusterRegionLabel(cluster?: capiv1alpha3.ICluster) {
 
   switch (cluster.spec?.infrastructureRef?.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return 'Azure region';
 
     case 'infrastructure.giantswarm.io/v1alpha3':
@@ -45,6 +46,7 @@ export function getClusterAccountIDLabel(cluster?: capiv1alpha3.ICluster) {
 
   switch (cluster.spec?.infrastructureRef?.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return 'Subscription ID';
 
     case 'infrastructure.giantswarm.io/v1alpha3':
@@ -63,6 +65,7 @@ export function getClusterAccountIDPath(
 
   switch (cluster.spec?.infrastructureRef?.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return 'https://portal.azure.com/';
 
     case 'infrastructure.giantswarm.io/v1alpha3':

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -797,6 +797,7 @@ export function getClusterConditions(
 
   switch (infrastructureRef.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       statuses.isConditionUnknown = typeof cluster.spec === 'undefined';
       statuses.isCreating = isClusterCreating(cluster);
       statuses.isUpgrading = isClusterUpgrading(cluster);

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -120,6 +120,7 @@ export async function fetchNodePoolListForCluster(
 
   switch (infrastructureRef.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       if (isCAPZCluster(cluster)) {
         list = await capiv1alpha4.getMachinePoolList(
           httpClientFactory(),
@@ -185,6 +186,7 @@ export function fetchNodePoolListForClusterKey(
 
   switch (infrastructureRef.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       if (isCAPZCluster(cluster)) {
         return capiv1alpha4.getMachinePoolListKey({
           labelSelector: {
@@ -401,7 +403,8 @@ export async function fetchControlPlaneNodesForCluster(
   }
 
   switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3': {
+    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4': {
       const cpNodes = await capzv1alpha3.getAzureMachineList(
         httpClientFactory(),
         auth,
@@ -466,6 +469,7 @@ export function fetchControlPlaneNodesForClusterKey(
 
   switch (infrastructureRef.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return capzv1alpha3.getAzureMachineListKey({
         labelSelector: {
           matchingLabels: {
@@ -502,6 +506,7 @@ export function fetchProviderClusterForCluster(
 
   switch (infrastructureRef.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return capzv1alpha3.getAzureCluster(
         httpClientFactory(),
         auth,
@@ -528,6 +533,7 @@ export function fetchProviderClusterForClusterKey(cluster: Cluster) {
 
   switch (infrastructureRef.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return capzv1alpha3.getAzureClusterKey(
         cluster.metadata.namespace!,
         infrastructureRef.name
@@ -804,6 +810,7 @@ export function getClusterDescription(
 
   switch (infrastructureRef.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return (
         cluster.metadata.annotations?.[
           capiv1alpha3.annotationClusterDescription


### PR DESCRIPTION
As seen on https://gigantic.slack.com/archives/C02FJACQ3D4/p1635861763020500

Looks like we messed this up during the AWS migration 😅 