### PR TITLE
Push to openstack-app-collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,18 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
+          name: push-happa-to-openstack-app-collection
+          app_name: "happa"
+          app_collection_repo: "openstack-app-collection"
+          requires:
+            - push-happa-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
           name: push-happa-to-vmware-app-collection
           app_name: "happa"
           app_collection_repo: "vmware-app-collection"


### PR DESCRIPTION
We would like for new releases to be deployed automatically to the openstack-app-collection so we don't have to update the app collection manually.
