### PR TITLE
clusters: update CLI guide for setting cluster labels for AWS clusters

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -142,6 +142,7 @@ const ClusterDetailOverview: React.FC<{}> = () => {
           <SetClusterLabelsGuide
             clusterName={cluster.metadata.name}
             clusterNamespace={cluster.metadata.namespace!}
+            provider={provider}
           />
         </Box>
       )}

--- a/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
+++ b/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
@@ -3,6 +3,8 @@ import * as docs from 'lib/docs';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
 import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
 import React from 'react';
+import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
 import CLIGuide from 'UI/Display/MAPI/CLIGuide';
 import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
 import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
@@ -12,11 +14,13 @@ interface ISetClusterLabelsGuideProps
   extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
   clusterName: string;
   clusterNamespace: string;
+  provider: PropertiesOf<typeof Providers>;
 }
 
 const SetClusterLabelsGuide: React.FC<ISetClusterLabelsGuideProps> = ({
   clusterName,
   clusterNamespace,
+  provider,
   ...props
 }) => {
   const context = getCurrentInstallationContextName();
@@ -58,7 +62,11 @@ const SetClusterLabelsGuide: React.FC<ISetClusterLabelsGuideProps> = ({
           title='2. Add a label to this cluster'
           command={`
           kubectl --context ${context} \\
-            patch cluster ${clusterName} \\
+            patch ${
+              provider === Providers.AWS
+                ? 'clusters.cluster.x-k8s.io'
+                : 'cluster'
+            } ${clusterName} \\
             -n ${clusterNamespace} \\
             --type merge \\
             --patch '{"metadata": {"labels": {"foo": "bar"}}}'


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/388.

This PR updates the CLI guide for setting cluster labels to use the full CRD name for clusters on AWS
<img width="1193" alt="Screen Shot 2021-11-03 at 14 43 25" src="https://user-images.githubusercontent.com/62935115/140071189-1dae179c-bd51-4358-9cdf-0006c2dde71a.png">


