### PR TITLE
Increase permissions overview column width

### DIFF
--- a/src/components/UI/Display/MAPI/permissions/PermissionsUseCases/PermissionsUseCases.tsx
+++ b/src/components/UI/Display/MAPI/permissions/PermissionsUseCases/PermissionsUseCases.tsx
@@ -12,9 +12,11 @@ import UseCasesForCategory from 'UI/Display/MAPI/permissions/PermissionsUseCases
 import UseCasesPreloader from 'UI/Display/MAPI/permissions/PermissionsUseCases/UseCasesPreloader';
 import Truncated from 'UI/Util/Truncated';
 import { groupBy } from 'underscore';
+import { getTruncationParams } from 'utils/helpers';
 
 import ScrollableContainer from './ScrollableContainer';
 
+const ORGANIZATION_MAX_LENGTH = 30;
 const ORGANIZATION_LABEL_HEIGHT = 60;
 
 const OrganizationLabel = styled(Text)`
@@ -84,7 +86,12 @@ const PermissionsUseCases: React.FC<IPermissionsUseCasesProps> = ({
                 height={`${ORGANIZATION_LABEL_HEIGHT}px`}
                 justify='start'
               >
-                <Truncated as={OrganizationLabel}>{org.id}</Truncated>
+                <Truncated
+                  as={OrganizationLabel}
+                  {...getTruncationParams(ORGANIZATION_MAX_LENGTH)}
+                >
+                  {org.id}
+                </Truncated>
               </Column>
             ))}
           </Box>

--- a/src/components/UI/Display/MAPI/permissions/PermissionsUseCases/StatusesForCategory.tsx
+++ b/src/components/UI/Display/MAPI/permissions/PermissionsUseCases/StatusesForCategory.tsx
@@ -10,9 +10,9 @@ import UseCaseStatus from './UseCaseStatus';
 
 export const Column = styled(Box)`
   align-items: center;
-  width: 120px;
-  min-width: 120px;
-  padding: 0 10px;
+  width: 140px;
+  min-width: 140px;
+  padding: 0 5px;
   text-align: center;
 `;
 


### PR DESCRIPTION
Permissions overview column width was increased to better fit longer organization names. Names that are longer than 30 characters are being truncated.

Before:
<img width="1222" alt="Screenshot 2022-05-20 at 13 21 25" src="https://user-images.githubusercontent.com/445309/169509075-f5633dc7-8287-43eb-9102-acd4f80fb767.png">

After:
<img width="1222" alt="Screenshot 2022-05-20 at 13 22 26" src="https://user-images.githubusercontent.com/445309/169509106-c4ae056e-d3c6-4df3-8113-47c03ad4a0e7.png">


