### PR TITLE
Update app CLI guide: use an installed app's `.spec.name` to search for app catalog entries for the app

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -295,6 +295,7 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
               appName={app.metadata.name}
               namespace={app.metadata.namespace!}
               newVersion={currentSelectedVersion ?? normalizedAppVersion!}
+              appCatalogEntryName={app.spec.name}
               catalogName={app.spec.catalog}
               catalogNamespace={catalogNamespace}
               canUpdateApps={appsPermissions?.canUpdate}

--- a/src/components/MAPI/apps/guides/UpdateAppGuide.tsx
+++ b/src/components/MAPI/apps/guides/UpdateAppGuide.tsx
@@ -14,6 +14,7 @@ interface IUpdateAppGuideProps
   appName: string;
   namespace: string;
   newVersion: string;
+  appCatalogEntryName: string;
   catalogName: string;
   catalogNamespace: string;
   canUpdateApps?: boolean;
@@ -23,6 +24,7 @@ const UpdateAppGuide: React.FC<IUpdateAppGuideProps> = ({
   appName,
   namespace,
   newVersion,
+  appCatalogEntryName,
   catalogName,
   catalogNamespace,
   canUpdateApps,
@@ -69,7 +71,7 @@ const UpdateAppGuide: React.FC<IUpdateAppGuideProps> = ({
           command={`
           kubectl --context ${context} \\
             get appcatalogentries \\
-            --selector application.giantswarm.io/catalog=${catalogName},app.kubernetes.io/name=${appName}${
+            --selector application.giantswarm.io/catalog=${catalogName},app.kubernetes.io/name=${appCatalogEntryName}${
             catalogNamespace
               ? ` \\
             --namespace ${catalogNamespace}`


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1058.

This PR fixes a bug in the CLI guide for updating app: we now use the App CR's `.spec.name` to look up `appcatalogentries` for updating the app.

An example from `gollum` where an App CR's `.spec.name` (`nginx-ingress-controller-app`) differs from its `.metadata.name` (`nginx-ingress-controller`):
<img width="930" alt="Screen Shot 2022-04-22 at 12 15 26" src="https://user-images.githubusercontent.com/62935115/164693556-b47d7475-d724-49d0-9218-7fe1cf159e54.png">

