### PR TITLE
Allow retrying cluster and nodepool creation

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/__tests__/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/__tests__/index.tsx
@@ -122,7 +122,8 @@ describe('ClusterCreate', () => {
             }),
           }),
         }),
-      })
+      }),
+      false
     );
 
     expect(
@@ -198,7 +199,8 @@ describe('ClusterCreate', () => {
             }),
           }),
         ]),
-      })
+      }),
+      false
     );
 
     expect(
@@ -244,7 +246,8 @@ describe('ClusterCreate', () => {
             }),
           }),
         ]),
-      })
+      }),
+      false
     );
 
     expect(

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -15,7 +15,7 @@ import { Providers } from 'model/constants';
 import { MainRoutes, OrganizationsRoutes } from 'model/constants/routes';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import { selectOrganizations } from 'model/stores/organization/selectors';
-import React, { useEffect, useMemo, useReducer, useRef } from 'react';
+import React, { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { Breadcrumb } from 'react-breadcrumbs';
 import { useDispatch, useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router';
@@ -255,13 +255,15 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
     });
   }, [releaseList?.items]);
 
+  const [isRetrying, setIsRetrying] = useState(false);
+
   const handleCreation = async (e: React.FormEvent<HTMLElement>) => {
     e.preventDefault();
 
     dispatch({ type: 'startCreation' });
 
     try {
-      await createCluster(clientFactory, auth, state);
+      await createCluster(clientFactory, auth, state, isRetrying);
 
       dispatch({ type: 'endCreation' });
 
@@ -294,15 +296,18 @@ const CreateCluster: React.FC<ICreateClusterProps> = (props) => {
       new FlashMessage(
         (
           <>
-            Could not create cluster <code>{state.cluster.metadata.name}</code>
+            Could not create cluster <code>{state.cluster.metadata.name}</code>:{' '}
+            {errorMessage}
           </>
         ),
         messageType.ERROR,
         messageTTL.LONG,
-        errorMessage
+        'Please try again or contact support: support@giantswarm.io'
       );
 
       ErrorReporter.getInstance().notify(err as Error);
+
+      setIsRetrying(true);
     }
   };
 

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -14,12 +14,14 @@ import {
   IProviderClusterForClusterName,
 } from 'MAPI/utils';
 import { IProviderNodePoolForNodePool } from 'MAPI/workernodes/utils';
+import { GenericResponse } from 'model/clients/GenericResponse';
 import { Constants, Providers } from 'model/constants';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
 import * as capzv1beta1 from 'model/services/mapi/capzv1beta1';
 import * as corev1 from 'model/services/mapi/corev1';
 import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
+import * as metav1 from 'model/services/mapi/metav1';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
 import { mutate } from 'swr';
 import ErrorReporter from 'utils/errors/ErrorReporter';
@@ -541,6 +543,7 @@ function createDefaultG8sControlPlane(config: {
   };
 }
 
+// eslint-disable-next-line complexity
 export async function createCluster(
   httpClientFactory: HttpClientFactory,
   auth: IOAuth2Provider,
@@ -548,145 +551,263 @@ export async function createCluster(
     cluster: Cluster;
     providerCluster: ProviderCluster;
     controlPlaneNodes: ControlPlaneNode[];
-  }
+  },
+  isRetrying: boolean
 ): Promise<{
   cluster: Cluster;
   providerCluster: ProviderCluster;
   controlPlaneNodes: ControlPlaneNode[];
 }> {
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let cluster: Cluster;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let providerCluster: ProviderCluster;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let controlPlaneNodes: ControlPlaneNode[];
+
   switch (config.providerCluster!.kind) {
     case capzv1beta1.AzureCluster: {
-      const providerCluster = await capzv1beta1.createAzureCluster(
-        httpClientFactory(),
-        auth,
-        config.providerCluster as capzv1beta1.IAzureCluster
-      );
-
-      mutate(
-        fetchProviderClusterForClusterKey(config.cluster),
-        providerCluster,
-        false
-      );
-
-      const controlPlaneNodes = await Promise.all(
-        config.controlPlaneNodes.map((n) =>
-          capzv1beta1.createAzureMachine(
-            httpClientFactory(),
-            auth,
-            n as capzv1beta1.IAzureMachine
+      // Azure cluster
+      try {
+        providerCluster = await capzv1beta1.createAzureCluster(
+          httpClientFactory(),
+          auth,
+          config.providerCluster as capzv1beta1.IAzureCluster
+        );
+      } catch (err) {
+        // if we are retrying, we ignore "already exists" errors
+        // and get the resource
+        if (
+          !isRetrying ||
+          !metav1.isStatusError(
+            (err as GenericResponse).data,
+            metav1.K8sStatusErrorReasons.AlreadyExists
           )
-        )
-      );
+        ) {
+          return Promise.reject(err);
+        }
+        providerCluster = await capzv1beta1.getAzureCluster(
+          httpClientFactory(),
+          auth,
+          config.providerCluster!.metadata.namespace!,
+          config.providerCluster!.metadata.name
+        );
+      }
 
-      mutate(
-        fetchControlPlaneNodesForClusterKey(config.cluster),
-        controlPlaneNodes,
-        false
-      );
+      // Control plane nodes
+      try {
+        controlPlaneNodes = await Promise.all(
+          config.controlPlaneNodes.map((n) =>
+            capzv1beta1.createAzureMachine(
+              httpClientFactory(),
+              auth,
+              n as capzv1beta1.IAzureMachine
+            )
+          )
+        );
+      } catch (err) {
+        if (
+          !isRetrying ||
+          !metav1.isStatusError(
+            (err as GenericResponse).data,
+            metav1.K8sStatusErrorReasons.AlreadyExists
+          )
+        ) {
+          return Promise.reject(err);
+        }
+        const controlPlaneNodesResponse = await capzv1beta1.getAzureMachineList(
+          httpClientFactory(),
+          auth,
+          {
+            labelSelector: {
+              matchingLabels: {
+                [capiv1beta1.labelCluster]: config.cluster.metadata.name,
+                [capzv1beta1.labelControlPlane]: 'true',
+              },
+            },
+            namespace: config.cluster.metadata.namespace,
+          }
+        );
+        controlPlaneNodes = controlPlaneNodesResponse.items;
+      }
 
-      const cluster = await capiv1beta1.createCluster(
-        httpClientFactory(),
-        auth,
-        config.cluster
-      );
+      // Cluster
+      try {
+        cluster = await capiv1beta1.createCluster(
+          httpClientFactory(),
+          auth,
+          config.cluster
+        );
+      } catch (err) {
+        if (
+          !isRetrying ||
+          !metav1.isStatusError(
+            (err as GenericResponse).data,
+            metav1.K8sStatusErrorReasons.AlreadyExists
+          )
+        ) {
+          return Promise.reject(err);
+        }
+        cluster = await capiv1beta1.getCluster(
+          httpClientFactory(),
+          auth,
+          config.cluster.metadata.namespace!,
+          config.cluster.metadata.name
+        );
+      }
 
-      mutate(
-        capiv1beta1.getClusterKey(
-          cluster.metadata.namespace!,
-          cluster.metadata.name
-        ),
-        cluster,
-        false
-      );
-
-      // Add the created cluster to the existing list.
-      mutate(
-        capiv1beta1.getClusterListKey({
-          namespace: cluster.metadata.namespace!,
-        }),
-        (draft?: capiv1beta1.IClusterList) => {
-          draft?.items.push(cluster);
-        },
-        false
-      );
-
-      return { cluster, providerCluster, controlPlaneNodes };
+      break;
     }
 
     case infrav1alpha3.AWSCluster: {
-      const providerCluster = await infrav1alpha3.createAWSCluster(
-        httpClientFactory(),
-        auth,
-        config.providerCluster as infrav1alpha3.IAWSCluster
-      );
+      // AWS cluster
+      try {
+        providerCluster = await infrav1alpha3.createAWSCluster(
+          httpClientFactory(),
+          auth,
+          config.providerCluster as infrav1alpha3.IAWSCluster
+        );
+      } catch (err) {
+        if (
+          !isRetrying ||
+          !metav1.isStatusError(
+            (err as GenericResponse).data,
+            metav1.K8sStatusErrorReasons.AlreadyExists
+          )
+        ) {
+          return Promise.reject(err);
+        }
+        providerCluster = await infrav1alpha3.getAWSCluster(
+          httpClientFactory(),
+          auth,
+          config.providerCluster!.metadata.namespace!,
+          config.providerCluster!.metadata.name
+        );
+      }
 
-      mutate(
-        fetchProviderClusterForClusterKey(config.cluster),
-        providerCluster,
-        false
-      );
+      // Cluster
+      try {
+        cluster = await capiv1beta1.createCluster(
+          httpClientFactory(),
+          auth,
+          config.cluster
+        );
+      } catch (err) {
+        if (
+          !isRetrying ||
+          !metav1.isStatusError(
+            (err as GenericResponse).data,
+            metav1.K8sStatusErrorReasons.AlreadyExists
+          )
+        ) {
+          return Promise.reject(err);
+        }
+        cluster = await capiv1beta1.getCluster(
+          httpClientFactory(),
+          auth,
+          config.cluster.metadata.namespace!,
+          config.cluster.metadata.name
+        );
+      }
 
-      const cluster = await capiv1beta1.createCluster(
-        httpClientFactory(),
-        auth,
-        config.cluster
-      );
+      // Control plane nodes
+      try {
+        controlPlaneNodes = await Promise.all<ControlPlaneNode>(
+          config.controlPlaneNodes.map((n) => {
+            switch (n.kind) {
+              case infrav1alpha3.AWSControlPlane:
+                return infrav1alpha3.createAWSControlPlane(
+                  httpClientFactory(),
+                  auth,
+                  n as infrav1alpha3.IAWSControlPlane
+                );
+              case infrav1alpha3.G8sControlPlane:
+                return infrav1alpha3.createG8sControlPlane(
+                  httpClientFactory(),
+                  auth,
+                  n as infrav1alpha3.IG8sControlPlane
+                );
+              default:
+                return Promise.reject(
+                  new Error('Unknown control plane node type.')
+                );
+            }
+          })
+        );
+      } catch (err) {
+        if (
+          !isRetrying ||
+          !metav1.isStatusError(
+            (err as GenericResponse).data,
+            metav1.K8sStatusErrorReasons.AlreadyExists
+          )
+        ) {
+          return Promise.reject(err);
+        }
+        const options = {
+          labelSelector: {
+            matchingLabels: {
+              [capiv1beta1.labelCluster]: config.cluster.metadata.name,
+            },
+          },
+          namespace: config.cluster.metadata.namespace,
+        };
+        const awsControlPlaneNodesResponse =
+          await infrav1alpha3.getAWSControlPlaneList(
+            httpClientFactory(),
+            auth,
+            options
+          );
+        const g8sControlPlaneNodesResponse =
+          await infrav1alpha3.getG8sControlPlaneList(
+            httpClientFactory(),
+            auth,
+            options
+          );
 
-      mutate(
-        capiv1beta1.getClusterKey(
-          cluster.metadata.namespace!,
-          cluster.metadata.name
-        ),
-        cluster,
-        false
-      );
+        controlPlaneNodes = [
+          ...awsControlPlaneNodesResponse.items,
+          ...g8sControlPlaneNodesResponse.items,
+        ];
+      }
 
-      // Add the created cluster to the existing list.
-      mutate(
-        capiv1beta1.getClusterListKey({
-          namespace: cluster.metadata.namespace!,
-        }),
-        (draft?: capiv1beta1.IClusterList) => {
-          draft?.items.push(cluster);
-        },
-        false
-      );
-
-      const controlPlaneNodes = await Promise.all<ControlPlaneNode>(
-        config.controlPlaneNodes.map((n) => {
-          switch (n.kind) {
-            case infrav1alpha3.AWSControlPlane:
-              return infrav1alpha3.createAWSControlPlane(
-                httpClientFactory(),
-                auth,
-                n as infrav1alpha3.IAWSControlPlane
-              );
-            case infrav1alpha3.G8sControlPlane:
-              return infrav1alpha3.createG8sControlPlane(
-                httpClientFactory(),
-                auth,
-                n as infrav1alpha3.IG8sControlPlane
-              );
-            default:
-              return Promise.reject(
-                new Error('Unknown control plane node type.')
-              );
-          }
-        })
-      );
-
-      mutate(
-        fetchControlPlaneNodesForClusterKey(config.cluster),
-        controlPlaneNodes,
-        false
-      );
-
-      return { cluster, providerCluster, controlPlaneNodes };
+      break;
     }
 
     default:
       return Promise.reject(new Error('Unsupported provider.'));
   }
+
+  mutate(
+    fetchProviderClusterForClusterKey(config.cluster),
+    providerCluster,
+    false
+  );
+  mutate(
+    fetchControlPlaneNodesForClusterKey(config.cluster),
+    controlPlaneNodes,
+    false
+  );
+  mutate(
+    capiv1beta1.getClusterKey(
+      cluster.metadata.namespace!,
+      cluster.metadata.name
+    ),
+    cluster,
+    false
+  );
+  // Add the created cluster to the existing list.
+  mutate(
+    capiv1beta1.getClusterListKey({
+      namespace: cluster.metadata.namespace!,
+    }),
+    (draft?: capiv1beta1.IClusterList) => {
+      draft?.items.push(cluster);
+    },
+    false
+  );
+
+  return { cluster, providerCluster, controlPlaneNodes };
 }
 
 export function findLatestReleaseVersion(

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -574,6 +574,11 @@ export async function createCluster(
           auth,
           config.providerCluster as capzv1beta1.IAzureCluster
         );
+        mutate(
+          fetchProviderClusterForClusterKey(config.cluster),
+          providerCluster,
+          false
+        );
       } catch (err) {
         // if we are retrying, we ignore "already exists" errors
         // and get the resource
@@ -604,6 +609,11 @@ export async function createCluster(
               n as capzv1beta1.IAzureMachine
             )
           )
+        );
+        mutate(
+          fetchControlPlaneNodesForClusterKey(config.cluster),
+          controlPlaneNodes,
+          false
         );
       } catch (err) {
         if (
@@ -638,6 +648,24 @@ export async function createCluster(
           auth,
           config.cluster
         );
+        mutate(
+          capiv1beta1.getClusterKey(
+            cluster.metadata.namespace!,
+            cluster.metadata.name
+          ),
+          cluster,
+          false
+        );
+        // Add the created cluster to the existing list.
+        mutate(
+          capiv1beta1.getClusterListKey({
+            namespace: cluster.metadata.namespace!,
+          }),
+          (draft?: capiv1beta1.IClusterList) => {
+            draft?.items.push(cluster);
+          },
+          false
+        );
       } catch (err) {
         if (
           !isRetrying ||
@@ -667,6 +695,11 @@ export async function createCluster(
           auth,
           config.providerCluster as infrav1alpha3.IAWSCluster
         );
+        mutate(
+          fetchProviderClusterForClusterKey(config.cluster),
+          providerCluster,
+          false
+        );
       } catch (err) {
         if (
           !isRetrying ||
@@ -691,6 +724,24 @@ export async function createCluster(
           httpClientFactory(),
           auth,
           config.cluster
+        );
+        mutate(
+          capiv1beta1.getClusterKey(
+            cluster.metadata.namespace!,
+            cluster.metadata.name
+          ),
+          cluster,
+          false
+        );
+        // Add the created cluster to the existing list.
+        mutate(
+          capiv1beta1.getClusterListKey({
+            namespace: cluster.metadata.namespace!,
+          }),
+          (draft?: capiv1beta1.IClusterList) => {
+            draft?.items.push(cluster);
+          },
+          false
         );
       } catch (err) {
         if (
@@ -733,6 +784,11 @@ export async function createCluster(
                 );
             }
           })
+        );
+        mutate(
+          fetchControlPlaneNodesForClusterKey(config.cluster),
+          controlPlaneNodes,
+          false
         );
       } catch (err) {
         if (
@@ -777,35 +833,6 @@ export async function createCluster(
     default:
       return Promise.reject(new Error('Unsupported provider.'));
   }
-
-  mutate(
-    fetchProviderClusterForClusterKey(config.cluster),
-    providerCluster,
-    false
-  );
-  mutate(
-    fetchControlPlaneNodesForClusterKey(config.cluster),
-    controlPlaneNodes,
-    false
-  );
-  mutate(
-    capiv1beta1.getClusterKey(
-      cluster.metadata.namespace!,
-      cluster.metadata.name
-    ),
-    cluster,
-    false
-  );
-  // Add the created cluster to the existing list.
-  mutate(
-    capiv1beta1.getClusterListKey({
-      namespace: cluster.metadata.namespace!,
-    }),
-    (draft?: capiv1beta1.IClusterList) => {
-      draft?.items.push(cluster);
-    },
-    false
-  );
 
   return { cluster, providerCluster, controlPlaneNodes };
 }

--- a/src/components/MAPI/workernodes/__tests__/WorkerNodesCreateNodePool.tsx
+++ b/src/components/MAPI/workernodes/__tests__/WorkerNodesCreateNodePool.tsx
@@ -156,7 +156,8 @@ describe('WorkerNodesCreateNodePool', () => {
             }),
           }),
         }),
