### PR TITLE
Allow impersonation headers via CORS

### DIFF
--- a/helm/happa/templates/happaapi-ingress.yaml
+++ b/helm/happa/templates/happaapi-ingress.yaml
@@ -14,6 +14,7 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 
     nginx.ingress.kubernetes.io/cors-allow-origin: {{ .Values.happa.address | quote }}
+    nginx.ingress.kubernetes.io/cors-allow-headers: DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, Impersonate-User, Impersonate-Group
     nginx.ingress.kubernetes.io/enable-cors: "true"
 
     {{- if .Values.happaapi.letsencrypt }}


### PR DESCRIPTION
As discussed in https://gigantic.slack.com/archives/C02FJACQ3D4/p1639653195111200

This takes the default headers from https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#enable-cors and adds `Impersonate-User` and `Impersonate-Group`.