### PR TITLE
Fix non-admin users not able to see Playground catalog

### DIFF
--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -1060,7 +1060,6 @@ export async function fetchCatalogListForOrganizations(
     labelSelector: {
       matchingLabels: {
         [applicationv1alpha1.labelCatalogVisibility]: 'public',
-        [applicationv1alpha1.labelCatalogType]: 'stable',
       },
     },
   };


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/20496.

This PR removes the label selector `application.giantswarm.io/catalog-type: stable` when fetching catalogs for non-admin users (non-GS staff) for the Apps page. This allows these users to see all catalogs with the label selector `application.giantswarm.io/catalog-type: public` in the namespaces they have access to. In the `default` namespace, these would be the Giantswarm and Playground catalogs.

<img width="284" alt="Screen Shot 2022-01-25 at 09 56 06" src="https://user-images.githubusercontent.com/62935115/150945341-1488859c-8a05-47b2-a94c-eafbc00878c4.png">

