### PR TITLE
Fix node pool list information mismatch

### DIFF
--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -13,6 +13,7 @@ import {
   getClusterDescription,
   getMachineTypes,
 } from 'MAPI/utils';
+import { mapNodePoolsToProviderNodePools } from 'MAPI/workernodes/utils';
 import { OrganizationsRoutes } from 'model/constants/routes';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
@@ -162,18 +163,22 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
 
   const machineTypes = useRef(getMachineTypes());
 
+  const nodePoolsWithProviderNodePools = useMemo(() => {
+    if (!nodePoolList?.items || !providerNodePools) return undefined;
+
+    return mapNodePoolsToProviderNodePools(
+      nodePoolList.items,
+      providerNodePools
+    );
+  }, [nodePoolList?.items, providerNodePools]);
+
   const workerNodesCPU = providerNodePoolsError
     ? -1
-    : getWorkerNodesCPU(
-        nodePoolList?.items,
-        providerNodePools,
-        machineTypes.current
-      );
+    : getWorkerNodesCPU(nodePoolsWithProviderNodePools, machineTypes.current);
   const workerNodesMemory = providerNodePoolsError
     ? -1
     : getWorkerNodesMemory(
-        nodePoolList?.items,
-        providerNodePools,
+        nodePoolsWithProviderNodePools,
         machineTypes.current
       );
 

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -4,7 +4,6 @@ import {
   ControlPlaneNode,
   NodePool,
   ProviderCluster,
-  ProviderNodePool,
 } from 'MAPI/types';
 import {
   determineRandomAZs,
@@ -16,6 +15,7 @@ import {
   IMachineType,
   IProviderClusterForClusterName,
 } from 'MAPI/utils';
+import { IProviderNodePoolForNodePool } from 'MAPI/workernodes/utils';
 import { Constants, Providers } from 'model/constants';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 import * as capzv1alpha3 from 'model/services/mapi/capzv1alpha3';
@@ -44,23 +44,20 @@ export function getWorkerNodesCount(nodePools?: NodePool[]) {
 }
 
 export function getWorkerNodesCPU(
-  nodePools?: NodePool[],
-  providerNodePools?: ProviderNodePool[],
+  nodePoolsWithProviderNodePools?: IProviderNodePoolForNodePool[],
   machineTypes?: Record<string, IMachineType>
 ) {
-  if (!nodePools || !providerNodePools || !machineTypes) return undefined;
+  if (!nodePoolsWithProviderNodePools || !machineTypes) return undefined;
 
   let count = 0;
 
-  for (let i = 0; i < providerNodePools.length; i++) {
-    const providerNp = providerNodePools[i];
-
-    switch (providerNp?.apiVersion) {
+  for (const { nodePool, providerNodePool } of nodePoolsWithProviderNodePools) {
+    switch (providerNodePool?.apiVersion) {
       case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
       case 'infrastructure.cluster.x-k8s.io/v1alpha4':
         {
-          const vmSize = providerNp.spec?.template.vmSize;
-          const readyReplicas = nodePools[i].status?.readyReplicas;
+          const vmSize = providerNodePool.spec?.template.vmSize;
+          const readyReplicas = nodePool.status?.readyReplicas;
 
           if (!vmSize) return -1;
 
@@ -78,8 +75,8 @@ export function getWorkerNodesCPU(
 
       case 'infrastructure.giantswarm.io/v1alpha2':
       case 'infrastructure.giantswarm.io/v1alpha3': {
-        const instanceType = providerNp.spec.provider.worker.instanceType;
-        const readyReplicas = nodePools[i].status?.readyReplicas;
+        const instanceType = providerNodePool.spec.provider.worker.instanceType;
+        const readyReplicas = nodePool.status?.readyReplicas;
 
         if (typeof readyReplicas !== 'undefined') {
           const machineTypeProperties = machineTypes[instanceType];
@@ -102,22 +99,19 @@ export function getWorkerNodesCPU(
 }
 
 export function getWorkerNodesMemory(
-  nodePools?: NodePool[],
-  providerNodePools?: ProviderNodePool[],
+  nodePoolsWithProviderNodePools?: IProviderNodePoolForNodePool[],
   machineTypes?: Record<string, IMachineType>
 ) {
-  if (!nodePools || !providerNodePools || !machineTypes) return undefined;
+  if (!nodePoolsWithProviderNodePools || !machineTypes) return undefined;
 
   let count = 0;
 
-  for (let i = 0; i < providerNodePools.length; i++) {
-    const providerNp = providerNodePools[i];
-
-    switch (providerNp?.apiVersion) {
+  for (const { nodePool, providerNodePool } of nodePoolsWithProviderNodePools) {
+    switch (providerNodePool?.apiVersion) {
       case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
       case 'infrastructure.cluster.x-k8s.io/v1alpha4': {
-        const vmSize = providerNp.spec?.template.vmSize;
-        const readyReplicas = nodePools[i].status?.readyReplicas;
+        const vmSize = providerNodePool.spec?.template.vmSize;
+        const readyReplicas = nodePool.status?.readyReplicas;
 
         if (!vmSize) return -1;
 
@@ -135,8 +129,8 @@ export function getWorkerNodesMemory(
 
       case 'infrastructure.giantswarm.io/v1alpha2':
       case 'infrastructure.giantswarm.io/v1alpha3': {
-        const instanceType = providerNp.spec.provider.worker.instanceType;
-        const readyReplicas = nodePools[i].status?.readyReplicas;
+        const instanceType = providerNodePool.spec.provider.worker.instanceType;
+        const readyReplicas = nodePool.status?.readyReplicas;
 
         if (typeof readyReplicas !== 'undefined') {
           const machineTypeProperties = machineTypes[instanceType];

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -604,7 +604,7 @@ export function fetchProviderClustersForClustersKey(clusters?: Cluster[]) {
 
 export function getNodePoolDescription(
   nodePool: NodePool,
-  providerNodePool: ProviderNodePool,
+  providerNodePool: ProviderNodePool | null,
   defaultValue = Constants.DEFAULT_NODEPOOL_DESCRIPTION
 ): string {
   switch (nodePool.apiVersion) {
@@ -752,7 +752,7 @@ interface INodesStatus {
 
 export function getNodePoolScaling(
   nodePool: NodePool,
-  providerNodePool: ProviderNodePool
+  providerNodePool: ProviderNodePool | null
 ): INodesStatus {
   switch (nodePool.apiVersion) {
     case 'exp.cluster.x-k8s.io/v1alpha3': {

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -220,61 +220,80 @@ export function fetchNodePoolListForClusterKey(
   }
 }
 
+export async function fetchProviderNodePoolForNodePool(
+  httpClientFactory: HttpClientFactory,
+  auth: IOAuth2Provider,
+  nodePool: NodePool
+): Promise<ProviderNodePool> {
+  const infrastructureRef = nodePool.spec?.template.spec?.infrastructureRef;
+  if (!infrastructureRef) {
+    return Promise.reject(
+      new Error('There is no infrastructure reference defined.')
+    );
+  }
+
+  switch (infrastructureRef.apiVersion) {
+    case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
+      return capzexpv1alpha3.getAzureMachinePool(
+        httpClientFactory(),
+        auth,
+        nodePool.metadata.namespace!,
+        infrastructureRef.name
+      );
+
+    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+      return capzv1alpha4.getAzureMachinePool(
+        httpClientFactory(),
+        auth,
+        nodePool.metadata.namespace!,
+        infrastructureRef.name
+      );
+
+    case 'infrastructure.giantswarm.io/v1alpha2':
+    case 'infrastructure.giantswarm.io/v1alpha3':
+      return infrav1alpha3.getAWSMachineDeployment(
+        httpClientFactory(),
+        auth,
+        nodePool.metadata.namespace!,
+        infrastructureRef.name
+      );
+
+    default:
+      return Promise.reject(new Error('Unsupported provider.'));
+  }
+}
+
+export interface IProviderNodePoolForNodePoolName {
+  nodePoolName: string;
+  providerNodePool: ProviderNodePool;
+}
+
 export async function fetchProviderNodePoolsForNodePools(
   httpClientFactory: HttpClientFactory,
   auth: IOAuth2Provider,
   nodePools: NodePool[]
-): Promise<ProviderNodePool[]> {
-  const responses = await Promise.allSettled(
-    nodePools.map((np: NodePool) => {
-      const infrastructureRef = np.spec?.template.spec?.infrastructureRef;
-      if (!infrastructureRef) {
-        return Promise.reject(
-          new Error('There is no infrastructure reference defined.')
+): Promise<IProviderNodePoolForNodePoolName[]> {
+  return Promise.all(
+    nodePools.map(async (nodePool) => {
+      try {
+        const providerNodePool = await fetchProviderNodePoolForNodePool(
+          httpClientFactory,
+          auth,
+          nodePool
         );
-      }
 
-      switch (infrastructureRef.apiVersion) {
-        case 'exp.infrastructure.cluster.x-k8s.io/v1alpha3':
-          return capzexpv1alpha3.getAzureMachinePool(
-            httpClientFactory(),
-            auth,
-            np.metadata.namespace!,
-            infrastructureRef.name
-          );
-
-        case 'infrastructure.cluster.x-k8s.io/v1alpha4':
-          return capzv1alpha4.getAzureMachinePool(
-            httpClientFactory(),
-            auth,
-            np.metadata.namespace!,
-            infrastructureRef.name
-          );
-
-        case 'infrastructure.giantswarm.io/v1alpha2':
-        case 'infrastructure.giantswarm.io/v1alpha3':
-          return infrav1alpha3.getAWSMachineDeployment(
-            httpClientFactory(),
-            auth,
-            np.metadata.namespace!,
-            infrastructureRef.name
-          );
-
-        default:
-          return Promise.reject(new Error('Unsupported provider.'));
+        return {
+          nodePoolName: nodePool.metadata.name,
+          providerNodePool,
+        };
+      } catch {
+        return {
+          nodePoolName: nodePool.metadata.name,
+          providerNodePool: undefined,
+        };
       }
     })
   );
-
-  const providerNodePools: ProviderNodePool[] = responses.map((r) => {
-    if (r.status === 'rejected') {
-      return undefined;
-    }
-
-    return r.value;
-  });
-
-  return providerNodePools;
 }
 
 export function fetchProviderNodePoolsForNodePoolsKey(nodePools?: NodePool[]) {

--- a/src/components/MAPI/workernodes/ClusterDetailWidgetWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWidgetWorkerNodes.tsx
@@ -25,6 +25,7 @@ import {
   getWorkerNodesCPU,
   getWorkerNodesMemory,
 } from '../clusters/utils';
+import { mapNodePoolsToProviderNodePools } from './utils';
 
 function formatMemory(value?: number) {
   if (typeof value === 'undefined') return undefined;
@@ -98,18 +99,23 @@ const ClusterDetailWidgetWorkerNodes: React.FC<IClusterDetailWidgetWorkerNodesPr
     const workerNodesCount = nodePoolsError
       ? -1
       : getWorkerNodesCount(nodePoolList?.items);
+
+    const nodePoolsWithProviderNodePools = useMemo(() => {
+      if (!nodePoolList?.items || !providerNodePools) return undefined;
+
+      return mapNodePoolsToProviderNodePools(
+        nodePoolList.items,
+        providerNodePools
+      );
+    }, [nodePoolList?.items, providerNodePools]);
+
     const workerNodesCPU = nodePoolsError
       ? -1
-      : getWorkerNodesCPU(
-          nodePoolList?.items,
-          providerNodePools,
-          machineTypes.current
-        );
+      : getWorkerNodesCPU(nodePoolsWithProviderNodePools, machineTypes.current);
     const workerNodesMemory = nodePoolsError
       ? -1
       : getWorkerNodesMemory(
-          nodePoolList?.items,
-          providerNodePools,
+          nodePoolsWithProviderNodePools,
           machineTypes.current
         );
 

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -1,6 +1,6 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { Box, Heading, Text } from 'grommet';
-import { NodePool, ProviderCluster } from 'MAPI/types';
+import { ProviderCluster } from 'MAPI/types';
 import { Cluster } from 'MAPI/types';
 import {
   extractErrorMessage,
@@ -10,8 +10,6 @@ import {
   fetchNodePoolListForClusterKey,
   fetchProviderClusterForCluster,
   fetchProviderClusterForClusterKey,
-  fetchProviderNodePoolsForNodePools,
-  fetchProviderNodePoolsForNodePoolsKey,
   isNodePoolMngmtReadOnly,
 } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
@@ -40,6 +38,12 @@ import DeleteNodePoolGuide from './guides/DeleteNodePoolGuide';
 import ListNodePoolsGuide from './guides/ListNodePoolsGuide';
 import ModifyNodePoolGuide from './guides/ModifyNodePoolGuide';
 import { IWorkerNodesAdditionalColumn } from './types';
+import {
+  fetchProviderNodePoolsWithNodePoolNames,
+  fetchProviderNodePoolsWithNodePoolNamesKey,
+  IProviderNodePoolForNodePoolName,
+  mapNodePoolsToProviderNodePools,
+} from './utils';
 import WorkerNodesCreateNodePool from './WorkerNodesCreateNodePool';
 import WorkerNodesNodePoolItem from './WorkerNodesNodePoolItem';
 import WorkerNodesSpotInstancesAWS from './WorkerNodesSpotInstancesAWS';
@@ -289,14 +293,15 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
 
     const hasNoNodePools = nodePoolList?.items.length === 0;
 
-    const { data: providerNodePools, error: providerNodePoolsError } = useSWR(
-      fetchProviderNodePoolsForNodePoolsKey(nodePoolList?.items),
-      () =>
-        fetchProviderNodePoolsForNodePools(
-          clientFactory,
-          auth,
-          nodePoolList!.items
-        )
+    const { data: providerNodePools, error: providerNodePoolsError } = useSWR<
+      IProviderNodePoolForNodePoolName[],
+      GenericResponseError
+    >(fetchProviderNodePoolsWithNodePoolNamesKey(nodePoolList?.items), () =>
+      fetchProviderNodePoolsWithNodePoolNames(
+        clientFactory,
+        auth,
+        nodePoolList!.items
+      )
     );
 
     useEffect(() => {
@@ -311,6 +316,15 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
         ErrorReporter.getInstance().notify(providerNodePoolsError);
       }
     }, [providerNodePoolsError]);
+
+    const nodePoolsWithProviderNodePools = useMemo(() => {
+      if (!nodePoolList?.items || !providerNodePools) return [];
+
+      return mapNodePoolsToProviderNodePools(
+        nodePoolList.items,
+        providerNodePools
+      );
+    }, [nodePoolList?.items, providerNodePools]);
 
     const additionalColumns = useMemo(
       () => getAdditionalColumns(provider),
@@ -422,25 +436,27 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
                   <AnimationWrapper>
                     <TransitionGroup>
                       {!nodePoolListIsLoading &&
-                        nodePoolList?.items.map((np: NodePool, idx: number) => (
-                          <BaseTransition
-                            in={false}
-                            key={np.metadata.name}
-                            appear={false}
-                            exit={true}
-                            timeout={{ enter: 200, exit: 200 }}
-                            delayTimeout={0}
-                            classNames='nodepool-list-item'
-                          >
-                            <WorkerNodesNodePoolItem
-                              nodePool={np}
-                              providerNodePool={providerNodePools?.[idx]}
-                              additionalColumns={additionalColumns}
-                              margin={{ bottom: 'small' }}
-                              readOnly={isReadOnly}
-                            />
-                          </BaseTransition>
-                        ))}
+                        nodePoolsWithProviderNodePools.map(
+                          ({ nodePool, providerNodePool }) => (
+                            <BaseTransition
+                              in={false}
+                              key={nodePool.metadata.name}
+                              appear={false}
+                              exit={true}
+                              timeout={{ enter: 200, exit: 200 }}
+                              delayTimeout={0}
+                              classNames='nodepool-list-item'
+                            >
+                              <WorkerNodesNodePoolItem
+                                nodePool={nodePool}
+                                providerNodePool={providerNodePool}
+                                additionalColumns={additionalColumns}
+                                margin={{ bottom: 'small' }}
+                                readOnly={isReadOnly}
+                              />
+                            </BaseTransition>
+                          )
+                        )}
                     </TransitionGroup>
                   </AnimationWrapper>
                 </Box>

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -10,6 +10,8 @@ import {
   fetchNodePoolListForClusterKey,
   fetchProviderClusterForCluster,
   fetchProviderClusterForClusterKey,
+  fetchProviderNodePoolsForNodePools,
+  fetchProviderNodePoolsForNodePoolsKey,
   isNodePoolMngmtReadOnly,
 } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
@@ -38,12 +40,7 @@ import DeleteNodePoolGuide from './guides/DeleteNodePoolGuide';
 import ListNodePoolsGuide from './guides/ListNodePoolsGuide';
 import ModifyNodePoolGuide from './guides/ModifyNodePoolGuide';
 import { IWorkerNodesAdditionalColumn } from './types';
-import {
-  fetchProviderNodePoolsWithNodePoolNames,
-  fetchProviderNodePoolsWithNodePoolNamesKey,
-  IProviderNodePoolForNodePoolName,
-  mapNodePoolsToProviderNodePools,
-} from './utils';
+import { mapNodePoolsToProviderNodePools } from './utils';
 import WorkerNodesCreateNodePool from './WorkerNodesCreateNodePool';
 import WorkerNodesNodePoolItem from './WorkerNodesNodePoolItem';
 import WorkerNodesSpotInstancesAWS from './WorkerNodesSpotInstancesAWS';
@@ -293,15 +290,14 @@ const ClusterDetailWorkerNodes: React.FC<IClusterDetailWorkerNodesProps> =
 
     const hasNoNodePools = nodePoolList?.items.length === 0;
 
-    const { data: providerNodePools, error: providerNodePoolsError } = useSWR<
-      IProviderNodePoolForNodePoolName[],
-      GenericResponseError
-    >(fetchProviderNodePoolsWithNodePoolNamesKey(nodePoolList?.items), () =>
-      fetchProviderNodePoolsWithNodePoolNames(
-        clientFactory,
-        auth,
-        nodePoolList!.items
-      )
+    const { data: providerNodePools, error: providerNodePoolsError } = useSWR(
+      fetchProviderNodePoolsForNodePoolsKey(nodePoolList?.items),
+      () =>
+        fetchProviderNodePoolsForNodePools(
+          clientFactory,
+          auth,
+          nodePoolList!.items
+        )
     );
 
     useEffect(() => {

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -62,7 +62,7 @@ const StyledDescriptionWrapper = styled(Box)<{ full?: boolean }>`
 interface IWorkerNodesNodePoolItemProps
   extends React.ComponentPropsWithoutRef<typeof Box> {
   nodePool?: NodePool;
-  providerNodePool?: ProviderNodePool;
+  providerNodePool?: ProviderNodePool | null;
   additionalColumns?: IWorkerNodesAdditionalColumn[];
   readOnly?: boolean;
 }
@@ -77,16 +77,17 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
   const clientFactory = useHttpClientFactory();
   const auth = useAuthProvider();
 
-  const description =
-    nodePool && providerNodePool
-      ? getNodePoolDescription(nodePool, providerNodePool)
-      : undefined;
+  const description = useMemo(() => {
+    if (!nodePool || typeof providerNodePool === 'undefined') return undefined;
+
+    return getNodePoolDescription(nodePool, providerNodePool, '');
+  }, [nodePool, providerNodePool]);
   const availabilityZones =
     nodePool && providerNodePool
       ? getNodePoolAvailabilityZones(nodePool, providerNodePool)
       : undefined;
   const scaling = useMemo(() => {
-    if (!nodePool) return undefined;
+    if (!nodePool || typeof providerNodePool === 'undefined') return undefined;
 
     return getNodePoolScaling(nodePool, providerNodePool);
   }, [nodePool, providerNodePool]);
@@ -244,7 +245,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
           <>
             <WorkerNodesNodePoolItemMachineType
               nodePool={nodePool}
-              providerNodePool={providerNodePool}
+              providerNodePool={providerNodePool ?? undefined}
             />
             <Box align='center'>
               <OptionalValue value={availabilityZones} loaderHeight={26}>
@@ -318,7 +319,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
 
             {additionalColumns?.map((column) => (
               <Box key={column.title} align='center'>
-                {column.render(nodePool, providerNodePool)}
+                {column.render(nodePool, providerNodePool ?? undefined)}
               </Box>
             ))}
 

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -293,9 +293,9 @@ export async function deleteProviderNodePool(
 
       providerNodePool.metadata.deletionTimestamp = new Date().toISOString();
 
-      mutate(
+      mutate<IProviderNodePoolForNodePoolName[]>(
         fetchProviderNodePoolsForNodePoolsKey([nodePool]),
-        { nodePoolName: nodePool.metadata.name, providerNodePool },
+        [{ nodePoolName: nodePool.metadata.name, providerNodePool }],
         false
       );
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/589.

When a node pool is deleted, for a moment before data refreshes, there is a mismatch between node pool description and other node pool information (e.g. name and instance type). This was because the list of node pools and provider node pools could sometimes be out of sync, and we were iterating through both lists using the index from one.

This PR associates the provider node pools with node pool names, so that we can then map node pools to their provider node pools more accurately (this is similar to [this PR](https://github.com/giantswarm/happa/pull/2929)). It also provides a fix for the node pool description placeholder getting stuck after node pool deletion.
