### PR TITLE
Revert dropping support for k8s > 1.19

### DIFF
--- a/helm/happa/Chart.yaml
+++ b/helm/happa/Chart.yaml
@@ -7,4 +7,3 @@ version: [[ .Version ]]
 appVersion: [[ .AppVersion ]]
 annotations:
   config.giantswarm.io/version: 1.x.x
-kubeVersion: ">=1.19.0-0"

--- a/helm/happa/templates/happaapi-ingress.yaml
+++ b/helm/happa/templates/happaapi-ingress.yaml
@@ -1,4 +1,8 @@
+{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
+{{ else }}
+apiVersion: networking.k8s.io/v1beta1
+{{ end }}
 kind: Ingress
 metadata:
   name: happaapi
@@ -29,10 +33,15 @@ spec:
       - path: /
         pathType: Prefix
         backend:
+{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:
             name: kubernetes
             port:
               number: 443
+{{ else }}
+          serviceName: kubernetes
+          servicePort: 443
+{{ end }}
   tls:
   - hosts:
     - {{ .Values.happaapi.host }}

--- a/helm/happa/templates/ingress.yaml
+++ b/helm/happa/templates/ingress.yaml
@@ -1,4 +1,8 @@
+{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
+{{ else }}
+apiVersion: networking.k8s.io/v1beta1
+{{ end }}
 kind: Ingress
 metadata:
   name: happa
@@ -27,10 +31,15 @@ spec:
       - path: /
         pathType: Prefix
         backend:
+{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:
             name: happa
             port:
               number: 8000
+{{ else }}
+          serviceName: happa
+          servicePort: 8000
+{{ end }}
   tls:
   - hosts:
     - {{ .Values.happa.host }}


### PR DESCRIPTION
This PR reverts changed done in #2992 to restore support for kubernetes below 1.19