### PR TITLE
Handle app catalog entry versions with `v-`  prefixes

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -3,6 +3,7 @@ import { AccordionPanel, Box, Text } from 'grommet';
 import { extractErrorMessage } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import { isAppManagedByFlux } from 'model/services/mapi/applicationv1alpha1';
 import React, {
   useEffect,
   useLayoutEffect,
@@ -70,27 +71,18 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
   isActive,
   onAppUninstalled,
 }) => {
-  const currentVersion = app
-    ? applicationv1alpha1.getAppCurrentVersion(app)
-    : undefined;
+  const currentVersion = useMemo(() => {
+    if (!app) return undefined;
+    const appVersion = applicationv1alpha1.getAppCurrentVersion(app);
+
+    return isAppManagedByFlux(app)
+      ? normalizeAppVersion(appVersion)
+      : appVersion;
+  }, [app]);
 
   const [currentSelectedVersion, setCurrentSelectedVersion] = useState<
     string | undefined
   >(undefined);
-
-  const normalizedAppVersion = useMemo(() => {
-    if (!app) return undefined;
-
-    return normalizeAppVersion(app.spec.version);
-  }, [app]);
-
-  useEffect(() => {
-    if (
-      typeof normalizedAppVersion !== 'undefined' &&
-      typeof currentSelectedVersion === 'undefined'
-    )
-      setCurrentSelectedVersion(normalizedAppVersion);
-  }, [normalizedAppVersion, currentSelectedVersion]);
 
   const isDeleted = typeof app?.metadata?.deletionTimestamp !== 'undefined';
   const isDisabled = typeof app === 'undefined' || isDeleted;
@@ -259,6 +251,7 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
           <ClusterDetailAppListWidgetVersionInspector
             app={app}
             appsPermissions={appsPermissions}
+            currentVersion={currentVersion}
             currentSelectedVersion={currentSelectedVersion}
             onSelectVersion={setCurrentSelectedVersion}
             catalogNamespace={catalogNamespace}
@@ -294,7 +287,7 @@ const ClusterDetailAppListItem: React.FC<IClusterDetailAppListItemProps> = ({
             <UpdateAppGuide
               appName={app.metadata.name}
               namespace={app.metadata.namespace!}
-              newVersion={currentSelectedVersion ?? normalizedAppVersion!}
+              newVersion={currentSelectedVersion ?? currentVersion!}
               appCatalogEntryName={app.spec.name}
               catalogName={app.spec.catalog}
               catalogNamespace={catalogNamespace}

--- a/src/components/MAPI/apps/ClusterDetailAppListItemStatus.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItemStatus.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from 'grommet';
 import { extractErrorMessage } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import { isAppManagedByFlux } from 'model/services/mapi/applicationv1alpha1';
 import React, { useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 import ErrorReporter from 'utils/errors/ErrorReporter';
@@ -10,7 +11,7 @@ import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClient } from 'utils/hooks/useHttpClient';
 
 import {
-  getLatestVersionForApp,
+  hasNewerVersionForApp,
   isAppChangingVersion,
   normalizeAppVersion,
 } from './utils';
@@ -77,14 +78,7 @@ const ClusterDetailAppListItemStatus: React.FC<
   const hasNewVersion = useMemo(() => {
     if (!appCatalogEntryList || isChangingVersion) return false;
 
-    const latestVersion = getLatestVersionForApp(
-      appCatalogEntryList.items,
-      app.spec.name
-    );
-
-    return (
-      latestVersion && latestVersion !== normalizeAppVersion(app.spec.version)
-    );
+    return hasNewerVersionForApp(appCatalogEntryList.items, app);
   }, [app, appCatalogEntryList, isChangingVersion]);
 
   return (
@@ -96,7 +90,10 @@ const ClusterDetailAppListItemStatus: React.FC<
             role='presentation'
             aria-hidden='true'
           />{' '}
-          Switching to {normalizeAppVersion(app.spec.version)}
+          Switching to{' '}
+          {isAppManagedByFlux(app)
+            ? normalizeAppVersion(app.spec.version)
+            : app.spec.version}
         </Text>
       )}
 

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersion.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersion.tsx
@@ -12,11 +12,7 @@ import ErrorReporter from 'utils/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClient } from 'utils/hooks/useHttpClient';
 
-import {
-  getLatestVersionForApp,
-  isAppChangingVersion,
-  normalizeAppVersion,
-} from './utils';
+import { hasNewerVersionForApp, isAppChangingVersion } from './utils';
 
 interface IClusterDetailAppListWidgetVersionProps
   extends Omit<
@@ -90,14 +86,7 @@ const ClusterDetailAppListWidgetVersion: React.FC<
   const hasNewVersion = useMemo(() => {
     if (!appCatalogEntryList || !app || isChangingVersion) return false;
 
-    const latestVersion = getLatestVersionForApp(
-      appCatalogEntryList.items,
-      app.spec.name
-    );
-
-    return (
-      latestVersion && latestVersion !== normalizeAppVersion(app.spec.version)
-    );
+    return hasNewerVersionForApp(appCatalogEntryList.items, app);
   }, [app, appCatalogEntryList, isChangingVersion]);
 
   return (

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -11,6 +11,7 @@ import { GenericResponse } from 'model/clients/GenericResponse';
 import { IHttpClient } from 'model/clients/HttpClient';
 import { AppConstants, Constants } from 'model/constants';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import { isAppManagedByFlux } from 'model/services/mapi/applicationv1alpha1';
 import * as authorizationv1 from 'model/services/mapi/authorizationv1';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as corev1 from 'model/services/mapi/corev1';
@@ -749,7 +750,9 @@ export function isAppChangingVersion(app: applicationv1alpha1.IApp): boolean {
 
   return (
     app.status.version.length > 0 &&
-    normalizeAppVersion(app.spec.version) !== app.status.version
+    (isAppManagedByFlux(app)
+      ? normalizeAppVersion(app.spec.version) !== app.status.version
+      : app.spec.version !== app.status.version)
   );
 }
 
@@ -775,6 +778,21 @@ export function getLatestVersionForApp(
   return versions.sort((a, b) =>
     compare(normalizeAppVersion(b), normalizeAppVersion(a))
   )[0];
+}
+
+export function hasNewerVersionForApp(
+  appCatalogEntries: applicationv1alpha1.IAppCatalogEntry[],
+  app: applicationv1alpha1.IApp
+): boolean {
+  const latestVersion = getLatestVersionForApp(
+    appCatalogEntries,
+    app.spec.name
+  );
+  if (!latestVersion) return false;
+
+  return isAppManagedByFlux(app)
+    ? latestVersion !== normalizeAppVersion(app.spec.version)
+    : latestVersion !== app.spec.version;
 }
 
 export function isAppCatalogVisibleToUsers(

--- a/src/model/services/mapi/applicationv1alpha1/key.ts
+++ b/src/model/services/mapi/applicationv1alpha1/key.ts
@@ -36,3 +36,7 @@ export function getAppCurrentVersion(app: IApp): string {
 
   return app.status.version;
 }
+
+export function isAppManagedByFlux(app: IApp): boolean {
+  return app.metadata.labels?.[labelManagedBy] === 'flux';
+}


### PR DESCRIPTION
Background: https://gigantic.slack.com/archives/C02BBLEE2KW/p1651154989199529

We had previously made a change to handle discrepancies in an installed app's `.spec.version` and `.status.version` (caused by Flux) by stripping the `v-` prefix when making comparisons between versions. However, this created an issue when app catalog entries have a `v-` prefix. GS app catalogs don't have entries with a `v-` prefix, but this poses an issue for customers who create their app catalog entries with the prefix.

This PR fixes the issue by adding an extra check and only normalizes (strips the `v-` prefix) of an app's `.spec.version` if it is managed by Flux. Otherwise, the app versions are unmodified so they can be properly matched with app catalog entry versions.