### PR TITLE
access control: improve roles list

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
@@ -114,8 +114,8 @@ describe('AccessControl', () => {
       name: 'cluster-admin',
     });
     expect(listItem).toBeInTheDocument();
-    expect(within(listItem).getByText('Groups: 1')).toBeInTheDocument();
-    expect(within(listItem).getByText('Users: None')).toBeInTheDocument();
+    expect(within(listItem).getByLabelText('Groups: 1')).toBeInTheDocument();
+    expect(within(listItem).queryByLabelText('Users')).not.toBeInTheDocument();
     expect(
       within(listItem).getByRole('presentation', { name: 'Cluster role' })
     ).toBeInTheDocument();
@@ -169,8 +169,8 @@ describe('AccessControl', () => {
       name: 'edit-all',
     });
     expect(listItem).toBeInTheDocument();
-    expect(within(listItem).getByText('Groups: 1')).toBeInTheDocument();
-    expect(within(listItem).getByText('Users: 2')).toBeInTheDocument();
+    expect(within(listItem).getByLabelText('Groups: 1')).toBeInTheDocument();
+    expect(within(listItem).getByLabelText('Users: 2')).toBeInTheDocument();
     expect(
       within(listItem).queryByRole('presentation', { name: 'Cluster role' })
     ).not.toBeInTheDocument();

--- a/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
@@ -115,7 +115,7 @@ describe('AccessControl', () => {
     });
     expect(listItem).toBeInTheDocument();
     expect(within(listItem).getByLabelText('Groups: 1')).toBeInTheDocument();
-    expect(within(listItem).queryByLabelText('Users')).not.toBeInTheDocument();
+    expect(within(listItem).getByLabelText('Users: 0')).toBeInTheDocument();
     expect(
       within(listItem).getByRole('presentation', { name: 'Cluster role' })
     ).toBeInTheDocument();

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -1,6 +1,7 @@
 import { Box, Card, CardBody, CardHeader, Heading, Text } from 'grommet';
 import * as React from 'react';
 import styled from 'styled-components';
+import RefreshableLabel from 'UI/Display/RefreshableLabel';
 import { Tooltip, TooltipContainer } from 'UI/Display/Tooltip';
 
 import { IAccessControlRoleItem } from './types';
@@ -126,8 +127,10 @@ const AccessControlRoleListItem = React.forwardRef<
                 size='small'
                 aria-label={`Groups: ${groupCountFormatted}`}
               >
-                <i className='fa fa-group' role='presentation' />{' '}
-                {groupCountFormatted}
+                <RefreshableLabel value={groupCount}>
+                  <i className='fa fa-group' role='presentation' />{' '}
+                  {groupCountFormatted}
+                </RefreshableLabel>
               </Text>
             </TooltipContainer>
             <TooltipContainer
@@ -142,8 +145,10 @@ const AccessControlRoleListItem = React.forwardRef<
                 size='small'
                 aria-label={`Users: ${userCountFormatted}`}
               >
-                <i className='fa fa-user' role='presentation' />{' '}
-                {userCountFormatted}
+                <RefreshableLabel value={userCount}>
+                  <i className='fa fa-user' role='presentation' />{' '}
+                  {userCountFormatted}
+                </RefreshableLabel>
               </Text>
             </TooltipContainer>
             <TooltipContainer
@@ -162,8 +167,10 @@ const AccessControlRoleListItem = React.forwardRef<
                 size='small'
                 aria-label={`Service accounts: ${serviceAccountCountFormatted}`}
               >
-                <i className='fa fa-service-account' role='presentation' />{' '}
-                {serviceAccountCountFormatted}
+                <RefreshableLabel value={serviceAccountCount}>
+                  <i className='fa fa-service-account' role='presentation' />{' '}
+                  {serviceAccountCountFormatted}
+                </RefreshableLabel>
               </Text>
             </TooltipContainer>
           </Box>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -15,6 +15,16 @@ function formatCounter(fromValue: number): string {
   }
 }
 
