### PR TITLE
Improve handling of fetch errors during login

### DIFF
--- a/src/model/clients/HttpClient.ts
+++ b/src/model/clients/HttpClient.ts
@@ -305,6 +305,15 @@ export class HttpClientImpl implements IHttpClient {
         return Promise.reject(res);
       }
 
+      if ((err as Error).name === 'TypeError') {
+        res.message = `Your request appears to be invalid: ${
+          (err as Error).message
+        }`;
+        res.headers = Object.assign({}, headers);
+
+        return Promise.reject(res);
+      }
+
       // We got a non-2xx status code.
       if (err instanceof Response) {
         res.data = (await getResponseData(err)) as T;

--- a/src/model/stores/batchActions.ts
+++ b/src/model/stores/batchActions.ts
@@ -83,7 +83,7 @@ export function batchedLayout(
         )
       ) {
         new FlashMessage(
-          `We couldn't execute a request. Please contact support at support@giantswarm.io`,
+          `We couldn't execute a request. Please try again later, and contact support at support@giantswarm.io if the problem persists.`,
           messageType.ERROR,
           messageTTL.LONG
         );

--- a/src/model/stores/batchActions.ts
+++ b/src/model/stores/batchActions.ts
@@ -1,5 +1,7 @@
 import { filterFunc } from 'components/Apps/AppsList/utils';
 import { push } from 'connected-react-router';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import { StatusCodes } from 'model/constants';
 import { MainRoutes, OrganizationsRoutes } from 'model/constants/routes';
 import { supportsMapiApps, supportsMapiClusters } from 'model/featureSupport';
 import {
@@ -74,11 +76,24 @@ export function batchedLayout(
       dispatch(push(MainRoutes.Login));
       dispatch(globalLoadError());
 
-      new FlashMessage(
-        'Please log in again, as your previously saved credentials appear to be invalid.',
-        messageType.WARNING,
-        messageTTL.MEDIUM
-      );
+      if (
+        (err as GenericResponseError).status === StatusCodes.BadRequest &&
+        (err as GenericResponseError).message.includes(
+          'Your request appears to be invalid'
+        )
+      ) {
+        new FlashMessage(
+          `We couldn't execute a request. Please contact support at support@giantswarm.io`,
+          messageType.ERROR,
+          messageTTL.LONG
+        );
+      } else {
+        new FlashMessage(
+          'Please log in again, as your previously saved credentials appear to be invalid.',
+          messageType.WARNING,
+          messageTTL.MEDIUM
+        );
+      }
 
       ErrorReporter.getInstance().notify(err as Error);
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20464.

This PR improves the handling of fetch errors thrown while a user is logging into the application. While we can't reliably check for specific network errors (e.g. `net::ERR_CONNECTION_CLOSED`), these errors fall under the `TypeError` exception thrown by `fetch()`. We improve handling by including the original error message in the error reported to Sentry, and displaying a more appropriate error message to the user in this case during login:

<img width="337" alt="Screen Shot 2022-01-25 at 09 51 27" src="https://user-images.githubusercontent.com/62935115/150943641-251c7737-8f2d-4352-b778-410888b41eea.png">

One thing to bear in mind is that these errors can occur for a number of different reasons (more information can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/fetch#exceptions)), so it wouldn't be appropriate to display a message that is too specific, and should rather prompt the user to reach out to support if this occurs during the login process.