### PR TITLE
Take into account that the `.spec` property of a StorageConfig can be omited

### DIFF
--- a/src/model/services/mapi/gscorev1alpha1/types.ts
+++ b/src/model/services/mapi/gscorev1alpha1/types.ts
@@ -14,7 +14,7 @@ export interface IStorageConfig {
   apiVersion: 'core.giantswarm.io/v1alpha1';
   kind: typeof StorageConfig;
   metadata: metav1.IObjectMeta;
-  spec: IStorageConfigSpec;
+  spec?: IStorageConfigSpec;
 }
 
 export const StorageConfigList = 'StorageConfigList';

--- a/src/model/services/mapi/legacy/keypairs/getKeyPairList.ts
+++ b/src/model/services/mapi/legacy/keypairs/getKeyPairList.ts
@@ -32,6 +32,8 @@ function findKeyPairsForCluster(
   clusterName: string,
   storageConfig: gscorev1alpha1.IStorageConfig
 ): IKeyPair[] {
+  if (typeof storageConfig.spec === 'undefined') return [];
+
   const storageKeyPrefix = createKeyPairStorageKey(clusterName, '');
 
   const keyPairs: IKeyPair[] = [];


### PR DESCRIPTION
Fixes https://sentry.io/organizations/giantswarm/issues/2796688169/