### PR TITLE
Change how we determine provider-specific cluster resources

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
@@ -29,13 +29,11 @@ import { getCredentialsAccountID } from './utils';
 export function getClusterRegionLabel(cluster?: capiv1alpha3.ICluster) {
   if (!cluster) return undefined;
 
-  switch (cluster.spec?.infrastructureRef?.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (cluster.spec?.infrastructureRef?.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       return 'Azure region';
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       return 'AWS region';
 
     default:
@@ -46,13 +44,11 @@ export function getClusterRegionLabel(cluster?: capiv1alpha3.ICluster) {
 export function getClusterAccountIDLabel(cluster?: capiv1alpha3.ICluster) {
   if (!cluster) return undefined;
 
-  switch (cluster.spec?.infrastructureRef?.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (cluster.spec?.infrastructureRef?.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       return 'Subscription ID';
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       return 'Account ID';
 
     default:
@@ -66,13 +62,11 @@ export function getClusterAccountIDPath(
 ) {
   if (!cluster || !accountID) return undefined;
 
-  switch (cluster.spec?.infrastructureRef?.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (cluster.spec?.infrastructureRef?.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       return 'https://portal.azure.com/';
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       return `https://${accountID}.signin.aws.amazon.com/console`;
 
     default:

--- a/src/components/MAPI/clusters/Clusters.tsx
+++ b/src/components/MAPI/clusters/Clusters.tsx
@@ -27,6 +27,7 @@ import ClusterListEmptyPlaceholder from 'UI/Display/MAPI/clusters/ClusterList/Cl
 import ClusterListErrorPlaceholder from 'UI/Display/MAPI/clusters/ClusterList/ClusterListErrorPlaceholder';
 import ClusterListNoOrgsPlaceholder from 'UI/Display/MAPI/clusters/ClusterList/ClusterListNoOrgsPlaceholder';
 import ErrorReporter from 'utils/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 import RoutePath from 'utils/routePath';
 
@@ -117,6 +118,13 @@ const Clusters: React.FC<{}> = () => {
 
   useEffect(() => {
     if (providerClusterListError) {
+      new FlashMessage(
+        'There was a problem loading the cluster list.',
+        messageType.ERROR,
+        messageTTL.MEDIUM,
+        providerClusterListError
+      );
+
       ErrorReporter.getInstance().notify(providerClusterListError);
     }
   }, [providerClusterListError]);

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -798,16 +798,14 @@ export function getClusterConditions(
     return statuses;
   }
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       statuses.isConditionUnknown = typeof cluster.status === 'undefined';
       statuses.isCreating = isClusterCreating(cluster);
       statuses.isUpgrading = isClusterUpgrading(cluster);
       break;
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3': {
+    case 'awscluster': {
       if (!providerCluster) break;
 
       statuses.isConditionUnknown = infrav1alpha3.isConditionUnknown(

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -877,16 +877,14 @@ export function getClusterDescription(
     return defaultValue;
   }
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       return (
         cluster.metadata.annotations?.[
           capiv1alpha3.annotationClusterDescription
         ] || defaultValue
       );
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       return (
         (providerCluster as infrav1alpha3.IAWSCluster)?.spec?.cluster
           .description ||

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1095,13 +1095,11 @@ export function supportsClientCertificates(cluster: Cluster): boolean {
     return false;
   }
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       return true;
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3': {
+    case 'awscluster': {
       const releaseVersion = getClusterReleaseVersion(cluster);
       if (!releaseVersion) return false;
 

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -118,9 +118,8 @@ export async function fetchNodePoolListForCluster(
   // eslint-disable-next-line @typescript-eslint/init-declarations
   let list: NodePoolList;
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       if (isCAPZCluster(cluster)) {
         list = await capiv1alpha4.getMachinePoolList(
           httpClientFactory(),
@@ -151,8 +150,7 @@ export async function fetchNodePoolListForCluster(
 
       break;
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       list = await capiv1alpha3.getMachineDeploymentList(
         httpClientFactory(),
         auth,
@@ -189,9 +187,8 @@ export function fetchNodePoolListForClusterKey(
     return null;
   }
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       if (isCAPZCluster(cluster)) {
         return capiv1alpha4.getMachinePoolListKey({
           labelSelector: {
@@ -212,8 +209,7 @@ export function fetchNodePoolListForClusterKey(
         namespace,
       });
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       return capiv1alpha3.getMachineDeploymentListKey({
         labelSelector: {
           matchingLabels: {
@@ -431,9 +427,8 @@ export async function fetchControlPlaneNodesForCluster(
     );
   }
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4': {
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster': {
       const cpNodes = await capzv1alpha3.getAzureMachineList(
         httpClientFactory(),
         auth,
@@ -451,8 +446,7 @@ export async function fetchControlPlaneNodesForCluster(
       return cpNodes.items;
     }
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3': {
+    case 'awscluster': {
       const [awsCP, g8sCP] = await Promise.allSettled([
         infrav1alpha3.getAWSControlPlaneList(httpClientFactory(), auth, {
           labelSelector: {
@@ -500,9 +494,8 @@ export function fetchControlPlaneNodesForClusterKey(
     return null;
   }
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       return capzv1alpha3.getAzureMachineListKey({
         labelSelector: {
           matchingLabels: {
@@ -512,8 +505,7 @@ export function fetchControlPlaneNodesForClusterKey(
         namespace: cluster.metadata.namespace,
       });
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       return infrav1alpha3.getAWSControlPlaneListKey({
         labelSelector: {
           matchingLabels: {
@@ -540,9 +532,8 @@ export async function fetchProviderClusterForCluster(
     );
   }
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       return capzv1alpha3.getAzureCluster(
         httpClientFactory(),
         auth,
@@ -550,8 +541,7 @@ export async function fetchProviderClusterForCluster(
         infrastructureRef.name
       );
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       return infrav1alpha3.getAWSCluster(
         httpClientFactory(),
         auth,
@@ -568,16 +558,14 @@ export function fetchProviderClusterForClusterKey(cluster: Cluster) {
   const infrastructureRef = cluster.spec?.infrastructureRef;
   if (!infrastructureRef) return null;
 
-  switch (infrastructureRef.apiVersion) {
-    case 'infrastructure.cluster.x-k8s.io/v1alpha3':
-    case 'infrastructure.cluster.x-k8s.io/v1alpha4':
+  switch (infrastructureRef.kind.toLocaleLowerCase()) {
+    case 'azurecluster':
       return capzv1alpha3.getAzureClusterKey(
         cluster.metadata.namespace!,
         infrastructureRef.name
       );
 
-    case 'infrastructure.giantswarm.io/v1alpha2':
-    case 'infrastructure.giantswarm.io/v1alpha3':
+    case 'awscluster':
       return infrav1alpha3.getAWSClusterKey(
         cluster.metadata.namespace!,
         infrastructureRef.name

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -599,7 +599,11 @@ export async function fetchProviderClustersForClusters(
           clusterName: cluster.metadata.name,
           providerCluster,
         };
-      } catch {
+      } catch (err) {
+        if ((err as Error).message.includes('Unsupported provider')) {
+          return Promise.reject((err as Error).message);
+        }
+
         return {
           clusterName: cluster.metadata.name,
           providerCluster: undefined,


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/795.

This PR changes how we determine which provider-specific cluster resources to fetch. This was previously done by checking `infrastructureRef.apiVersion`, which made us dependent on the specific API version specified in the CRD. We change this by checking `infrastructureRef.kind` instead, and matching its lowercased value to "azurecluster" or "awscluster".

This change affects the following components:
- cluster list overview: description, nodepool stats
- cluster details: description, nodepool stats, provider widget, control plane node(s) label
- client certs tab (whether client certificates are supported)

We also display a flash message when there is an error in fetching provider cluster resources, and provide the reason why:
<img width="333" alt="Screen Shot 2022-02-08 at 15 14 44" src="https://user-images.githubusercontent.com/62935115/153014380-0c7c8a43-77bc-433f-af08-3cac4fc6b255.png">

