### PR TITLE
Align managed app catalog label

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetCatalog.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetCatalog.tsx
@@ -1,5 +1,4 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
-import { Box, Text } from 'grommet';
 import {
   computeAppCatalogUITitle,
   getCatalogNamespace,
@@ -10,17 +9,13 @@ import { extractErrorMessage } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
 import React, { useEffect, useMemo, useRef } from 'react';
-import styled from 'styled-components';
 import useSWR, { useSWRConfig } from 'swr';
+import CatalogLabel from 'UI/Display/Apps/AppList/CatalogLabel';
 import ClusterDetailAppListWidget from 'UI/Display/MAPI/apps/ClusterDetailAppListWidget';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
-
-const CatalogType = styled(Text)`
-  text-transform: uppercase;
-`;
 
 interface IClusterDetailAppListWidgetCatalogProps
   extends Omit<
@@ -95,31 +90,16 @@ const ClusterDetailAppListWidgetCatalog: React.FC<
   const isManaged = catalog ? isAppCatalogVisibleToUsers(catalog) : false;
 
   return (
-    <ClusterDetailAppListWidget
-      title='Catalog'
-      contentProps={{
-        direction: 'row',
-        gap: 'small',
-        wrap: true,
-        align: 'baseline',
-      }}
-      {...props}
-    >
+    <ClusterDetailAppListWidget title='Catalog' {...props}>
       <OptionalValue value={catalogTitle} loaderWidth={150}>
-        {(value) => <Text aria-label={`App catalog: ${value}`}>{value}</Text>}
+        {(value) => (
+          <CatalogLabel
+            catalogName={value as string}
+            isManaged={isManaged}
+            aria-label={`App catalog: ${value}`}
+          />
+        )}
       </OptionalValue>
-
-      {isManaged && (
-        <Box
-          pad={{ horizontal: 'xsmall', vertical: 'none' }}
-          round='xxsmall'
-          background='#8dc163'
-        >
-          <CatalogType size='xsmall' color='background' weight='bold'>
-            managed
-          </CatalogType>
-        </Box>
-      )}
     </ClusterDetailAppListWidget>
   );
 };

--- a/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
+++ b/src/components/UI/Display/Apps/AppList/CatalogLabel.tsx
@@ -60,18 +60,19 @@ const CatalogLabel: React.FC<ICatalogLabelProps> = (props) => {
   const text = (
     <span>
       {props.catalogName}
-      {props.isManaged && <CatalogType>MANAGED</CatalogType>}
-      {props.catalogName === 'Giant Swarm Catalog' && (
+      {props.isManaged || props.catalogName === 'Giant Swarm Catalog' ? (
         <CatalogType>MANAGED</CatalogType>
-      )}
+      ) : null}
     </span>
   );
 
   return (
     <Wrapper {...props} hasError={Boolean(props.error)}>
-      <IconArea>
-        <Icon src={props.iconUrl} />
-      </IconArea>
+      {props.iconUrl && (
+        <IconArea>
+          <Icon src={props.iconUrl} />
+        </IconArea>
+      )}
       <Text>
         {props.description && (
           <TooltipContainer


### PR DESCRIPTION
Towards [giantswarm/roadmap/issues/825](https://github.com/giantswarm/roadmap/issues/825).

The "managed" label in the "Installed Apps" section has different style from the similar labels in other places. In this PR this label was changed so now it's being rendered by the same component that we use for other labels.

Before:
<img width="1227" alt="Screenshot 2022-03-10 at 15 40 12" src="https://user-images.githubusercontent.com/445309/157664918-b5cd0714-443e-450d-ba84-b54acc192623.png">

After:
<img width="1227" alt="Screenshot 2022-03-10 at 15 39 53" src="https://user-images.githubusercontent.com/445309/157664961-e2ad9358-dda0-4d45-b16f-c91ce2f1208a.png">
