### PR TITLE
Fix node pool creation: spot instances should be disabled by default

### DIFF
--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -713,13 +713,16 @@ export function getProviderNodePoolSpotInstances(
       const onDemandBaseCapacity =
         providerNodePool.spec.provider.instanceDistribution
           ?.onDemandBaseCapacity ?? 0;
+      const onDemandPercentageAboveBaseCapacity =
+        providerNodePool.spec.provider.instanceDistribution
+          ?.onDemandPercentageAboveBaseCapacity ?? 0;
 
       return {
-        enabled: onDemandBaseCapacity > 0,
+        // eslint-disable-next-line no-magic-numbers
+        enabled: onDemandPercentageAboveBaseCapacity < 100,
         onDemandBaseCapacity: onDemandBaseCapacity ?? 0,
         onDemandPercentageAboveBaseCapacity:
-          providerNodePool.spec.provider.instanceDistribution
-            ?.onDemandPercentageAboveBaseCapacity ?? 0,
+          onDemandPercentageAboveBaseCapacity ?? 0,
         nodeCount:
           providerNodePool.status?.provider?.worker?.spotInstances ?? 0,
       };

--- a/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesCreateNodePoolSpotInstances.tsx
@@ -85,7 +85,8 @@ const WorkerNodesCreateNodePoolSpotInstances: React.FC<IWorkerNodesCreateNodePoo
           appendChanges({
             enabled: e.target.checked,
             onDemandBaseCapacity: 0,
-            onDemandPercentageAboveBaseCapacity: 0,
+            // eslint-disable-next-line no-magic-numbers
+            onDemandPercentageAboveBaseCapacity: e.target.checked ? 0 : 100,
           });
           break;
       }

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -631,7 +631,7 @@ export function createDefaultAWSMachineDeployment(config: {
         },
         instanceDistribution: {
           onDemandBaseCapacity: 0,
-          onDemandPercentageAboveBaseCapacity: 0,
+          onDemandPercentageAboveBaseCapacity: 100,
         },
       },
     },


### PR DESCRIPTION
In the node pool creation form, there is an option to enable spot instances, and this option should be disabled by default in both the UI and the resulting CRD created by the form.

The percentage of spot instances is equal to the percentage of instances that are not on-demand. So in order to disable spot instances by default, we set `onDemandPercentageAboveBaseCapacity` to 100. When the option is enabled, we set `onDemandPercentageAboveBaseCapacity` to 0.