### PR TITLE
(chore) bump architect-orb to v4.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.12.0
+  architect: giantswarm/architect@4.13.0
 
 defaults: &defaults
   working_directory: ~/happa


### PR DESCRIPTION
This is needed so we can remove the manifests dir from the app collections.

https://github.com/giantswarm/aws-app-collection/tree/master/manifests

This holds the Argo application CRs and is now obsolete.
