### PR TITLE
Account for mixed-case organization names when creating clusters

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -181,6 +181,7 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
   const { orgId } = match.params;
   const organizations = useSelector(selectOrganizations());
   const selectedOrg = orgId ? organizations[orgId] : undefined;
+  const organizationID = selectedOrg?.name ?? selectedOrg?.id ?? orgId;
 
   const namespace = selectedOrg?.namespace ?? getNamespaceFromOrgName(orgId);
 
@@ -190,7 +191,7 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
     reducer,
     makeInitialState(provider, {
       namespace,
-      organization: orgId,
+      organization: organizationID,
       orgNamespace: namespace,
     })
   );


### PR DESCRIPTION
As seen here https://gigantic.slack.com/archives/C02HLSDH3DZ/p1637672187203800