### PR TITLE
Disable permissions revalidation when stale

### DIFF
--- a/src/components/MAPI/permissions/usePermissions.ts
+++ b/src/components/MAPI/permissions/usePermissions.ts
@@ -40,6 +40,7 @@ export function usePermissions() {
     GenericResponseError
   >(key, () => fetchPermissions(httpClientFactory, auth, organizations), {
     refreshInterval: Constants.PERMISSIONS_REFRESH_INTERVAL,
+    revalidateIfStale: false,
   });
 
   const isLoading =


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/870.

We have different hooks for different kinds of permissions, e.g. `usePermissionsForKeyPairs`, `usePermissionsForCertConfigs`, `usePermissionsForStorageConfigs`, etc. All of them use `usePermissions` hook which uses SWR to fetch permissions. As a result `usePermissions` hook is being called a lot and it triggers `useSWR` hook revalidation. (By default SWR should revalidate when it mounts and there is stale data - [docs](https://swr.vercel.app/docs/revalidation#disable-automatic-revalidations).) Revalidation causes a lot of extra re-renders of different components.

In this PR I disable permissions revalidation when stale. We still revalidate permissions `onFocus` and `onInterval`.