### PR TITLE
Make access control UI aware of permissions. Re-enable binding subjects.

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
@@ -175,7 +175,6 @@ const getStatusMessages = (
     {
       [ui.AccessControlRoleSubjectStatus.Created]: [],
       [ui.AccessControlRoleSubjectStatus.Bound]: [],
-      [ui.AccessControlRoleSubjectStatus.Updated]: [],
     }
   );
 

--- a/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
@@ -434,6 +434,21 @@ const AccessControlRoleSubjects: React.FC<IAccessControlRoleSubjectsProps> = ({
     }
   }, [serviceAccountSuggestionsError]);
 
+  const validateServiceAccountSubjects = (values: string[]): string => {
+    if (serviceAccountPermissions.canCreate) return '';
+
+    if (!serviceAccountSuggestions) {
+      return `You don't have the required permissions to create new service accounts. You can only bind existing ones.`;
+    }
+
+    const uniqueSuggestions = new Set(serviceAccountSuggestions);
+    if (values.some((v) => !uniqueSuggestions.has(v))) {
+      return `You don't have the required permissions to create new service accounts. You can only bind existing ones.`;
+    }
+
+    return '';
+  };
+
   return (
     <Box direction='column' gap='medium' pad={{ top: 'small' }} {...props}>
       {canListSubjects(groupCollection, groupPermissions) && (
@@ -557,6 +572,7 @@ const AccessControlRoleSubjects: React.FC<IAccessControlRoleSubjectsProps> = ({
             isAdding={serviceAccountType.isAdding}
             isLoading={serviceAccountType.isLoading}
             inputSuggestions={serviceAccountSuggestions}
+            onValidate={validateServiceAccountSubjects}
           />
           {serviceAccountType.isAdding && (
             <Box>

--- a/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
@@ -396,23 +396,6 @@ const AccessControlRoleSubjects: React.FC<IAccessControlRoleSubjectsProps> = ({
     };
   }, [roleName]);
 
-  const client = useHttpClient();
-  const auth = useAuthProvider();
-
-  const {
-    data: serviceAccountSuggestions,
-    error: serviceAccountSuggestionsError,
-  } = useSWR<string[], GenericResponseError>(
-    fetchServiceAccountSuggestionsKey(namespace),
-    () => fetchServiceAccountSuggestions(client, auth, namespace)
-  );
-
-  useEffect(() => {
-    if (serviceAccountSuggestionsError) {
-      ErrorReporter.getInstance().notify(serviceAccountSuggestionsError);
-    }
-  }, [serviceAccountSuggestionsError]);
-
   const groupCollection = Object.values(groups).sort(compareSubjects);
   const userCollection = Object.values(users).sort(compareSubjects);
   const serviceAccountCollection =
@@ -428,6 +411,28 @@ const AccessControlRoleSubjects: React.FC<IAccessControlRoleSubjectsProps> = ({
     permissions.subjects[ui.AccessControlSubjectTypes.User];
   const serviceAccountPermissions =
     permissions.subjects[ui.AccessControlSubjectTypes.ServiceAccount];
+
+  const client = useHttpClient();
+  const auth = useAuthProvider();
+
+  const serviceAccountSuggestionsKey =
+    serviceAccountPermissions.canBind &&
+    canListSubjects(serviceAccountCollection, serviceAccountPermissions)
+      ? fetchServiceAccountSuggestionsKey(namespace)
+      : null;
+
+  const {
+    data: serviceAccountSuggestions,
+    error: serviceAccountSuggestionsError,
+  } = useSWR<string[], GenericResponseError>(serviceAccountSuggestionsKey, () =>
+    fetchServiceAccountSuggestions(client, auth, namespace)
+  );
+
+  useEffect(() => {
+    if (serviceAccountSuggestionsError) {
+      ErrorReporter.getInstance().notify(serviceAccountSuggestionsError);
+    }
+  }, [serviceAccountSuggestionsError]);
 
   return (
     <Box direction='column' gap='medium' pad={{ top: 'small' }} {...props}>

--- a/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
@@ -160,7 +160,7 @@ const formatAccountNames = (accountNames: string[]): React.ReactNode => {
 };
 
 const getBindServiceAccountSuccessMessages = (
-  accounts: ui.IAccessControlServiceAccount[]
+  accounts: ui.IAccessControlRoleSubjectStatus[]
 ): React.ReactNode[] => {
   const accountsByStatus = {} as Record<
     ui.AccessControlRoleSubjectStatus,
@@ -236,7 +236,7 @@ interface IAccessControlRoleSubjectsProps
   onAdd: (
     type: ui.AccessControlSubjectTypes,
     names: string[]
-  ) => Promise<ui.IAccessControlServiceAccount[]>;
+  ) => Promise<ui.IAccessControlRoleSubjectStatus[]>;
   onDelete: (type: ui.AccessControlSubjectTypes, name: string) => Promise<void>;
 }
 

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -249,10 +249,45 @@ describe('AccessControlRoleSubjects', () => {
 
   it('can add subjects', async () => {
     jest.useFakeTimers();
-    const onAddMockfn = jest.fn(() => {
+    const onAddMockfn = jest.fn();
+
+    onAddMockfn.mockImplementationOnce(() => {
       return new Promise<ui.IAccessControlRoleSubjectStatus[]>((resolve) =>
-        // eslint-disable-next-line no-magic-numbers
-        setTimeout(resolve, 1000)
+        setTimeout(
+          () =>
+            resolve([
+              {
+                name: 'group1',
+                status: ui.AccessControlRoleSubjectStatus.Bound,
+              },
+              {
+                name: 'group2',
+                status: ui.AccessControlRoleSubjectStatus.Bound,
+              },
+              {
+                name: 'group3',
+                status: ui.AccessControlRoleSubjectStatus.Bound,
+              },
+            ]),
+          // eslint-disable-next-line no-magic-numbers
+          1000
+        )
+      );
+    });
+
+    onAddMockfn.mockImplementationOnce(() => {
+      return new Promise<ui.IAccessControlRoleSubjectStatus[]>((resolve) =>
+        setTimeout(
+          () =>
+            resolve([
+              {
+                name: 'group1',
+                status: ui.AccessControlRoleSubjectStatus.Bound,
+              },
+            ]),
+          // eslint-disable-next-line no-magic-numbers
+          1000
+        )
       );
     });
 
@@ -309,7 +344,9 @@ describe('AccessControlRoleSubjects', () => {
     expect(input).not.toBeInTheDocument();
 
     expect(
-      screen.getByText(/Subjects added successfully./)
+      await withMarkup(screen.findByText)(
+        'Groups group1, group2, group3 have been bound to the role.'
+      )
     ).toBeInTheDocument();
 
     fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
@@ -332,7 +369,11 @@ describe('AccessControlRoleSubjects', () => {
       expect(input).not.toBeInTheDocument();
     });
 
-    screen.getByText(/Subject added successfully./);
+    expect(
+      await withMarkup(screen.findByText)(
+        'Group group1 has been bound to the role.'
+      )
+    ).toBeInTheDocument();
 
     jest.useRealTimers();
   });
@@ -391,7 +432,9 @@ describe('AccessControlRoleSubjects', () => {
     });
 
     expect(
-      withMarkup(screen.getByText)('Subject test-group1 deleted successfully.')
+      await withMarkup(screen.findByText)(
+        'The binding for group test-group1 has been removed.'
+      )
     ).toBeInTheDocument();
 
     jest.useRealTimers();
@@ -473,7 +516,9 @@ describe('AccessControlRoleSubjects', () => {
     fireEvent.click(submitButton);
 
     expect(
-      await screen.findByText(/Could not add subjects:/)
+      await withMarkup(screen.findByText)(
+        'Could not bind groups group1, group2, group3 :'
+      )
     ).toBeInTheDocument();
     expect(
       screen.getByText(/There was a huge error. Abort the mission./)
@@ -486,7 +531,7 @@ describe('AccessControlRoleSubjects', () => {
     fireEvent.click(submitButton);
 
     expect(
-      await screen.findByText(/Could not add subject:/)
+      await withMarkup(screen.findByText)('Could not bind group group1 :')
     ).toBeInTheDocument();
     expect(
       screen.getAllByText(/There was a huge error. Abort the mission./)
@@ -533,7 +578,9 @@ describe('AccessControlRoleSubjects', () => {
     fireEvent.click(screen.getByText('Remove'));
 
     expect(
-      await screen.findByText(/Could not delete subject test-group1/)
+      await withMarkup(screen.findByText)(
+        'Could not delete binding for group test-group1 .'
+      )
     ).toBeInTheDocument();
     expect(
       screen.getByText(/There was a huge error. Abort the mission./)

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -42,6 +42,14 @@ function getComponent(
 }
 
 const defaultPermissions: ui.IAccessControlPermissions = {
+  roles: {
+    '': {
+      canList: true,
+    },
+    'org-test': {
+      canList: true,
+    },
+  },
   subjects: {
     [ui.AccessControlSubjectTypes.Group]: {
       canCreate: true,

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -44,17 +44,20 @@ function getComponent(
 const defaultPermissions: ui.IAccessControlPermissions = {
   subjects: {
     [ui.AccessControlSubjectTypes.Group]: {
-      canAdd: true,
+      canCreate: true,
+      canBind: true,
       canDelete: true,
       canList: true,
     },
     [ui.AccessControlSubjectTypes.User]: {
-      canAdd: true,
+      canCreate: true,
+      canBind: true,
       canDelete: true,
       canList: true,
     },
     [ui.AccessControlSubjectTypes.ServiceAccount]: {
-      canAdd: true,
+      canCreate: true,
+      canBind: true,
       canDelete: true,
       canList: true,
     },

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -239,7 +239,7 @@ describe('AccessControlRoleSubjects', () => {
   it('can add subjects', async () => {
     jest.useFakeTimers();
     const onAddMockfn = jest.fn(() => {
-      return new Promise<ui.IAccessControlServiceAccount[]>((resolve) =>
+      return new Promise<ui.IAccessControlRoleSubjectStatus[]>((resolve) =>
         // eslint-disable-next-line no-magic-numbers
         setTimeout(resolve, 1000)
       );

--- a/src/components/MAPI/organizations/AccessControl/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/index.tsx
@@ -13,12 +13,12 @@ import * as ui from 'UI/Display/MAPI/AccessControl/types';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
+import { usePermissionsForAccessControl } from '../permissions/usePermissionsForAccessControl';
 import BindRolesToSubjectsGuide from './guides/BindRolesToSubjectsGuide';
 import InspectRoleGuide from './guides/InspectRoleGuide';
 import ListRolesGuide from './guides/ListRolesGuide';
 import {
   appendSubjectsToRoleItem,
-  computePermissions,
   createRoleBindingWithSubjects,
   deleteSubjectFromRole,
   ensureServiceAccount,
@@ -37,7 +37,11 @@ const AccessControl: React.FC<IAccessControlProps> = ({
   organizationNamespace,
   ...props
 }) => {
-  const permissions = computePermissions(organizationNamespace);
+  const provider = window.config.info.general.provider;
+  const permissions = usePermissionsForAccessControl(
+    provider,
+    organizationNamespace
+  );
 
   const clientFactory = useHttpClientFactory();
   const auth = useAuthProvider();

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -708,41 +708,6 @@ export function fetchServiceAccountSuggestionsKey(
   return corev1.getServiceAccountListKey(namespace);
 }
 
-export function computePermissions(
-  namespace: string
-): ui.IAccessControlPermissions {
-  return {
-    roles: {
-      '': {
-        canList: true,
-      },
-      [namespace]: {
-        canList: true,
-      },
-    },
-    subjects: {
-      [ui.AccessControlSubjectTypes.Group]: {
-        canCreate: false,
-        canBind: false,
-        canDelete: false,
-        canList: true,
-      },
-      [ui.AccessControlSubjectTypes.User]: {
-        canCreate: false,
-        canBind: false,
-        canDelete: false,
-        canList: true,
-      },
-      [ui.AccessControlSubjectTypes.ServiceAccount]: {
-        canCreate: true,
-        canBind: true,
-        canDelete: true,
-        canList: true,
-      },
-    },
-  };
-}
-
 export function canListSubjects(
   subjectCollection: ui.IAccessControlRoleSubjectItem[],
   subjectPermissions: ui.IAccessControlSubjectPermissions

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -543,7 +543,7 @@ export async function ensureServiceAccount(
   auth: IOAuth2Provider,
   name: string,
   namespace: string
-): Promise<ui.IAccessControlServiceAccount> {
+): Promise<ui.IAccessControlRoleSubjectStatus> {
   try {
     await corev1.getServiceAccount(client, auth, name, namespace);
 

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -3,7 +3,6 @@ import { IHttpClient } from 'model/clients/HttpClient';
 import * as corev1 from 'model/services/mapi/corev1';
 import * as metav1 from 'model/services/mapi/metav1';
 import * as rbacv1 from 'model/services/mapi/rbacv1';
-import { IState } from 'model/stores/state';
 import * as ui from 'UI/Display/MAPI/AccessControl/types';
 import { HttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
@@ -31,56 +30,61 @@ export function isSubjectDelimiter(value: string): boolean {
 
 /**
  * Map all the resources necessary for rendering the whole UI.
- * @param clusterRoles
- * @param roles
- * @param roleBindings
+ * @param resources
  */
 export function mapResourcesToUiRoles(
-  clusterRoles: rbacv1.IClusterRoleList,
-  roles: rbacv1.IRoleList,
-  roleBindings: rbacv1.IRoleBindingList
+  resources: (rbacv1.IClusterRole | rbacv1.IRole | rbacv1.IRoleBinding)[]
 ): ui.IAccessControlRoleItem[] {
   const roleMap: Record<string, ui.IAccessControlRoleItem> = {};
 
-  for (const role of clusterRoles.items) {
-    if (
-      !roleMap.hasOwnProperty(role.metadata.name) &&
-      shouldDisplayRole(role)
-    ) {
-      roleMap[role.metadata.name] = {
-        name: role.metadata.name,
-        namespace: '',
-        managedBy: rbacv1.getManagedBy(role) ?? '',
-        groups: {},
-        serviceAccounts: {},
-        users: {},
-        permissions: getRolePermissions(role),
-      };
-    }
-  }
+  for (const res of resources) {
+    switch (res.kind) {
+      case rbacv1.ClusterRole:
+        if (
+          !roleMap.hasOwnProperty(res.metadata.name) &&
+          shouldDisplayRole(res)
+        ) {
+          roleMap[res.metadata.name] = {
+            name: res.metadata.name,
+            namespace: '',
+            managedBy: rbacv1.getManagedBy(res) ?? '',
+            groups: {},
+            serviceAccounts: {},
+            users: {},
+            permissions: getRolePermissions(res),
+          };
+        }
 
-  for (const role of roles.items) {
-    if (
-      // Don't override ClusterRoles with the same name.
-      !roleMap.hasOwnProperty(role.metadata.name) &&
-      shouldDisplayRole(role)
-    ) {
-      roleMap[role.metadata.name] = {
-        name: role.metadata.name,
-        namespace: role.metadata.namespace!,
-        managedBy: rbacv1.getManagedBy(role) ?? '',
-        groups: {},
-        serviceAccounts: {},
-        users: {},
-        permissions: getRolePermissions(role),
-      };
-    }
-  }
+        break;
 
-  for (const binding of roleBindings.items) {
-    const role = roleMap[binding.roleRef.name];
-    if (role) {
-      appendSubjectsToRoleItem(binding, role);
+      case rbacv1.Role:
+        // Don't override ClusterRoles with the same name.
+        if (
+          !roleMap.hasOwnProperty(res.metadata.name) &&
+          shouldDisplayRole(res)
+        ) {
+          roleMap[res.metadata.name] = {
+            name: res.metadata.name,
+            namespace: res.metadata.namespace!,
+            managedBy: rbacv1.getManagedBy(res) ?? '',
+            groups: {},
+            serviceAccounts: {},
+            users: {},
+            permissions: getRolePermissions(res),
+          };
+        }
+
+        break;
+
+      case rbacv1.RoleBinding:
+        {
+          const role = roleMap[res.roleRef.name];
+          if (role) {
+            appendSubjectsToRoleItem(res, role);
+          }
+        }
+
+        break;
     }
   }
 
@@ -220,41 +224,69 @@ export function sortPermissions(
  * data structure necessary for rendering the UI.
  * @param clientFactory
  * @param auth
+ * @param permissions
  * @param namespace
  */
 export async function getRoleItems(
   clientFactory: HttpClientFactory,
   auth: IOAuth2Provider,
+  permissions: ui.IAccessControlPermissions,
   namespace: string
 ) {
-  const response = await Promise.all([
-    rbacv1.getClusterRoleList(clientFactory(), auth),
-    rbacv1.getRoleList(clientFactory(), auth, namespace),
-    rbacv1.getRoleBindingList(clientFactory(), auth, namespace),
-  ]);
+  const requests = [];
 
-  return mapResourcesToUiRoles(...response);
+  if (permissions.roles[''].canList) {
+    requests.push(rbacv1.getClusterRoleList(clientFactory(), auth));
+  }
+
+  if (permissions.roles[namespace]?.canList) {
+    requests.push(rbacv1.getRoleList(clientFactory(), auth, namespace));
+  }
+
+  if (requests.length > 0) {
+    requests.push(rbacv1.getRoleBindingList(clientFactory(), auth, namespace));
+  } else {
+    return [];
+  }
+
+  const responses = await Promise.all(requests);
+  const items = responses.reduce<
+    (rbacv1.IClusterRole | rbacv1.IRole | rbacv1.IRoleBinding)[]
+  >((acc, res) => acc.concat(res.items), []);
+
+  return mapResourcesToUiRoles(items);
 }
 
 /**
  * Get the cache key used for the role getter request in.
+ * @param permissions
  * @param namespace
  */
-export function getRoleItemsKey(namespace: string): string | null {
-  const keyParts = [
-    rbacv1.getClusterRoleListKey(),
-    rbacv1.getRoleListKey(namespace),
-    rbacv1.getRoleBindingListKey(namespace),
-  ];
+export function getRoleItemsKey(
+  permissions: ui.IAccessControlPermissions,
+  namespace: string
+): string | null {
+  const keyParts: (string | null)[] = [];
 
-  let key = '';
-  for (const part of keyParts) {
-    if (!part) return null;
-
-    key += part;
+  if (permissions.roles[''].canList) {
+    keyParts.push(rbacv1.getClusterRoleListKey());
   }
 
-  return key;
+  if (permissions.roles[namespace]?.canList) {
+    keyParts.push(rbacv1.getRoleListKey(namespace));
+  }
+
+  if (keyParts.length > 0) {
+    keyParts.push(rbacv1.getRoleBindingListKey(namespace));
+  } else {
+    return null;
+  }
+
+  if (keyParts.some((s) => !s)) {
+    return null;
+  }
+
+  return keyParts.join();
 }
 
 /**
@@ -677,9 +709,17 @@ export function fetchServiceAccountSuggestionsKey(
 }
 
 export function computePermissions(
-  _state: IState
+  namespace: string
 ): ui.IAccessControlPermissions {
   return {
+    roles: {
+      '': {
+        canList: true,
+      },
+      [namespace]: {
+        canList: true,
+      },
+    },
     subjects: {
       [ui.AccessControlSubjectTypes.Group]: {
         canCreate: false,

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -682,17 +682,20 @@ export function computePermissions(
   return {
     subjects: {
       [ui.AccessControlSubjectTypes.Group]: {
-        canAdd: false,
+        canCreate: false,
+        canBind: false,
         canDelete: false,
         canList: true,
       },
       [ui.AccessControlSubjectTypes.User]: {
-        canAdd: false,
+        canCreate: false,
+        canBind: false,
         canDelete: false,
         canList: true,
       },
       [ui.AccessControlSubjectTypes.ServiceAccount]: {
-        canAdd: true,
+        canCreate: true,
+        canBind: true,
         canDelete: true,
         canList: true,
       },
@@ -704,7 +707,7 @@ export function canListSubjects(
   subjectCollection: ui.IAccessControlRoleSubjectItem[],
   subjectPermissions: ui.IAccessControlSubjectPermissions
 ): boolean {
-  if (!subjectPermissions.canAdd && subjectCollection.length < 1) return false;
+  if (!subjectPermissions.canBind && subjectCollection.length < 1) return false;
 
   return subjectPermissions.canList;
 }

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -579,7 +579,7 @@ export async function ensureServiceAccount(
   try {
     await corev1.getServiceAccount(client, auth, name, namespace);
 
-    return { name, status: ui.AccessControlRoleSubjectStatus.Updated };
+    return { name, status: ui.AccessControlRoleSubjectStatus.Bound };
   } catch (err) {
     // If the service account is not found, we'll create it.
     if (
@@ -715,4 +715,35 @@ export function canListSubjects(
   if (!subjectPermissions.canBind && subjectCollection.length < 1) return false;
 
   return subjectPermissions.canList;
+}
+
+export function formatSubjectType(
+  subject: ui.AccessControlSubjectTypes,
+  pluralize?: boolean
+): string {
+  switch (subject) {
+    case ui.AccessControlSubjectTypes.Group:
+      if (pluralize) {
+        return 'Groups';
+      }
+
+      return 'Group';
+
+    case ui.AccessControlSubjectTypes.User:
+      if (pluralize) {
+        return 'Users';
+      }
+
+      return 'User';
+
+    case ui.AccessControlSubjectTypes.ServiceAccount:
+      if (pluralize) {
+        return 'Service accounts';
+      }
+
+      return 'Service account';
+
+    default:
+      return '';
+  }
 }

--- a/src/components/MAPI/organizations/permissions/usePermissionsForAccessControl.ts
+++ b/src/components/MAPI/organizations/permissions/usePermissionsForAccessControl.ts
@@ -1,0 +1,123 @@
+import { usePermissions } from 'MAPI/permissions/usePermissions';
+import { hasPermission } from 'MAPI/permissions/utils';
+import { Providers } from 'model/constants';
+import * as ui from 'UI/Display/MAPI/AccessControl/types';
+
+export function usePermissionsForAccessControl(
+  _provider: PropertiesOf<typeof Providers>,
+  namespace: string
+): ui.IAccessControlPermissions {
+  const { data: permissions } = usePermissions();
+
+  if (!permissions) {
+    return {
+      roles: {
+        '': {
+          canList: false,
+        },
+        [namespace]: {
+          canList: false,
+        },
+      },
+      subjects: {
+        [ui.AccessControlSubjectTypes.Group]: {
+          canCreate: false,
+          canBind: false,
+          canDelete: false,
+          canList: false,
+        },
+        [ui.AccessControlSubjectTypes.User]: {
+          canCreate: false,
+          canBind: false,
+          canDelete: false,
+          canList: false,
+        },
+        [ui.AccessControlSubjectTypes.ServiceAccount]: {
+          canCreate: false,
+          canBind: false,
+          canDelete: false,
+          canList: false,
+        },
+      },
+    };
+  }
+
+  const canListClusterRoles = hasPermission(
+    permissions,
+    'default',
+    'list',
+    'rbac.authorization.k8s.io',
+    'clusterroles'
+  );
+  const canListRoles = hasPermission(
+    permissions,
+    namespace,
+    'list',
+    'rbac.authorization.k8s.io',
+    'roles'
+  );
+
+  const canDeleteSubjects =
+    hasPermission(
+      permissions,
+      namespace,
+      'delete',
+      'rbac.authorization.k8s.io',
+      'rolebindings'
+    ) &&
+    hasPermission(
+      permissions,
+      namespace,
+      'update',
+      'rbac.authorization.k8s.io',
+      'rolebindings'
+    );
+
+  const canBindSubjects = hasPermission(
+    permissions,
+    namespace,
+    'create',
+    'rbac.authorization.k8s.io',
+    'rolebindings'
+  );
+
+  return {
+    roles: {
+      '': {
+        canList: canListClusterRoles,
+      },
+      [namespace]: {
+        canList: canListRoles,
+      },
+    },
+    subjects: {
+      [ui.AccessControlSubjectTypes.Group]: {
+        canCreate: true,
+        canBind: canBindSubjects,
+        canDelete: canDeleteSubjects,
+        canList: canListClusterRoles || canListRoles,
+      },
+      [ui.AccessControlSubjectTypes.User]: {
+        canCreate: true,
+        canBind: canBindSubjects,
+        canDelete: canDeleteSubjects,
+        canList: canListClusterRoles || canListRoles,
+      },
+      [ui.AccessControlSubjectTypes.ServiceAccount]: {
+        canCreate: hasPermission(
+          permissions,
+          namespace,
+          'create',
+          '',
+          'serviceaccounts'
+        ),
+        canBind:
+          canBindSubjects &&
+          hasPermission(permissions, namespace, 'get', '', 'serviceaccounts') &&
+          hasPermission(permissions, namespace, 'list', '', 'serviceaccounts'),
+        canDelete: canDeleteSubjects,
+        canList: canListClusterRoles || canListRoles,
+      },
+    },
+  };
+}

--- a/src/components/MAPI/permissions/utils.ts
+++ b/src/components/MAPI/permissions/utils.ts
@@ -202,7 +202,7 @@ export function hasNamespacePermission(
 export function hasPermission(
   permissions: IPermissionMap,
   namespace: string,
-  verb: string,
+  verb: PermissionVerb,
   group: string,
   resource: string,
   resourceName?: string

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleDetail.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleDetail.tsx
@@ -10,7 +10,7 @@ import {
   AccessControlSubjectTypes,
   IAccessControlPermissions,
   IAccessControlRoleItem,
-  IAccessControlServiceAccount,
+  IAccessControlRoleSubjectStatus,
 } from './types';
 
 export function formatManagedBy(managedBy?: string): string {
@@ -26,7 +26,7 @@ interface IAccessControlRoleDetailProps
   onAdd: (
     type: AccessControlSubjectTypes,
     names: string[]
-  ) => Promise<IAccessControlServiceAccount[]>;
+  ) => Promise<IAccessControlRoleSubjectStatus[]>;
   onDelete: (type: AccessControlSubjectTypes, name: string) => Promise<void>;
   activeRole?: IAccessControlRoleItem;
 }

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleDetail.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleDetail.tsx
@@ -29,6 +29,7 @@ interface IAccessControlRoleDetailProps
   ) => Promise<IAccessControlRoleSubjectStatus[]>;
   onDelete: (type: AccessControlSubjectTypes, name: string) => Promise<void>;
   activeRole?: IAccessControlRoleItem;
+  isLoading?: boolean;
 }
 
 const AccessControlRoleDetail: React.FC<IAccessControlRoleDetailProps> = ({
@@ -37,13 +38,14 @@ const AccessControlRoleDetail: React.FC<IAccessControlRoleDetailProps> = ({
   activeRole,
   onAdd,
   onDelete,
+  isLoading,
   ...props
 }) => {
   return (
     <Box role='main' aria-label='Role details' {...props}>
-      {!activeRole && <AccessControlRoleDetailLoadingPlaceholder />}
+      {isLoading && <AccessControlRoleDetailLoadingPlaceholder />}
 
-      {activeRole && (
+      {!isLoading && activeRole && (
         <>
           <Box>
             <Heading level={4}>{activeRole.name}</Heading>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
@@ -29,11 +29,13 @@ interface IAccessControlRoleListProps
   activeRoleName: string;
   setActiveRoleName: (newName: string) => void;
   roles?: IAccessControlRoleItem[];
+  isLoading?: boolean;
   errorMessage?: string;
 }
 
 const AccessControlRoleList: React.FC<IAccessControlRoleListProps> = ({
   roles,
+  isLoading,
   activeRoleName,
   setActiveRoleName,
   errorMessage,
@@ -100,7 +102,7 @@ const AccessControlRoleList: React.FC<IAccessControlRoleListProps> = ({
             overflow={{ vertical: 'auto' }}
             pad='small'
           >
-            {!roles &&
+            {isLoading &&
               LOADING_COMPONENTS.map((idx) => (
                 <AccessControlRoleListItemLoadingPlaceholder
                   key={idx}
@@ -108,11 +110,16 @@ const AccessControlRoleList: React.FC<IAccessControlRoleListProps> = ({
                 />
               ))}
 
-            {roles && roles.length < 1 && <AccessControlRolePlaceholder />}
-
-            {roles && roles.length > 0 && filteredRoles.length < 1 && (
-              <AccessControlRoleSearchPlaceholder />
+            {!isLoading && roles && roles.length < 1 && (
+              <AccessControlRolePlaceholder />
             )}
+
+            {!isLoading &&
+              roles &&
+              roles.length > 0 &&
+              filteredRoles.length < 1 && (
+                <AccessControlRoleSearchPlaceholder />
+              )}
 
             <InfiniteScroll replace={true} items={filteredRoles} step={50}>
               {(role: IAccessControlRoleItem) => (

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectAddForm.tsx
@@ -116,7 +116,12 @@ const AccessControlSubjectAddForm: React.FC<IAccessControlSubjectAddFormProps> =
     return (
       <Box {...props}>
         {isAdding ? (
-          <Box direction='row' gap='small' align='center'>
+          <Box
+            direction='row'
+            gap='small'
+            align='center'
+            width={{ max: 'medium' }}
+          >
             <Keyboard onEsc={handleOnEsc}>
               <form onSubmit={handleSubmit} aria-label='Subjects to add'>
                 <TextInput

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
@@ -40,6 +40,7 @@ interface IAccessControlSubjectSetProps
   isAdding?: boolean;
   isLoading?: boolean;
   inputSuggestions?: string[];
+  onValidate?: (values: string[]) => string;
 }
 
 const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
@@ -52,6 +53,7 @@ const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
   isAdding,
   isLoading,
   inputSuggestions,
+  onValidate,
   ...props
 }) => {
   const [errorMessage, setErrorMessage] = useState('');
@@ -81,6 +83,10 @@ const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
       return `Subject '${duplicatedNames[0]}' already exists.`;
     } else if (duplicatedNames.length > 1) {
       return `Subjects '${duplicatedNames.join(`', '`)}' already exist.`;
+    }
+
+    if (onValidate) {
+      return onValidate(values);
     }
 
     return '';

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
@@ -114,7 +114,7 @@ const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
         </React.Fragment>
       ))}
 
-      {permissions.canAdd && (
+      {permissions.canBind && (
         <AccessControlSubjectAddForm
           margin={{ right: 'small', bottom: 'small' }}
           isAdding={isAdding}

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleDetail.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleDetail.tsx
@@ -7,17 +7,20 @@ import { AccessControlSubjectTypes, IAccessControlPermissions } from '../types';
 const defaultPermissions: IAccessControlPermissions = {
   subjects: {
     [AccessControlSubjectTypes.Group]: {
-      canAdd: true,
+      canCreate: true,
+      canBind: true,
       canDelete: true,
       canList: true,
     },
     [AccessControlSubjectTypes.User]: {
-      canAdd: true,
+      canCreate: true,
+      canBind: true,
       canDelete: true,
       canList: true,
     },
     [AccessControlSubjectTypes.ServiceAccount]: {
-      canAdd: true,
+      canCreate: true,
+      canBind: true,
       canDelete: true,
       canList: true,
     },

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleDetail.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleDetail.tsx
@@ -108,7 +108,7 @@ describe('AccessControlRoleDetail', () => {
     const { rerender } = renderWithStore(AccessControlRoleDetail, {
       namespace: 'org-test',
       permissions: defaultPermissions,
-      activeRole: undefined,
+      isLoading: true,
       onAdd: jest.fn(),
       onDelete: jest.fn(),
     });

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleDetail.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleDetail.tsx
@@ -5,6 +5,14 @@ import AccessControlRoleDetail from '../AccessControlRoleDetail';
 import { AccessControlSubjectTypes, IAccessControlPermissions } from '../types';
 
 const defaultPermissions: IAccessControlPermissions = {
+  roles: {
+    '': {
+      canList: true,
+    },
+    'org-test': {
+      canList: true,
+    },
+  },
   subjects: {
     [AccessControlSubjectTypes.Group]: {
       canCreate: true,

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleList.tsx
@@ -128,7 +128,7 @@ describe('AccessControlRoleList', () => {
     const { rerender } = renderWithTheme(AccessControlRoleList, {
       activeRoleName: '',
       setActiveRoleName: jest.fn(),
-      roles: undefined,
+      isLoading: true,
     });
     expect(screen.getAllByTitle('Loading...').length).toBeGreaterThan(0);
 

--- a/src/components/UI/Display/MAPI/AccessControl/types.ts
+++ b/src/components/UI/Display/MAPI/AccessControl/types.ts
@@ -61,7 +61,6 @@ export interface IAccessControlPermissions {
 
 export enum AccessControlRoleSubjectStatus {
   Created = 'Created',
-  Updated = 'Updated',
   Bound = 'Bound',
 }
 

--- a/src/components/UI/Display/MAPI/AccessControl/types.ts
+++ b/src/components/UI/Display/MAPI/AccessControl/types.ts
@@ -44,7 +44,8 @@ export interface IAccessControlRoleItem {
 }
 
 export interface IAccessControlSubjectPermissions {
-  canAdd: boolean;
+  canCreate: boolean;
+  canBind: boolean;
   canDelete: boolean;
   canList: boolean;
 }

--- a/src/components/UI/Display/MAPI/AccessControl/types.ts
+++ b/src/components/UI/Display/MAPI/AccessControl/types.ts
@@ -56,9 +56,10 @@ export interface IAccessControlPermissions {
 export enum AccessControlRoleSubjectStatus {
   Created = 'Created',
   Updated = 'Updated',
+  Bound = 'Bound',
 }
 
-export interface IAccessControlServiceAccount {
+export interface IAccessControlRoleSubjectStatus {
   name: string;
   status: AccessControlRoleSubjectStatus;
 }

--- a/src/components/UI/Display/MAPI/AccessControl/types.ts
+++ b/src/components/UI/Display/MAPI/AccessControl/types.ts
@@ -50,7 +50,12 @@ export interface IAccessControlSubjectPermissions {
   canList: boolean;
 }
 
+export interface IAccessControlRolePermissions {
+  canList: boolean;
+}
+
 export interface IAccessControlPermissions {
+  roles: Record<string, IAccessControlRolePermissions>;
   subjects: Record<AccessControlSubjectTypes, IAccessControlSubjectPermissions>;
 }
 

--- a/src/model/services/mapi/rbacv1/getClusterRoleBindingList.ts
+++ b/src/model/services/mapi/rbacv1/getClusterRoleBindingList.ts
@@ -3,9 +3,9 @@ import * as k8sUrl from 'model/services/mapi/k8sUrl';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
 
 import { getResource } from '../generic/getResource';
-import { IClusterRoleBindingList } from './types';
+import { ClusterRoleBinding, IClusterRoleBindingList } from './types';
 
-export function getClusterRoleBindingList(
+export async function getClusterRoleBindingList(
   client: IHttpClient,
   auth: IOAuth2Provider
 ) {
@@ -15,7 +15,17 @@ export function getClusterRoleBindingList(
     kind: 'clusterrolebindings',
   });
 
-  return getResource<IClusterRoleBindingList>(client, auth, url.toString());
+  const list = await getResource<IClusterRoleBindingList>(
+    client,
+    auth,
+    url.toString()
+  );
+  for (const item of list.items) {
+    item.kind = ClusterRoleBinding;
+    item.apiVersion = 'rbac.authorization.k8s.io/v1';
+  }
+
+  return list;
 }
 
 export function getClusterRoleBindingListKey() {

--- a/src/model/services/mapi/rbacv1/getClusterRoleList.ts
+++ b/src/model/services/mapi/rbacv1/getClusterRoleList.ts
@@ -3,9 +3,12 @@ import * as k8sUrl from 'model/services/mapi/k8sUrl';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
 
 import { getResource } from '../generic/getResource';
-import { IClusterRoleList } from './types';
+import { ClusterRole, IClusterRoleList } from './types';
 
-export function getClusterRoleList(client: IHttpClient, auth: IOAuth2Provider) {
+export async function getClusterRoleList(
+  client: IHttpClient,
+  auth: IOAuth2Provider
+) {
   const url = k8sUrl.create({
     baseUrl: window.config.mapiEndpoint,
     apiVersion: 'rbac.authorization.k8s.io/v1',
@@ -17,7 +20,17 @@ export function getClusterRoleList(client: IHttpClient, auth: IOAuth2Provider) {
     },
   });
 
-  return getResource<IClusterRoleList>(client, auth, url.toString());
+  const list = await getResource<IClusterRoleList>(
+    client,
+    auth,
+    url.toString()
+  );
+  for (const item of list.items) {
+    item.kind = ClusterRole;
+    item.apiVersion = 'rbac.authorization.k8s.io/v1';
+  }
+
+  return list;
 }
 
 export function getClusterRoleListKey() {

--- a/src/model/services/mapi/rbacv1/getRoleBindingList.ts
+++ b/src/model/services/mapi/rbacv1/getRoleBindingList.ts
@@ -3,9 +3,9 @@ import * as k8sUrl from 'model/services/mapi/k8sUrl';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
 
 import { getResource } from '../generic/getResource';
-import { IRoleBindingList } from './types';
+import { IRoleBindingList, RoleBinding } from './types';
 
-export function getRoleBindingList(
+export async function getRoleBindingList(
   client: IHttpClient,
   auth: IOAuth2Provider,
   namespace: string
@@ -17,7 +17,17 @@ export function getRoleBindingList(
     namespace,
   });
 
-  return getResource<IRoleBindingList>(client, auth, url.toString());
+  const list = await getResource<IRoleBindingList>(
+    client,
+    auth,
+    url.toString()
+  );
+  for (const item of list.items) {
+    item.kind = RoleBinding;
+    item.apiVersion = 'rbac.authorization.k8s.io/v1';
+  }
+
+  return list;
 }
 
 export function getRoleBindingListKey(namespace: string) {

--- a/src/model/services/mapi/rbacv1/getRoleList.ts
+++ b/src/model/services/mapi/rbacv1/getRoleList.ts
@@ -3,9 +3,9 @@ import * as k8sUrl from 'model/services/mapi/k8sUrl';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
 
 import { getResource } from '../generic/getResource';
-import { IRoleList } from './types';
+import { IRoleList, Role } from './types';
 
-export function getRoleList(
+export async function getRoleList(
   client: IHttpClient,
   auth: IOAuth2Provider,
   namespace: string
@@ -22,7 +22,13 @@ export function getRoleList(
     },
   });
 
-  return getResource<IRoleList>(client, auth, url.toString());
+  const list = await getResource<IRoleList>(client, auth, url.toString());
+  for (const item of list.items) {
+    item.kind = Role;
+    item.apiVersion = 'rbac.authorization.k8s.io/v1';
+  }
+
+  return list;
 }
 
 export function getRoleListKey(namespace: string) {


### PR DESCRIPTION
This PR re-enables being able to bind and remove bindings for all subjects. It also now includes more granular control over what users can and can't do, all relative to their RBAC permissions.

What we control:
- Fetching `Role`s/`ClusterRole`s or both, depending on what the user has access to
- Not allowing users to remove subjects, if they don't have access to do it
- Not allowing users to bind subjects, if they don't have access to do it
- Hiding the lists of subjects if there are no entries and the user doesn't have access to binding others
- Only allowing users to bind existing service accounts, if they don't have access to creating new ones
- Not fetching service account name suggestions if the user doesn't have access to do it

For the actual RBAC permissions required for all these, scroll down.

Please note that this is not meant to be the best example UX/DX in dealing with permissions in our codebase. It is just a step towards more granular permissions in the UI.