### PR TITLE
Increase header z-index to appear above other elements

### DIFF
--- a/src/components/UI/Controls/Navigation/Navigation.js
+++ b/src/components/UI/Controls/Navigation/Navigation.js
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 import RUMActionTarget from 'RUM/RUMActionTarget';
 import styled from 'styled-components';
 import { mq } from 'styles';
+import { BODY_CLASS_MODIFIER } from 'UI/Layout/Modal';
 
 import MainMenu from './MainMenu';
 import OrganizationDropdown from './OrganizationDropdown';
@@ -21,8 +22,14 @@ const OuterNav = styled.nav`
   top: 0px;
   left: 0px;
   right: 0px;
-  z-index: 1;
+  z-index: 10000; // To appear above other components fith fixed position
   background-color: ${(props) => props.theme.colors.shade1};
+  transition: z-index 0ms linear 500ms;
+
+  .${BODY_CLASS_MODIFIER} & {
+    z-index: 1;
+    transition-delay: 0ms;
+  }
 
   a {
     text-decoration: none;

--- a/src/components/UI/Layout/Modal/index.tsx
+++ b/src/components/UI/Layout/Modal/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Heading, Layer, Text } from 'grommet';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { VerticalScroll } from 'styles';
 import Button from 'UI/Controls/Button';
@@ -20,6 +20,8 @@ const Content = styled(Box)`
   ${VerticalScroll}
 `;
 
+export const BODY_CLASS_MODIFIER = 'modal-open';
+
 interface IModalProps
   extends Omit<React.ComponentPropsWithoutRef<typeof Layer>, 'title'> {
   title: React.ReactNode;
@@ -34,6 +36,19 @@ const Modal = React.forwardRef<HTMLDivElement, IModalProps>(
     { onClose, visible, title, footer, children, contentProps, ...props },
     ref
   ) => {
+    const bodyClassModified = useRef(false);
+    useEffect(() => {
+      if (visible && !document.body.classList.contains(BODY_CLASS_MODIFIER)) {
+        document.body.classList.add(BODY_CLASS_MODIFIER);
+        bodyClassModified.current = true;
+      } else {
+        if (bodyClassModified.current) {
+          document.body.classList.remove(BODY_CLASS_MODIFIER);
+          bodyClassModified.current = false;
+        }
+      }
+    }, [visible]);
+
     if (!visible) return null;
 
     return (

--- a/src/components/UI/Util/FlashMessages/FlashMessagesProvider.tsx
+++ b/src/components/UI/Util/FlashMessages/FlashMessagesProvider.tsx
@@ -1,4 +1,4 @@
-import { Layer } from 'grommet';
+import { Layer, ThemeContext } from 'grommet';
 import React, { useCallback, useLayoutEffect, useState } from 'react';
 import { TransitionGroup } from 'react-transition-group';
 import SlideTransition from 'styles/transitions/SlideTransition';
@@ -69,24 +69,50 @@ const FlashMessagesProvider: React.FC<IFlashMessagesProviderProps> = ({
   }, [onEnqueue, onRemove, onClear, controller]);
 
   return (
-    <Layer
-      position='top-right'
-      modal={false}
-      margin={{ vertical: 'large', horizontal: 'medium' }}
-      responsive={false}
-      plain={true}
-      role='log'
-      animation='none'
+    <ThemeContext.Extend
+      value={{
+        layer: {
+          zIndex: 10100, // To appear above the header, which has z-index of 10000
+        },
+      }}
     >
-      {animate && (
-        <TransitionGroup id='flash-messages'>
-          {queue.map((entry) => (
-            <SlideTransition
-              key={JSON.stringify(entry)}
-              appear={true}
-              direction='up'
-            >
+      <Layer
+        position='top-right'
+        modal={false}
+        margin={{ vertical: 'large', horizontal: 'medium' }}
+        responsive={false}
+        plain={true}
+        role='log'
+        animation='none'
+      >
+        {animate && (
+          <TransitionGroup id='flash-messages'>
+            {queue.map((entry) => (
+              <SlideTransition
+                key={JSON.stringify(entry)}
+                appear={true}
+                direction='up'
+              >
+                <FlashMessagesNotification
+                  onMouseEnter={() => controller.pause(entry)}
+                  onMouseLeave={() => controller.resume(entry)}
+                  onClose={() => controller.remove(entry)}
+                  title={entry.title}
+                  type={entry.type}
+                  margin={{ bottom: 'small' }}
+                >
+                  {entry.message}
+                </FlashMessagesNotification>
+              </SlideTransition>
+            ))}
+          </TransitionGroup>
+        )}
+
+        {!animate && (
+          <div id='flash-messages'>
+            {queue.map((entry) => (
               <FlashMessagesNotification
+                key={JSON.stringify(entry)}
                 onMouseEnter={() => controller.pause(entry)}
                 onMouseLeave={() => controller.resume(entry)}
                 onClose={() => controller.remove(entry)}
@@ -96,29 +122,11 @@ const FlashMessagesProvider: React.FC<IFlashMessagesProviderProps> = ({
               >
                 {entry.message}
               </FlashMessagesNotification>
-            </SlideTransition>
-          ))}
-        </TransitionGroup>
-      )}
-
-      {!animate && (
-        <div id='flash-messages'>
-          {queue.map((entry) => (
-            <FlashMessagesNotification
-              key={JSON.stringify(entry)}
-              onMouseEnter={() => controller.pause(entry)}
-              onMouseLeave={() => controller.resume(entry)}
-              onClose={() => controller.remove(entry)}
-              title={entry.title}
-              type={entry.type}
-              margin={{ bottom: 'small' }}
-            >
-              {entry.message}
-            </FlashMessagesNotification>
-          ))}
-        </div>
-      )}
-    </Layer>
+            ))}
+          </div>
+        )}
+      </Layer>
+    </ThemeContext.Extend>
   );
 };
 


### PR DESCRIPTION
Towards [giantswarm/roadmap/issues/821](https://github.com/giantswarm/roadmap/issues/821).

Version selector inside the app details can overlap the header. 
<img width="800" alt="Screen Shot 2022-02-16 at 17 55 42" src="https://user-images.githubusercontent.com/62935115/154316049-fbdcb797-ff75-4a25-8bc0-e81462b57a9e.png">

To fix that, `z-index` of the `Header` component was increased. Now it will be `10000` since we have some other components with `z-index: 9999`. The only component with higher `z-index` is `<FlashMessages />`.
<img width="1536" alt="Screenshot 2022-04-14 at 13 18 23" src="https://user-images.githubusercontent.com/445309/163365394-acda8b42-4b46-4a14-935f-2258be166f7e.png">

Another change in this PR is the additional body class modifier that I add when any modal on the page is opened. I do that to hide `Header` behind the modal. We can not simply have modal's `z-index` to be higher than Header's `z-index`, because in that case we would need to increase other components' `z-index` properties and that would put them above Header when modal is not open.