### PR TITLE
Keep happa available during upgrades

### DIFF
--- a/helm/happa/templates/deployment.yaml
+++ b/helm/happa/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                  - key: k8s-app
+                  - key: app
                     operator: In
                     values:
                     - happa

--- a/helm/happa/templates/pdb.yaml
+++ b/helm/happa/templates/pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: happa
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: happa
+{{- end }}


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/972

This PR

- Fixes the anti-affinity selector that should avoid all pods running on the same node
- Adds a `PodDisruptionBudget` template with `minAvailable: 1`