### PR TITLE
Fix flash messages duplication and content overflow

### DIFF
--- a/src/components/UI/Util/FlashMessages/FlashMessagesController.ts
+++ b/src/components/UI/Util/FlashMessages/FlashMessagesController.ts
@@ -53,7 +53,7 @@ export class FlashMessagesController {
   }
 
   public enqueue(entry: IFlashMessageEntry) {
-    if (this.queue.length >= MAX_COUNT) return;
+    if (this.queue.length >= MAX_COUNT || this.queue.includes(entry)) return;
 
     this.queue.add(entry);
 

--- a/src/components/UI/Util/FlashMessages/FlashMessagesNotification.tsx
+++ b/src/components/UI/Util/FlashMessages/FlashMessagesNotification.tsx
@@ -23,6 +23,8 @@ function mapMessageTypeToBackgroundColor(
 }
 
 const Content = styled(Box)`
+  word-break: break-word;
+
   code {
     background-color: ${({ theme }) => theme.global.colors['text-strong'].dark};
     color: ${({ theme }) => theme.global.colors['text-xxweak'].dark};

--- a/src/lib/Queue.ts
+++ b/src/lib/Queue.ts
@@ -66,7 +66,9 @@ class QueueImpl<T> implements IQueue<T>, Iterable<T> {
    * @param entry
    */
   public includes(entry: T) {
-    return this.entries.includes(entry);
+    return this.entries.some(
+      (currentEntry) => JSON.stringify(currentEntry) === JSON.stringify(entry)
+    );
   }
 
   /**

--- a/src/lib/Queue.ts
+++ b/src/lib/Queue.ts
@@ -1,3 +1,5 @@
+import { isEqual } from 'underscore';
+
 export interface IQueue<T> {
   add: (entry: T) => void;
   remove: (entry: T) => void;
@@ -66,9 +68,7 @@ class QueueImpl<T> implements IQueue<T>, Iterable<T> {
    * @param entry
    */
   public includes(entry: T) {
-    return this.entries.some(
-      (currentEntry) => JSON.stringify(currentEntry) === JSON.stringify(entry)
-    );
+    return this.entries.some((currentEntry) => isEqual(currentEntry, entry));
   }
 
   /**

--- a/src/lib/__tests__/flashMessage.tsx
+++ b/src/lib/__tests__/flashMessage.tsx
@@ -1,4 +1,4 @@
-import { act, screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import {
   FlashMessage,
   forceRemoveAll,
@@ -61,5 +61,34 @@ describe('FlashMessage', () => {
         await screen.findAllByText('Yo! Something went wrong.')
       ).toHaveLength(2);
     });
+  });
+
+  it(`won't display duplicate messages after the first one has been closed`, async () => {
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    renderWithTheme(() => <></>, {});
+
+    await act(async () => {
+      new FlashMessage(
+        `Sorry, your request failed.`,
+        messageType.ERROR,
+        messageTTL.MEDIUM
+      );
+
+      new FlashMessage(
+        `Sorry, your request failed.`,
+        messageType.ERROR,
+        messageTTL.MEDIUM
+      );
+
+      expect(
+        await screen.findAllByText('Sorry, your request failed.')
+      ).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(
+      screen.queryByText('Sorry, your request failed.')
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR fixes a bug with flash messages, where duplicate messages were being displayed after the user closes the first one. It also adds the `word-break` property to flash message content to prevent text content from overflowing.