-      })
+      }),
+      false
     );
 
     expect(
@@ -224,7 +225,8 @@ describe('WorkerNodesCreateNodePool', () => {
             }),
           }),
         }),
-      })
+      }),
+      false
     );
 
     expect(
@@ -284,7 +286,8 @@ describe('WorkerNodesCreateNodePool', () => {
             failureDomains: ['2', '3'],
           }),
         }),
-      })
+      }),
+      false
     );
 
     expect(
@@ -353,7 +356,8 @@ describe('WorkerNodesCreateNodePool', () => {
             replicas: 1,
           }),
         }),
-      })
+      }),
+      false
     );
 
     expect(
@@ -422,7 +426,8 @@ describe('WorkerNodesCreateNodePool', () => {
             }),
           }),
         }),
-      })
+      }),
+      false
     );
 
     expect(


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1014.

This PR changes cluster and node pool creation to allow for resubmission with the same inputs in case of an error. We also update the error flash message prompting users to try again or contact support:
<img width="337" alt="Screen Shot 2022-04-19 at 19 53 47" src="https://user-images.githubusercontent.com/62935115/164065781-8651ab74-10b4-4add-9b4d-c558a637271a.png">

The `createCluster` and `createNodePool` functions are changed to allow toggling behaviour with the `isRetrying` boolean flag. This is to handle errors on retries that an object already exists. In this case we don't return the error as a rejected promise, and fetch the corresponding existing resource.