### PR TITLE
Allow to display longer node pool names

### DIFF
--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -22,6 +22,7 @@ import ViewAndEditName, {
 import Truncated from 'UI/Util/Truncated';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
+import { getTruncationParams } from 'utils/helpers';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
 import { IWorkerNodesAdditionalColumn } from './types';
@@ -38,8 +39,12 @@ function formatAvailabilityZonesLabel(zones: string[]) {
   return `Availability zones: ${zones.join(', ')}`;
 }
 
-const Row = styled(Box)<{ additionalColumnsCount?: number }>`
-  ${({ additionalColumnsCount }) => NodePoolGridRow(additionalColumnsCount)}
+const Row = styled(Box)<{
+  additionalColumnsCount?: number;
+  nameColumnWidth?: number;
+}>`
+  ${({ additionalColumnsCount, nameColumnWidth }) =>
+    NodePoolGridRow(additionalColumnsCount, nameColumnWidth)}
 `;
 
 const StyledViewAndEditName = styled(ViewAndEditName)`
@@ -60,6 +65,8 @@ const StyledDescriptionWrapper = styled(Box)<{ full?: boolean }>`
   ${({ full }) => (full ? 'grid-column: 2 / fit-content' : undefined)}
 `;
 
+export const MAX_NAME_LENGTH = 10;
+
 interface IWorkerNodesNodePoolItemProps
   extends React.ComponentPropsWithoutRef<typeof Box> {
   nodePool?: NodePool;
@@ -68,6 +75,7 @@ interface IWorkerNodesNodePoolItemProps
   readOnly?: boolean;
   canUpdateNodePools?: boolean;
   canDeleteNodePools?: boolean;
+  nameColumnWidth?: number;
 }
 
 const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
@@ -77,6 +85,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
   readOnly,
   canUpdateNodePools,
   canDeleteNodePools,
+  nameColumnWidth,
   ...props
 }) => {
   const clientFactory = useHttpClientFactory();
@@ -201,8 +210,9 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
         background={isDeleting ? 'background-back' : 'background-front'}
         round='xsmall'
         additionalColumnsCount={additionalColumns?.length}
+        nameColumnWidth={nameColumnWidth}
       >
-        <Box align='center'>
+        <Box align='flex-start'>
           <OptionalValue
             value={nodePool?.metadata.name}
             loaderWidth={70}
@@ -213,8 +223,7 @@ const WorkerNodesNodePoolItem: React.FC<IWorkerNodesNodePoolItemProps> = ({
                 <Truncated
                   as={Code}
                   aria-label={`Name: ${value}`}
-                  numEnd={1}
-                  numStart={3}
+                  {...getTruncationParams(MAX_NAME_LENGTH)}
                 >
                   {value as string}
                 </Truncated>

--- a/src/components/MAPI/workernodes/__tests__/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/__tests__/WorkerNodesNodePoolItem.tsx
@@ -204,17 +204,19 @@ describe('WorkerNodesNodePoolItem', () => {
           ...capiexpv1alpha3Mocks.randomCluster1MachinePool1,
           metadata: {
             ...capiexpv1alpha3Mocks.randomCluster1MachinePool1.metadata,
-            name: 't6yo90',
+            name: 'qwertyuiopq',
           },
         },
         providerNodePool: capzexpv1alpha3Mocks.randomCluster1AzureMachinePool1,
       })
     );
 
-    expect(screen.getByLabelText('Name: t6yo90')).toHaveTextContent('t6y…0');
-    const label: HTMLSpanElement = screen.getByText('t6y…0');
+    expect(screen.getByLabelText('Name: qwertyuiopq')).toHaveTextContent(
+      'qwer…uiopq'
+    );
+    const label: HTMLSpanElement = screen.getByText('qwer…uiopq');
     fireEvent.mouseOver(label);
-    expect(screen.getByText('t6yo90')).toBeInTheDocument();
+    expect(screen.getByText('qwertyuiopq')).toBeInTheDocument();
   });
 
   it('can delete a node pool', async () => {

--- a/src/components/UI/Display/MAPI/workernodes/styles.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/styles.tsx
@@ -1,10 +1,13 @@
 import { css } from 'styled-components';
 
-export const NodePoolGridRow = (extraColumnCount: number = 0) => css`
+export const NodePoolGridRow = (
+  extraColumnCount: number = 0,
+  nameColumnWidth: number = 0
+) => css`
   display: grid;
   grid-gap: 0 ${({ theme }) => theme.global.edgeSize.small};
   grid-template-columns:
-    minmax(80px, 1fr)
+    minmax(80px, ${nameColumnWidth}px)
     minmax(50px, 4fr)
     4fr
     3fr

--- a/src/components/shared/Copyable.tsx
+++ b/src/components/shared/Copyable.tsx
@@ -14,8 +14,9 @@ const TooltipWrapper = styled.div`
   opacity: 0;
 `;
 
+export const COPYABLE_PADDING = 20;
 const Wrapper = styled.div`
-  padding-right: 20px;
+  padding-right: ${COPYABLE_PADDING}px;
   position: relative;
   overflow: inherit;
   text-overflow: inherit;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -97,11 +97,13 @@ export const FlexRowWithTwoBlocksOnEdges = styled.div`
 
 /* Style Wrappers & Reusable elements */
 
+export const CODE_CHAR_WIDTH = 6.75;
+export const CODE_PADDING = 12;
 export const Code = styled.code`
   font-family: ${(props) => props.theme.fontFamilies.console};
   background-color: ${(props) => props.theme.colors.shade2};
   border-radius: 2px;
-  padding: 0 12px;
+  padding: 0 ${CODE_PADDING}px;
   height: 30px;
   line-height: 30px;
   display: inline-block;

--- a/src/utils/__tests__/helpers.ts
+++ b/src/utils/__tests__/helpers.ts
@@ -3,6 +3,7 @@ import {
   compareDates,
   dedent,
   formatDate,
+  getTruncationParams,
   hasAppropriateLength,
   humanFileSize,
   IHumanFileSizeValue,
@@ -298,6 +299,24 @@ token: can't be blank`)
       const result = truncate(initial, 'NotReallyHelpful', 10, 8);
 
       expect(result).toBe('someReallyNotReallyHelpfulTruncate');
+    });
+  });
+
+  describe('getTruncationParams', () => {
+    it('returns correct parameters for the truncate function', () => {
+      // eslint-disable-next-line no-magic-numbers
+      expect(getTruncationParams(10)).toEqual({ numStart: 4, numEnd: 5 });
+      expect(getTruncationParams(9)).toEqual({ numStart: 4, numEnd: 4 });
+      expect(getTruncationParams(8)).toEqual({ numStart: 3, numEnd: 4 });
+      expect(getTruncationParams(7)).toEqual({ numStart: 3, numEnd: 3 });
+      expect(getTruncationParams(6)).toEqual({ numStart: 2, numEnd: 3 });
+      expect(getTruncationParams(5)).toEqual({ numStart: 2, numEnd: 2 });
+      expect(getTruncationParams(4)).toEqual({ numStart: 1, numEnd: 2 });
+      expect(getTruncationParams(3)).toEqual({ numStart: 1, numEnd: 1 });
+      expect(getTruncationParams(2)).toEqual({ numStart: 0, numEnd: 1 });
+      expect(getTruncationParams(1)).toEqual({ numStart: 0, numEnd: 0 });
+      expect(getTruncationParams(0)).toEqual({ numStart: 0, numEnd: 0 });
+      expect(getTruncationParams(-1)).toEqual({ numStart: 0, numEnd: 0 });
     });
   });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -257,6 +257,29 @@ export function truncate(
 }
 
 /**
+ * Calculates numStart and numEnd parameters for the truncate function
+ * based on the desired string length.
+ *
+ * @param length - number of characters you want to keep, including a replacer symbol.
+ */
+export function getTruncationParams(length: number) {
+  if (length <= 1) {
+    return {
+      numStart: 0,
+      numEnd: 0,
+    };
+  }
+
+  const numEnd = Math.floor(length / 2);
+  const numStart = length - numEnd - 1;
+
+  return {
+    numStart,
+    numEnd,
+  };
+}
+
+/**
  * Generate a kubeconfig YAML file.
  * @param cluster
  * @param keyPair


### PR DESCRIPTION
Towards [giantswarm/roadmap/issues/871](https://github.com/giantswarm/roadmap/issues/871).

Currently we use fixed width column to display node pools names. The width is 80px - it's calculated to fit 5 character long names. Names that are longer than 5 characters are being truncated to 5 character strings.

It was decided that we want to display longer names - up to 10 characters. In this PR I changed the width of the name column in the table. The width is being calculated to fit the longest name in the table. The minimum width is kept as it was before - 80px.

<img width="1240" alt="Screenshot 2022-04-19 at 10 39 46" src="https://user-images.githubusercontent.com/445309/163957713-a6275e13-b332-444a-8829-73e573c4c873.png">

