### PR TITLE
Fix CGroups annotation check

### DIFF
--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -1051,7 +1051,7 @@ export function getCGroupsVersion(
     return 'v1';
   }
   const hasCGroupV1Annotation = nodePool.metadata.annotations?.hasOwnProperty(
-    nodePool.metadata.annotations[capiv1beta1.annotationCGroupV1]
+    capiv1beta1.annotationCGroupV1
   );
 
   return hasCGroupV1Annotation ? 'v1' : 'v2';


### PR DESCRIPTION
This PR fixes a bug with CGroups version checking - the annotations object should not be accessed to get the annotation label.