### PR TITLE
Auto refresh cluster's application list

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailApps.tsx
@@ -40,8 +40,16 @@ import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 import ClusterDetailAppList from './ClusterDetailAppList';
 import ClusterDetailAppLoadingPlaceholder from './ClusterDetailAppLoadingPlaceholder';
 import { usePermissionsForApps } from './permissions/usePermissionsForApps';
-import { filterUserInstalledApps, mapDefaultApps } from './utils';
+import {
+  filterUserInstalledApps,
+  isAppChangingVersion,
+  mapDefaultApps,
+} from './utils';
 
+// eslint-disable-next-line no-magic-numbers
+const APP_LIST_REFRESH_INTERVAL = 60 * 1000; // 1 minute
+// eslint-disable-next-line no-magic-numbers
+const APP_LIST_SHORT_REFRESH_INTERVAL = 5 * 1000; // 5 seconds
 const LOADING_COMPONENTS = new Array(6).fill(0);
 
 function formatAppVersion(appMeta: AppConstants.IAppMetaApp) {
@@ -124,7 +132,17 @@ const ClusterDetailApps: React.FC<IClusterDetailApps> = ({
         appListClient.current,
         auth,
         appListGetOptions
-      )
+      ),
+    {
+      refreshInterval: (latestData) => {
+        const appChangingVersion =
+          latestData?.items?.find(isAppChangingVersion);
+
+        return typeof appChangingVersion !== 'undefined'
+          ? APP_LIST_SHORT_REFRESH_INTERVAL
+          : APP_LIST_REFRESH_INTERVAL;
+      },
+    }
   );
   const appListIsLoading =
     typeof appsPermissions.canList === 'undefined' ||


### PR DESCRIPTION
Applications list on the cluster details page is not being refreshed automatically. It brings about a poor experience when a user upgrades an application. We display "Switching to x.x.x" and it stays like this until the user does any actions to refetch applications.
<img width="1209" alt="Screenshot 2022-04-12 at 17 33 36" src="https://user-images.githubusercontent.com/445309/162986896-452f791e-1b91-419b-8ab5-8c150533a344.png">

In this PR I setup a refresh interval for application list. Normaly an application list will be refreshed every minute, but if there is an application in the list that is changing a version, refresh interval will be 5 seconds.
