### PR TITLE
Fix not being able to find cluster's organization in organization list

### DIFF
--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -105,7 +105,9 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
     const org = capiv1alpha3.getClusterOrganization(cluster);
     if (!org) return undefined;
 
-    return Object.values(organizations).find((o) => o.name === org);
+    return Object.values(organizations).find(
+      (o) => o.name === org || o.id === org
+    );
   }, [cluster, organizations]);
 
   const orgId = organization?.id;


### PR DESCRIPTION
This PR adds an additional check to how we find a cluster's organization within the organization list, by also checking for a match to the organization ID, if the name doesn't match.