### PR TITLE
Make cluster details > actions tab aware of permissions for a read-only user

### DIFF
--- a/src/components/MAPI/apps/permissions/usePermissionsForApps.ts
+++ b/src/components/MAPI/apps/permissions/usePermissionsForApps.ts
@@ -1,0 +1,77 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import {
+  fetchAccessForResource,
+  fetchAccessForResourceKey,
+} from 'MAPI/permissions/utils';
+import { extractErrorMessage } from 'MAPI/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import { Providers } from 'model/constants';
+import { useEffect } from 'react';
+import useSWR from 'swr';
+import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
+import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
+
+// eslint-disable-next-line no-magic-numbers
+const REFRESH_INTERVAL = 60 * 1000;
+
+export function usePermissionsForApps(
+  _provider: PropertiesOf<typeof Providers>,
+  namespace: string
+) {
+  const computed = {
+    canGet: false,
+    canList: false,
+    canUpdate: false,
+    canCreate: false,
+    canDelete: false,
+  };
+
+  const httpClientFactory = useHttpClientFactory();
+  const auth = useAuthProvider();
+
+  const verbs = ['get', 'list', 'update', 'create', 'delete'] as const;
+  const group = 'application.giantswarm.io';
+  const resource = 'apps';
+
+  const { data: appAccess, error } = useSWR<
+    Record<typeof verbs[number], boolean>,
+    GenericResponseError
+  >(
+    fetchAccessForResourceKey(namespace, verbs, group, resource),
+    () =>
+      fetchAccessForResource(
+        httpClientFactory,
+        auth,
+        namespace,
+        verbs,
+        group,
+        resource
+      ),
+    {
+      refreshInterval: REFRESH_INTERVAL,
+    }
+  );
+
+  useEffect(() => {
+    if (error) {
+      const message = extractErrorMessage(error);
+
+      new FlashMessage(
+        `Something went wrong while trying to compute your user's access to app resources.`,
+        messageType.ERROR,
+        messageTTL.LONG,
+        message
+      );
+    }
+  }, [error]);
+
+  if (!appAccess) return computed;
+
+  computed.canGet = appAccess.get;
+  computed.canList = appAccess.list;
+  computed.canUpdate = appAccess.update;
+  computed.canCreate = appAccess.create;
+  computed.canDelete = appAccess.delete;
+
+  return computed;
+}

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -284,6 +284,7 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
                 clusterName={name}
                 namespace={namespace!}
                 provider={provider}
+                canDeleteClusters={canDeleteClusters}
               />
             </Box>
           )}

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -30,6 +30,7 @@ import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
 import DeleteClusterGuide from '../guides/DeleteClusterGuide';
+import { usePermissionsForClusters } from '../permissions/usePermissionsForClusters';
 import { getWorkerNodesCount } from '../utils';
 import { deleteClusterResources } from './utils';
 
@@ -61,9 +62,15 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
 
   const namespace = org?.status?.namespace;
 
-  const clusterKey = namespace
-    ? fetchClusterKey(provider, namespace, clusterId)
-    : null;
+  const { canGet: canGetClusters } = usePermissionsForClusters(
+    provider,
+    namespace ?? ''
+  );
+
+  const clusterKey =
+    canGetClusters && namespace
+      ? fetchClusterKey(provider, namespace, clusterId)
+      : null;
 
   // The error is handled in the parent component.
   const { data: cluster, error: clusterError } = useSWR<

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -13,6 +13,7 @@ import {
   fetchProviderClusterForClusterKey,
   getClusterDescription,
 } from 'MAPI/utils';
+import { usePermissionsForNodePools } from 'MAPI/workernodes/permissions/usePermissionsForNodePools';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
 import * as securityv1alpha1 from 'model/services/mapi/securityv1alpha1';
@@ -84,11 +85,26 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
     fetchProviderClusterForCluster(clientFactory, auth, cluster!)
   );
 
+  const { canList: canListNodePools } = usePermissionsForNodePools(
+    provider,
+    cluster?.metadata.namespace ?? ''
+  );
+
+  const nodePoolListForClusterKey =
+    canListNodePools && cluster
+      ? fetchNodePoolListForClusterKey(cluster, cluster.metadata.namespace)
+      : null;
+
   const { data: nodePoolList, error: nodePoolListError } = useSWR<
     NodePoolList,
     GenericResponseError
