### PR TITLE
Change Select component z-index

### DIFF
--- a/src/components/UI/Inputs/Select/index.tsx
+++ b/src/components/UI/Inputs/Select/index.tsx
@@ -18,7 +18,7 @@ const customTheme: ThemeType = {
       border: {
         radius: '0',
       },
-      zIndex: '9999',
+      zIndex: '0',
     },
   },
   select: {


### PR DESCRIPTION
Towards [giantswarm/roadmap/issues/821](https://github.com/giantswarm/roadmap/issues/821).

Version selector inside the app details can overlap the header. To fix that, z-index of the `Select` component was decreased. Alternatively we can increase `z-index` of the `Header` (currently is 1), but that can cause issues with other elements. Currently this is the only place where we use `Select` component.

<img width="800" alt="Screen Shot 2022-02-16 at 17 55 42" src="https://user-images.githubusercontent.com/62935115/154316049-fbdcb797-ff75-4a25-8bc0-e81462b57a9e.png">
