### PR TITLE
Don't rely on `Rolebinding.subjects` being defined

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -119,6 +119,8 @@ export function appendSubjectsToRoleItem(
   binding: rbacv1.IRoleBinding,
   role: ui.IAccessControlRoleItem
 ) {
+  if (!binding.subjects) return;
+
   const uiRoleBinding: ui.IAccessControlRoleSubjectRoleBinding = {
     name: binding.metadata.name,
     namespace: binding.metadata.namespace!,

--- a/src/components/MAPI/organizations/AccessControl/utils.ts
+++ b/src/components/MAPI/organizations/AccessControl/utils.ts
@@ -462,6 +462,7 @@ export async function createRoleBindingWithSubjects(
       subject.namespace = namespace;
     }
 
+    roleBinding.subjects ??= [];
     roleBinding.subjects.push(subject);
   }
 
@@ -493,6 +494,9 @@ export async function deleteSubjectFromRoleBinding(
     binding.name,
     namespace
   );
+
+  // If there are no subjects to delete, then there's nothing to do here
+  if (!bindingResource.subjects) return bindingResource;
 
   // Delete the subjects that match.
   bindingResource.subjects = bindingResource.subjects.filter((s) => {

--- a/src/model/services/mapi/rbacv1/types.ts
+++ b/src/model/services/mapi/rbacv1/types.ts
@@ -50,7 +50,7 @@ export interface IClusterRoleBinding {
   kind: typeof ClusterRoleBinding;
   metadata: metav1.IObjectMeta;
   roleRef: IRoleRef;
-  subjects: ISubject[];
+  subjects?: ISubject[];
 }
 
 export const ClusterRoleBindingList = 'ClusterRoleBindingList';
@@ -84,7 +84,7 @@ export interface IRoleBinding {
   kind: typeof RoleBinding;
   metadata: metav1.IObjectMeta;
   roleRef: IRoleRef;
-  subjects: ISubject[];
+  subjects?: ISubject[];
 }
 
 export const RoleBindingList = 'RoleBindingList';


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/21113, related to the changes in `rbac-operator` from https://github.com/giantswarm/rbac-operator/pull/292.

This PR fixes the error we saw on `gauss` while testing the new changes in `rbac-operator`. It is possible for a `RoleBinding` to exist, and not be bound to any subjects, and the `subjects` field will be omitted if it's empty. We update the interfaces for `IClusterRoleBinding` and `IRoleBinding` to take this into account, and add some checks to prevent us from trying to use the `undefined` value.