### PR TITLE
Make cluster details overview aware of permissions for a read-only user

### DIFF
--- a/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/ClusterLabels.tsx
@@ -51,6 +51,7 @@ interface IClusterLabelsProps
   isLoading?: boolean;
   errorMessage?: string;
   showTitle?: boolean;
+  unauthorized?: boolean;
 }
 
 const ClusterLabels: FC<IClusterLabelsProps> = ({
@@ -59,6 +60,7 @@ const ClusterLabels: FC<IClusterLabelsProps> = ({
   isLoading,
   errorMessage,
   showTitle,
+  unauthorized,
   ...props
 }) => {
   const [allowEditing, setAllowEditing] = useState(true);
@@ -71,13 +73,15 @@ const ClusterLabels: FC<IClusterLabelsProps> = ({
       {noLabels ? (
         <NoLabels>
           This cluster has no labels.
-          <NoLabelsEditLabelTooltip
-            allowInteraction={!isLoading && allowEditing}
-            label=''
-            onOpen={(isOpen) => setAllowEditing(isOpen)}
-            onSave={onChange}
-            value=''
-          />
+          {!unauthorized && (
+            <NoLabelsEditLabelTooltip
+              allowInteraction={!isLoading && allowEditing}
+              label=''
+              onOpen={(isOpen) => setAllowEditing(isOpen)}
+              onSave={onChange}
+              value=''
+            />
+          )}
         </NoLabels>
       ) : (
         <>
@@ -91,16 +95,19 @@ const ClusterLabels: FC<IClusterLabelsProps> = ({
                     onOpen={(isOpen) => setAllowEditing(isOpen)}
                     onSave={onChange}
                     value={value}
+                    unauthorized={unauthorized}
                   />
                 </LabelWrapper>
               ))}
-            <EditLabelTooltip
-              allowInteraction={!isLoading && allowEditing}
-              label=''
-              onOpen={(isOpen) => setAllowEditing(isOpen)}
-              onSave={onChange}
-              value=''
-            />
+            {!unauthorized && (
+              <EditLabelTooltip
+                allowInteraction={!isLoading && allowEditing}
+                label=''
+                onOpen={(isOpen) => setAllowEditing(isOpen)}
+                onSave={onChange}
+                value=''
+              />
+            )}
           </LabelsWrapper>
           {errorMessage && (
             <ErrorText>Could not save labels. Please try again.</ErrorText>

--- a/src/components/Cluster/ClusterDetail/ClusterLabels/DeleteLabelButton.tsx
+++ b/src/components/Cluster/ClusterDetail/ClusterLabels/DeleteLabelButton.tsx
@@ -78,18 +78,20 @@ const DeleteLabelButton: FC<IDeleteLabelButtonProps> = ({
 
   return (
     <DeleteLabelButtonWrapper ref={divElement}>
-      <TooltipContainer
-        target={divElement}
-        content={<StyledTooltip>Delete this label</StyledTooltip>}
-      >
-        <Keyboard onSpace={handleDelete} onEnter={handleDelete}>
-          <StyledDeleteButton
-            tabIndex={allowInteraction ? 0 : -1}
-            onClick={handleDelete}
-            {...restProps}
-          />
-        </Keyboard>
-      </TooltipContainer>
+      <Keyboard onSpace={handleDelete} onEnter={handleDelete}>
+        <span>
+          <TooltipContainer
+            target={divElement}
+            content={<StyledTooltip>Delete this label</StyledTooltip>}
+          >
+            <StyledDeleteButton
+              tabIndex={allowInteraction ? 0 : -1}
+              onClick={handleDelete}
+              {...restProps}
+            />
+          </TooltipContainer>
+        </span>
+      </Keyboard>
       {isOpen && (
         <Tooltip
           id='delete-label'

--- a/src/components/MAPI/apps/ClusterDetailWidgetApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailWidgetApps.tsx
@@ -6,7 +6,7 @@ import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 import ClusterDetailCounter from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailCounter';
 import ClusterDetailWidget from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget';
 import ErrorReporter from 'utils/errors/ErrorReporter';
@@ -95,6 +95,8 @@ const ClusterDetailWidgetApps: React.FC<IClusterDetailWidgetAppsProps> = (
   const hasNoApps =
     typeof appCounters.apps === 'number' && appCounters.apps === 0;
 
+  const { cache } = useSWRConfig();
+
   const upgradableAppsKey = appList
     ? getUpgradableAppsKey(userInstalledApps)
     : null;
@@ -103,7 +105,7 @@ const ClusterDetailWidgetApps: React.FC<IClusterDetailWidgetAppsProps> = (
     string[],
     GenericResponseError
   >(upgradableAppsKey, () =>
-    getUpgradableApps(userInstalledApps, clientFactory, auth)
+    getUpgradableApps(clientFactory, auth, cache, userInstalledApps)
   );
 
   useEffect(() => {

--- a/src/components/MAPI/apps/ClusterDetailWidgetApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailWidgetApps.tsx
@@ -44,7 +44,8 @@ const ClusterDetailWidgetApps: React.FC<IClusterDetailWidgetAppsProps> = (
 
   const appListClient = useRef(clientFactory());
 
-  const { canList: canListApps } = usePermissionsForApps(provider, clusterId);
+  const { canList: canListApps, canCreate: canCreateApps } =
+    usePermissionsForApps(provider, clusterId);
 
   const appListGetOptions = { namespace: clusterId };
   const appListKey = canListApps
@@ -163,10 +164,12 @@ const ClusterDetailWidgetApps: React.FC<IClusterDetailWidgetAppsProps> = (
       {hasNoApps && (
         <Box fill={true} pad={{ bottom: 'xsmall' }}>
           <Text margin={{ bottom: 'small' }}>No apps installed</Text>
-          <Text size='small'>
-            To find apps to install, browse our{' '}
-            <StyledLink to={AppsRoutes.Home}>apps</StyledLink>.
-          </Text>
+          {canCreateApps && canReadCatalogResources && (
+            <Text size='small'>
+              To find apps to install, browse our{' '}
+              <StyledLink to={AppsRoutes.Home}>apps</StyledLink>.
+            </Text>
+          )}
         </Box>
       )}
 

--- a/src/components/MAPI/apps/__tests__/ClusterDetailWidgetApps.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailWidgetApps.tsx
@@ -12,6 +12,9 @@ import { getComponentWithStore } from 'test/renderUtils';
 import TestOAuth2 from 'utils/OAuth2/TestOAuth2';
 
 import ClusterDetailWidgetApps from '../ClusterDetailWidgetApps';
+import { usePermissionsForAppCatalogEntries } from '../permissions/usePermissionsForAppCatalogEntries';
+import { usePermissionsForApps } from '../permissions/usePermissionsForApps';
+import { usePermissionsForCatalogs } from '../permissions/usePermissionsForCatalogs';
 
 function generateApp(
   specName: string = 'some-app',
@@ -47,6 +50,7 @@ function generateApp(
     },
     spec: {
       catalog: 'default',
+      catalogNamespace: 'default',
       config: {
         configMap: {
           name: `${namespace}-cluster-values`,
@@ -114,6 +118,14 @@ function getComponent(
   );
 }
 
+const defaultPermissions = {
+  canGet: true,
+  canList: true,
+  canUpdate: true,
+  canCreate: true,
+  canDelete: true,
+};
+
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useParams: jest.fn().mockReturnValue({
@@ -122,14 +134,34 @@ jest.mock('react-router', () => ({
   }),
 }));
 
+jest.mock('MAPI/apps/permissions/usePermissionsForApps');
+jest.mock('MAPI/apps/permissions/usePermissionsForCatalogs');
+jest.mock('MAPI/apps/permissions/usePermissionsForAppCatalogEntries');
+
 describe('ClusterDetailWidgetApps', () => {
   it('displays loading animations if the cluster is still loading', () => {
+    (usePermissionsForApps as jest.Mock).mockReturnValue(defaultPermissions);
+    (usePermissionsForCatalogs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForAppCatalogEntries as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     render(getComponent({}));
 
     expect(screen.getAllByLabelText('Loading...').length).toEqual(4);
   });
 
   it('displays a placeholder if there are no apps', async () => {
+    (usePermissionsForApps as jest.Mock).mockReturnValue(defaultPermissions);
+    (usePermissionsForCatalogs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForAppCatalogEntries as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     nock(window.config.mapiEndpoint)
       .get(
         `/apis/application.giantswarm.io/v1alpha1/namespaces/${mockCapiv1alpha3.randomCluster1.metadata.name}/apps/`
@@ -158,6 +190,14 @@ describe('ClusterDetailWidgetApps', () => {
   });
 
   it('displays stats about the apps installed in the cluster', async () => {
+    (usePermissionsForApps as jest.Mock).mockReturnValue(defaultPermissions);
+    (usePermissionsForCatalogs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForAppCatalogEntries as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     nock(window.config.mapiEndpoint)
       .get(
         `/apis/application.giantswarm.io/v1alpha1/namespaces/${mockCapiv1alpha3.randomCluster1.metadata.name}/apps/`
@@ -183,6 +223,14 @@ describe('ClusterDetailWidgetApps', () => {
   });
 
   it('displays the number of upgradable apps', async () => {
+    (usePermissionsForApps as jest.Mock).mockReturnValue(defaultPermissions);
+    (usePermissionsForCatalogs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForAppCatalogEntries as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     nock(window.config.mapiEndpoint)
       .get(
         `/apis/application.giantswarm.io/v1alpha1/namespaces/${mockCapiv1alpha3.randomCluster1.metadata.name}/apps/`
@@ -197,7 +245,7 @@ describe('ClusterDetailWidgetApps', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        '/apis/application.giantswarm.io/v1alpha1/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
+        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
       )
       .reply(
         StatusCodes.Ok,
@@ -206,7 +254,7 @@ describe('ClusterDetailWidgetApps', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        '/apis/application.giantswarm.io/v1alpha1/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
+        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
       )
       .reply(
         StatusCodes.Ok,

--- a/src/components/MAPI/apps/permissions/usePermissionsForAppCatalogEntries.ts
+++ b/src/components/MAPI/apps/permissions/usePermissionsForAppCatalogEntries.ts
@@ -1,0 +1,58 @@
+import { usePermissions } from 'MAPI/permissions/usePermissions';
+import { hasPermission } from 'MAPI/permissions/utils';
+import { Providers } from 'model/constants';
+
+export function usePermissionsForAppCatalogEntries(
+  _provider: PropertiesOf<typeof Providers>,
+  namespace: string
+) {
+  const { data: permissions } = usePermissions();
+
+  const computed = {
+    canGet: false,
+    canList: false,
+    canUpdate: false,
+    canCreate: false,
+    canDelete: false,
+  };
+
+  if (!permissions) return computed;
+
+  computed.canGet = hasPermission(
+    permissions,
+    namespace,
+    'get',
+    'application.giantswarm.io',
+    'appcatalogentries'
+  );
+  computed.canList = hasPermission(
+    permissions,
+    namespace,
+    'list',
+    'application.giantswarm.io',
+    'appcatalogentries'
+  );
+  computed.canUpdate = hasPermission(
+    permissions,
+    namespace,
+    'update',
+    'application.giantswarm.io',
+    'appcatalogentries'
+  );
+  computed.canCreate = hasPermission(
+    permissions,
+    namespace,
+    'create',
+    'application.giantswarm.io',
+    'appcatalogentries'
+  );
+  computed.canDelete = hasPermission(
+    permissions,
+    namespace,
+    'delete',
+    'application.giantswarm.io',
+    'appcatalogentries'
+  );
+
+  return computed;
+}

--- a/src/components/MAPI/apps/permissions/usePermissionsForCatalogs.ts
+++ b/src/components/MAPI/apps/permissions/usePermissionsForCatalogs.ts
@@ -1,0 +1,58 @@
+import { usePermissions } from 'MAPI/permissions/usePermissions';
+import { hasPermission } from 'MAPI/permissions/utils';
+import { Providers } from 'model/constants';
+
+export function usePermissionsForCatalogs(
+  _provider: PropertiesOf<typeof Providers>,
+  namespace: string
+) {
+  const { data: permissions } = usePermissions();
+
+  const computed = {
+    canGet: false,
+    canList: false,
+    canUpdate: false,
+    canCreate: false,
+    canDelete: false,
+  };
+
+  if (!permissions) return computed;
+
+  computed.canGet = hasPermission(
+    permissions,
+    namespace,
+    'get',
+    'application.giantswarm.io',
+    'catalogs'
+  );
+  computed.canList = hasPermission(
+    permissions,
+    namespace,
+    'list',
+    'application.giantswarm.io',
+    'catalogs'
+  );
+  computed.canUpdate = hasPermission(
+    permissions,
+    namespace,
+    'update',
+    'application.giantswarm.io',
+    'catalogs'
+  );
+  computed.canCreate = hasPermission(
+    permissions,
+    namespace,
+    'create',
+    'application.giantswarm.io',
+    'catalogs'
+  );
+  computed.canDelete = hasPermission(
+    permissions,
+    namespace,
+    'delete',
+    'application.giantswarm.io',
+    'catalogs'
+  );
+
+  return computed;
+}

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -847,15 +847,26 @@ export function formatYAMLError(err: unknown): string {
 
 /**
  * Determines whether an app has a newer version
- * @param app
- * @param client
+ * @param clientFactory
  * @param auth
+ * @param cache
+ * @param app
  */
 export async function hasNewerVersion(
-  app: applicationv1alpha1.IApp,
-  client: IHttpClient,
-  auth: IOAuth2Provider
+  clientFactory: HttpClientFactory,
+  auth: IOAuth2Provider,
+  cache: Cache,
+  app: applicationv1alpha1.IApp
 ): Promise<{ name: string; hasNewerVersion: boolean }> {
+  const catalogNamespace = await getCatalogNamespace(
+    clientFactory,
+    auth,
+    cache,
+    app
+  );
+
+  const appCatalogEntryListItems: applicationv1alpha1.IAppCatalogEntry[] = [];
+
   const appCatalogEntryListGetOptions: applicationv1alpha1.IGetAppCatalogEntryListOptions =
     {
       labelSelector: {
@@ -864,16 +875,33 @@ export async function hasNewerVersion(
           [applicationv1alpha1.labelAppCatalog]: app.spec.catalog,
         },
       },
+      namespace: catalogNamespace ?? undefined,
     };
 
-  const appCatalogEntryList = await applicationv1alpha1.getAppCatalogEntryList(
-    client,
-    auth,
+  const appCatalogEntryListKey = applicationv1alpha1.getAppCatalogEntryListKey(
     appCatalogEntryListGetOptions
   );
 
+  const cachedAppCatalogEntryList:
+    | applicationv1alpha1.IAppCatalogEntryList
+    | undefined = cache.get(appCatalogEntryListKey);
+
+  if (cachedAppCatalogEntryList) {
+    appCatalogEntryListItems.push(...cachedAppCatalogEntryList.items);
+  } else {
+    const appCatalogEntryList =
+      await applicationv1alpha1.getAppCatalogEntryList(
+        clientFactory(),
+        auth,
+        appCatalogEntryListGetOptions
+      );
+
+    appCatalogEntryListItems.push(...appCatalogEntryList.items);
+    cache.set(appCatalogEntryListKey, appCatalogEntryList);
+  }
+
   const latestVersion = getLatestVersionForApp(
-    appCatalogEntryList.items,
+    appCatalogEntryListItems,
     app.spec.name
   );
 
@@ -887,17 +915,19 @@ export async function hasNewerVersion(
 
 /**
  * Get names of apps that can be upgraded (i.e. has newer versions)
- * @param apps
  * @param clientFactory
  * @param auth
+ * @param cache
+ * @param apps
  */
 export async function getUpgradableApps(
-  apps: applicationv1alpha1.IApp[],
   clientFactory: HttpClientFactory,
-  auth: IOAuth2Provider
+  auth: IOAuth2Provider,
+  cache: Cache,
+  apps: applicationv1alpha1.IApp[]
 ) {
   const response = await Promise.all(
-    apps.map((app) => hasNewerVersion(app, clientFactory(), auth))
+    apps.map((app) => hasNewerVersion(clientFactory, auth, cache, app))
   );
 
   const upgradableApps = [];
@@ -914,7 +944,12 @@ export async function getUpgradableApps(
  * @param apps
  */
 export function getUpgradableAppsKey(apps: applicationv1alpha1.IApp[]) {
-  return apps.reduce((key, app) => key + app.spec.name, '');
+  if (apps.length === 0) return null;
+
+  return `getUpgradableApps${apps.reduce(
+    (key, app) => `${key}/${app.spec.catalog}/${app.spec.name}`,
+    ''
+  )}`;
 }
 
 /**
@@ -949,14 +984,17 @@ export async function getCatalogNamespace(
       if (cachedCatalogList) {
         catalogs.push(...cachedCatalogList.items);
       } else {
-        const catalogList = await applicationv1alpha1.getCatalogList(
-          clientFactory(),
-          auth,
-          getCatalogListOptions
-        );
-
-        cache.set(catalogListKey, catalogList);
-        catalogs.push(...catalogList.items);
+        try {
+          const catalogList = await applicationv1alpha1.getCatalogList(
+            clientFactory(),
+            auth,
+            getCatalogListOptions
+          );
+          cache.set(catalogListKey, catalogList);
+          catalogs.push(...catalogList.items);
+        } catch {
+          continue;
+        }
       }
     }
 

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -24,6 +24,7 @@ import ClusterDetailWidgetWorkerNodes from '../../workernodes/ClusterDetailWidge
 import InspectClusterGuide from '../guides/InspectClusterGuide';
 import InspectClusterReleaseGuide from '../guides/InspectClusterReleaseGuide';
 import SetClusterLabelsGuide from '../guides/SetClusterLabelsGuide';
+import { usePermissionsForClusters } from '../permissions/usePermissionsForClusters';
 import ClusterDetailWidgetControlPlaneNodes from './ClusterDetailWidgetControlPlaneNodes';
 import ClusterDetailWidgetCreated from './ClusterDetailWidgetCreated';
 import ClusterDetailWidgetKubernetesAPI from './ClusterDetailWidgetKubernetesAPI';
@@ -55,9 +56,15 @@ const ClusterDetailOverview: React.FC<{}> = () => {
 
   const namespace = org?.status?.namespace;
 
-  const clusterKey = namespace
-    ? fetchClusterKey(provider, namespace, clusterId)
-    : null;
+  const { canGet: canGetCluster } = usePermissionsForClusters(
+    provider,
+    namespace ?? ''
+  );
+
+  const clusterKey =
+    canGetCluster && namespace
+      ? fetchClusterKey(provider, namespace, clusterId)
+      : null;
 
   // The error is handled in the parent component.
   const { data: cluster } = useSWR<Cluster, GenericResponseError>(

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -56,10 +56,8 @@ const ClusterDetailOverview: React.FC<{}> = () => {
 
   const namespace = org?.status?.namespace;
 
-  const { canGet: canGetCluster } = usePermissionsForClusters(
-    provider,
-    namespace ?? ''
-  );
+  const { canGet: canGetCluster, canUpdate: canUpdateCluster } =
+    usePermissionsForClusters(provider, namespace ?? '');
 
   const clusterKey =
     canGetCluster && namespace
@@ -108,6 +106,7 @@ const ClusterDetailOverview: React.FC<{}> = () => {
       <ClusterDetailWidgetRelease
         cluster={cluster}
         providerCluster={providerCluster}
+        canUpdateCluster={canUpdateCluster}
         basis='100%'
       />
       <ClusterDetailWidgetLabels cluster={cluster} basis='100%' />

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -109,7 +109,11 @@ const ClusterDetailOverview: React.FC<{}> = () => {
         canUpdateCluster={canUpdateCluster}
         basis='100%'
       />
-      <ClusterDetailWidgetLabels cluster={cluster} basis='100%' />
+      <ClusterDetailWidgetLabels
+        cluster={cluster}
+        canUpdateCluster={canUpdateCluster}
+        basis='100%'
+      />
       <ClusterDetailWidgetControlPlaneNodes
         cluster={cluster}
         providerCluster={providerCluster}

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -153,6 +153,7 @@ const ClusterDetailOverview: React.FC<{}> = () => {
             clusterName={cluster.metadata.name}
             clusterNamespace={cluster.metadata.namespace!}
             provider={provider}
+            canUpdateCluster={canUpdateCluster}
           />
         </Box>
       )}

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
@@ -1,7 +1,10 @@
 import URIBlock from 'Cluster/ClusterDetail/URIBlock';
+import { usePermissionsForKeyPairs } from 'MAPI/keypairs/permissions/usePermissionsForKeyPairs';
 import { OrganizationsRoutes } from 'model/constants/routes';
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+import { selectOrganizations } from 'model/stores/organization/selectors';
 import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { Link, useParams } from 'react-router-dom';
 import Button from 'UI/Controls/Button';
 import ClusterDetailWidget from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget';
@@ -24,6 +27,12 @@ const ClusterDetailWidgetKubernetesAPI: React.FC<
     orgId: string;
   }>();
 
+  const provider = window.config.info.general.provider;
+
+  const organizations = useSelector(selectOrganizations());
+  const selectedOrg = orgId ? organizations[orgId] : undefined;
+  const namespace = selectedOrg?.namespace;
+
   const k8sApiURL = cluster
     ? capiv1alpha3.getKubernetesAPIEndpointURL(cluster)
     : undefined;
@@ -34,6 +43,11 @@ const ClusterDetailWidgetKubernetesAPI: React.FC<
       { orgId, clusterId }
     );
   }, [orgId, clusterId]);
+
+  const { canCreate: canCreateKeyPairs } = usePermissionsForKeyPairs(
+    provider,
+    namespace ?? ''
+  );
 
   return (
     <ClusterDetailWidget
@@ -53,7 +67,7 @@ const ClusterDetailWidgetKubernetesAPI: React.FC<
         {(value) => <URIBlock>{value}</URIBlock>}
       </OptionalValue>
 
-      {typeof k8sApiURL !== 'undefined' && (
+      {canCreateKeyPairs && typeof k8sApiURL !== 'undefined' && (
         <Link to={gettingStartedPath}>
           <Button
             tabIndex={-1}

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetLabels.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetLabels.tsx
@@ -18,10 +18,12 @@ interface IClusterDetailWidgetLabelsProps
     'title'
   > {
   cluster?: capiv1alpha3.ICluster;
+  canUpdateCluster?: boolean;
 }
 
 const ClusterDetailWidgetLabels: React.FC<IClusterDetailWidgetLabelsProps> = ({
   cluster,
+  canUpdateCluster,
   ...props
 }) => {
   const clientFactory = useHttpClientFactory();
@@ -103,6 +105,7 @@ const ClusterDetailWidgetLabels: React.FC<IClusterDetailWidgetLabelsProps> = ({
             errorMessage={labelsError}
             isLoading={labelsIsLoading}
             showTitle={false}
+            unauthorized={!canUpdateCluster}
           />
         )}
       </OptionalValue>

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetControlPlaneNodes.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetControlPlaneNodes.tsx
@@ -9,6 +9,7 @@ import * as capzv1alpha3Mocks from 'test/mockHttpCalls/capzv1alpha3';
 import { getComponentWithStore } from 'test/renderUtils';
 import TestOAuth2 from 'utils/OAuth2/TestOAuth2';
 
+import { usePermissionsForCPNodes } from '../../permissions/usePermissionsForCPNodes';
 import ClusterDetailWidgetControlPlaneNodes from '../ClusterDetailWidgetControlPlaneNodes';
 
 function getComponent(
@@ -35,12 +36,26 @@ function getComponent(
   );
 }
 
+const defaultPermissions = {
+  canGet: true,
+  canList: true,
+  canUpdate: true,
+  canCreate: true,
+  canDelete: true,
+};
+
+jest.mock('MAPI/clusters/permissions/usePermissionsForCPNodes');
+
 describe('ClusterDetailWidgetControlPlaneNodes', () => {
   it('renders without crashing', () => {
+    (usePermissionsForCPNodes as jest.Mock).mockReturnValue(defaultPermissions);
+
     render(getComponent({}));
   });
 
   it('displays loading animations if the cluster is still loading', () => {
+    (usePermissionsForCPNodes as jest.Mock).mockReturnValue(defaultPermissions);
+
     render(
       getComponent({
         cluster: undefined,
@@ -51,9 +66,11 @@ describe('ClusterDetailWidgetControlPlaneNodes', () => {
   });
 
   it('displays the number of control plane nodes that are ready on Azure', async () => {
+    (usePermissionsForCPNodes as jest.Mock).mockReturnValue(defaultPermissions);
+
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster2.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster2.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster2.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList2);
 
@@ -69,9 +86,11 @@ describe('ClusterDetailWidgetControlPlaneNodes', () => {
   });
 
   it('displays if all control planes are ready on Azure', async () => {
+    (usePermissionsForCPNodes as jest.Mock).mockReturnValue(defaultPermissions);
+
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster2.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 
@@ -87,9 +106,11 @@ describe('ClusterDetailWidgetControlPlaneNodes', () => {
   });
 
   it('displays if the cluster is not in an availability zone', async () => {
+    (usePermissionsForCPNodes as jest.Mock).mockReturnValue(defaultPermissions);
+
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster2.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster2.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster2.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList2);
 
@@ -104,9 +125,11 @@ describe('ClusterDetailWidgetControlPlaneNodes', () => {
   });
 
   it(`displays the cluster's availability zone`, async () => {
+    (usePermissionsForCPNodes as jest.Mock).mockReturnValue(defaultPermissions);
+
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster2.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
@@ -1,15 +1,34 @@
 import { screen } from '@testing-library/react';
+import { usePermissionsForKeyPairs } from 'MAPI/keypairs/permissions/usePermissionsForKeyPairs';
 import * as capiv1alpha3Mocks from 'test/mockHttpCalls/capiv1alpha3';
 import { renderWithStore } from 'test/renderUtils';
 
 import ClusterDetailWidgetKubernetesAPI from '../ClusterDetailWidgetKubernetesAPI';
 
+const defaultPermissions = {
+  canGet: true,
+  canList: true,
+  canUpdate: true,
+  canCreate: true,
+  canDelete: true,
+};
+
+jest.mock('MAPI/keypairs/permissions/usePermissionsForKeypairs');
+
 describe('ClusterDetailWidgetKubernetesAPI', () => {
   it('renders without crashing', () => {
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     renderWithStore(ClusterDetailWidgetKubernetesAPI, {});
   });
 
   it('displays loading animations if the cluster is still loading', () => {
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     renderWithStore(ClusterDetailWidgetKubernetesAPI, {
       cluster: undefined,
     });
@@ -18,6 +37,10 @@ describe('ClusterDetailWidgetKubernetesAPI', () => {
   });
 
   it('displays the kubernetes API endpoint URL for the cluster', () => {
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     renderWithStore(ClusterDetailWidgetKubernetesAPI, {
       cluster: capiv1alpha3Mocks.randomCluster1,
     });
@@ -26,6 +49,10 @@ describe('ClusterDetailWidgetKubernetesAPI', () => {
   });
 
   it('displays the getting started button', () => {
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     renderWithStore(ClusterDetailWidgetKubernetesAPI, {
       cluster: capiv1alpha3Mocks.randomCluster1,
     });
@@ -35,5 +62,22 @@ describe('ClusterDetailWidgetKubernetesAPI', () => {
         name: 'Get started',
       })
     ).toBeInTheDocument();
+  });
+
+  it('does not display the getting started button if the user does not have permission to create key pairs', () => {
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue({
+      ...defaultPermissions,
+      canCreate: false,
+    });
+
+    renderWithStore(ClusterDetailWidgetKubernetesAPI, {
+      cluster: capiv1alpha3Mocks.randomCluster1,
+    });
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Get started',
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
@@ -1,8 +1,8 @@
 import { screen } from '@testing-library/react';
-import { usePermissionsForKeyPairs } from 'MAPI/keypairs/permissions/usePermissionsForKeyPairs';
 import * as capiv1alpha3Mocks from 'test/mockHttpCalls/capiv1alpha3';
 import { renderWithStore } from 'test/renderUtils';
 
+import { usePermissionsForKeyPairs } from '../../../keypairs/permissions/usePermissionsForKeyPairs';
 import ClusterDetailWidgetKubernetesAPI from '../ClusterDetailWidgetKubernetesAPI';
 
 const defaultPermissions = {
@@ -13,7 +13,7 @@ const defaultPermissions = {
   canDelete: true,
 };
 
-jest.mock('MAPI/keypairs/permissions/usePermissionsForKeypairs');
+jest.mock('MAPI/keypairs/permissions/usePermissionsForKeyPairs');
 
 describe('ClusterDetailWidgetKubernetesAPI', () => {
   it('renders without crashing', () => {

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -146,10 +146,8 @@ const ClusterDetail: React.FC<{}> = () => {
 
   const provider = window.config.info.general.provider;
 
-  const { canGet: canGetCluster } = usePermissionsForClusters(
-    provider,
-    namespace ?? ''
-  );
+  const { canGet: canGetCluster, canUpdate: canUpdateCluster } =
+    usePermissionsForClusters(provider, namespace ?? '');
 
   const clusterKey =
     canGetCluster && namespace
@@ -376,6 +374,7 @@ const ClusterDetail: React.FC<{}> = () => {
                     onSave={updateDescription}
                     aria-label={value as string}
                     variant={ViewAndEditNameVariant.Description}
+                    unauthorized={!canUpdateCluster}
                   />
                 )}
               </OptionalValue>

--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -3,6 +3,7 @@ import { push } from 'connected-react-router';
 import differenceInHours from 'date-fns/fp/differenceInHours';
 import toDate from 'date-fns-tz/toDate';
 import { Box, Card, CardBody, Text } from 'grommet';
+import { usePermissionsForKeyPairs } from 'MAPI/keypairs/permissions/usePermissionsForKeyPairs';
 import { NodePoolList, ProviderCluster } from 'MAPI/types';
 import {
   extractErrorMessage,
@@ -227,12 +228,19 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
   const hasError = typeof nodePoolListError !== 'undefined';
   const isLoading = typeof cluster === 'undefined';
 
+  const selectedOrg = organizations && orgId ? organizations[orgId] : undefined;
+  const namespace = selectedOrg?.namespace;
+  const { canCreate: canCreateKeyPairs } = usePermissionsForKeyPairs(
+    provider,
+    namespace ?? ''
+  );
+
   const shouldDisplayGetStarted = useMemo(() => {
     if (
       isDeleting ||
       isLoading ||
       !creationDate ||
-      !canCreateClusters ||
+      !canCreateKeyPairs ||
       isPreviewRelease
     )
       return false;

--- a/src/components/MAPI/clusters/ClusterList/__tests__/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/__tests__/ClusterListItem.tsx
@@ -4,6 +4,7 @@ import add from 'date-fns/fp/add';
 import format from 'date-fns/fp/format';
 import sub from 'date-fns/fp/sub';
 import { createMemoryHistory } from 'history';
+import { usePermissionsForKeyPairs } from 'MAPI/keypairs/permissions/usePermissionsForKeyPairs';
 import { usePermissionsForNodePools } from 'MAPI/workernodes/permissions/usePermissionsForNodePools';
 import { StatusCodes } from 'model/constants';
 import nock from 'nock';
@@ -42,29 +43,36 @@ function getComponent(
   );
 }
 
+const defaultPermissions = {
+  canGet: true,
+  canList: true,
+  canUpdate: true,
+  canCreate: true,
+  canDelete: true,
+};
+
 jest.mock('MAPI/workernodes/permissions/usePermissionsForNodePools');
+jest.mock('MAPI/keypairs/permissions/usePermissionsForKeyPairs');
 
 describe('ClusterListItem', () => {
   it('renders without crashing', () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
-    });
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
 
     render(getComponent({}));
   });
 
   it('displays a loading animation if the cluster is not loaded yet', () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
-    });
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
 
     render(getComponent({}));
 
@@ -75,13 +83,12 @@ describe('ClusterListItem', () => {
   });
 
   it('displays if a cluster was deleted', () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
-    });
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
 
     const deletionDate = sub({
       hours: 1,
@@ -106,13 +113,12 @@ describe('ClusterListItem', () => {
   });
 
   it('displays the getting started button if the cluster has been created recently', () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
-    });
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
 
     let creationDate = sub({
       days: 20,
@@ -158,13 +164,13 @@ describe('ClusterListItem', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not displays the getting started button if the user does not have permissions create clusters', () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
+  it('does not displays the getting started button if the user does not have permissions create key pairs', () => {
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue({
+      ...defaultPermissions,
+      canCreate: false,
     });
 
     render(
@@ -181,13 +187,12 @@ describe('ClusterListItem', () => {
   });
 
   it('displays various information about the cluster', () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
-    });
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
 
     const creationDate = sub({
       hours: 1,
@@ -223,13 +228,12 @@ describe('ClusterListItem', () => {
   });
 
   it('displays stats about worker nodes', async () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
-    });
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
 
     nock(window.config.mapiEndpoint)
       .get(
@@ -270,13 +274,12 @@ describe('ClusterListItem', () => {
   });
 
   it(`displays the cluster's current status`, () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
-    });
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
 
     const { rerender } = render(
       getComponent({
@@ -355,13 +358,12 @@ describe('ClusterListItem', () => {
   });
 
   it('displays information if an upgrade has been scheduled', async () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue({
-      canGet: true,
-      canList: true,
-      canUpdate: true,
-      canCreate: true,
-      canDelete: true,
-    });
+    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
 
     const targetTime = `${format('dd MMM yy HH:mm')(
       add({ days: 1 })(new Date())

--- a/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
+++ b/src/components/MAPI/clusters/guides/SetClusterLabelsGuide.tsx
@@ -1,5 +1,6 @@
 import { Text } from 'grommet';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
+import UnauthorizedMessage from 'MAPI/guides/UnauthorizedMessage';
 import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
 import { Providers } from 'model/constants';
 import * as docs from 'model/constants/docs';
@@ -14,12 +15,14 @@ interface ISetClusterLabelsGuideProps
   clusterName: string;
   clusterNamespace: string;
   provider: PropertiesOf<typeof Providers>;
+  canUpdateCluster?: boolean;
 }
 
 const SetClusterLabelsGuide: React.FC<ISetClusterLabelsGuideProps> = ({
   clusterName,
   clusterNamespace,
   provider,
+  canUpdateCluster,
   ...props
 }) => {
   const context = getCurrentInstallationContextName();
@@ -56,6 +59,7 @@ const SetClusterLabelsGuide: React.FC<ISetClusterLabelsGuideProps> = ({
       {...props}
     >
       <CLIGuideStepList>
+        {!canUpdateCluster && <UnauthorizedMessage />}
         <LoginGuideStep />
         <CLIGuideStep
           title='2. Add a label to this cluster'

--- a/src/components/MAPI/organizations/OrganizationDetailGeneral/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/OrganizationDetailGeneral/__tests__/index.tsx
@@ -298,19 +298,19 @@ describe('OrganizationDetailGeneral', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster2.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster2.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList2);
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster3.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/org-org1/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster3.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList3);
 

--- a/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
+++ b/src/components/MAPI/releases/ClusterDetailReleaseDetailsModal.tsx
@@ -27,6 +27,7 @@ interface IClusterDetailReleaseDetailsModalProps {
   components?: IClusterDetailReleaseDetailsModalComponent[];
   releaseNotesURL?: string;
   supportedUpgradeVersions?: ui.IReleaseVersion[];
+  canUpdateCluster?: boolean;
 }
 
 const ClusterDetailReleaseDetailsModal: React.FC<
@@ -40,6 +41,7 @@ const ClusterDetailReleaseDetailsModal: React.FC<
   components,
   releaseNotesURL,
   supportedUpgradeVersions,
+  canUpdateCluster,
 }) => {
   const title = `Details for release ${version}`;
 
@@ -97,6 +99,7 @@ const ClusterDetailReleaseDetailsModal: React.FC<
             <ClusterDetailReleaseDetailsUpgradeOptions
               supportedVersions={supportedUpgradeVersions}
               onVersionClick={onUpgradeVersionSelect}
+              canUpdateCluster={canUpdateCluster}
             />
           </StyledReleaseDetailsModalSection>
         )}

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -273,24 +273,35 @@ const ClusterDetailWidgetRelease: React.FC<
     <ClusterDetailWidget title='Release' inline={true} {...props}>
       <Box direction='row' gap='xsmall' wrap={true} align='center'>
         <OptionalValue value={releaseVersion} replaceEmptyValue={false}>
-          {(value) => (
-            <Keyboard onSpace={handleVersionClick}>
-              <StyledLink
-                href='#'
-                aria-label={`Cluster release version ${value}`}
-                onClick={handleVersionClick}
-              >
-                <Text>
-                  <i
-                    className='fa fa-version-tag'
-                    role='presentation'
-                    aria-hidden='true'
-                  />
-                </Text>{' '}
-                <VersionLabel>{value || <NotAvailable />}</VersionLabel>
-              </StyledLink>
-            </Keyboard>
-          )}
+          {(value) =>
+            canListReleases ? (
+              <Keyboard onSpace={handleVersionClick}>
+                <StyledLink
+                  href='#'
+                  aria-label={`Cluster release version ${value}`}
+                  onClick={handleVersionClick}
+                >
+                  <Text>
+                    <i
+                      className='fa fa-version-tag'
+                      role='presentation'
+                      aria-hidden='true'
+                    />
+                  </Text>{' '}
+                  <VersionLabel>{value || <NotAvailable />}</VersionLabel>
+                </StyledLink>
+              </Keyboard>
+            ) : (
+              <Text aria-label={`Cluster release version ${value}`}>
+                <i
+                  className='fa fa-version-tag'
+                  role='presentation'
+                  aria-hidden='true'
+                />{' '}
+                {value || <NotAvailable />}
+              </Text>
+            )
+          }
         </OptionalValue>
         <StyledDot />
         <OptionalValue value={k8sVersion} replaceEmptyValue={false}>

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -361,6 +361,7 @@ const ClusterDetailWidgetRelease: React.FC<
             canUpgrade ? supportedUpgradeVersions : undefined
           }
           onUpgradeVersionSelect={handleUpgradeVersionSelect}
+          canUpdateCluster={canUpdateCluster}
         />
       )}
 

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -34,6 +34,7 @@ import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
 import ClusterDetailReleaseDetailsModal from './ClusterDetailReleaseDetailsModal';
 import ClusterDetailUpgradeModal from './ClusterDetailUpgradeModal';
+import { usePermissionsForReleases } from './permissions/usePermissionsForReleases';
 
 const StyledDot = styled(Dot)`
   padding: 0;
@@ -64,19 +65,30 @@ interface IClusterDetailWidgetReleaseProps
   > {
   cluster?: capiv1alpha3.ICluster;
   providerCluster?: ProviderCluster;
+  canUpdateCluster?: boolean;
 }
 
 const ClusterDetailWidgetRelease: React.FC<
   IClusterDetailWidgetReleaseProps
-> = ({ cluster, providerCluster, ...props }) => {
+> = ({ cluster, providerCluster, canUpdateCluster, ...props }) => {
   const clientFactory = useHttpClientFactory();
   const auth = useAuthProvider();
 
+  const provider = window.config.info.general.provider;
+
   const releaseListClient = useRef(clientFactory());
+  const { canList: canListReleases } = usePermissionsForReleases(
+    provider,
+    'default'
+  );
+  const releaseListKey = canListReleases
+    ? releasev1alpha1.getReleaseListKey()
+    : null;
+
   const { data: releaseList, error: releaseListError } = useSWR<
     releasev1alpha1.IReleaseList,
     GenericResponseError
-  >(releasev1alpha1.getReleaseListKey(), () =>
+  >(releaseListKey, () =>
     releasev1alpha1.getReleaseList(releaseListClient.current, auth)
   );
 
@@ -102,16 +114,15 @@ const ClusterDetailWidgetRelease: React.FC<
   }, [releaseList?.items, releaseVersion]);
 
   const k8sVersion = useMemo(() => {
-    if (!releaseList) return undefined;
+    if (!releaseList && canListReleases) return undefined;
     if (!currentRelease) return '';
 
     const version = releasev1alpha1.getK8sVersion(currentRelease);
     if (!version) return '';
 
     return version;
-  }, [releaseList, currentRelease]);
+  }, [releaseList, canListReleases, currentRelease]);
 
-  const provider = window.config.info.general.provider;
   const isAdmin = useSelector(getUserIsAdmin);
 
   const supportedUpgradeVersions: ui.IReleaseVersion[] = useMemo(() => {
@@ -306,8 +317,24 @@ const ClusterDetailWidgetRelease: React.FC<
       </Box>
 
       {canUpgrade && (
-        <Box margin={{ top: 'small' }}>
-          <Button onClick={handleUpgradeButtonClick}>Upgrade cluster…</Button>
+        <Box
+          direction='row'
+          align='center'
+          margin={{ top: 'small' }}
+          gap='small'
+        >
+          <Button
+            onClick={handleUpgradeButtonClick}
+            unauthorized={!canUpdateCluster}
+          >
+            Upgrade cluster…
+          </Button>
+          {!canUpdateCluster && (
+            <Text color='text-weak' size='small'>
+              For upgrading this cluster, you need additional permissions.
+              Please talk to your administrator.
+            </Text>
+          )}
         </Box>
       )}
 

--- a/src/components/MAPI/releases/__tests__/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/__tests__/ClusterDetailWidgetRelease.tsx
@@ -19,6 +19,7 @@ import * as ui from 'UI/Display/MAPI/releases/types';
 import TestOAuth2 from 'utils/OAuth2/TestOAuth2';
 
 import ClusterDetailWidgetRelease from '../ClusterDetailWidgetRelease';
+import { usePermissionsForReleases } from '../permissions/usePermissionsForReleases';
 import { getReleaseComponentsDiff } from '../utils';
 
 function getComponent(
@@ -43,12 +44,30 @@ function getComponent(
   );
 }
 
+const defaultPermissions = {
+  canGet: true,
+  canList: true,
+  canUpdate: true,
+  canCreate: true,
+  canDelete: true,
+};
+
+jest.mock('MAPI/releases/permissions/usePermissionsForReleases');
+
 describe('ClusterDetailWidgetRelease', () => {
   it('renders without crashing', () => {
+    (usePermissionsForReleases as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     render(getComponent({}));
   });
 
   it('displays loading animations if the cluster is still loading', () => {
+    (usePermissionsForReleases as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     render(
       getComponent({
         cluster: undefined,
@@ -59,6 +78,10 @@ describe('ClusterDetailWidgetRelease', () => {
   });
 
   it('displays the Kubernetes version used', async () => {
+    (usePermissionsForReleases as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     nock(window.config.mapiEndpoint)
       .get('/apis/release.giantswarm.io/v1alpha1/releases/')
       .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
@@ -73,6 +96,10 @@ describe('ClusterDetailWidgetRelease', () => {
   });
 
   it('displays details about the release when clicking on the release version', async () => {
+    (usePermissionsForReleases as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     nock(window.config.mapiEndpoint)
       .get('/apis/release.giantswarm.io/v1alpha1/releases/')
       .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
@@ -120,6 +147,10 @@ describe('ClusterDetailWidgetRelease', () => {
   });
 
   it('displays information if an upgrade has been scheduled', async () => {
+    (usePermissionsForReleases as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     nock(window.config.mapiEndpoint)
       .get('/apis/release.giantswarm.io/v1alpha1/releases/')
       .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
@@ -148,6 +179,10 @@ describe('ClusterDetailWidgetRelease', () => {
   });
 
   it('displays a warning when there is an upgrade available', async () => {
+    (usePermissionsForReleases as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     nock(window.config.mapiEndpoint)
       .get('/apis/release.giantswarm.io/v1alpha1/releases/')
       .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
@@ -162,6 +197,10 @@ describe('ClusterDetailWidgetRelease', () => {
   });
 
   it('can upgrade a cluster', async () => {
+    (usePermissionsForReleases as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
     nock(window.config.mapiEndpoint)
       .get('/apis/release.giantswarm.io/v1alpha1/releases/')
       .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
@@ -191,6 +230,7 @@ describe('ClusterDetailWidgetRelease', () => {
     render(
       getComponent({
         cluster: capiv1alpha3Mocks.randomCluster1,
+        canUpdateCluster: true,
       })
     );
 
@@ -252,6 +292,33 @@ describe('ClusterDetailWidgetRelease', () => {
 
     expect(
       await screen.findByText('Cluster upgrade initiated.')
+    ).toBeInTheDocument();
+  });
+
+  it('displays a warning message and the cluster upgrade button as disabled if the user does not have permissions to upgrade clusters', async () => {
+    (usePermissionsForReleases as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
+    nock(window.config.mapiEndpoint)
+      .get('/apis/release.giantswarm.io/v1alpha1/releases/')
+      .reply(StatusCodes.Ok, releasev1alpha1Mocks.releasesList);
+
+    render(
+      getComponent({
+        cluster: capiv1alpha3Mocks.randomCluster1,
+        canUpdateCluster: false,
+      })
+    );
+
+    expect(
+      await screen.findByRole('button', { name: 'Upgrade cluster…' })
+    ).toBeDisabled();
+
+    expect(
+      screen.getByText(
+        'For upgrading this cluster, you need additional permissions. Please talk to your administrator.'
+      )
     ).toBeInTheDocument();
   });
 });

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -444,6 +444,7 @@ export async function fetchControlPlaneNodesForCluster(
               [capzv1alpha3.labelControlPlane]: 'true',
             },
           },
+          namespace: cluster.metadata.namespace,
         }
       );
 
@@ -459,6 +460,7 @@ export async function fetchControlPlaneNodesForCluster(
               [infrav1alpha3.labelCluster]: cluster.metadata.name,
             },
           },
+          namespace: cluster.metadata.namespace,
         }),
         infrav1alpha3.getG8sControlPlaneList(httpClientFactory(), auth, {
           labelSelector: {
@@ -466,6 +468,7 @@ export async function fetchControlPlaneNodesForCluster(
               [infrav1alpha3.labelCluster]: cluster.metadata.name,
             },
           },
+          namespace: cluster.metadata.namespace,
         }),
       ]);
 
@@ -506,6 +509,7 @@ export function fetchControlPlaneNodesForClusterKey(
             [capiv1alpha3.labelCluster]: cluster.metadata.name,
           },
         },
+        namespace: cluster.metadata.namespace,
       });
 
     case 'infrastructure.giantswarm.io/v1alpha2':
@@ -516,6 +520,7 @@ export function fetchControlPlaneNodesForClusterKey(
             [infrav1alpha3.labelCluster]: cluster.metadata.name,
           },
         },
+        namespace: cluster.metadata.namespace,
       });
 
     default:

--- a/src/components/MAPI/workernodes/__tests__/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/__tests__/WorkerNodesCreateNodePool.tsx
@@ -118,7 +118,7 @@ describe('WorkerNodesCreateNodePool', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster1.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 
@@ -180,7 +180,7 @@ describe('WorkerNodesCreateNodePool', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster1.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 
@@ -248,7 +248,7 @@ describe('WorkerNodesCreateNodePool', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster1.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 
@@ -308,7 +308,7 @@ describe('WorkerNodesCreateNodePool', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster1.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 
@@ -377,7 +377,7 @@ describe('WorkerNodesCreateNodePool', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster1.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 
@@ -446,7 +446,7 @@ describe('WorkerNodesCreateNodePool', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
+        `/apis/infrastructure.cluster.x-k8s.io/v1alpha3/namespaces/${capiv1alpha3Mocks.randomCluster1.metadata.namespace}/azuremachines/?labelSelector=giantswarm.io%2Fcluster%3D${capiv1alpha3Mocks.randomCluster1.metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3Dtrue`
       )
       .reply(StatusCodes.Ok, capzv1alpha3Mocks.randomAzureMachineList1);
 

--- a/src/components/Modals/ReleaseDetailsModal/ReleaseDetailsModalUpgradeOptionsVersion.tsx
+++ b/src/components/Modals/ReleaseDetailsModal/ReleaseDetailsModalUpgradeOptionsVersion.tsx
@@ -19,11 +19,12 @@ interface IReleaseDetailsModalUpgradeOptionsVersionProps
   extends React.ComponentPropsWithoutRef<'span'> {
   version: string;
   isBeta: boolean;
+  unauthorized?: boolean;
 }
 
 const ReleaseDetailsModalUpgradeOptionsVersion: React.FC<
   IReleaseDetailsModalUpgradeOptionsVersionProps
-> = ({ version, isBeta, ...rest }) => {
+> = ({ version, isBeta, unauthorized, ...rest }) => {
   const formattedVersion = `v${version}`;
 
   let label = formattedVersion;
@@ -32,8 +33,16 @@ const ReleaseDetailsModalUpgradeOptionsVersion: React.FC<
   }
 
   return (
-    <span role='button' aria-label={label} {...rest}>
-      <Version>{formattedVersion}</Version>{' '}
+    <span
+      role={unauthorized ? undefined : 'button'}
+      aria-label={label}
+      {...rest}
+    >
+      {unauthorized ? (
+        <span>{formattedVersion}</span>
+      ) : (
+        <Version>{formattedVersion}</Version>
+      )}{' '}
       {isBeta && <ReleaseDetailsModalUpgradeOptionsBetaLabel />}
     </span>
   );

--- a/src/components/UI/Display/Cluster/ClusterLabels/DeleteLabelButton.tsx
+++ b/src/components/UI/Display/Cluster/ClusterLabels/DeleteLabelButton.tsx
@@ -1,5 +1,5 @@
 import { Anchor } from 'grommet';
-import React, { FC } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 interface IButtonProps {}
@@ -25,10 +25,10 @@ const StyledAnchor = styled(Anchor)`
   }
 `;
 
-const DeleteLabelButton: FC<IButtonProps> = (props) => (
+const DeleteLabelButton = React.forwardRef<IButtonProps>((props, _) => (
   <StyledAnchor size='large' {...props}>
     <i className='fa fa-close' role='presentation' title='Delete' />
   </StyledAnchor>
-);
+));
 
 export default DeleteLabelButton;

--- a/src/components/UI/Display/MAPI/releases/ClusterDetailReleaseDetailsUpgradeOptions.tsx
+++ b/src/components/UI/Display/MAPI/releases/ClusterDetailReleaseDetailsUpgradeOptions.tsx
@@ -12,13 +12,14 @@ function isReleaseBeta(release: IReleaseVersion) {
 interface IClusterDetailReleaseDetailsUpgradeOptionsProps {
   supportedVersions: IReleaseVersion[];
   onVersionClick: (version: string) => void;
+  canUpdateCluster?: boolean;
 }
 
 const ClusterDetailReleaseDetailsUpgradeOptions: React.FC<
   IClusterDetailReleaseDetailsUpgradeOptionsProps
-> = ({ supportedVersions, onVersionClick }) => {
+> = ({ supportedVersions, onVersionClick, canUpdateCluster }) => {
   const handleVersionClick = (version: string) => () => {
-    onVersionClick(version);
+    if (canUpdateCluster) onVersionClick(version);
   };
 
   const handleKeyDown =
@@ -47,7 +48,8 @@ const ClusterDetailReleaseDetailsUpgradeOptions: React.FC<
               version={release.version}
               isBeta={isReleaseBeta(release)}
               onClick={handleVersionClick(release.version)}
-              tabIndex={0}
+              tabIndex={canUpdateCluster ? 0 : -1}
+              unauthorized={canUpdateCluster}
             />
           </Keyboard>
           .
@@ -76,7 +78,8 @@ const ClusterDetailReleaseDetailsUpgradeOptions: React.FC<
               version={release.version}
               isBeta={isReleaseBeta(release)}
               onClick={handleVersionClick(release.version)}
-              tabIndex={0}
+              tabIndex={canUpdateCluster ? 0 : -1}
+              unauthorized={!canUpdateCluster}
             />
           </Keyboard>
         </Box>

--- a/src/components/UI/Display/ValueLabel.tsx
+++ b/src/components/UI/Display/ValueLabel.tsx
@@ -54,7 +54,7 @@ const ValueWrapper = styled.span<{ outline: boolean }>`
     `}
 `;
 
-interface IValueLabelProps extends React.ComponentPropsWithoutRef<'div'> {
+interface IValueLabelProps extends React.ComponentPropsWithRef<'div'> {
   label: ReactNode;
   value: ReactNode;
 
@@ -62,24 +62,20 @@ interface IValueLabelProps extends React.ComponentPropsWithoutRef<'div'> {
   outline?: boolean;
 }
 
-const ValueLabel = ({
-  label,
-  value,
-  color,
-  outline,
-  ...props
-}: IValueLabelProps) => {
-  return (
-    <Wrapper {...props}>
-      <LabelWrapper color={color} outline={Boolean(outline)}>
-        {label}
-      </LabelWrapper>
-      <ValueWrapper color={color} outline={Boolean(outline)}>
-        {value}
-      </ValueWrapper>
-    </Wrapper>
-  );
-};
+const ValueLabel = React.forwardRef(
+  ({ label, value, color, outline, ...props }: IValueLabelProps, _) => {
+    return (
+      <Wrapper {...props}>
+        <LabelWrapper color={color} outline={Boolean(outline)}>
+          {label}
+        </LabelWrapper>
+        <ValueWrapper color={color} outline={Boolean(outline)}>
+          {value}
+        </ValueWrapper>
+      </Wrapper>
+    );
+  }
+);
 
 ValueLabel.defaultProps = {
   value: '',

--- a/src/components/UI/Inputs/ViewEditName.tsx
+++ b/src/components/UI/Inputs/ViewEditName.tsx
@@ -221,6 +221,7 @@ class ViewAndEditName extends Component<
                 },
               }}
               contentProps={{ width: 'medium' }}
+              aria-label={`${typeLabel} ${variant}`}
             />
             {hasError && (
               <Tooltip


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/551.

This PR makes the cluster details overview page aware of permissions and adapts the UI for a read-only user.

(This PR looks big, but it's mostly due to the cluster details overview page consisting of many smaller "widgets", and thus spread out over many files.)

<details>
<summary>How to impersonate a user to test the changes of this PR</summary>

A "read-only" user as defined here is assumed to have the following permissions:
- the `read-all` ClusterRole permissions in an organization's namespace
- read permissions (`get`, `list`, `watch`) for `releases` at the cluster scope
- read permissions for `catalogs` and `appcatalogentries` in the `default` namespace
- read permissions for `apps` in a WC's namespace

<details>
  <summary>Here are some definitions that bind a user <code>test-user</code> to the above permissions. </summary>

Please substitute the appropriate org namespace and WC namespace, and the user's name if using a name other than `test-user`.
  
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test-read-releases
rules:
  - apiGroups: ['release.giantswarm.io']
    resources: ['releases']
    verbs: ['get', 'watch', 'list']
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test-read-catalogs
rules:
  - apiGroups: ['application.giantswarm.io']
    resources: ['catalogs', 'appcatalogentries']
    verbs: ['get', 'watch', 'list']
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test-read-apps
rules:
  - apiGroups: ['application.giantswarm.io']
    resources: ['apps']
    verbs: ['get', 'watch', 'list']
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: test-read-all-binding
  namespace: org-giantswarm # Please replace this with your org's namespace
subjects:
  - kind: User
    name: test-user # Your test user's name
    apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: read-all
  apiGroup: rbac.authorization.k8s.io
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: test-read-releases-binding
subjects:
  - kind: User
    name: test-user # Your test user's name
    apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: test-read-releases
  apiGroup: rbac.authorization.k8s.io
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: test-read-catalogs-binding
  namespace: default
subjects:
  - kind: User
    name: test-user # Your test user's name
    apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: test-read-catalogs
  apiGroup: rbac.authorization.k8s.io
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: test-read-apps-binding
  namespace: i2h6z # Please replace this with WC namespace
subjects:
  - kind: User
    name: test-user # Your test user's name
    apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: test-read-apps
  apiGroup: rbac.authorization.k8s.io

```
</details>

Save the above to a yaml file and apply the file: `kubectl apply -f your-file-name.yaml`
To revert when finished, execute: `kubectl delete -f your-file-name.yaml`
</details>

<details>
<summary>A summary of the UI changes (w/ screenshots)</summary>

### Disable cluster description editing and adapt tooltip message:
<img width="367" alt="Screen Shot 2021-12-17 at 13 48 18" src="https://user-images.githubusercontent.com/62935115/146559346-e5958c78-247b-4df5-95c1-a4cbd81e33e9.png">

### Don't show links to add node pools, install apps, or create client certificates:
<img width="1197" alt="Screen Shot 2021-12-17 at 13 48 54" src="https://user-images.githubusercontent.com/62935115/146559471-9b13e016-d888-4fa2-ac77-5083b336e326.png">

### Disable "Upgrade cluster..." button and display warning message:
<img width="1201" alt="Screen Shot 2021-12-16 at 13 35 07" src="https://user-images.githubusercontent.com/62935115/146559627-24451655-bf28-437e-bc18-574a359f0f2a.png">

### In release details modal, display upgradable versions as plaintext instead of links:
<img width="651" alt="Screen Shot 2021-12-17 at 14 22 54" src="https://user-images.githubusercontent.com/62935115/146559786-c030642f-9ffc-4652-a9f7-b0f4fa595b12.png">

### Make cluster labels read-only by removing delete button, "Add labels" button, and adapting the message for editing:
<img width="450" alt="Screen Shot 2021-12-17 at 13 52 26" src="https://user-images.githubusercontent.com/62935115/146560001-138e1ffb-6054-4c13-8c08-1e2a21ce4789.png">

### Disable "Switch to HA..." button and display warning message:
<img width="1201" alt="Screen Shot 2021-12-16 at 21 18 01" src="https://user-images.githubusercontent.com/62935115/146559708-3a1f1768-8fbc-4cb5-ba91-3548cfbd95da.png">

### Remove "Get started" button from K8s API widget:
<img width="1194" alt="Screen Shot 2021-12-16 at 21 58 07" src="https://user-images.githubusercontent.com/62935115/146559875-d6fa36eb-bd11-4c3e-bdc6-caab8ab49b5d.png">

### Display warning in CLI guide for setting cluster labels:
<img width="1197" alt="Screen Shot 2021-12-17 at 15 34 50" src="https://user-images.githubusercontent.com/62935115/146560283-055e3005-cf37-4aea-8c11-024a993982e4.png">
</details>

Specifications of the UI is [here](https://docs.google.com/presentation/d/1yCIv2B9Q9QmdN_s430r_NRqj0RobfQN7A3cAWioOsBk/edit#slide=id.gfc63257f33_0_0)