### PR TITLE
Align style of scrollbars

### DIFF
--- a/src/components/MAPI/organizations/AccessControl/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/index.tsx
@@ -183,7 +183,7 @@ const AccessControl: React.FC<IAccessControlProps> = ({
         <AccessControlRoleDescription margin={{ bottom: 'medium' }} />
         <Box direction='row' fill='horizontal'>
           <AccessControlRoleList
-            pad={{ left: 'none', right: 'medium' }}
+            pad={{ left: 'none', right: 'small' }}
             border={{ side: 'right' }}
             height={{ min: '400px' }}
             flex={{

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
@@ -24,6 +24,22 @@ const Content = styled(Box)`
   top: 110px;
 `;
 
+const RoleListWrapper = styled(Box)`
+  scrollbar-gutter: stable;
+  scrollbar-color: ${({ theme }) => `${theme.colors.shade6} transparent`};
+
+  ::-webkit-scrollbar {
+    background-color: ${({ theme }) => theme.colors.shade5};
+    border-radius: 5px;
+    width: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.colors.shade6};
+    border-radius: 5px;
+  }
+`;
+
 interface IAccessControlRoleListProps
   extends React.ComponentPropsWithoutRef<typeof Sidebar> {
   activeRoleName: string;
@@ -73,7 +89,10 @@ const AccessControlRoleList: React.FC<IAccessControlRoleListProps> = ({
   return (
     <Sidebar responsive={false} as='aside' aria-label='Role list' {...props}>
       <Content>
-        <Box margin={{ bottom: 'small' }} pad={{ horizontal: 'small' }}>
+        <Box
+          margin={{ bottom: 'small' }}
+          pad={{ left: 'small', right: 'medium' }}
+        >
           <TextInput
             icon={
               <i
@@ -97,10 +116,10 @@ const AccessControlRoleList: React.FC<IAccessControlRoleListProps> = ({
             (e.target as HTMLElement).click();
           }}
         >
-          <Box
+          <RoleListWrapper
             height={{ max: '60vh' }}
             overflow={{ vertical: 'auto' }}
-            pad='small'
+            pad={{ horizontal: 'small', top: '1px' }}
           >
             {isLoading &&
               LOADING_COMPONENTS.map((idx) => (
@@ -132,7 +151,7 @@ const AccessControlRoleList: React.FC<IAccessControlRoleListProps> = ({
                 />
               )}
             </InfiniteScroll>
-          </Box>
+          </RoleListWrapper>
         </Keyboard>
       </Content>
     </Sidebar>

--- a/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
+++ b/src/components/UI/Display/MAPI/AccessControl/AccessControlRoleList.tsx
@@ -2,6 +2,7 @@ import { Box, InfiniteScroll, Keyboard, Sidebar } from 'grommet';
 import { filterRoles } from 'MAPI/organizations/AccessControl/utils';
 import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
+import { VerticalScroll } from 'styles';
 import TextInput from 'UI/Inputs/TextInput';
 import useDebounce from 'utils/hooks/useDebounce';
 
@@ -25,19 +26,7 @@ const Content = styled(Box)`
 `;
 
 const RoleListWrapper = styled(Box)`
-  scrollbar-gutter: stable;
-  scrollbar-color: ${({ theme }) => `${theme.colors.shade6} transparent`};
-
-  ::-webkit-scrollbar {
-    background-color: ${({ theme }) => theme.colors.shade5};
-    border-radius: 5px;
-    width: 10px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: ${({ theme }) => theme.colors.shade6};
-    border-radius: 5px;
-  }
+  ${VerticalScroll}
 `;
 
 interface IAccessControlRoleListProps

--- a/src/components/UI/Layout/Modal/index.tsx
+++ b/src/components/UI/Layout/Modal/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Heading, Layer, Text } from 'grommet';
 import React from 'react';
 import styled from 'styled-components';
+import { VerticalScroll } from 'styles';
 import Button from 'UI/Controls/Button';
 
 const CloseButton = styled(Button)`
@@ -16,20 +17,7 @@ const CloseButtonText = styled(Text)`
 `;
 
 const Content = styled(Box)`
-  scrollbar-color: ${({ theme }) =>
-    `${theme.global.colors.border.dark} transparent`};
-  scrollbar-width: medium;
-
-  ::-webkit-scrollbar {
-    background-color: ${({ theme }) => theme.colors.shade5};
-    border-radius: 5px;
-    width: 10px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: ${({ theme }) => theme.global.colors.border.dark};
-    border-radius: 5px;
-  }
+  ${VerticalScroll}
 `;
 
 interface IModalProps

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -39,6 +39,22 @@ export const Ellipsis = css`
   overflow: hidden;
 `;
 
+export const VerticalScroll = css`
+  scrollbar-gutter: stable;
+  scrollbar-color: ${(props) => `${props.theme.colors.shade6} transparent`};
+
+  ::-webkit-scrollbar {
+    background-color: ${(props) => props.theme.colors.shade5};
+    border-radius: 5px;
+    width: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: ${(props) => props.theme.colors.shade6};
+    border-radius: 5px;
+  }
+`;
+
 /***** STYLED ELEMENTS *****/
 
 // Layout


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/901.

This PR aligns the style of the scrollbar in the access control UI roles list with that of the app installation modal. The style used is based off of the scrollbar style of the `<CodeBlock>` component. The css rules for the scrollbars are also separated for easier reuse in the future.
<img width="270" alt="Screen Shot 2022-03-17 at 17 05 02" src="https://user-images.githubusercontent.com/62935115/158854260-ccbbeb01-73d5-4e76-95c9-1147b05eb9a3.png">