### PR TITLE
Upgrade @braintree/sanitize-url from 3.1.0 to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "webpack-merge": "5.8.0"
   },
   "resolutions": {
+    "@braintree/sanitize-url": "^6.0.0",
     "kind-of": "6.0.3",
     "lodash": "4.17.21",
     "http-proxy": "1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,10 +2361,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@braintree/sanitize-url@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz#8ff71d51053cd5ee4981e5a501d80a536244f7fd"
-  integrity sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg==
+"@braintree/sanitize-url@^3.1.0", "@braintree/sanitize-url@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz#fe364f025ba74f6de6c837a84ef44bdb1d61e68f"
+  integrity sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"


### PR DESCRIPTION
`@braintree/sanitize-url` package has a known [security vulnerability](https://security.snyk.io/vuln/SNYK-JS-BRAINTREESANITIZEURL-2339882). It's a sub-dependency of the`mermaid` package. They already merged a [PR](https://github.com/mermaid-js/mermaid/pull/2790) with the fix but it's not released yet. So we temporary add `@braintree/sanitize-url` into the resolutions in `package.json` to upgrade it manually to the latest version.