### PR TITLE
Improve build time in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ workflows:
             - gather-facts
           <<: *job_filters
       - build-container:
+          context: architect
           requires:
             - test
             - lint
@@ -64,32 +65,6 @@ workflows:
             - typecheck
             - build
           <<: *job_filters
-
-      - architect/push-to-docker:
-          name: push-happa-to-docker
-          context: "architect"
-          image: "docker.io/giantswarm/happa"
-          username_envar: "DOCKER_USERNAME"
-          password_envar: "DOCKER_PASSWORD"
-          requires:
-            - build-container
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
-          name: push-happa-to-quay
-          context: architect
-          image: *image_name
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
-          requires:
-            - build-container
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
 
       - architect/push-to-docker:
           name: push-happa-to-aliyun
@@ -112,8 +87,7 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "happa"
           requires:
-            - push-happa-to-quay
-            - push-happa-to-docker
+            - build-container
           # Needed to trigger job also on git tag.
           filters:
             tags:
@@ -392,10 +366,17 @@ jobs:
           command: |
             echo -n "${IMAGE_NAME}:$(cat VERSION)" > .docker_image_name
 
-      - run:
-          name: Build Docker image
-          command: |
-            docker build -t "$(cat .docker_image_name)" .
+      - architect/push-to-docker:
+          tag-latest-branch: "main"
+          image: "docker.io/giantswarm/happa"
+          username_envar: "DOCKER_USERNAME"
+          password_envar: "DOCKER_PASSWORD"
+
+      - architect/push-to-docker:
+          tag-latest-branch: "main"
+          image: *image_name
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
 
       - run:
           name: Launch container for tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ workflows:
           # Needed to trigger job only on git tag.
           filters:
             branches:
-              only: master
+              only: main
             tags:
               only: /^v.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,15 +177,6 @@ workflows:
             tags:
               only: /^v.*/
 
-      - build-fe-docs-container:
-          requires:
-            - build-fe-docs
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
       - architect/push-to-docker:
           name: push-fe-docs-to-quay
           context: architect
@@ -194,7 +185,7 @@ workflows:
           password_envar: "QUAY_PASSWORD"
           dockerfile: "./Dockerfile.fe-docs"
           requires:
-            - build-fe-docs-container
+            - build-fe-docs
           filters:
             branches:
               ignore: /.*/
@@ -406,27 +397,3 @@ jobs:
       - persist_to_workspace:
           root: ~/happa
           <<: *whitelist
-
-  build-fe-docs-container:
-    executor: architect/architect
-
-    working_directory: ~/happa
-    steps:
-      - checkout
-
-      - setup_remote_docker
-
-      - attach_workspace:
-          at: ~/happa
-
-      - run:
-          environment:
-            IMAGE_NAME: *image_name_fe_docs
-          name: Generate container image tag
-          command: |
-            echo -n "${IMAGE_NAME}:$(architect project version)" > .docker_image_name_fe_docs
-
-      - run:
-          name: Build Docker image
-          command: |
-            docker build -t "$(cat .docker_image_name_fe_docs)" . --file "./Dockerfile.fe-docs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,14 +44,6 @@ workflows:
           requires:
             - checkout
           <<: *job_filters
-      - prettier:
-          requires:
-            - checkout
-          <<: *job_filters
-      - typecheck:
-          requires:
-            - checkout
-          <<: *job_filters
       - build:
           requires:
             - gather-facts
@@ -61,8 +53,6 @@ workflows:
           requires:
             - test
             - lint
-            - prettier
-            - typecheck
             - build
           <<: *job_filters
 
@@ -264,7 +254,7 @@ jobs:
           root: ~/happa
           <<: *whitelist
 
-  typecheck:
+  lint:
     <<: *defaults
 
     steps:
@@ -277,27 +267,9 @@ jobs:
           name: Typecheck code using the TypeScript compiler
           command: yarn run typecheck
 
-  lint:
-    <<: *defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: ~/happa
-
       - run:
           name: Lint code using ESlint
           command: yarn run lint --no-color
-
-  prettier:
-    <<: *defaults
-
-    steps:
-      - checkout
-
-      - attach_workspace:
-          at: ~/happa
 
       - run:
           name: Validate code style using prettier

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,12 +197,20 @@ workflows:
       - build-fe-docs:
           requires:
             - checkout
-          <<: *job_filters
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
 
       - build-fe-docs-container:
           requires:
             - build-fe-docs
-          <<: *job_filters
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
 
       - architect/push-to-docker:
           name: push-fe-docs-to-quay
@@ -213,8 +221,9 @@ workflows:
           dockerfile: "./Dockerfile.fe-docs"
           requires:
             - build-fe-docs-container
-          # Needed to trigger job also on git tag.
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*/
 
@@ -227,8 +236,9 @@ workflows:
           explicit_allow_chart_name_mismatch: true
           requires:
             - push-fe-docs-to-quay
-          # Needed to trigger job also on git tag.
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*/
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1042.

This PR makes some changes in an effort to reduce build time/credit usage in CircleCI:
- only build and push fe-docs when creating a release
- combine pushing to docker and quay with `build-container` step to prevent building image and attaching workspace multiple times (attaching the workspace takes up most of the time in these steps)
- combine building and pushing fe-docs to quay to prevent building image and attaching workspace twice