### PR TITLE
Fix upgradable apps count calculation in cluster details overview

### DIFF
--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -941,16 +941,9 @@ export async function hasNewerVersion(
     }
   }
 
-  const latestVersion = getLatestVersionForApp(
-    appCatalogEntryListItems,
-    app.spec.name
-  );
-
   return {
     name: app.spec.name,
-    hasNewerVersion:
-      typeof latestVersion !== 'undefined' &&
-      latestVersion !== normalizeAppVersion(app.spec.version),
+    hasNewerVersion: hasNewerVersionForApp(appCatalogEntryListItems, app),
   };
 }
 


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/happa/pull/3400.

This PR fixes how we calculate the upgradable apps count  by changing it to use the utility function created in the linked PR. This takes into account app version normalization for Flux- and non-Flux managed resources.