### PR TITLE
Fix CLI guide for inspecting clusters displaying incorrect information on AWS

### DIFF
--- a/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
@@ -109,6 +109,50 @@ const InspectClusterGuide: React.FC<IInspectClusterGuideProps> = ({
             />
           </>
         )}
+        {provider === Providers.AWS && (
+          <>
+            <CLIGuideStep
+              title={
+                <>
+                  3. Show the <code>AWSCluster</code> resource
+                </>
+              }
+              command={`
+              kubectl --context ${context} \\
+                get awscluster.infrastructure.giantswarm.io ${clusterName} \\
+                --namespace ${clusterNamespace} --output json
+              `}
+            />
+            <CLIGuideStep
+              title={
+                <>
+                  4. Show the <code>AWSControlPlane</code> resources
+                  representing the control plane nodes
+                </>
+              }
+              command={`
+              kubectl --context ${context} \\
+                get awscontrolplanes.infrastructure.giantswarm.io \\
+                --selector cluster.x-k8s.io/cluster-name=${clusterName} \\
+                --namespace ${clusterNamespace}
+              `}
+            />
+            <CLIGuideStep
+              title={
+                <>
+                  5. Show the <code>G8sControlPlane</code> resources
+                  representing the control plane nodes
+                </>
+              }
+              command={`
+              kubectl --context ${context} \\
+                get g8scontrolplanes.infrastructure.giantswarm.io \\
+                --selector cluster.x-k8s.io/cluster-name=${clusterName} \\
+                --namespace ${clusterNamespace}
+              `}
+            />
+          </>
+        )}
       </CLIGuideStepList>
     </CLIGuide>
   );

--- a/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
@@ -14,6 +14,44 @@ import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalI
 import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
 import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
 
+function getProviderCRDLinks(provider: PropertiesOf<typeof Providers>) {
+  switch (provider) {
+    case Providers.AZURE:
+      return [
+        {
+          label: 'AzureCluster CRD schema',
+          href: docs.crdSchemaURL(docs.crds.xk8sio.azureCluster),
+          external: true,
+        },
+        {
+          label: 'AzureMachine CRD schema',
+          href: docs.crdSchemaURL(docs.crds.xk8sio.azureMachine),
+          external: true,
+        },
+      ];
+    case Providers.AWS:
+      return [
+        {
+          label: 'AWSCluster CRD schema',
+          href: docs.crdSchemaURL(docs.crds.giantswarmio.awsCluster),
+          external: true,
+        },
+        {
+          label: 'AWSControlPlane CRD schema',
+          href: docs.crdSchemaURL(docs.crds.giantswarmio.awsControlPlane),
+          external: true,
+        },
+        {
+          label: 'G8SControlPlane CRD schema',
+          href: docs.crdSchemaURL(docs.crds.giantswarmio.g8sControlPlane),
+          external: true,
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
 interface IInspectClusterGuideProps
   extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
   provider: PropertiesOf<typeof Providers>;
@@ -45,16 +83,7 @@ const InspectClusterGuide: React.FC<IInspectClusterGuideProps> = ({
               href: docs.crdSchemaURL(docs.crds.xk8sio.cluster),
               external: true,
             },
-            {
-              label: 'AzureCluster CRD schema',
-              href: docs.crdSchemaURL(docs.crds.xk8sio.azureCluster),
-              external: true,
-            },
-            {
-              label: 'AzureMachine CRD schema',
-              href: docs.crdSchemaURL(docs.crds.xk8sio.azureMachine),
-              external: true,
-            },
+            ...getProviderCRDLinks(provider),
             {
               label: 'Management API introduction',
               href: docs.managementAPIIntroduction,

--- a/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/InspectClusterGuide.tsx
@@ -1,3 +1,4 @@
+import { Box } from 'grommet';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
 import {
   getCurrentInstallationContextName,
@@ -109,7 +110,7 @@ const InspectClusterGuide: React.FC<IInspectClusterGuideProps> = ({
         />
 
         {provider === Providers.AZURE && (
-          <>
+          <Box direction='column' gap='medium'>
             <CLIGuideStep
               title={
                 <>
@@ -136,10 +137,10 @@ const InspectClusterGuide: React.FC<IInspectClusterGuideProps> = ({
                 --namespace ${clusterNamespace}
               `}
             />
-          </>
+          </Box>
         )}
         {provider === Providers.AWS && (
-          <>
+          <Box direction='column' gap='medium'>
             <CLIGuideStep
               title={
                 <>
@@ -180,7 +181,7 @@ const InspectClusterGuide: React.FC<IInspectClusterGuideProps> = ({
                 --namespace ${clusterNamespace}
               `}
             />
-          </>
+          </Box>
         )}
       </CLIGuideStepList>
     </CLIGuide>

--- a/src/model/constants/docs.ts
+++ b/src/model/constants/docs.ts
@@ -118,6 +118,9 @@ export const crds = {
     release: 'releases.release.giantswarm.io',
     catalog: 'catalogs.application.giantswarm.io/',
     appCatalogEntry: 'appcatalogentries.application.giantswarm.io',
+    awsCluster: 'awsclusters.infrastructure.giantswarm.io',
+    awsControlPlane: 'awscontrolplanes.infrastructure.giantswarm.io',
+    g8sControlPlane: 'g8scontrolplanes.infrastructure.giantswarm.io',
   },
   xk8sio: {
     azureCluster: 'azureclusters.infrastructure.cluster.x-k8s.io',


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/796.

This PR fixes the information displayed in the "Inspect this cluster" CLI guide for AWS installations by showing commands to inspect the appropriate CRDs and fixing the links to external CRD documentation:
<img width="898" alt="Screen Shot 2022-02-24 at 12 40 46" src="https://user-images.githubusercontent.com/62935115/155518138-cfe417c3-4512-4f51-9d7c-e5ac160acb56.png">

<img width="898" alt="Screen Shot 2022-02-24 at 12 40 57" src="https://user-images.githubusercontent.com/62935115/155518132-2841df7a-6677-4f2c-9ead-ee0821e8b82b.png">

