### PR TITLE
node pools: update CLI guide for node pool deletion on AWS

### DIFF
--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -508,6 +508,7 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
                 {!isReadOnly && (
                   <DeleteNodePoolGuide
                     clusterNamespace={cluster.metadata.namespace!}
+                    provider={provider}
                   />
                 )}
               </Box>

--- a/src/components/MAPI/workernodes/guides/DeleteNodePoolGuide.tsx
+++ b/src/components/MAPI/workernodes/guides/DeleteNodePoolGuide.tsx
@@ -3,6 +3,8 @@ import * as docs from 'lib/docs';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
 import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
 import React from 'react';
+import { Providers } from 'shared/constants';
+import { PropertiesOf } from 'shared/types';
 import CLIGuide from 'UI/Display/MAPI/CLIGuide';
 import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalInfo';
 import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
@@ -11,10 +13,12 @@ import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
 interface IDeleteNodePoolGuideProps
   extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
   clusterNamespace: string;
+  provider: PropertiesOf<typeof Providers>;
 }
 
 const DeleteNodePoolGuide: React.FC<IDeleteNodePoolGuideProps> = ({
   clusterNamespace,
+  provider,
   ...props
 }) => {
   const context = getCurrentInstallationContextName();
@@ -46,7 +50,11 @@ const DeleteNodePoolGuide: React.FC<IDeleteNodePoolGuideProps> = ({
           title='2. Delete a node pool'
           command={`
           kubectl --context ${context} \\
-            delete machinepools.exp.cluster.x-k8s.io my-np \\
+            delete ${
+              provider === Providers.AWS
+                ? 'machinedeployments.cluster.x-k8s.io,awsmachinedeployments.infrastructure.giantswarm.io'
+                : 'machinepools.exp.cluster.x-k8s.io'
+            } my-np \\
             --namespace ${clusterNamespace}
           `}
         >


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/388.

This PR updates the commands in the CLI guide for deleting node pools on AWS.
<img width="1193" alt="Screen Shot 2021-11-03 at 15 16 28" src="https://user-images.githubusercontent.com/62935115/140077323-618dc669-760b-41ba-b851-cfe3af1c9ae2.png">