### PR TITLE
Add a 'pipeline' tag to Sentry events, to distinguish stable/testing

### DIFF
--- a/helm/happa/templates/configmap.yaml
+++ b/helm/happa/templates/configmap.yaml
@@ -28,6 +28,7 @@ data:
     sentry-dsn: https://e2d0c60518114bf1b920f3cac4ee3f26@o346224.ingest.sentry.io/5739870
     sentry-environment: {{ .Values.managementCluster.name }}
     sentry-release-version: {{ .Values.image.tag }}
+    sentry-pipeline: {{ .Values.managementCluster.pipeline }}
     sentry-debug: false
     sentry-sample-rate: 0.5
 

--- a/scripts/getConfigurationValues.ts
+++ b/scripts/getConfigurationValues.ts
@@ -23,6 +23,7 @@ export interface IConfigurationValues {
   sentryEnvironment: string;
   sentryReleaseVersion: string;
   sentryDebug: boolean;
+  sentryPipeline: string;
   sentrySampleRate: number;
 
   FEATURE_MAPI_AUTH: boolean;
@@ -97,6 +98,7 @@ export async function getConfigurationValues(
   config.setDefault('sentry-environment', 'development');
   config.setDefault('sentry-release-version', 'development');
   config.setDefault('sentry-sample-rate', 0.5);
+  config.setDefault('sentry-pipeline', 'testing');
 
   config.setDefault('feature-monitoring', true);
 
@@ -133,6 +135,7 @@ export async function getConfigurationValues(
     sentryDsn: config.getString('sentry-dsn'),
     sentryEnvironment: config.getString('sentry-environment'),
     sentryReleaseVersion: config.getString('sentry-release-version'),
+    sentryPipeline: config.getString('sentry-pipeline'),
     sentryDebug: config.getBoolean('sentry-debug'),
     sentrySampleRate: config.getNumber('sentry-sample-rate'),
 

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -23,6 +23,7 @@ interface IGlobalConfig {
   sentryDsn: string;
   sentryEnvironment: string;
   sentryReleaseVersion: string;
+  sentryPipeline: string;
   sentryDebug: boolean;
   sentrySampleRate: number;
   info: {

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -40,6 +40,7 @@ if (window.config.environment !== 'development') {
     environment: window.config.sentryEnvironment,
     debug: window.config.sentryDebug,
     sampleRate: window.config.sentrySampleRate,
+    pipeline: window.config.sentryPipeline,
     history,
   });
 }

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -51,6 +51,7 @@
         sentryDsn: '{!= sentryDsn !}',
         sentryEnvironment: '{!= sentryEnvironment !}',
         sentryReleaseVersion: '{!= sentryReleaseVersion !}',
+        sentryPipeline: '{!= sentryPipeline !}',
         sentryDebug: {!= sentryDebug !},
         sentrySampleRate: {!= sentrySampleRate !},
         info: {

--- a/src/utils/errors/SentryErrorNotifier.ts
+++ b/src/utils/errors/SentryErrorNotifier.ts
@@ -15,6 +15,8 @@ export interface ISentryErrorNotifierConfig {
   history: History<History.LocationState>;
   debug?: boolean;
   sampleRate?: number;
+  // Type of the installation. Either 'testing' or 'stable'.
+  pipeline: string;
 }
 
 export class SentryErrorNotifier implements IErrorReporterNotifier {
@@ -33,6 +35,10 @@ export class SentryErrorNotifier implements IErrorReporterNotifier {
       debug: config.debug,
       environment: config.environment,
     });
+
+    if (config.pipeline !== '') {
+      Sentry.setTag('pipeline', config.pipeline);
+    }
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
This PR adds a [custom tag](https://docs.sentry.io/platforms/javascript/enriching-events/tags/) named `pipeline` to any Sentry event. We can use that to filter out issues created in test installations from notifications.