### PR TITLE
Only set impersonation group header if groups is defined

### DIFF
--- a/src/model/services/mapi/generic/ensureClientAuth.ts
+++ b/src/model/services/mapi/generic/ensureClientAuth.ts
@@ -30,7 +30,7 @@ export async function ensureClientAuth(
 
     if (
       impersonationMetadata.groups &&
-      impersonationMetadata.groups?.length > 0
+      impersonationMetadata.groups.length > 0
     ) {
       client.setHeader('Impersonate-Group', impersonationMetadata.groups[0]);
     }

--- a/src/model/services/mapi/generic/ensureClientAuth.ts
+++ b/src/model/services/mapi/generic/ensureClientAuth.ts
@@ -28,8 +28,11 @@ export async function ensureClientAuth(
   if (impersonationMetadata) {
     client.setHeader('Impersonate-User', impersonationMetadata.user);
 
-    if (impersonationMetadata.groups?.length !== 0) {
-      client.setHeader('Impersonate-Group', impersonationMetadata.groups![0]);
+    if (
+      impersonationMetadata.groups &&
+      impersonationMetadata.groups?.length > 0
+    ) {
+      client.setHeader('Impersonate-Group', impersonationMetadata.groups[0]);
     }
   }
 


### PR DESCRIPTION
I noticed that if `groups` is not set, the condition for setting "Impersonate-Group" in headers still evaluates to true, and impersonation doesn't behave as expected.