### PR TITLE
clusters: add support for v1alpha2 resources

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
@@ -33,6 +33,7 @@ export function getClusterRegionLabel(cluster?: capiv1alpha3.ICluster) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return 'Azure region';
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return 'AWS region';
 
@@ -49,6 +50,7 @@ export function getClusterAccountIDLabel(cluster?: capiv1alpha3.ICluster) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return 'Subscription ID';
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return 'Account ID';
 
@@ -68,6 +70,7 @@ export function getClusterAccountIDPath(
     case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return 'https://portal.azure.com/';
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return `https://${accountID}.signin.aws.amazon.com/console`;
 

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -32,8 +32,10 @@ export function withClusterReleaseVersion(
   orgNamespace: string
 ): ClusterPatch {
   return (cluster, providerCluster, controlPlaneNodes) => {
+    const apiVersion = providerCluster?.apiVersion;
     const hasNonNamespacedResources =
-      providerCluster?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3' &&
+      (apiVersion === 'infrastructure.giantswarm.io/v1alpha2' ||
+        apiVersion === 'infrastructure.giantswarm.io/v1alpha3') &&
       compare(newVersion, Constants.AWS_NAMESPACED_CLUSTERS_VERSION) < 0;
     const defaultNamespace = 'default';
 
@@ -73,11 +75,13 @@ export function withClusterDescription(newDescription: string): ClusterPatch {
     cluster.metadata.annotations[capiv1alpha3.annotationClusterDescription] =
       newDescription;
 
+    const apiVersion = providerCluster?.apiVersion;
     if (
-      providerCluster?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3' &&
-      providerCluster.spec
+      (apiVersion === 'infrastructure.giantswarm.io/v1alpha2' ||
+        apiVersion === 'infrastructure.giantswarm.io/v1alpha3') &&
+      providerCluster!.spec
     ) {
-      providerCluster.spec.cluster.description = newDescription;
+      providerCluster!.spec.cluster.description = newDescription;
     }
   };
 }
@@ -98,6 +102,8 @@ export function withClusterControlPlaneNodesCount(count: number): ClusterPatch {
 
     for (const controlPlaneNode of controlPlaneNodes) {
       if (
+        controlPlaneNode.apiVersion !==
+          'infrastructure.giantswarm.io/v1alpha2' &&
         controlPlaneNode.apiVersion !== 'infrastructure.giantswarm.io/v1alpha3'
       ) {
         continue;

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -75,6 +75,7 @@ export function getWorkerNodesCPU(
 
         break;
 
+      case 'infrastructure.giantswarm.io/v1alpha2':
       case 'infrastructure.giantswarm.io/v1alpha3': {
         const instanceType = providerNp.spec.provider.worker.instanceType;
         const readyReplicas = nodePools[i].status?.readyReplicas;
@@ -131,6 +132,7 @@ export function getWorkerNodesMemory(
         break;
       }
 
+      case 'infrastructure.giantswarm.io/v1alpha2':
       case 'infrastructure.giantswarm.io/v1alpha3': {
         const instanceType = providerNp.spec.provider.worker.instanceType;
         const readyReplicas = nodePools[i].status?.readyReplicas;
@@ -364,6 +366,7 @@ export function createDefaultCluster(config: {
 }) {
   switch (config.providerCluster?.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return createDefaultV1Alpha3Cluster(config);
 
@@ -415,6 +418,7 @@ export function createDefaultControlPlaneNodes(config: {
   switch (config.providerCluster?.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
       return [createDefaultAzureMachine(config)];
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3': {
       const name = generateUID(5);
       const awsCP = createDefaultAWSControlPlane({ ...config, name });
@@ -623,6 +627,7 @@ export async function createCluster(
       return { cluster, providerCluster, controlPlaneNodes };
     }
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3': {
       const providerCluster = await infrav1alpha3.createAWSCluster(
         httpClientFactory(),
@@ -669,13 +674,13 @@ export async function createCluster(
               return infrav1alpha3.createAWSControlPlane(
                 httpClientFactory(),
                 auth,
-                n
+                n as infrav1alpha3.IAWSControlPlane
               );
             case infrav1alpha3.G8sControlPlane:
               return infrav1alpha3.createG8sControlPlane(
                 httpClientFactory(),
                 auth,
-                n
+                n as infrav1alpha3.IG8sControlPlane
               );
             default:
               return Promise.reject(
@@ -803,6 +808,7 @@ export function getClusterConditions(
       statuses.isUpgrading = isClusterUpgrading(cluster);
       break;
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3': {
       if (!providerCluster) break;
 

--- a/src/components/MAPI/organizations/OrganizationDetailGeneral/utils.ts
+++ b/src/components/MAPI/organizations/OrganizationDetailGeneral/utils.ts
@@ -206,6 +206,7 @@ function appendProviderNodePoolsStats(
         break;
       }
 
+      case 'infrastructure.giantswarm.io/v1alpha2':
       case 'infrastructure.giantswarm.io/v1alpha3': {
         const instanceType = providerNp.spec.provider.worker.instanceType;
         const readyReplicas = nodePools[i].status?.readyReplicas;

--- a/src/components/MAPI/types.ts
+++ b/src/components/MAPI/types.ts
@@ -5,15 +5,20 @@ import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
 import * as capzv1alpha4 from 'model/services/mapi/capzv1alpha4';
 import * as gscorev1alpha1 from 'model/services/mapi/gscorev1alpha1';
+import * as infrav1alpha2 from 'model/services/mapi/infrastructurev1alpha2';
 import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
 
 export type ControlPlaneNode =
   | capzv1alpha3.IAzureMachine
+  | infrav1alpha2.IAWSControlPlane
+  | infrav1alpha2.IG8sControlPlane
   | infrav1alpha3.IAWSControlPlane
   | infrav1alpha3.IG8sControlPlane;
 
 export type ControlPlaneNodeList =
   | capzv1alpha3.IAzureMachineList
+  | infrav1alpha2.IAWSControlPlaneList
+  | infrav1alpha2.IG8sControlPlaneList
   | infrav1alpha3.IAWSControlPlaneList
   | infrav1alpha3.IG8sControlPlaneList;
 
@@ -23,11 +28,13 @@ export type ClusterList = capiv1alpha3.IClusterList;
 
 export type ProviderCluster =
   | capzv1alpha3.IAzureCluster
+  | infrav1alpha2.IAWSCluster
   | infrav1alpha3.IAWSCluster
   | undefined;
 
 export type ProviderClusterList =
   | capzv1alpha3.IAzureClusterList
+  | infrav1alpha2.IAWSClusterList
   | infrav1alpha3.IAWSClusterList;
 
 export type NodePool =
@@ -43,11 +50,14 @@ export type NodePoolList =
 export type ProviderNodePool =
   | capzexpv1alpha3.IAzureMachinePool
   | capzv1alpha4.IAzureMachinePool
+  | infrav1alpha2.IAWSMachineDeployment
   | infrav1alpha3.IAWSMachineDeployment
   | undefined;
 
 export type ProviderNodePoolList =
   | capzexpv1alpha3.IAzureMachinePoolList
-  | capzv1alpha4.IAzureMachinePoolList;
+  | capzv1alpha4.IAzureMachinePoolList
+  | infrav1alpha2.IAWSMachineDeploymentList
+  | infrav1alpha3.IAWSMachineDeploymentList;
 
 export type BootstrapConfig = gscorev1alpha1.ISpark | undefined;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -149,6 +149,7 @@ export async function fetchNodePoolListForCluster(
 
       break;
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       list = await capiv1alpha3.getMachineDeploymentList(
         httpClientFactory(),
@@ -205,6 +206,7 @@ export function fetchNodePoolListForClusterKey(
         },
       });
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return capiv1alpha3.getMachineDeploymentListKey({
         labelSelector: {
@@ -250,6 +252,7 @@ export async function fetchProviderNodePoolsForNodePools(
             infrastructureRef.name
           );
 
+        case 'infrastructure.giantswarm.io/v1alpha2':
         case 'infrastructure.giantswarm.io/v1alpha3':
           return infrav1alpha3.getAWSMachineDeployment(
             httpClientFactory(),
@@ -421,6 +424,7 @@ export async function fetchControlPlaneNodesForCluster(
       return cpNodes.items;
     }
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3': {
       const [awsCP, g8sCP] = await Promise.allSettled([
         infrav1alpha3.getAWSControlPlaneList(httpClientFactory(), auth, {
@@ -478,6 +482,7 @@ export function fetchControlPlaneNodesForClusterKey(
         },
       });
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return infrav1alpha3.getAWSControlPlaneListKey({
         labelSelector: {
@@ -492,11 +497,11 @@ export function fetchControlPlaneNodesForClusterKey(
   }
 }
 
-export function fetchProviderClusterForCluster(
+export async function fetchProviderClusterForCluster(
   httpClientFactory: HttpClientFactory,
   auth: IOAuth2Provider,
   cluster: Cluster
-) {
+): Promise<ProviderCluster> {
   const infrastructureRef = cluster.spec?.infrastructureRef;
   if (!infrastructureRef) {
     return Promise.reject(
@@ -514,6 +519,7 @@ export function fetchProviderClusterForCluster(
         infrastructureRef.name
       );
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return infrav1alpha3.getAWSCluster(
         httpClientFactory(),
@@ -539,6 +545,7 @@ export function fetchProviderClusterForClusterKey(cluster: Cluster) {
         infrastructureRef.name
       );
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return infrav1alpha3.getAWSClusterKey(
         cluster.metadata.namespace!,
@@ -605,6 +612,8 @@ export function getNodePoolDescription(
       );
     case 'cluster.x-k8s.io/v1alpha3':
       if (
+        providerNodePool?.apiVersion ===
+          'infrastructure.giantswarm.io/v1alpha2' ||
         providerNodePool?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3'
       ) {
         return providerNodePool.spec.nodePool.description || defaultValue;
@@ -637,6 +646,7 @@ export function getProviderNodePoolMachineTypes(
     case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
     case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return { primary: providerNodePool.spec?.template.vmSize ?? '' };
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return {
         primary: providerNodePool.spec.provider.worker.instanceType,
@@ -698,6 +708,7 @@ export function getProviderNodePoolSpotInstances(
       }
     }
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3': {
       const onDemandBaseCapacity =
         providerNodePool.spec.provider.instanceDistribution
@@ -770,6 +781,8 @@ export function getNodePoolScaling(
 
     case 'cluster.x-k8s.io/v1alpha3': {
       if (
+        providerNodePool?.apiVersion ===
+          'infrastructure.giantswarm.io/v1alpha2' ||
         providerNodePool?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3'
       ) {
         return {
@@ -798,6 +811,8 @@ export function getNodePoolAvailabilityZones(
       return nodePool.spec?.failureDomains ?? [];
     case 'cluster.x-k8s.io/v1alpha3': {
       if (
+        providerNodePool?.apiVersion ===
+          'infrastructure.giantswarm.io/v1alpha2' ||
         providerNodePool?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3'
       ) {
         return providerNodePool.spec.provider.availabilityZones;
@@ -837,6 +852,7 @@ export function getClusterDescription(
           capiv1alpha3.annotationClusterDescription
         ] || defaultValue
       );
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return (
         (providerCluster as infrav1alpha3.IAWSCluster)?.spec?.cluster
@@ -858,6 +874,7 @@ export function getProviderClusterLocation(
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
       return providerCluster.spec?.location ?? '';
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3': {
       const region = providerCluster.spec?.provider.region;
       if (typeof region === 'undefined') return '';
@@ -881,6 +898,7 @@ export function getProviderClusterAccountID(
       return id;
     }
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return '';
 
@@ -1051,6 +1069,7 @@ export function supportsClientCertificates(cluster: Cluster): boolean {
     case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return true;
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3': {
       const releaseVersion = getClusterReleaseVersion(cluster);
       if (!releaseVersion) return false;

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
@@ -23,6 +23,7 @@ function getLabel(providerNodePool: ProviderNodePool): string {
   switch (providerNodePool?.apiVersion) {
     case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
       return 'Spot virtual machines';
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return 'Instance distribution';
     default:
@@ -34,6 +35,7 @@ function getToggleLabel(providerNodePool: ProviderNodePool): string {
   switch (providerNodePool?.apiVersion) {
     case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
       return 'Enabled';
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return 'Enable Spot instances';
     default:

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemMachineType.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemMachineType.tsx
@@ -25,6 +25,7 @@ function formatMachineTypeLabel(providerNodePool?: ProviderNodePool) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha4':
       return `VM size: ${machineTypes?.primary ?? 'n/a'}`;
 
+    case 'infrastructure.giantswarm.io/v1alpha2':
     case 'infrastructure.giantswarm.io/v1alpha3':
       return `Instance type: ${machineTypes?.primary ?? 'n/a'}`;
 

--- a/src/components/MAPI/workernodes/patches.ts
+++ b/src/components/MAPI/workernodes/patches.ts
@@ -28,6 +28,8 @@ export function withNodePoolDescription(newDescription: string): NodePoolPatch {
         capiexpv1alpha3.annotationMachinePoolDescription
       ] = newDescription;
     } else if (
+      providerNodePool?.apiVersion ===
+        'infrastructure.giantswarm.io/v1alpha2' ||
       providerNodePool?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3'
     ) {
       providerNodePool.spec.nodePool.description = newDescription;
@@ -56,6 +58,7 @@ export function withNodePoolMachineType(
       case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
         providerNodePool.spec!.template.vmSize = config.primary;
         break;
+      case 'infrastructure.giantswarm.io/v1alpha2':
       case 'infrastructure.giantswarm.io/v1alpha3':
         providerNodePool.spec.provider.worker.instanceType = config.primary;
         providerNodePool.spec.provider.worker.useAlikeInstanceTypes = (
@@ -71,6 +74,8 @@ export function withNodePoolAvailabilityZones(zones?: string[]): NodePoolPatch {
     if (nodePool.kind === capiexpv1alpha3.MachinePool) {
       nodePool.spec!.failureDomains = zones;
     } else if (
+      providerNodePool?.apiVersion ===
+        'infrastructure.giantswarm.io/v1alpha2' ||
       providerNodePool?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3'
     ) {
       providerNodePool.spec.provider.availabilityZones = zones ?? [];
@@ -91,6 +96,8 @@ export function withNodePoolScaling(min: number, max: number): NodePoolPatch {
         capiexpv1alpha3.annotationMachinePoolMaxSize
       ] = max.toString();
     } else if (
+      providerNodePool?.apiVersion ===
+        'infrastructure.giantswarm.io/v1alpha2' ||
       providerNodePool?.apiVersion === 'infrastructure.giantswarm.io/v1alpha3'
     ) {
       providerNodePool.spec.nodePool.scaling.min = min;
@@ -134,6 +141,7 @@ export function withNodePoolSpotInstances(
 
         break;
 
+      case 'infrastructure.giantswarm.io/v1alpha2':
       case 'infrastructure.giantswarm.io/v1alpha3':
         providerNodePool.spec.provider.instanceDistribution = {
           onDemandBaseCapacity: (config as INodePoolSpotInstancesConfigAWS)

--- a/src/model/services/mapi/infrastructurev1alpha2/index.ts
+++ b/src/model/services/mapi/infrastructurev1alpha2/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/model/services/mapi/infrastructurev1alpha2/types.ts
+++ b/src/model/services/mapi/infrastructurev1alpha2/types.ts
@@ -1,0 +1,41 @@
+import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
+
+export interface IAWSCluster
+  extends Omit<infrav1alpha3.IAWSCluster, 'apiVersion'> {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha2';
+}
+
+export interface IAWSClusterList
+  extends Omit<infrav1alpha3.IAWSClusterList, 'apiVersion'> {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha2';
+}
+
+export interface IAWSControlPlane
+  extends Omit<infrav1alpha3.IAWSControlPlane, 'apiVersion'> {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha2';
+}
+
+export interface IAWSControlPlaneList
+  extends Omit<infrav1alpha3.IAWSControlPlaneList, 'apiVersion'> {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha2';
+}
+
+export interface IG8sControlPlane
+  extends Omit<infrav1alpha3.IG8sControlPlane, 'apiVersion'> {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha2';
+}
+
+export interface IG8sControlPlaneList
+  extends Omit<infrav1alpha3.IG8sControlPlaneList, 'apiVersion'> {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha2';
+}
+
+export interface IAWSMachineDeployment
+  extends Omit<infrav1alpha3.IAWSMachineDeployment, 'apiVersion'> {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha2';
+}
+
+export interface IAWSMachineDeploymentList
+  extends Omit<infrav1alpha3.IAWSMachineDeploymentList, 'apiVersion'> {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha2';
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/388

So turns out that GS-specific `v1alpha2` resources are still used in some old AWS clusters. This PR introduces a very very hacky way of dealing with them. We fool the type system a little bit, but behind the scenes we still operate on `v1alpha3` resources, which is fine, since there are conversion webhooks set up on the backend side.