### PR TITLE
Prolong display of flash messages for configuring app values

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetConfiguration.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetConfiguration.tsx
@@ -53,7 +53,7 @@ const ClusterDetailAppListWidgetConfiguration: React.FC<
             </>
           ),
           messageType.SUCCESS,
-          messageTTL.SHORT
+          messageTTL.LONG
         );
       } else {
         new FlashMessage(
@@ -66,7 +66,7 @@ const ClusterDetailAppListWidgetConfiguration: React.FC<
             </>
           ),
           messageType.SUCCESS,
-          messageTTL.SHORT
+          messageTTL.LONG
         );
       }
     } catch (err) {
@@ -116,7 +116,7 @@ const ClusterDetailAppListWidgetConfiguration: React.FC<
             </>
           ),
           messageType.SUCCESS,
-          messageTTL.SHORT
+          messageTTL.LONG
         );
       } else {
         new FlashMessage(
@@ -129,7 +129,7 @@ const ClusterDetailAppListWidgetConfiguration: React.FC<
             </>
           ),
           messageType.SUCCESS,
-          messageTTL.SHORT
+          messageTTL.LONG
         );
       }
     } catch (err) {


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1009.

This PR increases the TTL of flash messages we display when configuring app values (ConfigMaps and Secrets) from short (1500ms) to long (10000ms). This is to allow more time for reading the content.