### PR TITLE
Fix cluster deletion for KVM

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -266,7 +266,7 @@ const ClusterDetailActions: React.FC<IClusterDetailActionsProps> = (props) => {
               onDelete={handleDelete}
               isLoading={isLoading}
               disabled={hasError}
-              canDeleteClusters={canDeleteClusters}
+              unauthorized={!canDeleteClusters}
               variant={ClusterDetailDeleteActionNameVariant.Name}
               basis='3/4'
               flex={{ grow: 1, shrink: 0 }}

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction.tsx
@@ -42,7 +42,7 @@ interface IClusterDetailDeleteActionProps
   isLoading?: boolean;
   variant?: ClusterDetailDeleteActionNameVariant;
   disabled?: boolean;
-  canDeleteClusters?: boolean;
+  unauthorized?: boolean;
 }
 
 const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
@@ -56,7 +56,7 @@ const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
   isLoading,
   variant,
   disabled,
-  canDeleteClusters,
+  unauthorized,
   ...props
 }) => {
   const [confirmationStep, setConfirmationStep] = useState(
@@ -111,16 +111,16 @@ const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
   return (
     <Box direction='column' gap='medium' pad={{ top: 'medium' }} {...props}>
       <Box width={{ max: 'large' }}>
-        {canDeleteClusters ? (
+        {unauthorized ? (
+          <Text>
+            For deleting this cluster, you need additional permissions. Please
+            talk to your administrator.
+          </Text>
+        ) : (
           <Text>
             Please make sure you really want to delete this cluster before you
             proceed, as there is no way to undo this. Data stored on the worker
             nodes will be lost. Workloads will be terminated.
-          </Text>
-        ) : (
-          <Text>
-            For deleting this cluster, you need additional permissions. Please
-            talk to your administrator.
           </Text>
         )}
       </Box>
@@ -180,7 +180,7 @@ const ClusterDetailDeleteAction: React.FC<IClusterDetailDeleteActionProps> = ({
               onClick={showConfirmation}
               loading={isLoading}
               disabled={disabled}
-              unauthorized={!canDeleteClusters}
+              unauthorized={unauthorized}
             >
               <i
                 className='fa fa-delete'

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailDeleteAction.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailDeleteAction.tsx
@@ -32,7 +32,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 0,
       workerNodesCount: 0,
       onDelete: jest.fn(),
-      canDeleteClusters: true,
+      unauthorized: false,
     });
 
     expect(screen.getByRole('button', { name: /Delete/ })).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe('ClusterDetailDeleteAction', () => {
       workerNodesCount: 3,
       userInstalledAppsCount: 5,
       onDelete: jest.fn(),
-      canDeleteClusters: true,
+      unauthorized: false,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -84,7 +84,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 1,
       workerNodesCount: 1,
       onDelete: jest.fn(),
-      canDeleteClusters: true,
+      unauthorized: false,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -106,7 +106,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 1,
       workerNodesCount: 1,
       onDelete: onDeleteMockFn,
-      canDeleteClusters: true,
+      unauthorized: false,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -149,7 +149,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 1,
       workerNodesCount: 1,
       onDelete: jest.fn(),
-      canDeleteClusters: true,
+      unauthorized: false,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -169,7 +169,7 @@ describe('ClusterDetailDeleteAction', () => {
       workerNodesCount: 1,
       variant: ClusterDetailDeleteActionNameVariant.ID,
       onDelete: jest.fn(),
-      canDeleteClusters: true,
+      unauthorized: false,
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
@@ -192,7 +192,7 @@ describe('ClusterDetailDeleteAction', () => {
       nodePoolsCount: 0,
       workerNodesCount: 0,
       onDelete: jest.fn(),
-      canDeleteClusters: false,
+      unauthorized: true,
     });
 
     expect(screen.getByRole('button', { name: /Delete/ })).toBeDisabled();


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20227.

The cluster deletion page on KVM was incorrectly displaying that the user does not have sufficient permissions for deleting clusters. This PR fixes a bug introduced by the permissions check in https://github.com/giantswarm/happa/pull/3035.