### PR TITLE
access control: don't display flash messages on successful role binding events

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/AccessControlRoleSubjects.tsx
@@ -160,76 +160,6 @@ const formatSubjectNames = (subjectNames: string[]): React.ReactNode => {
   ));
 };
 
-const getStatusMessages = (
-  type: ui.AccessControlSubjectTypes,
-  statuses: ui.IAccessControlRoleSubjectStatus[]
-): React.ReactNode[] => {
-  const subjectNamesByStatus = statuses.reduce<
-    Record<ui.AccessControlRoleSubjectStatus, string[]>
-  >(
-    (acc, status) => {
-      acc[status.status].push(status.name);
-
-      return acc;
-    },
-    {
-      [ui.AccessControlRoleSubjectStatus.Created]: [],
-      [ui.AccessControlRoleSubjectStatus.Bound]: [],
-    }
-  );
-
-  const messages: React.ReactNode[] = [];
-  for (const [status, subjectNames] of Object.entries(subjectNamesByStatus)) {
-    if (subjectNames.length === 0) continue;
-
-    const key = subjectNames.join();
-
-    switch (status) {
-      case ui.AccessControlRoleSubjectStatus.Created:
-        if (subjectNames.length === 1) {
-          messages.push(
-            <React.Fragment key={key}>
-              {formatSubjectType(type, subjectNames.length !== 1)}{' '}
-              {formatSubjectNames(subjectNames)} has been created and bound to
-              the role.
-            </React.Fragment>
-          );
-        } else {
-          messages.push(
-            <React.Fragment key={key}>
-              {formatSubjectType(type, subjectNames.length !== 1)}{' '}
-              {formatSubjectNames(subjectNames)} have been created and bound to
-              the role.
-            </React.Fragment>
-          );
-        }
-
-        break;
-
-      case ui.AccessControlRoleSubjectStatus.Bound:
-        if (subjectNames.length === 1) {
-          messages.push(
-            <React.Fragment key={key}>
-              {formatSubjectType(type, subjectNames.length !== 1)}{' '}
-              {formatSubjectNames(subjectNames)} has been bound to the role.
-            </React.Fragment>
-          );
-        } else {
-          messages.push(
-            <React.Fragment key={key}>
-              {formatSubjectType(type, subjectNames.length !== 1)}{' '}
-              {formatSubjectNames(subjectNames)} have been bound to the role.
-            </React.Fragment>
-          );
-        }
-
-        break;
-    }
-  }
-
-  return messages;
-};
-
 interface IAccessControlRoleSubjectsProps
   extends Pick<
       ui.IAccessControlRoleItem,
