### PR TITLE
Add a warning message to client certificates list

### DIFF
--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
@@ -170,12 +170,18 @@ const ClusterDetailKeyPairs: React.FC<IClusterDetailKeyPairsProps> = () => {
       >
         <>
           <Box>
-            <Box>
+            <Box gap='small'>
               <Text>
                 Client certificates consist of an RSA private key and an X.509
                 certificate, signed by the certificate authority (CA) belonging
                 to this cluster. They are used for access to the cluster via the
                 Kubernetes API.
+              </Text>
+              <Text>
+                <strong>Caution:</strong> This list does not include client
+                certificates created via the
+                <code>kubectl gs login</code> command or directly via CertConfig
+                resources.
               </Text>
             </Box>
             <Table width='100%' margin={{ top: 'medium' }}>

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
@@ -178,6 +178,11 @@ const ClusterDetailKeyPairs: React.FC<IClusterDetailKeyPairsProps> = () => {
                 Kubernetes API.
               </Text>
               <Text>
+                <i
+                  className='fa fa-info'
+                  aria-hidden={true}
+                  role='presentation'
+                />{' '}
                 <strong>Caution:</strong> This list does not include client
                 certificates created via the
                 <code>kubectl gs login</code> command or directly via CertConfig

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
@@ -184,9 +184,8 @@ const ClusterDetailKeyPairs: React.FC<IClusterDetailKeyPairsProps> = () => {
                   role='presentation'
                 />{' '}
                 <strong>Caution:</strong> This list does not include client
-                certificates created via the
-                <code>kubectl gs login</code> command or directly via CertConfig
-                resources.
+                certificates created via the <code>kubectl gs login</code>{' '}
+                command or directly via CertConfig resources.
               </Text>
             </Box>
             <Table width='100%' margin={{ top: 'medium' }}>


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19161#issuecomment-972737232.

This PR adds a warning message to the client certificates list:
<img width="1209" alt="Screen Shot 2021-11-18 at 13 39 53" src="https://user-images.githubusercontent.com/62935115/142416925-23fcbae1-3d5c-4fd0-be02-e07865b787ee.png">