### PR TITLE
Auto refresh relative dates

### DIFF
--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListItem.tsx
@@ -196,7 +196,9 @@ describe('ClusterDetailAppListItem', () => {
     ).toBeInTheDocument();
 
     expect(
-      await screen.findByText('released less than a minute ago')
+      await screen.findByText((_content, node) =>
+        node ? node.textContent === 'released less than a minute ago' : false
+      )
     ).toBeInTheDocument();
     expect(
       screen.getByText('includes upstream version 1.6.5')
@@ -209,7 +211,9 @@ describe('ClusterDetailAppListItem', () => {
       const row = await screen.findByLabelText(entry.spec.version);
       expect(within(row).getByText(entry.spec.version)).toBeInTheDocument();
       expect(
-        within(row).getByText('released less than a minute ago')
+        within(row).getByText((_content, node) =>
+          node ? node.textContent === 'released less than a minute ago' : false
+        )
       ).toBeInTheDocument();
       expect(
         within(row).getByText(

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetCreated.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetCreated.tsx
@@ -10,6 +10,12 @@ const StyledDot = styled(Dot)`
   padding: 0;
 `;
 
+const CapitalizedText = styled.div`
+  &:first-letter {
+    text-transform: uppercase;
+  }
+`;
+
 interface IClusterDetailWidgetCreatedProps
   extends Omit<
     React.ComponentPropsWithoutRef<typeof ClusterDetailWidget>,
@@ -36,7 +42,11 @@ const ClusterDetailWidgetCreated: React.FC<
       {...props}
     >
       <OptionalValue value={creationDate}>
-        {(value) => <Date relative={true} value={value as string} />}
+        {(value) => (
+          <CapitalizedText>
+            <Date relative={true} value={value as string} />
+          </CapitalizedText>
+        )}
       </OptionalValue>
       <StyledDot />
       <OptionalValue value={creationDate} loaderWidth={150}>

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairDetailsModal.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairDetailsModal.tsx
@@ -6,7 +6,6 @@ import Button from 'UI/Controls/Button';
 import Date from 'UI/Display/Date';
 import NotAvailable from 'UI/Display/NotAvailable';
 import Modal from 'UI/Layout/Modal';
-import { getRelativeDateFromNow } from 'utils/helpers';
 
 const Label = styled(Text).attrs({
   color: 'text-weak',
@@ -87,7 +86,7 @@ const ClusterDetailKeyPairDetailsModal: React.FC<
           {creationDate ? (
             <Text>
               <Date value={creationDate} /> &ndash;{' '}
-              {getRelativeDateFromNow(creationDate)}
+              <Date value={creationDate} relative={true} />
             </Text>
           ) : (
             <NotAvailable />
@@ -98,7 +97,7 @@ const ClusterDetailKeyPairDetailsModal: React.FC<
           {expirationDate ? (
             <Text color={isExpiringSoon ? 'status-warning' : undefined}>
               <Date value={expirationDate} /> &ndash;{' '}
-              {getRelativeDateFromNow(expirationDate)}
+              <Date value={expirationDate} relative={true} />
             </Text>
           ) : (
             <NotAvailable />

--- a/src/components/UI/Display/MAPI/apps/AppVersionInspectorOption.tsx
+++ b/src/components/UI/Display/MAPI/apps/AppVersionInspectorOption.tsx
@@ -2,9 +2,9 @@ import { Box, Text } from 'grommet';
 import React from 'react';
 import styled from 'styled-components';
 import { Dot } from 'styles';
+import Date from 'UI/Display/Date';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 import Truncated from 'UI/Util/Truncated';
-import { getRelativeDateFromNow } from 'utils/helpers';
 
 const StyledText = styled(Text)`
   line-height: unset;
@@ -62,7 +62,7 @@ const AppVersionInspectorOption: React.FC<IAppVersionInspectorOptionProps> = ({
       >
         {(value) => (
           <StyledText weight={textWeight}>
-            released {getRelativeDateFromNow(value as string)}
+            released <Date value={value as string} relative={true} />
           </StyledText>
         )}
       </OptionalValue>

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteActionClusterDetails.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteActionClusterDetails.tsx
@@ -5,7 +5,6 @@ import ClusterIDLabel, {
 } from 'UI/Display/Cluster/ClusterIDLabel';
 import Date from 'UI/Display/Date';
 import NotAvailable from 'UI/Display/NotAvailable';
-import { getRelativeDateFromNow } from 'utils/helpers';
 
 import { ClusterDetailDeleteActionNameVariant } from './ClusterDetailDeleteAction';
 
@@ -111,7 +110,7 @@ const ClusterDetailDeleteActionClusterDetails: React.FC<
       </Box>
       <Box direction='row'>
         <Text>
-          Created: {getRelativeDateFromNow(creationDate)} (
+          Created: <Date value={creationDate} relative={true} /> (
           <Date value={creationDate} />)
         </Text>
       </Box>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -182,11 +182,23 @@ export function formatDate(date: string | number | Date): string {
  * @param date
  */
 export function getRelativeDateFromNow(date: string | number | Date): string {
-  const givenDate = parseDate(date);
-  const now = new Date();
-  let distance = formatDistance(now)(givenDate);
+  return getRelativeDate(date, new Date());
+}
 
-  if (compareAsc(now)(givenDate) < 0) {
+/**
+ * Get a formatted date structure, relative to other date (e.g. 2 days ago, or 1 year ago).
+ * @param dateA
+ * @param dateB
+ */
+export function getRelativeDate(
+  dateA: string | number | Date,
+  dateB: string | number | Date
+): string {
+  const baseDate = parseDate(dateA);
+  const date = parseDate(dateB);
+  let distance = formatDistance(date)(baseDate);
+
+  if (compareAsc(date)(baseDate) < 0) {
     distance += ' ago';
   } else {
     distance = `in ${distance}`;


### PR DESCRIPTION
Towards [giantswarm/roadmap/issues/971](https://github.com/giantswarm/roadmap/issues/971).

We have a `<Date />` component that displays a date in a relative form, e.g. 5 minutes ago, or 1 year ago. After being displayed, relative date stays the same until next rerender - it's unpredictable when a rerender can happen or it can not happen at all. As a result relative dates can be outdated. In this PR I changed the `<Date />` component so it updates the displayed value every minute. "Auto refresh" happens only for dates that are in 45 minutes from current time, because after 45 minutes, formatted date looks like `about 1 hour`, `about [2..24] hours`, `1 day` and so forth and it's not necessary to auto refresh it anymore.

Some other small changes:
- `<Date />` component was reused in some other places where we display relative dates;
- cluster creation date on the cluster details page was capitalized