@@ -277,14 +207,8 @@ const AccessControlRoleSubjects: React.FC<IAccessControlRoleSubjectsProps> = ({
 
       try {
         dispatch({ type: 'startLoading', subjectType: type });
-        const statuses = await onAdd(type, values);
+        await onAdd(type, values);
         dispatch({ type: 'stopAdding', subjectType: type });
-
-        const messages = getStatusMessages(type, statuses);
-
-        for (const message of messages) {
-          new FlashMessage(message, messageType.SUCCESS, messageTTL.MEDIUM);
-        }
       } catch (err) {
         let message: React.ReactNode = {};
         if (type === ui.AccessControlSubjectTypes.ServiceAccount) {
@@ -329,19 +253,6 @@ const AccessControlRoleSubjects: React.FC<IAccessControlRoleSubjectsProps> = ({
           subjectName: name,
         });
         await onDelete(type, name);
-
-        const subjectType = formatSubjectType(type).toLowerCase();
-        const deletionMessage = (
-          <>
-            The binding for {subjectType} <code>{name}</code> has been removed.
-          </>
-        );
-
-        new FlashMessage(
-          deletionMessage,
-          messageType.SUCCESS,
-          messageTTL.SHORT
-        );
       } catch (err) {
         const subjectType = formatSubjectType(type).toLowerCase();
         const deletionMessage = (

--- a/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/AccessControlRoleSubjects.tsx
@@ -347,12 +347,6 @@ describe('AccessControlRoleSubjects', () => {
     });
     expect(input).not.toBeInTheDocument();
 
-    expect(
-      await withMarkup(screen.findByText)(
-        'Groups group1, group2, group3 have been bound to the role.'
-      )
-    ).toBeInTheDocument();
-
     fireEvent.click(within(section).getByRole('button', { name: 'Add' }));
 
     input = within(section).getByPlaceholderText(
@@ -372,12 +366,6 @@ describe('AccessControlRoleSubjects', () => {
     await waitFor(() => {
       expect(input).not.toBeInTheDocument();
     });
-
-    expect(
-      await withMarkup(screen.findByText)(
-        'Group group1 has been bound to the role.'
-      )
-    ).toBeInTheDocument();
   });
 
   it('can delete subjects', async () => {
@@ -432,12 +420,6 @@ describe('AccessControlRoleSubjects', () => {
         within(subject).queryByRole('progressbar')
       ).not.toBeInTheDocument();
     });
-
-    expect(
-      await withMarkup(screen.findByText)(
-        'The binding for group test-group1 has been removed.'
-      )
-    ).toBeInTheDocument();
   });
 
   it('can cancel deleting subjects', async () => {

--- a/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/__tests__/index.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { usePermissionsForAccessControl } from 'MAPI/organizations/permissions/usePermissionsForAccessControl';
 import { StatusCodes } from 'model/constants';
@@ -359,14 +365,14 @@ describe('AccessControl', () => {
     expect(within(section).getByRole('progressbar')).toBeInTheDocument();
 
     expect(
-      await withMarkup(screen.findByText)(
-        'Groups subject1, subject2, subject3 have been bound to the role.'
-      )
+      await within(section).findByLabelText('subject1')
     ).toBeInTheDocument();
-
-    expect(within(section).getByLabelText('subject1')).toBeInTheDocument();
-    expect(within(section).getByLabelText('subject2')).toBeInTheDocument();
-    expect(within(section).getByLabelText('subject3')).toBeInTheDocument();
+    expect(
+      await within(section).findByLabelText('subject2')
+    ).toBeInTheDocument();
+    expect(
+      await within(section).findByLabelText('subject3')
+    ).toBeInTheDocument();
 
     (Date.now as unknown as jest.SpyInstance).mockClear();
   });
@@ -570,15 +576,11 @@ describe('AccessControl', () => {
     expect(within(section).getByRole('progressbar')).toBeInTheDocument();
 
     expect(
-      await withMarkup(screen.findByText)(
-        'Users subject1@example.com, subject2 have been bound to the role.'
-      )
+      await within(section).findByLabelText('subject1@example.com')
     ).toBeInTheDocument();
-
     expect(
-      within(section).getByLabelText('subject1@example.com')
+      await within(section).findByLabelText('subject2')
     ).toBeInTheDocument();
-    expect(within(section).getByLabelText('subject2')).toBeInTheDocument();
 
     (Date.now as unknown as jest.SpyInstance).mockClear();
   });
@@ -784,13 +786,9 @@ describe('AccessControl', () => {
     fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
-    expect(
-      await withMarkup(screen.findByText)(
-        'The binding for group Admins has been removed.'
-      )
-    ).toBeInTheDocument();
-
-    expect(within(section).queryByLabelText('Admins')).not.toBeInTheDocument();
+    await waitForElementToBeRemoved(() =>
+      within(section).queryByLabelText('Admins')
+    );
   });
 
   it('displays an error if deleting a group fails', async () => {
@@ -980,15 +978,10 @@ describe('AccessControl', () => {
     fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
-    expect(
-      await withMarkup(screen.findByText)(
-        'The binding for user test@test.com has been removed.'
-      )
-    ).toBeInTheDocument();
 
-    expect(
+    await waitForElementToBeRemoved(() =>
       within(section).queryByLabelText('test@test.com')
-    ).not.toBeInTheDocument();
+    );
   });
 
   it('displays an error if deleting a user fails', async () => {
@@ -1110,15 +1103,10 @@ describe('AccessControl', () => {
     fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
-    expect(
-      await withMarkup(screen.findByText)(
-        'The binding for service account some-random-account has been removed.'
-      )
-    ).toBeInTheDocument();
 
-    expect(
+    await waitForElementToBeRemoved(() =>
       within(section).queryByLabelText('some-random-account')
-    ).not.toBeInTheDocument();
+    );
   });
 
   it('can create service accounts', async () => {
@@ -1260,13 +1248,9 @@ describe('AccessControl', () => {
     expect(within(section).getByRole('progressbar')).toBeInTheDocument();
 
     expect(
-      await withMarkup(screen.findByText)(
-        'Service accounts automation, random have been created and bound to the role.'
-      )
+      await within(section).findByLabelText('automation')
     ).toBeInTheDocument();
-
-    expect(within(section).getByLabelText('automation')).toBeInTheDocument();
-    expect(within(section).getByLabelText('random')).toBeInTheDocument();
+    expect(await within(section).findByLabelText('random')).toBeInTheDocument();
 
     (Date.now as unknown as jest.SpyInstance).mockClear();
   });
@@ -1373,13 +1357,7 @@ describe('AccessControl', () => {
     fireEvent.click(within(section).getByRole('button', { name: 'OK' }));
     expect(within(section).getByRole('progressbar')).toBeInTheDocument();
 
-    expect(
-      await withMarkup(screen.findByText)(
-        'Service account random has been bound to the role.'
-      )
-    ).toBeInTheDocument();
-
-    expect(within(section).getByLabelText('random')).toBeInTheDocument();
+    expect(await within(section).findByLabelText('random')).toBeInTheDocument();
 
     (Date.now as unknown as jest.SpyInstance).mockClear();
   });
@@ -1592,13 +1570,10 @@ describe('AccessControl', () => {
     fireEvent.click(screen.getByText('Remove'));
 
     expect(within(subject).getByRole('progressbar')).toBeInTheDocument();
-    expect(
-      await withMarkup(screen.findByText)(
-        'The binding for service account el-toro has been removed.'
-      )
-    ).toBeInTheDocument();
 
-    expect(within(section).queryByLabelText('el-toro')).not.toBeInTheDocument();
+    await waitForElementToBeRemoved(() =>
+      within(section).queryByLabelText('el-toro')
+    );
   });
 
   it('displays an error if deleting a service account fails', async () => {


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/900, following on from this comment: https://github.com/giantswarm/happa/pull/3251#issuecomment-1064894008.

This PR removes the flash messages we used to display on successful role binding events (creation and deletion). Newly added subjects are already temporarily highlighted, and the subject counts are also temporarily highlighted as they're incremented/decremented. This change minimizes the number of simultaneous events in the UI that convey similar messages.

https://user-images.githubusercontent.com/62935115/158616287-e6a0ca91-b95e-4015-bf43-2d67fb8a5321.mov

Note that flash messages for errors are unchanged, and will continue to be displayed as they occur.