### PR TITLE
Check installed app's `.spec.name` against app catalog entry name

### DIFF
--- a/src/components/MAPI/apps/AppList/__tests__/AppDetail.tsx
+++ b/src/components/MAPI/apps/AppList/__tests__/AppDetail.tsx
@@ -63,7 +63,7 @@ jest.mock('react-router', () => ({
     url: '',
     params: {
       catalogName: 'default',
-      app: 'coredns',
+      app: 'coredns-app',
       version: '1.2.0',
     },
   }),

--- a/src/components/MAPI/apps/AppList/__tests__/index.tsx
+++ b/src/components/MAPI/apps/AppList/__tests__/index.tsx
@@ -199,7 +199,7 @@ describe('AppList', () => {
   });
 
   it('can search for a specific app', async () => {
-    const app = 'coredns';
+    const app = 'coredns-app';
 
     nock(window.config.mapiEndpoint)
       .get('/apis/application.giantswarm.io/v1alpha1/catalogs/')
@@ -333,7 +333,7 @@ describe('AppList', () => {
       )
     ).toBeInTheDocument();
 
-    const appNameContainer = screen.getByText('coredns');
+    const appNameContainer = screen.getByText('coredns-app');
 
     expect(
       await within(appNameContainer).findByTitle('Installed in this cluster')

--- a/src/components/MAPI/apps/__tests__/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/__tests__/AppInstallModal.tsx
@@ -309,7 +309,7 @@ describe('AppInstallModal', () => {
     render(
       getComponent(
         {
-          appName: app.metadata.name,
+          appName: app.spec.name,
           chartName: app.spec.name,
           catalogName: app.spec.catalog,
           versions: [],
@@ -356,7 +356,7 @@ describe('AppInstallModal', () => {
 
     render(
       getComponent({
-        appName: app.metadata.name,
+        appName: app.spec.name,
         chartName: app.spec.name,
         catalogName: app.spec.catalog,
         versions: [],

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListItemStatus.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListItemStatus.tsx
@@ -128,14 +128,14 @@ describe('ClusterDetailAppListItemStatus', () => {
   it('displays a warning if a newer version is available', async () => {
     nock(window.config.mapiEndpoint)
       .get(
-        '/apis/application.giantswarm.io/v1alpha1/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
+        '/apis/application.giantswarm.io/v1alpha1/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns-app%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
       )
       .reply(
         StatusCodes.Ok,
         applicationv1alpha1Mocks.defaultCatalogAppCatalogEntryList
       );
 
-    const app = generateApp('coredns', '1.1.0');
+    const app = generateApp('coredns-app', '1.1.0');
     delete app.status;
 
     render(getComponent({ app, canListAppCatalogEntries: true }));

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetVersion.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetVersion.tsx
@@ -157,14 +157,14 @@ describe('ClusterDetailAppListWidgetVersion', () => {
   it('displays a warning if a newer version is available', async () => {
     nock(window.config.mapiEndpoint)
       .get(
-        '/apis/application.giantswarm.io/v1alpha1/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
+        '/apis/application.giantswarm.io/v1alpha1/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns-app%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
       )
       .reply(
         StatusCodes.Ok,
         applicationv1alpha1Mocks.defaultCatalogAppCatalogEntryList
       );
 
-    const app = generateApp('coredns', '1.1.0');
+    const app = generateApp('coredns-app', '1.1.0');
     delete app.status;
 
     render(getComponent({ app, canListAppCatalogEntries: true }));

--- a/src/components/MAPI/apps/__tests__/ClusterDetailWidgetApps.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailWidgetApps.tsx
@@ -295,14 +295,14 @@ describe('ClusterDetailWidgetApps', () => {
       .reply(StatusCodes.Ok, {
         ...applicationv1alpha1Mocks.randomCluster1AppsList,
         items: [
-          generateApp('coredns', 'deployed', '1.2.0'),
-          generateApp('coredns', 'deployed', '1.3.0'),
+          generateApp('coredns-app', 'deployed', '1.2.0'),
+          generateApp('coredns-app', 'deployed', '1.3.0'),
         ],
       });
 
     nock(window.config.mapiEndpoint)
       .get(
-        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
+        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns-app%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
       )
       .reply(
         StatusCodes.Ok,
@@ -311,7 +311,7 @@ describe('ClusterDetailWidgetApps', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
-        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
+        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/?labelSelector=app.kubernetes.io%2Fname%3Dcoredns-app%2Capplication.giantswarm.io%2Fcatalog%3Ddefault'
       )
       .reply(
         StatusCodes.Ok,
@@ -343,8 +343,8 @@ describe('ClusterDetailWidgetApps', () => {
       .reply(StatusCodes.Ok, {
         ...applicationv1alpha1Mocks.randomCluster1AppsList,
         items: [
-          generateApp('coredns', 'deployed', '1.2.0'),
-          generateApp('coredns', 'deployed', '1.3.0'),
+          generateApp('coredns-app', 'deployed', '1.2.0'),
+          generateApp('coredns-app', 'deployed', '1.3.0'),
         ],
       });
 

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -1305,7 +1305,7 @@ export async function fetchAppsForClusters(
       const clusterWithOrg = `${cluster.metadata.namespace}/${cluster.metadata.name}`;
 
       appsForClusters[clusterWithOrg] = appList.items.map((app) => {
-        return { appName: app.metadata.name, catalogName: app.spec.catalog };
+        return { appName: app.spec.name, catalogName: app.spec.catalog };
       });
     }
   }

--- a/test/mockHttpCalls/applicationv1alpha1/appcatalogentries.ts
+++ b/test/mockHttpCalls/applicationv1alpha1/appcatalogentries.ts
@@ -7,31 +7,31 @@ export const defaultCatalogAppCatalogEntry1: applicationv1alpha1.IAppCatalogEntr
     metadata: {
       annotations: {
         'application.giantswarm.io/metadata':
-          'https://catalogs.io/default-catalog/coredns-1.2.0.tgz-meta/main.yaml',
+          'https://catalogs.io/default-catalog/coredns-app-1.2.0.tgz-meta/main.yaml',
         'application.giantswarm.io/readme':
-          'https://catalogs.io/default-catalog/coredns-1.2.0.tgz-meta/README.md',
+          'https://catalogs.io/default-catalog/coredns-app-1.2.0.tgz-meta/README.md',
         'application.giantswarm.io/values-schema':
-          'https://catalogs.io/default-catalog/coredns-1.2.0.tgz-meta/values.schema.json',
+          'https://catalogs.io/default-catalog/coredns-app-1.2.0.tgz-meta/values.schema.json',
       },
       creationTimestamp: '2021-04-17T13:07:38Z',
       generation: 2,
       labels: {
-        'app.kubernetes.io/name': 'coredns',
+        'app.kubernetes.io/name': 'coredns-app',
         'app.kubernetes.io/version': '1.2.0',
         'application.giantswarm.io/catalog': 'default',
         'application.giantswarm.io/catalog-type': 'stable',
         'giantswarm.io/managed-by': 'app-operator-unique',
         latest: 'false',
       },
-      name: 'default-coredns-1.2.0',
+      name: 'default-coredns-app-1.2.0',
       namespace: 'default',
       resourceVersion: '415976118',
       selfLink:
-        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/default-coredns-1.2.0',
+        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/default-coredns-app-1.2.0',
       uid: 'a24ffaa1-216d-4807-90a5-2b66596795df',
     },
     spec: {
-      appName: 'coredns',
+      appName: 'coredns-app',
       appVersion: '1.6.5',
       catalog: {
         name: 'default',
@@ -39,7 +39,7 @@ export const defaultCatalogAppCatalogEntry1: applicationv1alpha1.IAppCatalogEntr
       },
       chart: {
         apiVersion: 'v1',
-        home: 'https://github.com/default/coredns',
+        home: 'https://github.com/default/coredns-app',
         icon: 'https://s.giantswarm.io/app-icons/1/png/coredns-light.png',
         description: 'A cool app for friends and family',
         keywords: ['cool app', 'really awesome'],
@@ -57,31 +57,31 @@ export const defaultCatalogAppCatalogEntry2: applicationv1alpha1.IAppCatalogEntr
     metadata: {
       annotations: {
         'application.giantswarm.io/metadata':
-          'https://catalogs.io/default-catalog/coredns-1.2.1.tgz-meta/main.yaml',
+          'https://catalogs.io/default-catalog/coredns-app-1.2.1.tgz-meta/main.yaml',
         'application.giantswarm.io/readme':
-          'https://catalogs.io/default-catalog/coredns-1.2.1.tgz-meta/README.md',
+          'https://catalogs.io/default-catalog/coredns-app-1.2.1.tgz-meta/README.md',
         'application.giantswarm.io/values-schema':
-          'https://catalogs.io/default-catalog/coredns-1.2.1.tgz-meta/values.schema.json',
+          'https://catalogs.io/default-catalog/coredns-app-1.2.1.tgz-meta/values.schema.json',
       },
       creationTimestamp: '2021-04-18T13:07:38Z',
       generation: 2,
       labels: {
-        'app.kubernetes.io/name': 'coredns',
+        'app.kubernetes.io/name': 'coredns-app',
         'app.kubernetes.io/version': '1.2.1',
         'application.giantswarm.io/catalog': 'default',
         'application.giantswarm.io/catalog-type': 'stable',
         'giantswarm.io/managed-by': 'app-operator-unique',
         latest: 'false',
       },
-      name: 'default-coredns-1.2.1',
+      name: 'default-coredns-app-1.2.1',
       namespace: 'default',
       resourceVersion: '415976118',
       selfLink:
-        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/default-coredns-1.2.1',
+        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/default-coredns-app-1.2.1',
       uid: 'a24ffaa1-216d-4807-90a5-2b66596795df',
     },
     spec: {
-      appName: 'coredns',
+      appName: 'coredns-app',
       appVersion: '1.6.5',
       catalog: {
         name: 'default',
@@ -89,7 +89,7 @@ export const defaultCatalogAppCatalogEntry2: applicationv1alpha1.IAppCatalogEntr
       },
       chart: {
         apiVersion: 'v1',
-        home: 'https://github.com/default/coredns',
+        home: 'https://github.com/default/coredns-app',
         icon: 'https://s.giantswarm.io/app-icons/1/png/coredns-light.png',
       },
       dateCreated: '2021-04-18T13:05:28Z',
@@ -105,31 +105,31 @@ export const defaultCatalogAppCatalogEntry3: applicationv1alpha1.IAppCatalogEntr
     metadata: {
       annotations: {
         'application.giantswarm.io/metadata':
-          'https://catalogs.io/default-catalog/coredns-1.3.0.tgz-meta/main.yaml',
+          'https://catalogs.io/default-catalog/coredns-app-1.3.0.tgz-meta/main.yaml',
         'application.giantswarm.io/readme':
-          'https://catalogs.io/default-catalog/coredns-1.3.0.tgz-meta/README.md',
+          'https://catalogs.io/default-catalog/coredns-app-1.3.0.tgz-meta/README.md',
         'application.giantswarm.io/values-schema':
-          'https://catalogs.io/default-catalog/coredns-1.3.0.tgz-meta/values.schema.json',
+          'https://catalogs.io/default-catalog/coredns-app-1.3.0.tgz-meta/values.schema.json',
       },
       creationTimestamp: '2021-04-19T13:07:38Z',
       generation: 2,
       labels: {
-        'app.kubernetes.io/name': 'coredns',
+        'app.kubernetes.io/name': 'coredns-app',
         'app.kubernetes.io/version': '1.3.0',
         'application.giantswarm.io/catalog': 'default',
         'application.giantswarm.io/catalog-type': 'stable',
         'giantswarm.io/managed-by': 'app-operator-unique',
         latest: 'false',
       },
-      name: 'default-coredns-1.3.0',
+      name: 'default-coredns-app-1.3.0',
       namespace: 'default',
       resourceVersion: '415976118',
       selfLink:
-        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/default-coredns-1.3.0',
+        '/apis/application.giantswarm.io/v1alpha1/namespaces/default/appcatalogentries/default-coredns-app-1.3.0',
       uid: 'a24ffaa1-216d-4807-90a5-2b66596795df',
     },
     spec: {
-      appName: 'coredns',
+      appName: 'coredns-app',
       appVersion: '1.7.0',
       catalog: {
         name: 'default',
@@ -137,7 +137,7 @@ export const defaultCatalogAppCatalogEntry3: applicationv1alpha1.IAppCatalogEntr
       },
       chart: {
         apiVersion: 'v1',
-        home: 'https://github.com/default/coredns',
+        home: 'https://github.com/default/coredns-app',
         icon: 'https://s.giantswarm.io/app-icons/1/png/coredns-light.png',
       },
       dateCreated: '2021-04-19T13:05:28Z',


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1052.

This PR fixes the bug described in the linked issue, where an installed app was not being appropriately displayed in the app catalogs. This was caused by matching the App CR's `.metadata.name` instead of its `.spec.name` against the AppCatalogEntry's name.

The mock AppCatalogEntry list items data we use in our tests was also updated to match the data we would expect to receive in a real call, and the affected test cases updated.