-  >(fetchNodePoolListForClusterKey(cluster), () =>
-    fetchNodePoolListForCluster(clientFactory, auth, cluster)
+  >(nodePoolListForClusterKey, () =>
+    fetchNodePoolListForCluster(
+      clientFactory,
+      auth,
+      cluster,
+      cluster!.metadata.namespace
+    )
   );
 
   useEffect(() => {

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -62,10 +62,8 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
 
   const namespace = org?.status?.namespace;
 
-  const { canGet: canGetClusters } = usePermissionsForClusters(
-    provider,
-    namespace ?? ''
-  );
+  const { canGet: canGetClusters, canDelete: canDeleteClusters } =
+    usePermissionsForClusters(provider, namespace ?? '');
 
   const clusterKey =
     canGetClusters && namespace
@@ -268,6 +266,7 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
               onDelete={handleDelete}
               isLoading={isLoading}
               disabled={hasError}
+              canDeleteClusters={canDeleteClusters}
               variant={ClusterDetailDeleteActionNameVariant.Name}
               basis='3/4'
               flex={{ grow: 1, shrink: 0 }}

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -1,5 +1,6 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { Box, Heading } from 'grommet';
+import { usePermissionsForApps } from 'MAPI/apps/permissions/usePermissionsForApps';
 import { filterUserInstalledApps } from 'MAPI/apps/utils';
 import { Cluster, NodePoolList, ProviderCluster } from 'MAPI/types';
 import {
@@ -110,11 +111,18 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
   }, [nodePoolListError, clusterId]);
 
   const appListClient = useRef(clientFactory());
+
+  const { canList: canListApps } = usePermissionsForApps(provider, clusterId);
+
   const appListGetOptions = { namespace: clusterId };
+  const appListKey = canListApps
+    ? applicationv1alpha1.getAppListKey(appListGetOptions)
+    : null;
+
   const { data: appList, error: appListError } = useSWR<
     applicationv1alpha1.IAppList,
     GenericResponseError
-  >(applicationv1alpha1.getAppListKey(appListGetOptions), () =>
+  >(appListKey, () =>
     applicationv1alpha1.getAppList(
       appListClient.current,
       auth,

--- a/src/components/MAPI/clusters/guides/DeleteClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/DeleteClusterGuide.tsx
@@ -1,5 +1,6 @@
 import { Text } from 'grommet';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import UnauthorizedMessage from 'MAPI/guides/UnauthorizedMessage';
 import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
 import { Providers } from 'model/constants';
 import * as docs from 'model/constants/docs';
@@ -15,12 +16,14 @@ interface IDeleteClusterGuideProps
   clusterName: string;
   namespace: string;
   provider: PropertiesOf<typeof Providers>;
+  canDeleteClusters?: boolean;
 }
 
 const DeleteClusterGuide: React.FC<IDeleteClusterGuideProps> = ({
   clusterName,
   namespace,
   provider,
+  canDeleteClusters,
   ...props
 }) => {
   const context = useSelector(getCurrentInstallationContextName);
@@ -47,6 +50,7 @@ const DeleteClusterGuide: React.FC<IDeleteClusterGuideProps> = ({
       {...props}
     >
       <CLIGuideStepList>
+        {!canDeleteClusters && <UnauthorizedMessage />}
         <LoginGuideStep />
         <CLIGuideStep
           title='2. Delete the cluster'

--- a/src/components/MAPI/workernodes/permissions/usePermissionsForNodePools.ts
+++ b/src/components/MAPI/workernodes/permissions/usePermissionsForNodePools.ts
@@ -2,11 +2,18 @@ import { usePermissions } from 'MAPI/permissions/usePermissions';
 import { hasPermission } from 'MAPI/permissions/utils';
 import { Providers } from 'model/constants';
 
+import { usePermissionsForSparks } from './usePermissionsForSparks';
+
 // eslint-disable-next-line complexity
 export function usePermissionsForNodePools(
   provider: PropertiesOf<typeof Providers>,
   namespace: string
 ) {
+  const { canCreate: canCreateSparks } = usePermissionsForSparks(
+    provider,
+    namespace
+  );
+
   const { data: permissions } = usePermissions();
 
   const computed = {
@@ -105,6 +112,7 @@ export function usePermissionsForNodePools(
 
     case Providers.AZURE:
       computed.canCreate =
+        canCreateSparks &&
         hasPermission(
           permissions,
           namespace,
@@ -125,13 +133,6 @@ export function usePermissionsForNodePools(
           'create',
           'exp.infrastructure.cluster.x-k8s.io',
           'azuremachinepools'
-        ) &&
-        hasPermission(
-          permissions,
-          namespace,
-          'create',
-          'core.giantswarm.io',
-          'sparks'
         );
 
       computed.canDelete =
@@ -155,13 +156,6 @@ export function usePermissionsForNodePools(
           'delete',
           'exp.infrastructure.cluster.x-k8s.io',
           'azuremachinepools'
-        ) &&
-        hasPermission(
-          permissions,
-          namespace,
-          'delete',
-          'core.giantswarm.io',
-          'sparks'
         );
 
       computed.canUpdate =
@@ -185,13 +179,6 @@ export function usePermissionsForNodePools(
           'update',
           'exp.infrastructure.cluster.x-k8s.io',
           'azuremachinepools'
-        ) &&
-        hasPermission(
-          permissions,
-          namespace,
-          'update',
-          'core.giantswarm.io',
-          'sparks'
         );
 
       computed.canGet =
@@ -215,13 +202,6 @@ export function usePermissionsForNodePools(
           'get',
           'exp.infrastructure.cluster.x-k8s.io',
           'azuremachinepools'
-        ) &&
-        hasPermission(
-          permissions,
-          namespace,
-          'get',
-          'core.giantswarm.io',
-          'sparks'
         );
 
       computed.canList =
@@ -245,13 +225,6 @@ export function usePermissionsForNodePools(
           'list',
           'exp.infrastructure.cluster.x-k8s.io',
           'azuremachinepools'
-        ) &&
-        hasPermission(
-          permissions,
-          namespace,
-          'list',
-          'core.giantswarm.io',
-          'sparks'
         );
 
       break;

--- a/src/components/MAPI/workernodes/permissions/usePermissionsForSparks.ts
+++ b/src/components/MAPI/workernodes/permissions/usePermissionsForSparks.ts
@@ -1,0 +1,62 @@
+import { usePermissions } from 'MAPI/permissions/usePermissions';
+import { hasPermission } from 'MAPI/permissions/utils';
+import { Providers } from 'model/constants';
+
+export function usePermissionsForSparks(
+  _provider: PropertiesOf<typeof Providers>,
+  namespace: string
+) {
+  const { data: permissions } = usePermissions();
+
+  const computed = {
+    canGet: false,
+    canList: false,
+    canUpdate: false,
+    canCreate: false,
+    canDelete: false,
+  };
+
+  if (!permissions) return computed;
+
+  computed.canCreate = hasPermission(
+    permissions,
+    namespace,
+    'create',
+    'core.giantswarm.io',
+    'sparks'
+  );
+
+  computed.canDelete = hasPermission(
+    permissions,
+    namespace,
+    'delete',
+    'core.giantswarm.io',
+    'sparks'
+  );
+
+  computed.canUpdate = hasPermission(
+    permissions,
+    namespace,
+    'update',
+    'core.giantswarm.io',
+    'sparks'
+  );
+
+  computed.canGet = hasPermission(
+    permissions,
+    namespace,
+    'get',
+    'core.giantswarm.io',
+    'sparks'
+  );
+
+  computed.canList = hasPermission(
+    permissions,
+    namespace,
+    'list',
+    'core.giantswarm.io',
+    'sparks'
+  );
+
+  return computed;
+}

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction.tsx
@@ -42,6 +42,7 @@ interface IClusterDetailDeleteActionProps
   isLoading?: boolean;
   variant?: ClusterDetailDeleteActionNameVariant;
   disabled?: boolean;
+  canDeleteClusters?: boolean;
 }
 
 const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
@@ -55,6 +56,7 @@ const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
   isLoading,
   variant,
   disabled,
+  canDeleteClusters,
   ...props
 }) => {
   const [confirmationStep, setConfirmationStep] = useState(
@@ -109,11 +111,18 @@ const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
   return (
     <Box direction='column' gap='medium' pad={{ top: 'medium' }} {...props}>
       <Box width={{ max: 'large' }}>
-        <Text>
-          Please make sure you really want to delete this cluster before you
-          proceed, as there is no way to undo this. Data stored on the worker
-          nodes will be lost. Workloads will be terminated.
-        </Text>
+        {canDeleteClusters ? (
+          <Text>
+            Please make sure you really want to delete this cluster before you
+            proceed, as there is no way to undo this. Data stored on the worker
+            nodes will be lost. Workloads will be terminated.
+          </Text>
+        ) : (
+          <Text>
+            For deleting this cluster, you need additional permissions. Please
+            talk to your administrator.
+          </Text>
+        )}
       </Box>
       <Box>
         <ConfirmationPrompt
@@ -171,6 +180,7 @@ const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
               onClick={showConfirmation}
               loading={isLoading}
               disabled={disabled}
+              unauthorized={!canDeleteClusters}
             >
               <i
                 className='fa fa-delete'

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailDeleteAction.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailDeleteAction.tsx
@@ -32,6 +32,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 0,
       workerNodesCount: 0,
       onDelete: jest.fn(),
+      canDeleteClusters: true,
     });
 
     expect(screen.getByRole('button', { name: /Delete/ })).toBeInTheDocument();
@@ -55,6 +56,7 @@ describe('ClusterDetailDeleteAction', () => {
       workerNodesCount: 3,
       userInstalledAppsCount: 5,
       onDelete: jest.fn(),
+      canDeleteClusters: true,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -82,6 +84,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 1,
       workerNodesCount: 1,
       onDelete: jest.fn(),
+      canDeleteClusters: true,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -103,6 +106,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 1,
       workerNodesCount: 1,
       onDelete: onDeleteMockFn,
+      canDeleteClusters: true,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -145,6 +149,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 1,
       workerNodesCount: 1,
       onDelete: jest.fn(),
+      canDeleteClusters: true,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -164,6 +169,7 @@ describe('ClusterDetailDeleteAction', () => {
       workerNodesCount: 1,
       variant: ClusterDetailDeleteActionNameVariant.ID,
       onDelete: jest.fn(),
+      canDeleteClusters: true,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -175,6 +181,26 @@ describe('ClusterDetailDeleteAction', () => {
 
     expect(
       await screen.findByText('If yes, please enter the cluster ID:')
+    ).toBeInTheDocument();
+  });
+
+  it('displays a warning message and the delete button as disabled if the user does not have permissions to delete clusters', () => {
+    renderWithTheme(ClusterDetailDeleteAction, {
+      name: 'at3s7',
+      description: 'A test cluster',
+      creationDate: new Date().toISOString(),
+      nodePoolsCount: 0,
+      workerNodesCount: 0,
+      onDelete: jest.fn(),
+      canDeleteClusters: false,
+    });
+
+    expect(screen.getByRole('button', { name: /Delete/ })).toBeDisabled();
+
+    expect(
+      screen.getByText(
+        'For deleting this cluster, you need additional permissions. Please talk to your administrator.'
+      )
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Towards [giantswarm/roadmap#551](https://github.com/giantswarm/roadmap/issues/551).

This PR makes the cluster details > actions tab aware of permissions. The UI is adapted in the following ways for a read-only user:

**Disable "Delete..." button and adapt warning message:**
<img width="933" alt="Screen Shot 2021-12-13 at 20 38 30" src="https://user-images.githubusercontent.com/62935115/145980883-38738d01-064c-4be4-8e1e-44b4caffeb53.png">
The cursor is also displayed in the `not-allowed` style on hover over the button.

**Display warning message in CLI guide:**
<img width="1200" alt="Screen Shot 2021-12-13 at 20 40 39" src="https://user-images.githubusercontent.com/62935115/145981037-daed3fee-13aa-4c10-b2c1-5f340fe02023.png">


**Checking for permissions for node pools and apps:**
Although the deletion confirmation step (the step showing number of worker nodes and apps installed in the cluster) is not shown for a read-only user, the data is fetched in the same parent component. Thus, we check whether the user has permissions to read this data before fetching.