+function getSubjectTooltipMessage(
+  subjectType: string,
+  count: number,
+  isClusterRole: boolean
+): string {
+  return `This ${
+    isClusterRole ? 'cluster role' : 'role'
+  } is bound to ${count} ${subjectType}${count === 1 ? '' : 's'}`;
+}
+
 const StyledCard = styled(Card)`
   min-height: auto;
   box-shadow: ${(props) =>
@@ -69,6 +79,8 @@ const AccessControlRoleListItem = React.forwardRef<
     const serviceAccountCount = Object.values(serviceAccounts).length;
     const serviceAccountCountFormatted = formatCounter(serviceAccountCount);
 
+    const isClusterRole = namespace.length < 1;
+
     return (
       <StyledCard
         pad={{ vertical: 'small', horizontal: 'medium' }}
@@ -88,7 +100,7 @@ const AccessControlRoleListItem = React.forwardRef<
             <Box direction='row' align='center'>
               <Text truncate={true}>{name}</Text>
 
-              {namespace.length < 1 && (
+              {isClusterRole && (
                 <Text margin={{ left: 'xxsmall' }}>
                   <i
                     className='fa fa-globe'
@@ -102,36 +114,58 @@ const AccessControlRoleListItem = React.forwardRef<
         </CardHeader>
         <CardBody margin={{ top: 'xsmall' }}>
           <Box justify='start' direction='row' flex='grow' gap='medium'>
-            <Text
-              color={groupCount > 0 ? 'text-weak' : 'text-xweak'}
-              size='small'
-              aria-label={`Groups: ${groupCountFormatted}`}
+            <TooltipContainer
+              content={
+                <Tooltip>
+                  {getSubjectTooltipMessage('group', groupCount, isClusterRole)}
+                </Tooltip>
+              }
             >
-              <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
-                <i className='fa fa-group' role='presentation' />
-              </TooltipContainer>{' '}
-              {groupCountFormatted}
-            </Text>
-            <Text
-              color={userCount > 0 ? 'text-weak' : 'text-xweak'}
-              size='small'
-              aria-label={`Users: ${userCountFormatted}`}
+              <Text
+                color={groupCount > 0 ? 'text-weak' : 'text-xweak'}
+                size='small'
+                aria-label={`Groups: ${groupCountFormatted}`}
+              >
+                <i className='fa fa-group' role='presentation' />{' '}
+                {groupCountFormatted}
+              </Text>
+            </TooltipContainer>
+            <TooltipContainer
+              content={
+                <Tooltip>
+                  {getSubjectTooltipMessage('user', userCount, isClusterRole)}
+                </Tooltip>
+              }
             >
-              <TooltipContainer content={<Tooltip>Users</Tooltip>}>
-                <i className='fa fa-user' role='presentation' />
-              </TooltipContainer>{' '}
-              {userCountFormatted}
-            </Text>
-            <Text
-              color={serviceAccountCount > 0 ? 'text-weak' : 'text-xweak'}
-              size='small'
-              aria-label={`Service accounts: ${serviceAccountCountFormatted}`}
+              <Text
+                color={userCount > 0 ? 'text-weak' : 'text-xweak'}
+                size='small'
+                aria-label={`Users: ${userCountFormatted}`}
+              >
+                <i className='fa fa-user' role='presentation' />{' '}
+                {userCountFormatted}
+              </Text>
+            </TooltipContainer>
+            <TooltipContainer
+              content={
+                <Tooltip>
+                  {getSubjectTooltipMessage(
+                    'service account',
+                    serviceAccountCount,
+                    isClusterRole
+                  )}
+                </Tooltip>
+              }
             >
-              <TooltipContainer content={<Tooltip>Service accounts</Tooltip>}>
-                <i className='fa fa-service-account' role='presentation' />
-              </TooltipContainer>{' '}
-              {serviceAccountCountFormatted}
-            </Text>
+              <Text
+                color={serviceAccountCount > 0 ? 'text-weak' : 'text-xweak'}
+                size='small'
+                aria-label={`Service accounts: ${serviceAccountCountFormatted}`}
+              >
+                <i className='fa fa-service-account' role='presentation' />{' '}
+                {serviceAccountCountFormatted}
+              </Text>
+            </TooltipContainer>
           </Box>
         </CardBody>
       </StyledCard>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -66,6 +66,9 @@ const AccessControlRoleListItem = React.forwardRef<
     const userCount = Object.values(users).length;
     const serviceAccountCount = Object.values(serviceAccounts).length;
 
+    const hasBoundSubjects =
+      groupCount > 0 || userCount > 0 || serviceAccountCount > 0;
+
     return (
       <StyledCard
         pad={{ vertical: 'small', horizontal: 'medium' }}
@@ -97,54 +100,56 @@ const AccessControlRoleListItem = React.forwardRef<
             </Box>
           </StyledHeading>
         </CardHeader>
-        <CardBody margin={{ top: 'xsmall' }}>
-          <Box direction='row'>
-            {groupCount > 0 && (
-              <Box width='30%'>
-                <Text color='text-weak' size='small'>
-                  <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
-                    <i
-                      className='fa fa-group'
-                      role='presentation'
-                      aria-label='Groups'
-                    />
-                  </TooltipContainer>{' '}
-                  {formatCounter(groupCount)}
-                </Text>
-              </Box>
-            )}
-            {userCount > 0 && (
-              <Box width='30%'>
-                <Text color='text-weak' size='small'>
-                  <TooltipContainer content={<Tooltip>Users</Tooltip>}>
-                    <i
-                      className='fa fa-user'
-                      role='presentation'
-                      aria-label='Users'
-                    />
-                  </TooltipContainer>{' '}
-                  {formatCounter(userCount)}
-                </Text>
-              </Box>
-            )}
-            {serviceAccountCount > 0 && (
-              <Box width='30%'>
-                <Text color='text-weak' size='small'>
-                  <TooltipContainer
-                    content={<Tooltip>Service accounts</Tooltip>}
-                  >
-                    <i
-                      className='fa fa-service-account'
-                      role='presentation'
-                      aria-label='Service accounts'
-                    />
-                  </TooltipContainer>{' '}
-                  {formatCounter(serviceAccountCount)}
-                </Text>
-              </Box>
-            )}
-          </Box>
-        </CardBody>
+        {hasBoundSubjects && (
+          <CardBody margin={{ top: 'xsmall' }}>
+            <Box direction='row'>
+              {groupCount > 0 && (
+                <Box width='30%'>
+                  <Text color='text-weak' size='small'>
+                    <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
+                      <i
+                        className='fa fa-group'
+                        role='presentation'
+                        aria-label='Groups'
+                      />
+                    </TooltipContainer>{' '}
+                    {formatCounter(groupCount)}
+                  </Text>
+                </Box>
+              )}
+              {userCount > 0 && (
+                <Box width='30%'>
+                  <Text color='text-weak' size='small'>
+                    <TooltipContainer content={<Tooltip>Users</Tooltip>}>
+                      <i
+                        className='fa fa-user'
+                        role='presentation'
+                        aria-label='Users'
+                      />
+                    </TooltipContainer>{' '}
+                    {formatCounter(userCount)}
+                  </Text>
+                </Box>
+              )}
+              {serviceAccountCount > 0 && (
+                <Box width='30%'>
+                  <Text color='text-weak' size='small'>
+                    <TooltipContainer
+                      content={<Tooltip>Service accounts</Tooltip>}
+                    >
+                      <i
+                        className='fa fa-service-account'
+                        role='presentation'
+                        aria-label='Service accounts'
+                      />
+                    </TooltipContainer>{' '}
+                    {formatCounter(serviceAccountCount)}
+                  </Text>
+                </Box>
+              )}
+            </Box>
+          </CardBody>
+        )}
       </StyledCard>
     );
   }

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -63,8 +63,11 @@ const AccessControlRoleListItem = React.forwardRef<
     ref
   ) => {
     const groupCount = Object.values(groups).length;
+    const groupCountFormatted = formatCounter(groupCount);
     const userCount = Object.values(users).length;
+    const userCountFormatted = formatCounter(userCount);
     const serviceAccountCount = Object.values(serviceAccounts).length;
+    const serviceAccountCountFormatted = formatCounter(serviceAccountCount);
 
     const hasBoundSubjects =
       groupCount > 0 || userCount > 0 || serviceAccountCount > 0;
@@ -105,45 +108,48 @@ const AccessControlRoleListItem = React.forwardRef<
             <Box direction='row'>
               {groupCount > 0 && (
                 <Box width='30%'>
-                  <Text color='text-weak' size='small'>
+                  <Text
+                    color='text-weak'
+                    size='small'
+                    aria-label={`Groups: ${groupCountFormatted}`}
+                  >
                     <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
-                      <i
-                        className='fa fa-group'
-                        role='presentation'
-                        aria-label='Groups'
-                      />
+                      <i className='fa fa-group' role='presentation' />
                     </TooltipContainer>{' '}
-                    {formatCounter(groupCount)}
+                    {groupCountFormatted}
                   </Text>
                 </Box>
               )}
               {userCount > 0 && (
                 <Box width='30%'>
-                  <Text color='text-weak' size='small'>
+                  <Text
+                    color='text-weak'
+                    size='small'
+                    aria-label={`Users: ${userCountFormatted}`}
+                  >
                     <TooltipContainer content={<Tooltip>Users</Tooltip>}>
-                      <i
-                        className='fa fa-user'
-                        role='presentation'
-                        aria-label='Users'
-                      />
+                      <i className='fa fa-user' role='presentation' />
                     </TooltipContainer>{' '}
-                    {formatCounter(userCount)}
+                    {userCountFormatted}
                   </Text>
                 </Box>
               )}
               {serviceAccountCount > 0 && (
                 <Box width='30%'>
-                  <Text color='text-weak' size='small'>
+                  <Text
+                    color='text-weak'
+                    size='small'
+                    aria-label={`Service accounts: ${serviceAccountCountFormatted}`}
+                  >
                     <TooltipContainer
                       content={<Tooltip>Service accounts</Tooltip>}
                     >
                       <i
                         className='fa fa-service-account'
                         role='presentation'
-                        aria-label='Service accounts'
                       />
                     </TooltipContainer>{' '}
-                    {formatCounter(serviceAccountCount)}
+                    {serviceAccountCountFormatted}
                   </Text>
                 </Box>
               )}

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -50,71 +50,100 @@ interface IAccessControlRoleListItemProps
 const AccessControlRoleListItem = React.forwardRef<
   HTMLDivElement,
   IAccessControlRoleListItemProps
->(({ name, namespace, active, permissions, groups, users, ...props }, ref) => {
-  const groupCount = formatCounter(Object.values(groups).length);
-  const userCount = formatCounter(Object.values(users).length);
+>(
+  (
+    {
+      name,
+      namespace,
+      active,
+      permissions,
+      groups,
+      users,
+      serviceAccounts,
+      ...props
+    },
+    ref
+  ) => {
+    const groupCount = formatCounter(Object.values(groups).length);
+    const userCount = formatCounter(Object.values(users).length);
+    const serviceAccountCount = formatCounter(
+      Object.values(serviceAccounts).length
+    );
 
-  return (
-    <StyledCard
-      pad={{ vertical: 'small', horizontal: 'medium' }}
-      round='xsmall'
-      elevation='none'
-      overflow='visible'
-      background='background-front'
-      aria-selected={active}
-      role='button'
-      tabIndex={active ? -1 : 0}
-      aria-label={name}
-      {...props}
-      ref={ref}
-    >
-      <CardHeader>
-        <StyledHeading level={5} margin='none'>
-          <Box direction='row' align='center'>
-            <Text truncate={true}>{name}</Text>
+    return (
+      <StyledCard
+        pad={{ vertical: 'small', horizontal: 'medium' }}
+        round='xsmall'
+        elevation='none'
+        overflow='visible'
+        background='background-front'
+        aria-selected={active}
+        role='button'
+        tabIndex={active ? -1 : 0}
+        aria-label={name}
+        {...props}
+        ref={ref}
+      >
+        <CardHeader>
+          <StyledHeading level={5} margin='none'>
+            <Box direction='row' align='center'>
+              <Text truncate={true}>{name}</Text>
 
-            {namespace.length < 1 && (
-              <Text margin={{ left: 'xxsmall' }}>
-                <i
-                  className='fa fa-globe'
-                  role='presentation'
-                  aria-label='Cluster role'
-                />
+              {namespace.length < 1 && (
+                <Text margin={{ left: 'xxsmall' }}>
+                  <i
+                    className='fa fa-globe'
+                    role='presentation'
+                    aria-label='Cluster role'
+                  />
+                </Text>
+              )}
+            </Box>
+          </StyledHeading>
+        </CardHeader>
+        <CardBody margin={{ top: 'xsmall' }}>
+          <Box direction='row'>
+            <Box width='30%'>
+              <Text color='text-weak' size='small'>
+                <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
+                  <i
+                    className='fa fa-group'
+                    role='presentation'
+                    aria-label='Groups'
+                  />
+                </TooltipContainer>{' '}
+                {groupCount}
               </Text>
-            )}
+            </Box>
+            <Box width='30%'>
+              <Text color='text-weak' size='small'>
+                <TooltipContainer content={<Tooltip>Users</Tooltip>}>
+                  <i
+                    className='fa fa-user'
+                    role='presentation'
+                    aria-label='Users'
+                  />
+                </TooltipContainer>{' '}
+                {userCount}
+              </Text>
+            </Box>
+            <Box width='30%'>
+              <Text color='text-weak' size='small'>
+                <TooltipContainer content={<Tooltip>Service accounts</Tooltip>}>
+                  <i
+                    className='fa fa-service-account'
+                    role='presentation'
+                    aria-label='Service accounts'
+                  />
+                </TooltipContainer>{' '}
+                {serviceAccountCount}
+              </Text>
+            </Box>
           </Box>
-        </StyledHeading>
-      </CardHeader>
-      <CardBody margin={{ top: 'xsmall' }}>
-        <Box justify='between' direction='row'>
-          <Box width='100px'>
-            <Text color='text-weak' size='small'>
-              <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
-                <i
-                  className='fa fa-group'
-                  role='presentation'
-                  aria-label='Groups'
-                />
-              </TooltipContainer>{' '}
-              {groupCount}
-            </Text>
-          </Box>
-          <Box width='100px'>
-            <Text color='text-weak' size='small'>
-              <TooltipContainer content={<Tooltip>Users</Tooltip>}>
-                <i
-                  className='fa fa-user'
-                  role='presentation'
-                  aria-label='Users'
-                />
-              </TooltipContainer>{' '}
-              {userCount}
-            </Text>
-          </Box>
-        </Box>
-      </CardBody>
-    </StyledCard>
-  );
-});
+        </CardBody>
+      </StyledCard>
+    );
+  }
+);
 
 export default AccessControlRoleListItem;

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -7,8 +7,6 @@ import { IAccessControlRoleItem } from './types';
 
 function formatCounter(fromValue: number): string {
   switch (true) {
-    case fromValue === 0:
-      return 'None';
     // eslint-disable-next-line no-magic-numbers
     case fromValue > 99:
       return '99+';
@@ -64,11 +62,9 @@ const AccessControlRoleListItem = React.forwardRef<
     },
     ref
   ) => {
-    const groupCount = formatCounter(Object.values(groups).length);
-    const userCount = formatCounter(Object.values(users).length);
-    const serviceAccountCount = formatCounter(
-      Object.values(serviceAccounts).length
-    );
+    const groupCount = Object.values(groups).length;
+    const userCount = Object.values(users).length;
+    const serviceAccountCount = Object.values(serviceAccounts).length;
 
     return (
       <StyledCard
@@ -103,42 +99,50 @@ const AccessControlRoleListItem = React.forwardRef<
         </CardHeader>
         <CardBody margin={{ top: 'xsmall' }}>
           <Box direction='row'>
-            <Box width='30%'>
-              <Text color='text-weak' size='small'>
-                <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
-                  <i
-                    className='fa fa-group'
-                    role='presentation'
-                    aria-label='Groups'
-                  />
-                </TooltipContainer>{' '}
-                {groupCount}
-              </Text>
-            </Box>
-            <Box width='30%'>
-              <Text color='text-weak' size='small'>
-                <TooltipContainer content={<Tooltip>Users</Tooltip>}>
-                  <i
-                    className='fa fa-user'
-                    role='presentation'
-                    aria-label='Users'
-                  />
-                </TooltipContainer>{' '}
-                {userCount}
-              </Text>
-            </Box>
-            <Box width='30%'>
-              <Text color='text-weak' size='small'>
-                <TooltipContainer content={<Tooltip>Service accounts</Tooltip>}>
-                  <i
-                    className='fa fa-service-account'
-                    role='presentation'
-                    aria-label='Service accounts'
-                  />
-                </TooltipContainer>{' '}
-                {serviceAccountCount}
-              </Text>
-            </Box>
+            {groupCount > 0 && (
+              <Box width='30%'>
+                <Text color='text-weak' size='small'>
+                  <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
+                    <i
+                      className='fa fa-group'
+                      role='presentation'
+                      aria-label='Groups'
+                    />
+                  </TooltipContainer>{' '}
+                  {formatCounter(groupCount)}
+                </Text>
+              </Box>
+            )}
+            {userCount > 0 && (
+              <Box width='30%'>
+                <Text color='text-weak' size='small'>
+                  <TooltipContainer content={<Tooltip>Users</Tooltip>}>
+                    <i
+                      className='fa fa-user'
+                      role='presentation'
+                      aria-label='Users'
+                    />
+                  </TooltipContainer>{' '}
+                  {formatCounter(userCount)}
+                </Text>
+              </Box>
+            )}
+            {serviceAccountCount > 0 && (
+              <Box width='30%'>
+                <Text color='text-weak' size='small'>
+                  <TooltipContainer
+                    content={<Tooltip>Service accounts</Tooltip>}
+                  >
+                    <i
+                      className='fa fa-service-account'
+                      role='presentation'
+                      aria-label='Service accounts'
+                    />
+                  </TooltipContainer>{' '}
+                  {formatCounter(serviceAccountCount)}
+                </Text>
+              </Box>
+            )}
           </Box>
         </CardBody>
       </StyledCard>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -1,6 +1,7 @@
 import { Box, Card, CardBody, CardHeader, Heading, Text } from 'grommet';
 import * as React from 'react';
 import styled from 'styled-components';
+import { Tooltip, TooltipContainer } from 'UI/Display/Tooltip';
 
 import { IAccessControlRoleItem } from './types';
 
@@ -87,10 +88,28 @@ const AccessControlRoleListItem = React.forwardRef<
       <CardBody margin={{ top: 'xsmall' }}>
         <Box justify='between' direction='row'>
           <Box width='100px'>
-            <Text color='text-weak'>Groups: {groupCount}</Text>
+            <Text color='text-weak' size='small'>
+              <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
+                <i
+                  className='fa fa-group'
+                  role='presentation'
+                  aria-label='Groups'
+                />
+              </TooltipContainer>{' '}
+              {groupCount}
+            </Text>
           </Box>
           <Box width='100px'>
-            <Text color='text-weak'>Users: {userCount}</Text>
+            <Text color='text-weak' size='small'>
+              <TooltipContainer content={<Tooltip>Users</Tooltip>}>
+                <i
+                  className='fa fa-user'
+                  role='presentation'
+                  aria-label='Users'
+                />
+              </TooltipContainer>{' '}
+              {userCount}
+            </Text>
           </Box>
         </Box>
       </CardBody>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -101,43 +101,37 @@ const AccessControlRoleListItem = React.forwardRef<
           </StyledHeading>
         </CardHeader>
         <CardBody margin={{ top: 'xsmall' }}>
-          <Box justify='between' direction='row'>
-            <Box width='100px'>
-              <Text
-                color={groupCount > 0 ? 'text-weak' : 'text-xweak'}
-                size='small'
-                aria-label={`Groups: ${groupCountFormatted}`}
-              >
-                <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
-                  <i className='fa fa-group' role='presentation' />
-                </TooltipContainer>{' '}
-                {groupCountFormatted}
-              </Text>
-            </Box>
-            <Box width='100px'>
-              <Text
-                color={userCount > 0 ? 'text-weak' : 'text-xweak'}
-                size='small'
-                aria-label={`Users: ${userCountFormatted}`}
-              >
-                <TooltipContainer content={<Tooltip>Users</Tooltip>}>
-                  <i className='fa fa-user' role='presentation' />
-                </TooltipContainer>{' '}
-                {userCountFormatted}
-              </Text>
-            </Box>
-            <Box width='100px'>
-              <Text
-                color={serviceAccountCount > 0 ? 'text-weak' : 'text-xweak'}
-                size='small'
-                aria-label={`Service accounts: ${serviceAccountCountFormatted}`}
-              >
-                <TooltipContainer content={<Tooltip>Service accounts</Tooltip>}>
-                  <i className='fa fa-service-account' role='presentation' />
-                </TooltipContainer>{' '}
-                {serviceAccountCountFormatted}
-              </Text>
-            </Box>
+          <Box justify='start' direction='row' flex='grow' gap='medium'>
+            <Text
+              color={groupCount > 0 ? 'text-weak' : 'text-xweak'}
+              size='small'
+              aria-label={`Groups: ${groupCountFormatted}`}
+            >
+              <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
+                <i className='fa fa-group' role='presentation' />
+              </TooltipContainer>{' '}
+              {groupCountFormatted}
+            </Text>
+            <Text
+              color={userCount > 0 ? 'text-weak' : 'text-xweak'}
+              size='small'
+              aria-label={`Users: ${userCountFormatted}`}
+            >
+              <TooltipContainer content={<Tooltip>Users</Tooltip>}>
+                <i className='fa fa-user' role='presentation' />
+              </TooltipContainer>{' '}
+              {userCountFormatted}
+            </Text>
+            <Text
+              color={serviceAccountCount > 0 ? 'text-weak' : 'text-xweak'}
+              size='small'
+              aria-label={`Service accounts: ${serviceAccountCountFormatted}`}
+            >
+              <TooltipContainer content={<Tooltip>Service accounts</Tooltip>}>
+                <i className='fa fa-service-account' role='presentation' />
+              </TooltipContainer>{' '}
+              {serviceAccountCountFormatted}
+            </Text>
           </Box>
         </CardBody>
       </StyledCard>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleListItem.tsx
@@ -69,9 +69,6 @@ const AccessControlRoleListItem = React.forwardRef<
     const serviceAccountCount = Object.values(serviceAccounts).length;
     const serviceAccountCountFormatted = formatCounter(serviceAccountCount);
 
-    const hasBoundSubjects =
-      groupCount > 0 || userCount > 0 || serviceAccountCount > 0;
-
     return (
       <StyledCard
         pad={{ vertical: 'small', horizontal: 'medium' }}
@@ -103,59 +100,46 @@ const AccessControlRoleListItem = React.forwardRef<
             </Box>
           </StyledHeading>
         </CardHeader>
-        {hasBoundSubjects && (
-          <CardBody margin={{ top: 'xsmall' }}>
-            <Box direction='row'>
-              {groupCount > 0 && (
-                <Box width='30%'>
-                  <Text
-                    color='text-weak'
-                    size='small'
-                    aria-label={`Groups: ${groupCountFormatted}`}
-                  >
-                    <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
-                      <i className='fa fa-group' role='presentation' />
-                    </TooltipContainer>{' '}
-                    {groupCountFormatted}
-                  </Text>
-                </Box>
-              )}
-              {userCount > 0 && (
-                <Box width='30%'>
-                  <Text
-                    color='text-weak'
-                    size='small'
-                    aria-label={`Users: ${userCountFormatted}`}
-                  >
-                    <TooltipContainer content={<Tooltip>Users</Tooltip>}>
-                      <i className='fa fa-user' role='presentation' />
-                    </TooltipContainer>{' '}
-                    {userCountFormatted}
-                  </Text>
-                </Box>
-              )}
-              {serviceAccountCount > 0 && (
-                <Box width='30%'>
-                  <Text
-                    color='text-weak'
-                    size='small'
-                    aria-label={`Service accounts: ${serviceAccountCountFormatted}`}
-                  >
-                    <TooltipContainer
-                      content={<Tooltip>Service accounts</Tooltip>}
-                    >
-                      <i
-                        className='fa fa-service-account'
-                        role='presentation'
-                      />
-                    </TooltipContainer>{' '}
-                    {serviceAccountCountFormatted}
-                  </Text>
-                </Box>
-              )}
+        <CardBody margin={{ top: 'xsmall' }}>
+          <Box justify='between' direction='row'>
+            <Box width='100px'>
+              <Text
+                color={groupCount > 0 ? 'text-weak' : 'text-xweak'}
+                size='small'
+                aria-label={`Groups: ${groupCountFormatted}`}
+              >
+                <TooltipContainer content={<Tooltip>Groups</Tooltip>}>
+                  <i className='fa fa-group' role='presentation' />
+                </TooltipContainer>{' '}
+                {groupCountFormatted}
+              </Text>
             </Box>
-          </CardBody>
-        )}
+            <Box width='100px'>
+              <Text
+                color={userCount > 0 ? 'text-weak' : 'text-xweak'}
+                size='small'
+                aria-label={`Users: ${userCountFormatted}`}
+              >
+                <TooltipContainer content={<Tooltip>Users</Tooltip>}>
+                  <i className='fa fa-user' role='presentation' />
+                </TooltipContainer>{' '}
+                {userCountFormatted}
+              </Text>
+            </Box>
+            <Box width='100px'>
+              <Text
+                color={serviceAccountCount > 0 ? 'text-weak' : 'text-xweak'}
+                size='small'
+                aria-label={`Service accounts: ${serviceAccountCountFormatted}`}
+              >
+                <TooltipContainer content={<Tooltip>Service accounts</Tooltip>}>
+                  <i className='fa fa-service-account' role='presentation' />
+                </TooltipContainer>{' '}
+                {serviceAccountCountFormatted}
+              </Text>
+            </Box>
+          </Box>
+        </CardBody>
       </StyledCard>
     );
   }

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSet.tsx
@@ -21,6 +21,7 @@ export interface IAccessControlSubjectSetRenderer
   isLoading: boolean;
   isNewlyAdded: boolean;
   onDelete: () => void;
+  removeFromNewlyAdded: () => void;
 }
 
 export interface IAccessControlSubjectSetItem {
@@ -41,6 +42,7 @@ interface IAccessControlSubjectSetProps
   isLoading?: boolean;
   inputSuggestions?: string[];
   onValidate?: (values: string[]) => string;
+  removeFromNewlyAdded?: (name: string) => void;
 }
 
 const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
@@ -106,6 +108,10 @@ const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
     onAdd(newValue);
   };
 
+  const removeFromNewlyAdded = (n: string) => {
+    setNewlyAddedSubjects((prev) => prev.filter((subject) => subject !== n));
+  };
+
   return (
     <Box direction='row' wrap={true} align='start' {...props}>
       {items.map(({ name, isEditable, isLoading: isItemLoading }) => (
@@ -115,6 +121,7 @@ const AccessControlSubjectSet: React.FC<IAccessControlSubjectSetProps> = ({
             isEditable: permissions.canDelete && isEditable,
             isLoading: isItemLoading,
             isNewlyAdded: newlyAddedSubjects.includes(name),
+            removeFromNewlyAdded: () => removeFromNewlyAdded(name),
             onDelete: () => onDeleteItem(name),
           })}
         </React.Fragment>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlSubjectSetItem.tsx
@@ -53,6 +53,7 @@ const AccessControlSubjectSetItem: React.FC<
   isEditable,
   isLoading,
   isNewlyAdded,
+  removeFromNewlyAdded,
   onDelete,
   deleteTooltipMessage,
   deleteConfirmationMessage,
@@ -92,10 +93,12 @@ const AccessControlSubjectSetItem: React.FC<
     onDelete();
   };
 
-  const [isHighlightedValue, setIsHiglightedValue] = useState(isNewlyAdded);
   useEffect(() => {
-    if (isHighlightedValue) setIsHiglightedValue(false);
-  }, [isHighlightedValue]);
+    if (isNewlyAdded) {
+      removeFromNewlyAdded();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Box
@@ -108,7 +111,7 @@ const AccessControlSubjectSetItem: React.FC<
       margin={{ right: 'small', bottom: 'small' }}
       {...props}
     >
-      <RefreshableLabel value={Number(isHighlightedValue)}>
+      <RefreshableLabel value={Number(isNewlyAdded)}>
         {typeof name === 'string' ? (
           <Text color='text-weak'>{name}</Text>
         ) : (

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleList.tsx
@@ -105,8 +105,8 @@ describe('AccessControlRoleList', () => {
       .getByText('some-role')
       .closest('[role=button]') as HTMLElement;
     expect(within(role).getByLabelText('Cluster role')).toBeInTheDocument();
-    expect(within(role).getByText('Groups: None')).toBeInTheDocument();
-    expect(within(role).getByText('Users: None')).toBeInTheDocument();
+    expect(within(role).queryByLabelText('Groups')).not.toBeInTheDocument();
+    expect(within(role).queryByLabelText('Users')).not.toBeInTheDocument();
 
     role = screen
       .getByText('some-other-role')
@@ -114,8 +114,8 @@ describe('AccessControlRoleList', () => {
     expect(
       within(role).queryByLabelText('Cluster role')
     ).not.toBeInTheDocument();
-    expect(within(role).getByText('Groups: 1')).toBeInTheDocument();
-    expect(within(role).getByText('Users: 1')).toBeInTheDocument();
+    expect(within(role).getByLabelText('Groups: 1')).toBeInTheDocument();
+    expect(within(role).getByLabelText('Users: 1')).toBeInTheDocument();
 
     role = screen
       .getByText('some-cool-role')
@@ -123,8 +123,8 @@ describe('AccessControlRoleList', () => {
     expect(
       within(role).queryByLabelText('Cluster role')
     ).not.toBeInTheDocument();
-    expect(within(role).getByText('Groups: None')).toBeInTheDocument();
-    expect(within(role).getByText('Users: 99+')).toBeInTheDocument();
+    expect(within(role).queryByLabelText('Groups')).not.toBeInTheDocument();
+    expect(within(role).getByLabelText('Users: 99+')).toBeInTheDocument();
   });
 
   it('renders a loading placeholder if the data is not present', () => {

--- a/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/__tests__/AccessControlRoleList.tsx
@@ -105,8 +105,8 @@ describe('AccessControlRoleList', () => {
       .getByText('some-role')
       .closest('[role=button]') as HTMLElement;
     expect(within(role).getByLabelText('Cluster role')).toBeInTheDocument();
-    expect(within(role).queryByLabelText('Groups')).not.toBeInTheDocument();
-    expect(within(role).queryByLabelText('Users')).not.toBeInTheDocument();
+    expect(within(role).getByLabelText('Groups: 0')).toBeInTheDocument();
+    expect(within(role).getByLabelText('Users: 0')).toBeInTheDocument();
 
     role = screen
       .getByText('some-other-role')
@@ -123,7 +123,7 @@ describe('AccessControlRoleList', () => {
     expect(
       within(role).queryByLabelText('Cluster role')
     ).not.toBeInTheDocument();
-    expect(within(role).queryByLabelText('Groups')).not.toBeInTheDocument();
+    expect(within(role).getByLabelText('Groups: 0')).toBeInTheDocument();
     expect(within(role).getByLabelText('Users: 99+')).toBeInTheDocument();
   });
 

--- a/src/components/UI/Display/RefreshableLabel.js
+++ b/src/components/UI/Display/RefreshableLabel.js
@@ -51,7 +51,7 @@ function RefreshableLabel({ children, value, className }) {
   useEffect(() => {
     const sToMs = 1000;
     const compareData = () => {
-      if (prevValue && value !== prevValue) {
+      if (typeof prevValue !== 'undefined' && value !== prevValue) {
         setHasDataChanged(true);
       }
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/656.

This PR brings some improvements to the roles list in the access control UI to make it easier to see which roles are bound in the namespace. The following changes have been made:
- display number of service accounts bound to a role
- subject labels (i.e. "Groups", "Users", "Service Accounts") have been replaced by subject icons, with a tooltip displaying the label on hover
- display subject icon and count in a "lighter" colour if there are no subjects of that type bound to a role
- briefly highlight the subject icon when the count changes

<img width="891" alt="Screen Shot 2022-03-10 at 16 26 36 PM" src="https://user-images.githubusercontent.com/62935115/157712872-93f5e8de-bfbd-40a0-be71-83d1e0272040.png">

Hovering over a role list subject icon:
<img width="286" alt="Screen Shot 2022-03-10 at 16 27 10 PM" src="https://user-images.githubusercontent.com/62935115/157712865-2287882b-67ed-4d36-aa8d-1054dfa8093d.png">

In addition, a small bug was fixed to prevent a newly added subject from being repeatedly highlighted when toggling between items in the roles list.