### PR TITLE
Only display placeholders if the right resources were loaded

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -196,9 +196,10 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
   const isLoading = isLoadingResources || isDeleting;
 
   const name = cluster?.metadata.name ?? '';
-  const description = cluster
-    ? getClusterDescription(cluster, providerCluster)
-    : '';
+  const description =
+    cluster && providerCluster
+      ? getClusterDescription(cluster, providerCluster)
+      : '';
   const creationDate = cluster?.metadata.creationTimestamp ?? '';
 
   const workerNodePoolsCount = nodePoolList?.items.length ?? 0;

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/index.tsx
@@ -70,6 +70,16 @@ describe('ClusterDetail', () => {
       )
       .reply(StatusCodes.Ok, mockCapiv1alpha3.randomCluster1);
 
+    nock(window.config.mapiEndpoint)
+      .get(
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${
+          mockCapiv1alpha3.randomCluster1.metadata.namespace
+        }/azureclusters/${
+          mockCapiv1alpha3.randomCluster1.spec!.infrastructureRef!.name
+        }/`
+      )
+      .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureCluster1);
+
     render(getComponent({}));
 
     expect(await screen.findByText('Random Cluster')).toBeInTheDocument();

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -230,9 +230,10 @@ const ClusterDetail: React.FC<{}> = () => {
     }
   }, [providerClusterError]);
 
-  const clusterDescription = cluster
-    ? getClusterDescription(cluster, providerCluster)
-    : undefined;
+  const clusterDescription =
+    cluster && providerCluster
+      ? getClusterDescription(cluster, providerCluster)
+      : undefined;
   const clusterReleaseVersion = cluster
     ? capiv1alpha3.getReleaseVersion(cluster)
     : undefined;

--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -81,7 +81,7 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
 }) => {
   const name = cluster?.metadata.name;
   const description = useMemo(() => {
-    if (!cluster) return undefined;
+    if (!cluster || !providerCluster) return undefined;
 
     return getClusterDescription(cluster, providerCluster, '');
   }, [cluster, providerCluster]);

--- a/src/components/MAPI/clusters/ClusterList/__tests__/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/__tests__/ClusterListItem.tsx
@@ -134,6 +134,7 @@ describe('ClusterListItem', () => {
             creationTimestamp: creationDate.toISOString(),
           },
         },
+        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
         releases: releasev1alpha1Mocks.releasesList.items,
       })
     );

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -798,7 +798,7 @@ export function getClusterConditions(
   switch (infrastructureRef.apiVersion) {
     case 'infrastructure.cluster.x-k8s.io/v1alpha3':
     case 'infrastructure.cluster.x-k8s.io/v1alpha4':
-      statuses.isConditionUnknown = typeof cluster.spec === 'undefined';
+      statuses.isConditionUnknown = typeof cluster.status === 'undefined';
       statuses.isCreating = isClusterCreating(cluster);
       statuses.isUpgrading = isClusterUpgrading(cluster);
       break;

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -81,9 +81,10 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
     nodePool && providerNodePool
       ? getNodePoolDescription(nodePool, providerNodePool)
       : undefined;
-  const availabilityZones = nodePool
-    ? getNodePoolAvailabilityZones(nodePool, providerNodePool)
-    : undefined;
+  const availabilityZones =
+    nodePool && providerNodePool
+      ? getNodePoolAvailabilityZones(nodePool, providerNodePool)
+      : undefined;
   const scaling = useMemo(() => {
     if (!nodePool) return undefined;
 

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItemMachineType.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItemMachineType.tsx
@@ -41,9 +41,10 @@ interface IWorkerNodesNodePoolItemMachineTypeProps
 
 const WorkerNodesNodePoolItemMachineType: React.FC<IWorkerNodesNodePoolItemMachineTypeProps> =
   ({ nodePool, providerNodePool, ...props }) => {
-    const machineTypes = nodePool
-      ? getProviderNodePoolMachineTypes(providerNodePool)
-      : undefined;
+    const machineTypes =
+      nodePool && providerNodePool
+        ? getProviderNodePoolMachineTypes(providerNodePool)
+        : undefined;
 
     const allMachineTypes = (
       machineTypes as INodePoolMachineTypesAWS | undefined


### PR DESCRIPTION
This pretty much only affects AWS clusters, so this is towards https://github.com/giantswarm/roadmap/issues/388

This PR makes sure that we display loading animations when it's right to do so, and we don't display placeholders unless we tried to load everything there is to load.