### PR TITLE
Don't display "Get Started" guide if the cluster is not in the organization namespace

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetKubernetesAPI.tsx
@@ -49,6 +49,16 @@ const ClusterDetailWidgetKubernetesAPI: React.FC<
     namespace ?? ''
   );
 
+  const clusterInOrgNamespace = cluster?.metadata.namespace !== 'default';
+
+  const shouldDisplayGetStarted = useMemo(
+    () =>
+      canCreateKeyPairs &&
+      typeof k8sApiURL !== 'undefined' &&
+      clusterInOrgNamespace,
+    [canCreateKeyPairs, clusterInOrgNamespace, k8sApiURL]
+  );
+
   return (
     <ClusterDetailWidget
       title='Kubernetes API'
@@ -67,7 +77,7 @@ const ClusterDetailWidgetKubernetesAPI: React.FC<
         {(value) => <URIBlock>{value}</URIBlock>}
       </OptionalValue>
 
-      {canCreateKeyPairs && typeof k8sApiURL !== 'undefined' && (
+      {shouldDisplayGetStarted && (
         <Link to={gettingStartedPath}>
           <Button
             tabIndex={-1}

--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -235,13 +235,16 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
     namespace ?? ''
   );
 
+  const clusterInOrgNamespace = cluster?.metadata.namespace !== 'default';
+
   const shouldDisplayGetStarted = useMemo(() => {
     if (
       isDeleting ||
       isLoading ||
       !creationDate ||
       !canCreateKeyPairs ||
-      isPreviewRelease
+      isPreviewRelease ||
+      !clusterInOrgNamespace
     )
       return false;
 
@@ -255,8 +258,9 @@ const ClusterListItem: React.FC<IClusterListItemProps> = ({
     isDeleting,
     isLoading,
     creationDate,
-    canCreateClusters,
+    canCreateKeyPairs,
     isPreviewRelease,
+    clusterInOrgNamespace,
   ]);
 
   const dispatch = useDispatch();


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/20418.

This PR adds a check to whether the "Get Started" guide should be displayed. If the cluster is in the `default` namespace (i.e. if `cluster.metadata.namespace` is set to `default`), then we don't display the "Get Started" guide.