### PR TITLE
Improve upgrade cluster CLI guide

### DIFF
--- a/src/components/MAPI/clusters/guides/UpgradeClusterGuide.tsx
+++ b/src/components/MAPI/clusters/guides/UpgradeClusterGuide.tsx
@@ -1,3 +1,4 @@
+import { Text } from 'grommet';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
 import UnauthorizedMessage from 'MAPI/guides/UnauthorizedMessage';
 import {
@@ -46,6 +47,11 @@ const UpgradeClusterGuide: React.FC<IUpgradeClusterGuideProps> = ({
               external: true,
             },
             {
+              label: 'kubectl gs update cluster command',
+              href: docs.kubectlGSUpdateClusterURL,
+              external: true,
+            },
+            {
               label: 'Cluster CRD schema',
               href: docs.crdSchemaURL(docs.crds.xk8sio.cluster),
               external: true,
@@ -75,7 +81,21 @@ const UpgradeClusterGuide: React.FC<IUpgradeClusterGuideProps> = ({
             }),
             withFormatting()
           )}
-        />
+        >
+          <Text>
+            <strong>Note:</strong> Add{' '}
+            <code>
+              --scheduled-time <var>TIME</var>
+            </code>{' '}
+            to schedule a workload cluster upgrade in the future.{' '}
+            <code>
+              <var>TIME</var>
+            </code>{' '}
+            should be in the <code>&quot;YYYY-MM-DD HH:MM&quot;</code> format.
+            Timezone UTC is assumed. If not given, the upgrade happens as soon
+            as possible.
+          </Text>
+        </CLIGuideStep>
       </CLIGuideStepList>
     </CLIGuide>
   );

--- a/src/components/UI/Display/Documentation/Styles.js
+++ b/src/components/UI/Display/Documentation/Styles.js
@@ -24,6 +24,10 @@ const Styles = styled.div`
     padding-right: 55px;
     overflow: visible;
     font-size: 15px;
+
+    var {
+      font-style: normal;
+    }
   }
   .codeblock--container .content {
     overflow-x: auto;

--- a/src/components/UI/Display/MAPI/CLIGuide/index.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/index.tsx
@@ -14,6 +14,10 @@ const StyledAccordion = styled(Accordion)`
     background-color: ${({ theme }) =>
       theme.global.colors['accent-strong'].dark};
     font-size: 1em;
+
+    var {
+      font-style: normal;
+    }
   }
 `;
 

--- a/src/model/constants/docs.ts
+++ b/src/model/constants/docs.ts
@@ -75,6 +75,9 @@ export const kubectlGSLoginURL =
 export const kubectlGSGetClustersURL =
   'https://docs.giantswarm.io/ui-api/kubectl-gs/get-clusters/';
 
+export const kubectlGSUpdateClusterURL =
+  'https://docs.giantswarm.io/ui-api/kubectl-gs/update-cluster/';
+
 export const kubectlGSGetCatalogsURL =
   'https://docs.giantswarm.io/ui-api/kubectl-gs/get-catalogs/';
 


### PR DESCRIPTION
In this PR CLI guide for upgrading a cluster was changed:
- note about `--scheduled-time` modifier was added;
- link to the [docs](https://docs.giantswarm.io/ui-api/kubectl-gs/update-cluster/) was added.

<img width="1240" alt="Screenshot 2022-04-19 at 17 25 02" src="https://user-images.githubusercontent.com/445309/164029277-66ada256-aca3-48d8-8db7-3b803a898d2a.png">

