### PR TITLE
Handle the error when items are missing in a release list

### DIFF
--- a/src/model/services/mapi/releasev1alpha1/getReleaseList.ts
+++ b/src/model/services/mapi/releasev1alpha1/getReleaseList.ts
@@ -1,4 +1,6 @@
+import { GenericResponseError } from 'model/clients/GenericResponseError';
 import { IHttpClient } from 'model/clients/HttpClient';
+import { StatusCodes } from 'model/constants';
 import * as k8sUrl from 'model/services/mapi/k8sUrl';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
 
@@ -12,7 +14,22 @@ export function getReleaseList(client: IHttpClient, auth: IOAuth2Provider) {
     kind: 'releases',
   });
 
-  return getResource<IReleaseList>(client, auth, url.toString());
+  return getResource<IReleaseList>(client, auth, url.toString()).then(
+    (data) => {
+      if (data.items === undefined) {
+        const invalidResponseError = new GenericResponseError();
+        invalidResponseError.status = StatusCodes.Ok;
+        invalidResponseError.requestConfig = client.getRequestConfig();
+        invalidResponseError.data = data;
+        invalidResponseError.message =
+          'Invalid response. Release list items are missing.';
+
+        throw invalidResponseError;
+      }
+
+      return data;
+    }
+  );
 }
 
 export function getReleaseListKey() {


### PR DESCRIPTION
Towards [giantswarm/roadmap/issues/970](https://github.com/giantswarm/roadmap/issues/970).

We have a rare case when a `ReleaseList` API request returns information without `items` field, which is unexpected and causes unhandled error screen.
![image](https://user-images.githubusercontent.com/273727/160586636-cf034beb-9545-4bb6-a169-796931753367.png)

In this PR I added an additional handler for such case. When `ReleaseList` information is being received without items, an error is being thrown with information about the response. This error will be handled correctly - the error will be reported to Sentry and the request revalidation will be triggered. The UI will not break, as it happens right now, and we will get additional information to investigate in the future.