### PR TITLE
Add tenant id in cluster details on Azure

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetProvider.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetProvider.tsx
@@ -1,16 +1,44 @@
-import { render, screen } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+  within,
+} from '@testing-library/react';
 import { createMemoryHistory } from 'history';
+import { usePermissionsForOrgCredentials } from 'MAPI/clusters/permissions/usePermissionsForOrgCredentials';
+import { ProviderCluster } from 'MAPI/types';
+import * as providers from 'model/constants/providers';
+import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
+import * as legacyCredentials from 'model/services/mapi/legacy/credentials';
+import { IMainState } from 'model/stores/main/types';
+import { IOrganizationState } from 'model/stores/organization/types';
+import { IState } from 'model/stores/state';
 import React from 'react';
+import { useParams } from 'react-router';
 import { SWRConfig } from 'swr';
-import * as mockCapiv1alpha3 from 'test/mockHttpCalls/capiv1alpha3';
+import * as capiv1alpha3Mocks from 'test/mockHttpCalls/capiv1alpha3';
 import * as capzv1alpha3Mocks from 'test/mockHttpCalls/capzv1alpha3';
+import * as infrav1alpha3Mocks from 'test/mockHttpCalls/infrastructurev1alpha3';
 import { getComponentWithStore } from 'test/renderUtils';
 import TestOAuth2 from 'utils/OAuth2/TestOAuth2';
 
 import ClusterDetailWidgetProvider from '../ClusterDetailWidgetProvider';
 
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useParams: jest.fn(),
+}));
+
+jest.mock('MAPI/clusters/permissions/usePermissionsForOrgCredentials');
+
+jest.mock('model/services/mapi/legacy/credentials', () => ({
+  ...jest.requireActual('model/services/mapi/legacy/credentials'),
+  getCredentialList: jest.fn(),
+}));
+
 function getComponent(
-  props: React.ComponentPropsWithoutRef<typeof ClusterDetailWidgetProvider>
+  props: React.ComponentPropsWithoutRef<typeof ClusterDetailWidgetProvider>,
+  state: IState
 ) {
   const history = createMemoryHistory();
   const auth = new TestOAuth2(history, true);
@@ -24,57 +52,252 @@ function getComponent(
   return getComponentWithStore(
     Component,
     props,
-    undefined,
+    state,
     undefined,
     history,
     auth
   );
 }
 
-jest.mock('react-router', () => ({
-  ...jest.requireActual('react-router'),
-  useParams: jest.fn().mockReturnValue({
-    orgId: 'org1',
-    clusterId: mockCapiv1alpha3.randomCluster1.metadata.name,
-  }),
-}));
+const defaultState: IState = {
+  main: {
+    selectedOrganization: 'org1',
+  } as IMainState,
+  entities: {
+    organizations: {
+      lastUpdated: 0,
+      isFetching: false,
+      credentials: {
+        lastUpdated: 0,
+        isFetching: false,
+        items: [],
+        showForm: false,
+      },
+      items: {
+        org1: {
+          id: 'org1',
+          name: 'org1',
+          namespace: 'org-org1',
+        },
+      },
+    } as IOrganizationState,
+  } as IState['entities'],
+} as IState;
 
-describe('ClusterDetailWidgetProvider', () => {
-  it('renders without crashing', () => {
-    render(getComponent({}));
+function setup(
+  cluster?: capiv1alpha3.ICluster,
+  providerCluster?: ProviderCluster
+) {
+  (useParams as jest.Mock).mockReturnValue({
+    orgId: defaultState.main.selectedOrganization,
+    clusterId: cluster?.metadata.name,
+  });
+
+  const utils = render(
+    getComponent(
+      {
+        cluster,
+        providerCluster,
+      },
+      defaultState
+    )
+  );
+
+  return {
+    ...utils,
+  };
+}
+
+async function setupAWS() {
+  const utils = setup(
+    capiv1alpha3Mocks.randomAWSCluster1,
+    infrav1alpha3Mocks.randomAWSCluster1
+  );
+
+  if (screen.queryAllByText('Loading...').length > 0) {
+    await waitForElementToBeRemoved(() => screen.queryAllByText('Loading...'));
+  }
+
+  return {
+    ...utils,
+  };
+}
+
+async function setupAzure() {
+  const utils = setup(
+    capiv1alpha3Mocks.randomCluster1,
+    capzv1alpha3Mocks.randomAzureCluster1
+  );
+
+  if (screen.queryAllByText('Loading...').length > 0) {
+    await waitForElementToBeRemoved(() => screen.queryAllByText('Loading...'));
+  }
+
+  return {
+    ...utils,
+  };
+}
+
+describe('ClusterDetailWidgetProvider on AWS when user can not list credentials', () => {
+  const provider: PropertiesOf<typeof providers> =
+    window.config.info.general.provider;
+
+  beforeAll(() => {
+    window.config.info.general.provider = providers.AWS;
+
+    (usePermissionsForOrgCredentials as jest.Mock).mockReturnValue({
+      canList: false,
+    });
+  });
+
+  afterAll(() => {
+    window.config.info.general.provider = provider;
   });
 
   it('displays loading animations if the cluster is still loading', () => {
-    render(
-      getComponent({
-        cluster: undefined,
-      })
-    );
-
+    setup();
     expect(screen.getAllByLabelText('Loading...').length).toEqual(4);
   });
 
-  it('displays the cluster region on Azure', () => {
-    render(
-      getComponent({
-        cluster: mockCapiv1alpha3.randomCluster1,
-        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
-      })
-    );
+  it('displays cluster region and account ID', async () => {
+    await setupAWS();
+    const groups = screen.getAllByTestId('provider-group');
+    expect(groups.length).toEqual(2);
+    expect(within(groups[0]).getByText('AWS region')).toBeInTheDocument();
+    expect(within(groups[0]).getByText('eu-west-1')).toBeInTheDocument();
+    expect(within(groups[1]).getByText('Account ID')).toBeInTheDocument();
+    expect(within(groups[1]).getByText('n/a')).toBeInTheDocument();
+    expect(within(groups[1]).queryByRole('link')).not.toBeInTheDocument();
+  });
+});
 
-    expect(screen.getByText('Azure region')).toBeInTheDocument();
-    expect(screen.getByText('westeurope')).toBeInTheDocument();
+describe('ClusterDetailWidgetProvider on AWS when user can list credentials', () => {
+  const provider: PropertiesOf<typeof providers> =
+    window.config.info.general.provider;
+
+  beforeAll(() => {
+    window.config.info.general.provider = providers.AWS;
+
+    (usePermissionsForOrgCredentials as jest.Mock).mockReturnValue({
+      canList: true,
+    });
+
+    (legacyCredentials.getCredentialList as jest.Mock).mockReturnValue({
+      items: [
+        {
+          awsOperatorRole: 'credential-account-id',
+        },
+      ],
+    });
   });
 
-  it('displays the subscription ID on Azure', () => {
-    render(
-      getComponent({
-        cluster: mockCapiv1alpha3.randomCluster1,
-        providerCluster: capzv1alpha3Mocks.randomAzureCluster1,
-      })
-    );
+  afterAll(() => {
+    window.config.info.general.provider = provider;
+  });
 
-    expect(screen.getByText('Subscription ID')).toBeInTheDocument();
-    expect(screen.getByText('test-subscription')).toBeInTheDocument();
+  it('displays loading animations if the cluster is still loading', () => {
+    setup();
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(4);
+  });
+
+  it('displays cluster region and account ID', async () => {
+    await setupAWS();
+    const groups = screen.getAllByTestId('provider-group');
+    expect(groups.length).toEqual(2);
+    expect(within(groups[0]).getByText('AWS region')).toBeInTheDocument();
+    expect(within(groups[0]).getByText('eu-west-1')).toBeInTheDocument();
+    expect(within(groups[1]).getByText('Account ID')).toBeInTheDocument();
+    expect(
+      within(groups[1]).getByText('credential-account-id')
+    ).toBeInTheDocument();
+    expect(within(groups[1]).getByRole('link')).toHaveAttribute(
+      'href',
+      'https://credential-account-id.signin.aws.amazon.com/console'
+    );
+  });
+});
+
+describe('ClusterDetailWidgetProvider on Azure when user can not list credentials', () => {
+  const provider: PropertiesOf<typeof providers> =
+    window.config.info.general.provider;
+
+  beforeAll(() => {
+    window.config.info.general.provider = providers.AZURE;
+
+    (usePermissionsForOrgCredentials as jest.Mock).mockReturnValue({
+      canList: false,
+    });
+  });
+
+  afterAll(() => {
+    window.config.info.general.provider = provider;
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    setup();
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(6);
+  });
+
+  it('displays cluster region, subscription ID and tenant ID', async () => {
+    await setupAzure();
+    const groups = screen.getAllByTestId('provider-group');
+    expect(groups.length).toEqual(3);
+    expect(within(groups[0]).getByText('Azure region')).toBeInTheDocument();
+    expect(within(groups[0]).getByText('westeurope')).toBeInTheDocument();
+    expect(within(groups[1]).getByText('Subscription ID')).toBeInTheDocument();
+    expect(
+      within(groups[1]).getByText('test-subscription')
+    ).toBeInTheDocument();
+    expect(within(groups[1]).queryByRole('link')).not.toBeInTheDocument();
+    expect(within(groups[2]).getByText('Tenant ID')).toBeInTheDocument();
+    expect(within(groups[2]).getByText('n/a')).toBeInTheDocument();
+  });
+});
+
+describe('ClusterDetailWidgetProvider on Azure when user can list credentials', () => {
+  const provider: PropertiesOf<typeof providers> =
+    window.config.info.general.provider;
+
+  beforeAll(() => {
+    window.config.info.general.provider = providers.AZURE;
+
+    (usePermissionsForOrgCredentials as jest.Mock).mockReturnValue({
+      canList: true,
+    });
+
+    (legacyCredentials.getCredentialList as jest.Mock).mockReturnValue({
+      items: [
+        {
+          azureSubscriptionID: 'credential-subscription-id',
+          azureTenantID: 'credential-tenant-id',
+        },
+      ],
+    });
+  });
+
+  afterAll(() => {
+    window.config.info.general.provider = provider;
+  });
+
+  it('displays loading animations if the cluster is still loading', () => {
+    setup();
+    expect(screen.getAllByLabelText('Loading...').length).toEqual(6);
+  });
+
+  it('displays cluster region, subscription ID and tenant ID', async () => {
+    await setupAzure();
+    const groups = screen.getAllByTestId('provider-group');
+    expect(groups.length).toEqual(3);
+    expect(within(groups[0]).getByText('Azure region')).toBeInTheDocument();
+    expect(within(groups[0]).getByText('westeurope')).toBeInTheDocument();
+    expect(within(groups[1]).getByText('Subscription ID')).toBeInTheDocument();
+    expect(
+      within(groups[1]).getByText('credential-subscription-id')
+    ).toBeInTheDocument();
+    expect(within(groups[1]).queryByRole('link')).not.toBeInTheDocument();
+    expect(within(groups[2]).getByText('Tenant ID')).toBeInTheDocument();
+    expect(
+      within(groups[2]).getByText('credential-tenant-id')
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/MAPI/clusters/ClusterDetail/utils.ts
+++ b/src/components/MAPI/clusters/ClusterDetail/utils.ts
@@ -298,19 +298,23 @@ export async function updateClusterLabels(
   return capiv1alpha3.updateCluster(httpClient, auth, cluster);
 }
 
-export function getCredentialsAccountID(
-  credentials?: legacyCredentials.ICredential[]
-) {
-  if (!credentials) return undefined;
-  if (credentials.length < 1) return '';
-
-  const mainCredential = credentials.find((credential, _, collection) => {
+function getMainCredential(credentials: legacyCredentials.ICredential[]) {
+  return credentials.find((credential, _, collection) => {
     // If only the default credential is present, display it.
     if (collection.length === 1) return true;
 
     // If there are custom credentials, display the first one.
     return credential.name !== legacyCredentials.defaultCredentialName;
   });
+}
+
+export function getCredentialsAccountID(
+  credentials?: legacyCredentials.ICredential[]
+) {
+  if (!credentials) return undefined;
+  if (credentials.length < 1) return '';
+
+  const mainCredential = getMainCredential(credentials);
   if (!mainCredential) return '';
 
   switch (true) {
@@ -321,6 +325,18 @@ export function getCredentialsAccountID(
     default:
       return '';
   }
+}
+
+export function getCredentialsAzureTenantID(
+  credentials?: legacyCredentials.ICredential[]
+) {
+  if (!credentials) return undefined;
+  if (credentials.length < 1) return '';
+
+  const mainCredential = getMainCredential(credentials);
+  if (!mainCredential) return '';
+
+  return mainCredential.azureTenantID || '';
 }
 
 export interface IControlPlaneNodesStats {

--- a/test/mockHttpCalls/capiv1alpha3/clusters.ts
+++ b/test/mockHttpCalls/capiv1alpha3/clusters.ts
@@ -1,5 +1,51 @@
 import * as capiv1alpha3 from 'model/services/mapi/capiv1alpha3';
 
+export const randomAWSCluster1: capiv1alpha3.ICluster = {
+  apiVersion: 'cluster.x-k8s.io/v1alpha3',
+  kind: capiv1alpha3.Cluster,
+  metadata: {
+    annotations: {
+      'cluster.giantswarm.io/description': 'Random Cluster',
+    },
+    creationTimestamp: '2022-03-29T06:38:39Z',
+    finalizers: [
+      'encryption-provider-operator.finalizers.giantswarm.io',
+      'operatorkit.giantswarm.io/cluster-operator-cluster-controller',
+      'operatorkit.giantswarm.io/prometheus-meta-operator-cluster-api-controller',
+    ],
+    generation: 1,
+    labels: {
+      'cluster-operator.giantswarm.io/version': '3.13.0',
+      'cluster.x-k8s.io/cluster-name': 'c7hm5',
+      'giantswarm.io/cluster': 'c7hm5',
+      'giantswarm.io/organization': 'org1',
+      'release.giantswarm.io/version': '17.0.3',
+    },
+    name: 'c7hm5',
+    namespace: 'org-org1',
+    resourceVersion: '540373278',
+    selfLink:
+      '/apis/cluster.x-k8s.io/v1alpha3/namespaces/org-org1/clusters/c7hm5',
+    uid: '7a2858d1-fbff-4337-b89f-e8b9dc41b113',
+  },
+  spec: {
+    controlPlaneEndpoint: {
+      host: '',
+      port: 0,
+    },
+    infrastructureRef: {
+      apiVersion: 'infrastructure.giantswarm.io/v1alpha3',
+      kind: 'AWSCluster',
+      name: 'c7hm5',
+      namespace: 'org-org1',
+    },
+  },
+  status: {
+    controlPlaneInitialized: false,
+    infrastructureReady: false,
+  },
+};
+
 export const randomCluster1: capiv1alpha3.ICluster = {
   apiVersion: 'cluster.x-k8s.io/v1alpha3',
   kind: capiv1alpha3.Cluster,

--- a/test/mockHttpCalls/infrastructurev1alpha3/clusters.ts
+++ b/test/mockHttpCalls/infrastructurev1alpha3/clusters.ts
@@ -1,0 +1,74 @@
+import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
+
+export const randomAWSCluster1: infrav1alpha3.IAWSCluster = {
+  apiVersion: 'infrastructure.giantswarm.io/v1alpha3',
+  kind: 'AWSCluster',
+  metadata: {
+    creationTimestamp: '2022-03-29T06:38:38Z',
+    generation: 1,
+    labels: {
+      'aws-operator.giantswarm.io/version': '10.18.0',
+      'cluster.x-k8s.io/cluster-name': 'c7hm5',
+      'giantswarm.io/cluster': 'c7hm5',
+      'giantswarm.io/organization': 'org1',
+      'release.giantswarm.io/version': '17.0.3',
+    },
+    name: 'c7hm5',
+    namespace: 'org-org1',
+    resourceVersion: '540376281',
+    selfLink:
+      '/apis/infrastructure.giantswarm.io/v1alpha3/namespaces/org-org1/awsclusters/c7hm5',
+    uid: 'bc8a1afc-1aee-4ec4-879d-efbb45bc065b',
+  },
+  spec: {
+    cluster: {
+      description: 'Random Cluster',
+      dns: {
+        domain: 'ginger.eu-west-1.aws.gigantic.io',
+      },
+      kubeProxy: {
+        conntrackMaxPerCore: 0,
+      },
+      oidc: {
+        claims: {
+          groups: '',
+          username: '',
+        },
+        clientID: '',
+        issuerURL: '',
+      },
+    },
+    provider: {
+      credentialSecret: {
+        name: 'credential-default',
+        namespace: 'giantswarm',
+      },
+      master: {
+        availabilityZone: '',
+        instanceType: '',
+      },
+      nodes: {
+        networkPool: '',
+      },
+      pods: {
+        cidrBlock: '172.18.128.0/18',
+        externalSNAT: false,
+      },
+      region: 'eu-west-1',
+    },
+  },
+  status: {
+    cluster: {
+      conditions: [
+        {
+          condition: 'Creating',
+          lastTransitionTime: '2022-03-29T06:40:52Z',
+        },
+      ],
+      id: 'c7hm5',
+    },
+    provider: {
+      network: {},
+    },
+  },
+};

--- a/test/mockHttpCalls/infrastructurev1alpha3/index.ts
+++ b/test/mockHttpCalls/infrastructurev1alpha3/index.ts
@@ -1,0 +1,1 @@
+export * from './clusters';


### PR DESCRIPTION
On Azure together with subscription ID we also show tenant ID. But it is missing on a cluster details page.
![image](https://user-images.githubusercontent.com/273727/122180108-6c226680-ce88-11eb-9f71-eee64816e15e.png)

Changes in the PR:
1. Tenant ID was added to a cluster details page on Azure
2. Subscription ID link was removed for Azure clusters (because it wasn't very helpful anyway)

Before:
<img width="1211" alt="Screenshot 2022-03-29 at 13 26 40" src="https://user-images.githubusercontent.com/445309/160597934-a8c8432f-30c0-4df2-a407-002ec133f81a.png">
After:
<img width="1211" alt="Screenshot 2022-03-29 at 13 25 59" src="https://user-images.githubusercontent.com/445309/160597984-e08e6f77-ced0-46c8-acf2-2b2255e7e4fb.png">

3. Dot separated list was improved to work better on narrow screens

Before:
<img width="817" alt="Screenshot 2022-03-29 at 14 11 39" src="https://user-images.githubusercontent.com/445309/160599304-426db82d-59b5-4ac2-b1fa-f06f9295135d.png">
After:
<img width="817" alt="Screenshot 2022-03-29 at 14 12 12" src="https://user-images.githubusercontent.com/445309/160599170-35f994c1-288d-4235-8553-6e78f2e737b9.png">
