### PR TITLE
Ensure SVG app icons are appropriate for a dark background

### DIFF
--- a/src/components/UI/Display/Apps/AppList/AppIcon.tsx
+++ b/src/components/UI/Display/Apps/AppList/AppIcon.tsx
@@ -54,6 +54,8 @@ const Icon: React.FC<IIconProps> = ({ name, src, ...rest }) => {
   let imagesrc = src;
   if (imagesrc?.endsWith('light.png')) {
     imagesrc = imagesrc.replace('light.png', 'dark.png');
+  } else if (imagesrc?.endsWith('light.svg')) {
+    imagesrc = imagesrc.replace('light.svg', 'dark.svg');
   }
 
   return (


### PR DESCRIPTION
This PR applies the same logic to SVG icons that we apply to PNG icons for making sure that the version shown is optimized for a dark background.

## Before

![image](https://user-images.githubusercontent.com/273727/152120644-eaa34185-d801-4c25-b6d9-34987783ceb2.png)

## After

![image](https://user-images.githubusercontent.com/273727/152123184-9dbf01bf-7eee-43f3-a402-1c95394bfa56.png)
