### PR TITLE
Improve app uninstallation confirmation info

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetUninstall.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetUninstall.tsx
@@ -37,13 +37,13 @@ function getAppUninstallConfirmationInfo(
 
   switch (true) {
     case hasConfigMap && hasSecrets:
-      configResourcesMessage += `Uninstalling this app will not remove the existing ConfigMap and Secret configuration resources. `;
+      configResourcesMessage += `Uninstalling this app will leave the existing ConfigMap and Secret configuration resources in place. `;
       break;
     case hasConfigMap:
-      configResourcesMessage += `Uninstalling this app will not remove the existing ConfigMap configuration resources. `;
+      configResourcesMessage += `Uninstalling this app will leave the existing ConfigMap configuration resource in place. `;
       break;
     case hasSecrets:
-      configResourcesMessage += `Uninstalling this app will not remove the existing Secret configuration resources. `;
+      configResourcesMessage += `Uninstalling this app will leave the existing Secret configuration resource in place. `;
       break;
   }
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/691.

Currently, the only additional information we show for confirming an app uninstallation is the ambiguous phrase: "There is no undo." This PR seeks to improve the message shown, informing users about what happens to any configuration resources after uninstallation, and that the app can be easily re-installed .

Both ConfigMap and Secret are used to configure the app:
<img width="1164" alt="Screen Shot 2022-01-27 at 17 03 09" src="https://user-images.githubusercontent.com/62935115/151396505-3437dc63-8014-4849-99e7-171d9f9c9aad.png">

Just ConfigMap exists (the case where just Secret exists is similar):
<img width="1164" alt="Screen Shot 2022-01-27 at 17 05 34" src="https://user-images.githubusercontent.com/62935115/151396861-22ef5df1-3466-4039-98fe-5072bd79c568.png">


No configurations exist:
<img width="1164" alt="Screen Shot 2022-01-27 at 13 43 15" src="https://user-images.githubusercontent.com/62935115/151364026-bd37961f-9f2e-4b2f-a1f1-2b1e1e4a33a0.png">