### PR TITLE
Add staff support for impersonating users

### DIFF
--- a/src/components/Auth/MAPI/MapiUnauthorized.tsx
+++ b/src/components/Auth/MAPI/MapiUnauthorized.tsx
@@ -1,10 +1,12 @@
 import { Anchor, Box, Heading, Paragraph, Text } from 'grommet';
 import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
 import { IOAuth2ImpersonationMetadata } from 'lib/OAuth2/OAuth2';
+import { usePermissionsKey } from 'MAPI/permissions/usePermissions';
 import React, { useEffect, useMemo, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { MainRoutes } from 'shared/constants/routes';
 import styled from 'styled-components';
+import { mutate } from 'swr';
 import Button from 'UI/Controls/Button';
 
 import { useAuthProvider } from './MapiAuthProvider';
@@ -45,6 +47,8 @@ const MapiUnauthorized: React.FC<IMapiUnauthorizedProps> = ({
 
   const clearImpersonation = async () => {
     await auth.setImpersonationMetadata(null);
+
+    mutate(usePermissionsKey);
 
     new FlashMessage(
       'Impersonation removed successfully.',

--- a/src/components/Auth/MAPI/MapiUnauthorized.tsx
+++ b/src/components/Auth/MAPI/MapiUnauthorized.tsx
@@ -1,8 +1,13 @@
 import { Anchor, Box, Heading, Paragraph, Text } from 'grommet';
-import * as React from 'react';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import { IOAuth2ImpersonationMetadata } from 'lib/OAuth2/OAuth2';
+import React, { useEffect, useMemo, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { MainRoutes } from 'shared/constants/routes';
 import styled from 'styled-components';
+import Button from 'UI/Controls/Button';
+
+import { useAuthProvider } from './MapiAuthProvider';
 
 const StyledBox = styled(Box)`
   position: relative;
@@ -17,10 +22,38 @@ const MapiUnauthorized: React.FC<IMapiUnauthorizedProps> = ({
   user,
   ...props
 }) => {
-  const email = user?.email ?? 'Not logged in';
+  const auth = useAuthProvider();
 
-  let groups = user?.groups?.join(', ');
-  groups ||= 'none';
+  const [impersonationMetadata, setImpersonationMetadata] =
+    useState<IOAuth2ImpersonationMetadata | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const metadata = await auth.getImpersonationMetadata();
+
+      setImpersonationMetadata(metadata);
+    })();
+  }, [auth]);
+
+  const groups = useMemo(() => {
+    if (impersonationMetadata) {
+      return impersonationMetadata.groups?.join(', ') || 'none';
+    }
+
+    return user?.groups?.join(', ') || 'none';
+  }, [impersonationMetadata, user?.groups]);
+
+  const clearImpersonation = async () => {
+    await auth.setImpersonationMetadata(null);
+
+    new FlashMessage(
+      'Impersonation removed successfully.',
+      messageType.SUCCESS,
+      messageTTL.MEDIUM
+    );
+  };
+
+  const email = user?.email ?? 'Not logged in';
 
   return (
     <StyledBox width='large' margin='auto' {...props}>
@@ -51,21 +84,38 @@ const MapiUnauthorized: React.FC<IMapiUnauthorizedProps> = ({
         Please provide this additional information on request:
       </Paragraph>
       <Box direction='column' gap='xsmall' margin={{ top: 'small' }}>
-        <Box direction='row' gap='xsmall'>
-          <Text weight='bold'>Email:</Text>
-          <Text>{email}</Text>
-        </Box>
+        {impersonationMetadata ? (
+          <Box direction='row' gap='xsmall'>
+            <Text weight='bold'>User:</Text>
+            <Text>
+              {impersonationMetadata.user} (impersonated by {email})
+            </Text>
+          </Box>
+        ) : (
+          <Box direction='row' gap='xsmall'>
+            <Text weight='bold'>Email:</Text>
+            <Text>{email}</Text>
+          </Box>
+        )}
         <Box direction='row' gap='xsmall'>
           <Text weight='bold'>Groups:</Text>
           <Text>{groups}</Text>
         </Box>
       </Box>
-      <Box direction='column' gap='xsmall' margin={{ top: 'medium' }}>
-        <Paragraph fill={true}>
-          <NavLink href={MainRoutes.Logout} to={MainRoutes.Logout}>
-            Try logging in again
-          </NavLink>
-        </Paragraph>
+      <Box
+        direction='row'
+        gap='small'
+        align='center'
+        margin={{ top: 'medium' }}
+      >
+        {impersonationMetadata && (
+          <Button secondary={true} onClick={clearImpersonation}>
+            Clear impersonation
+          </Button>
+        )}
+        <NavLink href={MainRoutes.Logout} to={MainRoutes.Logout}>
+          Try logging in again
+        </NavLink>
       </Box>
     </StyledBox>
   );

--- a/src/components/MAPI/Experiments.tsx
+++ b/src/components/MAPI/Experiments.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { AccountSettingsRoutes } from 'shared/constants/routes';
 import * as featureFlags from 'shared/featureFlags';
+import { mutate } from 'swr';
 import Button from 'UI/Controls/Button';
 import {
   Table,
@@ -16,6 +17,8 @@ import {
 } from 'UI/Display/Table';
 import CheckBoxInput from 'UI/Inputs/CheckBoxInput';
 import TextInput from 'UI/Inputs/TextInput';
+
+import { usePermissionsKey } from './permissions/usePermissions';
 
 interface IExperimentsProps {}
 
@@ -45,13 +48,17 @@ const Experiments: React.FC<IExperimentsProps> = () => {
     })();
   }, [auth]);
 
-  const handleSetImpersonation = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSetImpersonation = async (
+    e: React.FormEvent<HTMLFormElement>
+  ) => {
     e.preventDefault();
 
-    auth.setImpersonationMetadata({
+    await auth.setImpersonationMetadata({
       user: impersonationUser,
       groups: impersonationGroup ? [impersonationGroup] : undefined,
     });
+
+    mutate(usePermissionsKey);
 
     new FlashMessage(
       'Impersonation configured successfully.',
@@ -60,11 +67,13 @@ const Experiments: React.FC<IExperimentsProps> = () => {
     );
   };
 
-  const handleClearImpersonation = () => {
+  const handleClearImpersonation = async () => {
     setImpersonationUser('');
     setImpersonationGroup('');
 
-    auth.setImpersonationMetadata(null);
+    await auth.setImpersonationMetadata(null);
+
+    mutate(usePermissionsKey);
 
     new FlashMessage(
       'Impersonation removed successfully.',

--- a/src/components/MAPI/Experiments.tsx
+++ b/src/components/MAPI/Experiments.tsx
@@ -1,9 +1,12 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import DocumentTitle from 'components/shared/DocumentTitle';
 import { Box, Heading, Text } from 'grommet';
-import React from 'react';
+import { FlashMessage, messageTTL, messageType } from 'lib/flashMessage';
+import React, { useEffect, useState } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { AccountSettingsRoutes } from 'shared/constants/routes';
 import * as featureFlags from 'shared/featureFlags';
+import Button from 'UI/Controls/Button';
 import {
   Table,
   TableBody,
@@ -12,6 +15,7 @@ import {
   TableRow,
 } from 'UI/Display/Table';
 import CheckBoxInput from 'UI/Inputs/CheckBoxInput';
+import TextInput from 'UI/Inputs/TextInput';
 
 interface IExperimentsProps {}
 
@@ -26,6 +30,44 @@ const Experiments: React.FC<IExperimentsProps> = () => {
     if (featureFlags.flags.hasOwnProperty(featureName)) {
       featureFlags.flags[featureName].enabled = e.target.checked;
     }
+  };
+
+  const auth = useAuthProvider();
+  const [impersonationUser, setImpersonationUser] = useState<string>('');
+  const [impersonationGroup, setImpersonationGroup] = useState<string>('');
+
+  useEffect(() => {
+    (async () => {
+      const metadata = await auth.getImpersonationMetadata();
+
+      setImpersonationUser(metadata?.user ?? '');
+      setImpersonationGroup(metadata?.groups?.[0] ?? '');
+    })();
+  }, [auth]);
+
+  const handleSetImpersonation = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    auth.setImpersonationMetadata({
+      user: impersonationUser,
+      groups: impersonationGroup ? [impersonationGroup] : undefined,
+    });
+
+    new FlashMessage(
+      'Impersonation configured successfully.',
+      messageType.SUCCESS,
+      messageTTL.MEDIUM
+    );
+  };
+
+  const handleClearImpersonation = () => {
+    auth.setImpersonationMetadata(null);
+
+    new FlashMessage(
+      'Impersonation removed successfully.',
+      messageType.SUCCESS,
+      messageTTL.MEDIUM
+    );
   };
 
   return (
@@ -79,6 +121,61 @@ const Experiments: React.FC<IExperimentsProps> = () => {
               ))}
             </TableBody>
           </Table>
+        </Box>
+        <Box
+          margin={{ top: 'large' }}
+          background='background-back'
+          pad='large'
+          round='xsmall'
+          justify='start'
+          direction='row'
+        >
+          <Box
+            flex={{ grow: 0, shrink: 1 }}
+            basis='medium'
+            pad={{ horizontal: 'small' }}
+          >
+            <Heading level={2} margin='none'>
+              Impersonation
+            </Heading>
+            <Text margin={{ top: 'small' }} color='text-weak'>
+              You can set up impersonation to act as another user. This is
+              useful for debugging permissions.
+            </Text>
+          </Box>
+          <Box
+            flex={{ grow: 1, shrink: 1 }}
+            basis='medium'
+            width={{ max: 'large' }}
+            gap='small'
+          >
+            <form onSubmit={handleSetImpersonation}>
+              <TextInput
+                label='Username'
+                id='username'
+                name='username'
+                help='The user defined in the RoleBinding.'
+                required={true}
+                value={impersonationUser}
+                onChange={(e) => setImpersonationUser(e.target.value)}
+              />
+              <TextInput
+                label='Group'
+                id='group'
+                name='group'
+                help='Impersonate a specific group that the user is a part of.'
+                placeholder='Optional'
+                value={impersonationGroup}
+                onChange={(e) => setImpersonationGroup(e.target.value)}
+              />
+              <Box direction='row' margin={{ top: 'medium' }} gap='small'>
+                <Button primary={true} type='submit'>
+                  Set
+                </Button>
+                <Button onClick={handleClearImpersonation}>Clear</Button>
+              </Box>
+            </form>
+          </Box>
         </Box>
       </DocumentTitle>
     </Breadcrumb>

--- a/src/components/MAPI/Experiments.tsx
+++ b/src/components/MAPI/Experiments.tsx
@@ -61,6 +61,9 @@ const Experiments: React.FC<IExperimentsProps> = () => {
   };
 
   const handleClearImpersonation = () => {
+    setImpersonationUser('');
+    setImpersonationGroup('');
+
     auth.setImpersonationMetadata(null);
 
     new FlashMessage(

--- a/src/components/MAPI/permissions/usePermissions.ts
+++ b/src/components/MAPI/permissions/usePermissions.ts
@@ -17,6 +17,8 @@ import { fetchPermissions } from './utils';
 // eslint-disable-next-line no-magic-numbers
 const REFRESH_INTERVAL = 60 * 1000; // In ms.
 
+export const usePermissionsKey = 'getUserPermissions';
+
 export function usePermissions() {
   const user = useSelector(getLoggedInUser);
 
@@ -33,7 +35,7 @@ export function usePermissions() {
 
   const key =
     firstLoadComplete && user?.type === LoggedInUserTypes.MAPI
-      ? 'getUserPermissions'
+      ? usePermissionsKey
       : null;
   const { data, error, isValidating } = useSWR<
     IPermissionMap,

--- a/src/lib/OAuth2/TestOAuth2.ts
+++ b/src/lib/OAuth2/TestOAuth2.ts
@@ -3,7 +3,12 @@ import { createMemoryHistory } from 'history';
 import { compareDates } from 'lib/helpers';
 import { AuthorizationTypes } from 'shared/constants';
 
-import { IOAuth2EventCallbacks, IOAuth2Provider, OAuth2Events } from './OAuth2';
+import {
+  IOAuth2EventCallbacks,
+  IOAuth2ImpersonationMetadata,
+  IOAuth2Provider,
+  OAuth2Events,
+} from './OAuth2';
 import { IOAuth2User } from './OAuth2User';
 
 class TestOAuth2 implements IOAuth2Provider {
@@ -56,6 +61,18 @@ class TestOAuth2 implements IOAuth2Provider {
     this.loggedInUser = null;
     this.dispatchEvent(OAuth2Events.UserUnloaded);
 
+    return Promise.resolve();
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public async getImpersonationMetadata(): Promise<IOAuth2ImpersonationMetadata | null> {
+    return Promise.resolve(null);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public async setImpersonationMetadata(
+    _metadata: IOAuth2ImpersonationMetadata | null
+  ): Promise<void> {
     return Promise.resolve();
   }
 

--- a/src/model/services/mapi/generic/ensureClientAuth.ts
+++ b/src/model/services/mapi/generic/ensureClientAuth.ts
@@ -24,6 +24,15 @@ export async function ensureClientAuth(
 
   client.setAuthorizationToken(user.authorizationType, user.idToken);
 
+  const impersonationMetadata = await auth.getImpersonationMetadata();
+  if (impersonationMetadata) {
+    client.setHeader('Impersonate-User', impersonationMetadata.user);
+
+    if (impersonationMetadata.groups?.length !== 0) {
+      client.setHeader('Impersonate-Group', impersonationMetadata.groups![0]);
+    }
+  }
+
   return Promise.resolve(client);
 }
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/564

This PR adds a new `Impersonation` section to the `Experiments` page.
With it we can act as other users, test permissions or debug problems.

This is only visible to Giant Swarm staff, for now. We can create better UI support for customers later on.

Impersonation is also persisted between sessions. If you get stuck, you can delete the `localStorage` entry from the DevTools Inspector.

[Read more about Kubernetes API impersonation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation)

## Preview

![image](https://user-images.githubusercontent.com/13508038/141354441-46495458-5ebf-4ebb-8726-c0455d7869f1.png)
