### PR TITLE
Inspect permissions for a service account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.20.0
+  architect: giantswarm/architect@4.21.0
 
 defaults: &defaults
   working_directory: ~/happa

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@types/express": "4.17.13",
     "@types/history": "4.7.11",
     "@types/isomorphic-fetch": "0.0.36",
-    "@types/jest": "27.5.1",
+    "@types/jest": "27.5.2",
     "@types/js-yaml": "4.0.5",
     "@types/lunr": "2.3.4",
     "@types/mermaid": "8.2.9",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "jest": "28.1.0",
     "jest-environment-jsdom": "28.1.0",
     "json-loader": "0.5.7",
-    "lint-staged": "12.4.3",
+    "lint-staged": "12.5.0",
     "mini-css-extract-plugin": "2.6.0",
     "nock": "13.2.4",
     "node-sass": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -216,15 +216,15 @@
     "request": "2.88.2",
     "sass-loader": "12.6.0",
     "style-loader": "3.3.1",
-    "terser-webpack-plugin": "5.3.1",
+    "terser-webpack-plugin": "5.3.3",
     "ts-node": "10.7.0",
     "type-fest": "2.13.0",
     "typescript": "4.6.4",
     "url-loader": "4.1.1",
-    "webpack": "5.72.1",
+    "webpack": "5.73.0",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.9.2",
-    "webpack-dev-server": "4.9.0",
+    "webpack-dev-server": "4.9.1",
     "webpack-merge": "5.8.0"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "styled-components": "5.3.5",
     "superagent": "7.1.3",
     "swr": "1.3.0",
-    "underscore": "1.13.3",
+    "underscore": "1.13.4",
     "uuid": "8.3.2",
     "validate.js": "0.13.1",
     "web-vitals": "2.1.4"
@@ -235,7 +235,7 @@
     "http-proxy": "1.18.1",
     "node-fetch": "2.6.7",
     "trim": "1.0.1",
-    "underscore": "1.13.3"
+    "underscore": "1.13.4"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "serialize-javascript": "6.0.0",
     "stacktrace-js": "2.0.2",
     "styled-components": "5.3.5",
-    "superagent": "7.1.3",
+    "superagent": "7.1.6",
     "swr": "1.3.0",
     "underscore": "1.13.4",
     "uuid": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "color-hash": "2.0.1",
     "connected-react-router": "6.9.2",
     "copy-to-clipboard": "3.3.1",
-    "core-js": "3.22.7",
+    "core-js": "3.22.8",
     "date-fns": "2.28.0",
     "date-fns-tz": "1.3.4",
     "deep-diff": "1.0.2",

--- a/src/components/MAPI/permissions/Permissions.tsx
+++ b/src/components/MAPI/permissions/Permissions.tsx
@@ -33,12 +33,16 @@ const Permissions: React.FC<IPermissionsProps> = () => {
   );
   const [subjectGroupName, setSubjectGroupName] = useState('');
   const [subjectUserName, setSubjectUserName] = useState('');
+  const [subjectServiceAccountName, setSubjectServiceAccountName] =
+    useState('');
 
   const handleSubjectFormSubmit = function (value: string) {
     if (subjectType === SubjectTypes.Group) {
       setSubjectGroupName(value);
     } else if (subjectType === SubjectTypes.User) {
       setSubjectUserName(value);
+    } else if (subjectType === SubjectTypes.ServiceAccount) {
+      setSubjectServiceAccountName(value);
     }
   };
 
@@ -74,6 +78,7 @@ const Permissions: React.FC<IPermissionsProps> = () => {
                 subjectType={subjectType}
                 groupName={subjectGroupName}
                 userName={subjectUserName}
+                serviceAccountName={subjectServiceAccountName}
                 onSubjectTypeChange={setSubjectType}
                 onSubmit={handleSubjectFormSubmit}
               />
@@ -86,6 +91,8 @@ const Permissions: React.FC<IPermissionsProps> = () => {
                   ? subjectGroupName
                   : subjectType === SubjectTypes.User
                   ? subjectUserName
+                  : subjectType === SubjectTypes.ServiceAccount
+                  ? subjectServiceAccountName
                   : ''
               }
             />

--- a/src/components/MAPI/permissions/Permissions.tsx
+++ b/src/components/MAPI/permissions/Permissions.tsx
@@ -7,7 +7,8 @@ import styled from 'styled-components';
 
 import PermissionsOverview from './PermissionsOverview';
 import PermissionsPreloader from './PermissionsPreloader';
-import SubjectForm, { SubjectType } from './SubjectForm';
+import SubjectForm from './SubjectForm';
+import { SubjectTypes } from './types';
 import { useUseCasesPermissions } from './useUseCasesPermissions';
 import { getPermissionsUseCases, hasAccessToInspectPermissions } from './utils';
 
@@ -27,14 +28,16 @@ const Permissions: React.FC<IPermissionsProps> = () => {
     ? hasAccessToInspectPermissions(ownPermissions)
     : false;
 
-  const [subjectType, setSubjectType] = useState(SubjectType.Myself);
+  const [subjectType, setSubjectType] = useState<SubjectTypes>(
+    SubjectTypes.Myself
+  );
   const [subjectGroupName, setSubjectGroupName] = useState('');
   const [subjectUserName, setSubjectUserName] = useState('');
 
   const handleSubjectFormSubmit = function (value: string) {
-    if (subjectType === SubjectType.Group) {
+    if (subjectType === SubjectTypes.Group) {
       setSubjectGroupName(value);
-    } else if (subjectType === SubjectType.User) {
+    } else if (subjectType === SubjectTypes.User) {
       setSubjectUserName(value);
     }
   };
@@ -79,9 +82,9 @@ const Permissions: React.FC<IPermissionsProps> = () => {
               key={subjectType}
               subjectType={subjectType}
               subjectName={
-                subjectType === SubjectType.Group
+                subjectType === SubjectTypes.Group
                   ? subjectGroupName
-                  : subjectType === SubjectType.User
+                  : subjectType === SubjectTypes.User
                   ? subjectUserName
                   : ''
               }

--- a/src/components/MAPI/permissions/PermissionsOverview/PermissionsOverview.tsx
+++ b/src/components/MAPI/permissions/PermissionsOverview/PermissionsOverview.tsx
@@ -5,7 +5,7 @@ import PermissionsUseCases from 'UI/Display/MAPI/permissions/PermissionsUseCases
 import { Tab, Tabs } from 'UI/Display/Tabs';
 
 import InspectPermissionsGuide from '../guides/InspectPermissionsGuide';
-import { SubjectType } from '../SubjectForm';
+import { SubjectTypes } from '../types';
 import { useUseCasesPermissions } from '../useUseCasesPermissions';
 import {
   getPermissionsUseCases,
@@ -14,7 +14,7 @@ import {
 } from '../utils';
 
 interface IPermissionsOverviewProps {
-  subjectType?: SubjectType;
+  subjectType?: SubjectTypes;
   subjectName?: string;
 }
 
@@ -53,7 +53,10 @@ const PermissionsOverview: React.FC<IPermissionsOverviewProps> = ({
     number[]
   >([]);
 
-  if (!useCases || (subjectType !== SubjectType.Myself && subjectName === '')) {
+  if (
+    !useCases ||
+    (subjectType !== SubjectTypes.Myself && subjectName === '')
+  ) {
     return null;
   }
 

--- a/src/components/MAPI/permissions/PermissionsOverview/PermissionsOverview.tsx
+++ b/src/components/MAPI/permissions/PermissionsOverview/PermissionsOverview.tsx
@@ -13,7 +13,7 @@ import {
   isGlobalUseCase,
 } from '../utils';
 
-interface IPermissionsOverviewProps {
+export interface IPermissionsOverviewProps {
   subjectType?: SubjectTypes;
   subjectName?: string;
 }

--- a/src/components/MAPI/permissions/PermissionsOverview/__tests__/PermissionsOverview.tsx
+++ b/src/components/MAPI/permissions/PermissionsOverview/__tests__/PermissionsOverview.tsx
@@ -444,7 +444,7 @@ describe('PermissionsOverview', () => {
     ).toBeInTheDocument();
   });
 
-  it.only('allows inspecting permissions for users', async () => {
+  it('allows inspecting permissions for users', async () => {
     nock(window.config.mapiEndpoint)
       .post(
         '/apis/authorization.k8s.io/v1/namespaces/default/localsubjectaccessreviews/',
@@ -547,7 +547,7 @@ describe('PermissionsOverview', () => {
     ).toBeInTheDocument();
   });
 
-  it.only('allows inspecting permissions for groups', async () => {
+  it('allows inspecting permissions for groups', async () => {
     nock(window.config.mapiEndpoint)
       .post(
         '/apis/authorization.k8s.io/v1/namespaces/default/localsubjectaccessreviews/',
@@ -650,7 +650,7 @@ describe('PermissionsOverview', () => {
     ).toBeInTheDocument();
   });
 
-  it.only('allows inspecting permissions for service accounts', async () => {
+  it('allows inspecting permissions for service accounts', async () => {
     nock(window.config.mapiEndpoint)
       .post(
         '/apis/authorization.k8s.io/v1/namespaces/default/localsubjectaccessreviews/',

--- a/src/components/MAPI/permissions/PermissionsOverview/__tests__/PermissionsOverview.tsx
+++ b/src/components/MAPI/permissions/PermissionsOverview/__tests__/PermissionsOverview.tsx
@@ -465,7 +465,7 @@ describe('PermissionsOverview', () => {
       )
       .reply(
         StatusCodes.Ok,
-        authorizationv1Mocks.localSubjectAccssReviewCanListOrgs
+        authorizationv1Mocks.localSubjectAccessReviewCanListOrgs
       );
     nock(window.config.mapiEndpoint)
       .get('/apis/rbac.authorization.k8s.io/v1/clusterroles/')
@@ -568,7 +568,7 @@ describe('PermissionsOverview', () => {
       )
       .reply(
         StatusCodes.Ok,
-        authorizationv1Mocks.localSubjectAccssReviewCanListOrgs
+        authorizationv1Mocks.localSubjectAccessReviewCanListOrgs
       );
     nock(window.config.mapiEndpoint)
       .get('/apis/rbac.authorization.k8s.io/v1/clusterroles/')
@@ -671,7 +671,7 @@ describe('PermissionsOverview', () => {
       )
       .reply(
         StatusCodes.Ok,
-        authorizationv1Mocks.localSubjectAccssReviewCanListOrgs
+        authorizationv1Mocks.localSubjectAccessReviewCanListOrgs
       );
     nock(window.config.mapiEndpoint)
       .get('/apis/rbac.authorization.k8s.io/v1/clusterroles/')

--- a/src/components/MAPI/permissions/SubjectForm/SubjectForm.tsx
+++ b/src/components/MAPI/permissions/SubjectForm/SubjectForm.tsx
@@ -1,5 +1,6 @@
 import { Box, Form, Text } from 'grommet';
 import { CSSBreakpoints } from 'model/constants';
+import { Constants } from 'model/constants';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { mq } from 'styles';
@@ -77,18 +78,19 @@ const StyledTextInput = styled(TextInput)<StyledTextInputProps>`
 `;
 
 const GROUP_NAME_PREFIX = 'customer:';
-function formatGroupName(value: string) {
-  if (value.startsWith(GROUP_NAME_PREFIX)) {
+function formatSubjectName(value: string, prefix: string) {
+  if (value.startsWith(prefix)) {
     return value;
   }
 
-  return GROUP_NAME_PREFIX;
+  return prefix;
 }
 
 interface ISubjectFormProps {
   subjectType: SubjectTypes;
   groupName: string;
   userName: string;
+  serviceAccountName: string;
   onSubjectTypeChange: (value: SubjectTypes) => void;
   onSubmit: (value: string) => void;
 }
@@ -97,16 +99,21 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
   subjectType,
   groupName,
   userName,
+  serviceAccountName,
   onSubjectTypeChange,
   onSubmit,
 }) => {
   const [userNameValue, setUserNameValue] = useState(userName);
   const [groupNameValue, setGroupNameValue] = useState(
-    formatGroupName(groupName)
+    formatSubjectName(groupName, GROUP_NAME_PREFIX)
+  );
+  const [serviceAccountNameValue, setServiceAccountNameValue] = useState(
+    formatSubjectName(serviceAccountName, Constants.SERVICE_ACCOUNT_PREFIX)
   );
 
   const groupNameInputRef = useRef<HTMLInputElement>(null);
   const userNameInputRef = useRef<HTMLInputElement>(null);
+  const serviceAccountNameInputRef = useRef<HTMLInputElement>(null);
   useLayoutEffect(() => {
     if (subjectType === SubjectTypes.Group) {
       setTimeout(() => {
@@ -114,12 +121,17 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
       });
     } else if (subjectType === SubjectTypes.User) {
       userNameInputRef.current?.focus();
+    } else if (subjectType === SubjectTypes.ServiceAccount) {
+      serviceAccountNameInputRef.current?.focus();
     }
   }, [subjectType]);
 
   const handleSubjectTypeChange = (type: SubjectTypes) => () => {
-    setGroupNameValue(formatGroupName(groupName));
+    setGroupNameValue(formatSubjectName(groupName, GROUP_NAME_PREFIX));
     setUserNameValue(userName);
+    setServiceAccountNameValue(
+      formatSubjectName(serviceAccountName, Constants.SERVICE_ACCOUNT_PREFIX)
+    );
     onSubjectTypeChange(type);
   };
 
@@ -131,12 +143,24 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
     onSubmit(userNameValue);
   };
 
+  const handleServiceAccountFormSubmit = () => {
+    onSubmit(serviceAccountNameValue);
+  };
+
   const handleGroupNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setGroupNameValue(formatGroupName(e.target.value));
+    setGroupNameValue(formatSubjectName(e.target.value, GROUP_NAME_PREFIX));
   };
 
   const handleUserNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUserNameValue(e.target.value);
+  };
+
+  const handleServiceAccountNameChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setServiceAccountNameValue(
+      formatSubjectName(e.target.value, Constants.SERVICE_ACCOUNT_PREFIX)
+    );
   };
 
   return (
@@ -171,6 +195,14 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
             checked={subjectType === SubjectTypes.User}
             name='permissions-type-user'
             onChange={handleSubjectTypeChange(SubjectTypes.User)}
+            formFieldProps={{ margin: { bottom: 'none' } }}
+          />
+          <RadioInput
+            id='permissions-type-service-account'
+            label='Service account'
+            checked={subjectType === SubjectTypes.ServiceAccount}
+            name='permissions-type-service-account'
+            onChange={handleSubjectTypeChange(SubjectTypes.ServiceAccount)}
             formFieldProps={{ margin: { bottom: 'none' } }}
           />
         </Box>
@@ -233,6 +265,42 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
               provider. It usually takes the form of an email address. Here it
               must match the exact spelling used in RoleBinding and
               ClusterRoleBinding resources, including upper/lower case.
+            </Text>
+          </Form>
+        </FormWrapper>
+      )}
+
+      {subjectType === SubjectTypes.ServiceAccount && (
+        <FormWrapper>
+          <Form onSubmit={handleServiceAccountFormSubmit}>
+            <FormGroup margin={{ bottom: 'medium' }}>
+              <Label htmlFor='serviceAccountName'>Service account name</Label>
+              <InputWrapper>
+                <StyledTextInput
+                  ref={serviceAccountNameInputRef}
+                  id='serviceAccountName'
+                  margin='none'
+                  dark={
+                    serviceAccountNameValue === Constants.SERVICE_ACCOUNT_PREFIX
+                  }
+                  value={serviceAccountNameValue}
+                  onChange={handleServiceAccountNameChange}
+                  spellCheck={false}
+                />
+              </InputWrapper>
+              <Button
+                type='submit'
+                disabled={
+                  serviceAccountNameValue === Constants.SERVICE_ACCOUNT_PREFIX
+                }
+              >
+                Show permissions
+              </Button>
+            </FormGroup>
+            <Text size='small'>
+              Please enter the service account name including the namespace,
+              using a colon as a separator, in the form of{' '}
+              <code>system:serviceaccount:NAMESPACE:NAME</code>
             </Text>
           </Form>
         </FormWrapper>

--- a/src/components/MAPI/permissions/SubjectForm/SubjectForm.tsx
+++ b/src/components/MAPI/permissions/SubjectForm/SubjectForm.tsx
@@ -7,6 +7,8 @@ import Button from 'UI/Controls/Button';
 import RadioInput from 'UI/Inputs/RadioInput';
 import TextInput from 'UI/Inputs/TextInput';
 
+import { SubjectTypes } from '../types';
+
 const RadioGroup = styled(Box)`
   display: flex;
   flex-direction: row;
@@ -74,12 +76,6 @@ const StyledTextInput = styled(TextInput)<StyledTextInputProps>`
   }
 `;
 
-export enum SubjectType {
-  Myself = 'MYSELF',
-  Group = 'GROUP',
-  User = 'USER',
-}
-
 const GROUP_NAME_PREFIX = 'customer:';
 function formatGroupName(value: string) {
   if (value.startsWith(GROUP_NAME_PREFIX)) {
@@ -90,10 +86,10 @@ function formatGroupName(value: string) {
 }
 
 interface ISubjectFormProps {
-  subjectType: SubjectType;
+  subjectType: SubjectTypes;
   groupName: string;
   userName: string;
-  onSubjectTypeChange: (value: SubjectType) => void;
+  onSubjectTypeChange: (value: SubjectTypes) => void;
   onSubmit: (value: string) => void;
 }
 
@@ -112,16 +108,16 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
   const groupNameInputRef = useRef<HTMLInputElement>(null);
   const userNameInputRef = useRef<HTMLInputElement>(null);
   useLayoutEffect(() => {
-    if (subjectType === SubjectType.Group) {
+    if (subjectType === SubjectTypes.Group) {
       setTimeout(() => {
         groupNameInputRef.current?.focus();
       });
-    } else if (subjectType === SubjectType.User) {
+    } else if (subjectType === SubjectTypes.User) {
       userNameInputRef.current?.focus();
     }
   }, [subjectType]);
 
-  const handleSubjectTypeChange = (type: SubjectType) => () => {
+  const handleSubjectTypeChange = (type: SubjectTypes) => () => {
     setGroupNameValue(formatGroupName(groupName));
     setUserNameValue(userName);
     onSubjectTypeChange(type);
@@ -156,31 +152,31 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
           <RadioInput
             id='permissions-type-myself'
             label='Myself'
-            checked={subjectType === SubjectType.Myself}
+            checked={subjectType === SubjectTypes.Myself}
             name='permissions-type-myself'
-            onChange={handleSubjectTypeChange(SubjectType.Myself)}
+            onChange={handleSubjectTypeChange(SubjectTypes.Myself)}
             formFieldProps={{ margin: { bottom: 'none' } }}
           />
           <RadioInput
             id='permissions-type-group'
             label='Group'
-            checked={subjectType === SubjectType.Group}
+            checked={subjectType === SubjectTypes.Group}
             name='permissions-type-group'
-            onChange={handleSubjectTypeChange(SubjectType.Group)}
+            onChange={handleSubjectTypeChange(SubjectTypes.Group)}
             formFieldProps={{ margin: { bottom: 'none' } }}
           />
           <RadioInput
             id='permissions-type-user'
             label='User'
-            checked={subjectType === SubjectType.User}
+            checked={subjectType === SubjectTypes.User}
             name='permissions-type-user'
-            onChange={handleSubjectTypeChange(SubjectType.User)}
+            onChange={handleSubjectTypeChange(SubjectTypes.User)}
             formFieldProps={{ margin: { bottom: 'none' } }}
           />
         </Box>
       </RadioGroup>
 
-      {subjectType === SubjectType.Group && (
+      {subjectType === SubjectTypes.Group && (
         <FormWrapper>
           <Form onSubmit={handleGroupFormSubmit}>
             <FormGroup margin={{ bottom: 'medium' }}>
@@ -213,7 +209,7 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
         </FormWrapper>
       )}
 
-      {subjectType === SubjectType.User && (
+      {subjectType === SubjectTypes.User && (
         <FormWrapper>
           <Form onSubmit={handleUserFormSubmit}>
             <FormGroup margin={{ bottom: 'medium' }}>
@@ -246,7 +242,7 @@ const SubjectForm: React.FC<ISubjectFormProps> = ({
 };
 
 SubjectForm.defaultProps = {
-  subjectType: SubjectType.Myself,
+  subjectType: SubjectTypes.Myself,
   groupName: '',
   userName: '',
 };

--- a/src/components/MAPI/permissions/SubjectForm/index.ts
+++ b/src/components/MAPI/permissions/SubjectForm/index.ts
@@ -1,4 +1,3 @@
-import SubjectForm, { SubjectType } from './SubjectForm';
+import SubjectForm from './SubjectForm';
 
-export { SubjectType };
 export default SubjectForm;

--- a/src/components/MAPI/permissions/__tests__/Permissions.tsx
+++ b/src/components/MAPI/permissions/__tests__/Permissions.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { useUseCasesPermissions } from 'MAPI/permissions/useUseCasesPermissions';
+import { mapOAuth2UserToUser } from 'model/stores/main/utils';
+import { IOrganizationState } from 'model/stores/organization/types';
+import { IState } from 'model/stores/state';
+import React from 'react';
+import { SWRConfig } from 'swr';
+import preloginState from 'test/preloginState';
+import { getComponentWithStore } from 'test/renderUtils';
+import TestOAuth2 from 'utils/OAuth2/TestOAuth2';
+
+import Permissions from '../Permissions';
+
+function getComponent() {
+  const history = createMemoryHistory();
+  const auth = new TestOAuth2(history, true);
+
+  const Component = () => (
+    <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>
+      <Permissions />
+    </SWRConfig>
+  );
+
+  return getComponentWithStore(
+    Component,
+    undefined,
+    {
+      ...preloginState,
+      main: {
+        ...preloginState.main,
+        loggedInUser: mapOAuth2UserToUser(auth.loggedInUser!),
+      },
+      entities: {
+        organizations: {
+          ...preloginState.entities.organizations,
+          items: {
+            org1: {
+              id: 'giantswarm',
+              name: 'giantswarm',
+              namespace: 'org-giantswarm',
+            },
+          },
+        } as IOrganizationState,
+      } as IState['entities'],
+    },
+    undefined,
+    history,
+    auth
+  );
+}
+
+function createDefaultPermissions() {
+  return {
+    '': {
+      'rbac.authorization.k8s.io:clusterroles:*': ['list'],
+      'rbac.authorization.k8s.io:clusterrolebindings:*': ['list'],
+      'rbac.authorization.k8s.io:roles:*': ['list'],
+      'rbac.authorization.k8s.io:rolebindings:*': ['list'],
+    },
+    default: {
+      '*:*:*': ['*'],
+    },
+    'org-giantswarm': {
+      '*:*:*': ['*'],
+    },
+  };
+}
+
+jest.unmock(
+  'model/services/mapi/authorizationv1/createLocalSubjectAccessReview'
+);
+jest.mock('MAPI/permissions/useUseCasesPermissions');
+
+describe('Permissions', () => {
+  it('renders without crashing', () => {
+    (useUseCasesPermissions as jest.Mock).mockReturnValue({});
+    render(getComponent());
+  });
+
+  it('displays permissions for the logged in user on initial load', () => {
+    (useUseCasesPermissions as jest.Mock).mockReturnValue({
+      data: createDefaultPermissions(),
+    });
+    render(getComponent());
+
+    expect(screen.getByLabelText('Myself')).toBeChecked();
+  });
+
+  it('does not display permissions inspection form if the user does not have permissions to do so', () => {
+    (useUseCasesPermissions as jest.Mock).mockReturnValue({});
+    render(getComponent());
+
+    expect(screen.queryByLabelText('Myself')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/permissions/guides/InspectPermissionsGuide.tsx
+++ b/src/components/MAPI/permissions/guides/InspectPermissionsGuide.tsx
@@ -8,36 +8,36 @@ import CLIGuideAdditionalInfo from 'UI/Display/MAPI/CLIGuide/CLIGuideAdditionalI
 import CLIGuideStep from 'UI/Display/MAPI/CLIGuide/CLIGuideStep';
 import CLIGuideStepList from 'UI/Display/MAPI/CLIGuide/CLIGuideStepList';
 
-import { SubjectType } from '../SubjectForm';
+import { SubjectTypes } from '../types';
 
 interface IInspectPermissionsGuideProps
   extends Omit<React.ComponentPropsWithoutRef<typeof CLIGuide>, 'title'> {
   forOrganizations: boolean;
   subjectName?: string;
-  subjectType?: SubjectType;
+  subjectType?: SubjectTypes;
 }
 
 const InspectPermissionsGuide: React.FC<IInspectPermissionsGuideProps> = ({
   forOrganizations,
   subjectName,
-  subjectType = SubjectType.Myself,
+  subjectType = SubjectTypes.Myself,
   ...props
 }) => {
   const context = getCurrentInstallationContextName();
 
   const currentSubjectType =
-    subjectType === SubjectType.User
+    subjectType === SubjectTypes.User
       ? 'for a user'
-      : subjectType === SubjectType.Group
+      : subjectType === SubjectTypes.Group
       ? 'for a group'
       : '';
 
   const currentSubjectPossessive =
-    subjectType === SubjectType.User ? (
+    subjectType === SubjectTypes.User ? (
       <>
         user <code>{subjectName}</code> has
       </>
-    ) : subjectType === SubjectType.Group ? (
+    ) : subjectType === SubjectTypes.Group ? (
       <>
         a member of group <code>{subjectName}</code> has
       </>
@@ -46,9 +46,9 @@ const InspectPermissionsGuide: React.FC<IInspectPermissionsGuideProps> = ({
     );
 
   const impersonationFlags =
-    subjectType === SubjectType.User
+    subjectType === SubjectTypes.User
       ? ` \\\n  --as ${subjectName}`
-      : subjectType === SubjectType.Group
+      : subjectType === SubjectTypes.Group
       ? ` \\\n  --as example@acme.org --as-group ${subjectName}`
       : '';
 

--- a/src/components/MAPI/permissions/guides/InspectPermissionsGuide.tsx
+++ b/src/components/MAPI/permissions/guides/InspectPermissionsGuide.tsx
@@ -30,6 +30,8 @@ const InspectPermissionsGuide: React.FC<IInspectPermissionsGuideProps> = ({
       ? 'for a user'
       : subjectType === SubjectTypes.Group
       ? 'for a group'
+      : subjectType === SubjectTypes.ServiceAccount
+      ? 'for a service account'
       : '';
 
   const currentSubjectPossessive =
@@ -41,12 +43,17 @@ const InspectPermissionsGuide: React.FC<IInspectPermissionsGuideProps> = ({
       <>
         a member of group <code>{subjectName}</code> has
       </>
+    ) : subjectType === SubjectTypes.ServiceAccount ? (
+      <>
+        service account <code>{subjectName}</code> has
+      </>
     ) : (
       `you have`
     );
 
   const impersonationFlags =
-    subjectType === SubjectTypes.User
+    subjectType === SubjectTypes.User ||
+    subjectType === SubjectTypes.ServiceAccount
       ? ` \\\n  --as ${subjectName}`
       : subjectType === SubjectTypes.Group
       ? ` \\\n  --as example@acme.org --as-group ${subjectName}`

--- a/src/components/MAPI/permissions/types.ts
+++ b/src/components/MAPI/permissions/types.ts
@@ -71,3 +71,13 @@ export interface IResourceRuleMap
 export type Bindings =
   | Omit<rbacv1.IRoleBinding, 'apiVersion' | 'kind'>[]
   | Omit<rbacv1.IClusterRoleBinding, 'apiVersion' | 'kind'>[];
+
+enum PermissionsSubjectTypes {
+  Myself = 'Myself',
+}
+
+export type SubjectTypes = rbacv1.SubjectKinds | PermissionsSubjectTypes;
+export const SubjectTypes = {
+  ...rbacv1.SubjectKinds,
+  ...PermissionsSubjectTypes,
+};

--- a/src/components/MAPI/permissions/types.ts
+++ b/src/components/MAPI/permissions/types.ts
@@ -81,3 +81,9 @@ export const SubjectTypes = {
   ...rbacv1.SubjectKinds,
   ...PermissionsSubjectTypes,
 };
+
+export interface IPermissionsSubject {
+  user?: string;
+  groups?: string[];
+  serviceAccount?: string;
+}

--- a/src/components/MAPI/permissions/useSubjectPermissions.ts
+++ b/src/components/MAPI/permissions/useSubjectPermissions.ts
@@ -9,18 +9,13 @@ import useSWR from 'swr';
 import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
-import { IPermissionMap } from './types';
+import { IPermissionMap, IPermissionsSubject } from './types';
 import {
   fetchPermissionsForSubject,
   fetchPermissionsForSubjectKey,
 } from './utils';
 
-export interface ISubject {
-  user?: string;
-  groups?: string[];
-}
-
-export function useSubjectPermissions(subject?: ISubject) {
+export function useSubjectPermissions(subject?: IPermissionsSubject) {
   const httpClientFactory = useHttpClientFactory();
   const auth = useAuthProvider();
 
@@ -28,21 +23,13 @@ export function useSubjectPermissions(subject?: ISubject) {
     Object.values(selectOrganizations()(state))
   );
 
-  const key = subject
-    ? fetchPermissionsForSubjectKey(subject.user, subject.groups)
-    : null;
+  const key = subject ? fetchPermissionsForSubjectKey(subject) : null;
 
   const { data, error, isValidating } = useSWR<
     IPermissionMap,
     GenericResponseError
   >(key, () =>
-    fetchPermissionsForSubject(
-      httpClientFactory,
-      auth,
-      organizations,
-      subject?.user,
-      subject?.groups
-    )
+    fetchPermissionsForSubject(httpClientFactory, auth, organizations, subject!)
   );
 
   const isLoading =

--- a/src/components/MAPI/permissions/useUseCasesPermissions.ts
+++ b/src/components/MAPI/permissions/useUseCasesPermissions.ts
@@ -10,7 +10,7 @@ import ErrorReporter from 'utils/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
-import { SubjectType } from './SubjectForm';
+import { SubjectTypes } from './types';
 import { IPermissionMap, IPermissionsUseCase } from './types';
 import { usePermissions } from './usePermissions';
 import { useSubjectPermissions } from './useSubjectPermissions';
@@ -38,7 +38,7 @@ function getCombinedPermissions(
 export function useUseCasesPermissions(
   useCases: IPermissionsUseCase[] | null,
   subjectName: string = '',
-  subjectType: SubjectType = SubjectType.Myself
+  subjectType: SubjectTypes = SubjectTypes.Myself
 ): {
   data: IPermissionMap | undefined;
   error: GenericResponseError | undefined;
@@ -48,9 +48,9 @@ export function useUseCasesPermissions(
     if (subjectName === '') return undefined;
 
     switch (subjectType) {
-      case SubjectType.User:
+      case SubjectTypes.User:
         return { user: subjectName };
-      case SubjectType.Group:
+      case SubjectTypes.Group:
         return { groups: [subjectName] };
       default:
         return undefined;
@@ -68,7 +68,7 @@ export function useUseCasesPermissions(
     isLoading: subjectPermissionsIsLoading,
   } = useSubjectPermissions(currentSubject);
   const namespacePermissions =
-    subjectType === SubjectType.Myself ? ownPermissions : subjectPermissions;
+    subjectType === SubjectTypes.Myself ? ownPermissions : subjectPermissions;
 
   const loggedInUser = useSelector(getLoggedInUser);
   const impersonation = useSelector(
@@ -76,7 +76,7 @@ export function useUseCasesPermissions(
   );
 
   const currentUser = useMemo(() => {
-    if (subjectType === SubjectType.Myself) {
+    if (subjectType === SubjectTypes.Myself) {
       return (
         impersonation || {
           user: loggedInUser?.email,

--- a/src/components/MAPI/permissions/useUseCasesPermissions.ts
+++ b/src/components/MAPI/permissions/useUseCasesPermissions.ts
@@ -10,7 +10,7 @@ import ErrorReporter from 'utils/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
-import { SubjectTypes } from './types';
+import { IPermissionsSubject, SubjectTypes } from './types';
 import { IPermissionMap, IPermissionsUseCase } from './types';
 import { usePermissions } from './usePermissions';
 import { useSubjectPermissions } from './useSubjectPermissions';
@@ -44,49 +44,43 @@ export function useUseCasesPermissions(
   error: GenericResponseError | undefined;
   isLoading: boolean;
 } {
-  const currentSubject = useMemo(() => {
-    if (subjectName === '') return undefined;
-
-    switch (subjectType) {
-      case SubjectTypes.User:
-        return { user: subjectName };
-      case SubjectTypes.Group:
-        return { groups: [subjectName] };
-      default:
-        return undefined;
-    }
-  }, [subjectName, subjectType]);
-
-  const {
-    data: ownPermissions,
-    error: ownPermissionsError,
-    isLoading: ownPermissionsIsLoading,
-  } = usePermissions();
-  const {
-    data: subjectPermissions,
-    error: subjectPermissionsError,
-    isLoading: subjectPermissionsIsLoading,
-  } = useSubjectPermissions(currentSubject);
-  const namespacePermissions =
-    subjectType === SubjectTypes.Myself ? ownPermissions : subjectPermissions;
-
   const loggedInUser = useSelector(getLoggedInUser);
   const impersonation = useSelector(
     (state: IState) => state.main.impersonation
   );
 
-  const currentUser = useMemo(() => {
-    if (subjectType === SubjectTypes.Myself) {
-      return (
-        impersonation || {
-          user: loggedInUser?.email,
-          groups: loggedInUser?.groups,
-        }
-      );
-    }
+  const currentSubject: IPermissionsSubject | undefined = useMemo(() => {
+    if (subjectName === '' && subjectType !== SubjectTypes.Myself)
+      return undefined;
 
-    return currentSubject;
-  }, [currentSubject, impersonation, loggedInUser, subjectType]);
+    switch (subjectType) {
+      case SubjectTypes.Myself:
+        return (
+          impersonation || {
+            user: loggedInUser?.email,
+            groups: loggedInUser?.groups,
+          }
+        );
+      case SubjectTypes.User:
+        return { user: subjectName };
+      case SubjectTypes.Group:
+        return { groups: [subjectName] };
+      case SubjectTypes.ServiceAccount:
+        return { serviceAccount: subjectName };
+      default:
+        return undefined;
+    }
+  }, [impersonation, loggedInUser, subjectName, subjectType]);
+
+  const useNamespacePermissions =
+    subjectType === SubjectTypes.Myself
+      ? usePermissions
+      : useSubjectPermissions;
+  const {
+    data: namespacePermissions,
+    error: namespacePermissionsError,
+    isLoading: namespacePermissionsIsLoading,
+  } = useNamespacePermissions(currentSubject);
 
   const clientFactory = useHttpClientFactory();
   const auth = useAuthProvider();
@@ -95,11 +89,8 @@ export function useUseCasesPermissions(
     isClusterScopeUseCase(useCase)
   );
   const permissionsAtClusterScopeKey =
-    namespacePermissions && clusterScopeUseCases
-      ? fetchPermissionsAtClusterScopeKey(
-          currentUser?.user,
-          currentUser?.groups
-        )
+    namespacePermissions && clusterScopeUseCases && currentSubject
+      ? fetchPermissionsAtClusterScopeKey(currentSubject)
       : null;
   const {
     data: permissionsAtClusterScope,
@@ -113,8 +104,7 @@ export function useUseCasesPermissions(
         auth,
         clusterScopeUseCases!,
         namespacePermissions!,
-        currentUser?.user,
-        currentUser?.groups
+        currentSubject!
       )
   );
 
@@ -136,14 +126,9 @@ export function useUseCasesPermissions(
     typeof permissionsAtClusterScopeError === 'undefined' &&
     permissionsAtClusterScopeIsValidating;
 
-  const error =
-    ownPermissionsError ||
-    subjectPermissionsError ||
-    permissionsAtClusterScopeError;
+  const error = namespacePermissionsError || permissionsAtClusterScopeError;
   const isLoading =
-    ownPermissionsIsLoading ||
-    subjectPermissionsIsLoading ||
-    permissionsAtClusterScopeIsLoading;
+    namespacePermissionsIsLoading || permissionsAtClusterScopeIsLoading;
 
   const combinedPermissions = useMemo(() => {
     if (!permissionsAtClusterScope || !namespacePermissions) return undefined;

--- a/src/components/MAPI/permissions/utils.ts
+++ b/src/components/MAPI/permissions/utils.ts
@@ -927,6 +927,8 @@ export function createRulesReviewResponseFromBindings(
 
   // Get all bindings bound to the subject.
   for (const binding of bindings) {
+    if (!binding.subjects) continue;
+
     if (
       binding.subjects?.find(
         (boundSubject) =>
@@ -936,7 +938,15 @@ export function createRulesReviewResponseFromBindings(
             subject.groups?.includes(boundSubject.name)) ||
           (isSubjectKindServiceAccount(boundSubject) &&
             boundSubject.namespace === serviceAccountNamespace &&
-            boundSubject.name === serviceAccountName)
+            boundSubject.name === serviceAccountName) ||
+          (subject.serviceAccount &&
+            isSubjectKindGroup(boundSubject) &&
+            subject.groups?.includes(Constants.SERVICE_ACCOUNTS_PREFIX)) ||
+          (subject.serviceAccount &&
+            isSubjectKindGroup(boundSubject) &&
+            subject.groups?.includes(
+              `${Constants.SERVICE_ACCOUNTS_PREFIX}${serviceAccountNamespace}`
+            ))
       )
     ) {
       // Determine role rules map to use based on the Kind of

--- a/src/components/MAPI/permissions/utils.ts
+++ b/src/components/MAPI/permissions/utils.ts
@@ -1,9 +1,11 @@
 import { getNamespaceFromOrgName } from 'MAPI/utils';
+import { Constants } from 'model/constants';
 import { Providers } from 'model/constants';
 import * as authorizationv1 from 'model/services/mapi/authorizationv1';
 import * as rbacv1 from 'model/services/mapi/rbacv1';
 import {
   isSubjectKindGroup,
+  isSubjectKindServiceAccount,
   isSubjectKindUser,
 } from 'model/services/mapi/rbacv1';
 import { LoggedInUserTypes } from 'model/stores/main/types';
@@ -19,6 +21,7 @@ import {
   INamespaceResourceRules,
   IPermissionMap,
   IPermissionsForUseCase,
+  IPermissionsSubject,
   IPermissionsUseCase,
   IResourceRuleMap,
   IRolesForNamespaces,
@@ -290,8 +293,7 @@ export async function fetchPermissionsForSubject(
   httpClientFactory: HttpClientFactory,
   auth: IOAuth2Provider,
   organizations: IOrganization[],
-  user?: string,
-  groups?: string[]
+  subject: IPermissionsSubject
 ): Promise<IPermissionMap> {
   // These are not organization namespaces, but we have resources in them.
   const namespaces = ['default', 'giantswarm'];
@@ -307,8 +309,8 @@ export async function fetchPermissionsForSubject(
       group: 'security.giantswarm.io',
       resource: 'organizations',
     },
-    user,
-    groups,
+    user: subject.user ?? subject.serviceAccount,
+    groups: subject.groups,
   };
   const accessReviewResponse =
     await authorizationv1.createLocalSubjectAccessReview(
@@ -331,8 +333,8 @@ export async function fetchPermissionsForSubject(
           group: 'security.giantswarm.io',
           resource: 'organizations',
         },
-        user,
-        groups,
+        user: subject.user ?? subject.serviceAccount,
+        groups: subject.groups,
       };
 
       return authorizationv1.createLocalSubjectAccessReview(
@@ -395,8 +397,7 @@ export async function fetchPermissionsForSubject(
         rolesRulesMap: rolesRulesMap[namespace],
         clusterRolesRulesMap,
       },
-      user,
-      groups
+      subject
     );
 
     reviews.push([namespace, review] as [typeof namespace, typeof review]);
@@ -407,13 +408,10 @@ export async function fetchPermissionsForSubject(
   return permissions;
 }
 
-export function fetchPermissionsForSubjectKey(
-  user?: string,
-  groups?: string[]
-) {
-  return `getUserPermissionsForSubject/${user ? user : ''}/${
-    groups ? groups.join(',') : ''
-  }`;
+export function fetchPermissionsForSubjectKey(subject: IPermissionsSubject) {
+  return `getUserPermissionsForSubject/${subject.user ?? ''}/${
+    subject.groups?.join(',') ?? ''
+  }/${subject.serviceAccount ?? ''}`;
 }
 
 export async function fetchPermissionsAtClusterScope(
@@ -421,8 +419,7 @@ export async function fetchPermissionsAtClusterScope(
   auth: IOAuth2Provider,
   useCases: IPermissionsUseCase[],
   namespacedPermissions: IPermissionMap,
-  user?: string,
-  groups?: string[]
+  subject: IPermissionsSubject
 ): Promise<IPermissionMap> {
   const requests: authorizationv1.ISelfSubjectAccessReviewSpec[] = [
     {
@@ -470,18 +467,16 @@ export async function fetchPermissionsAtClusterScope(
   return getPermissionsWithClusterRoleBindings(
     httpClientFactory,
     auth,
-    user,
-    groups
+    subject
   );
 }
 
 export function fetchPermissionsAtClusterScopeKey(
-  user?: string,
-  groups?: string[]
+  subject: IPermissionsSubject
 ): string {
-  return `getUserPermissionsAtClusterScope/${user ? user : ''}/${
-    groups ? groups?.join(',') : ''
-  }`;
+  return `getUserPermissionsAtClusterScope/${subject.user ?? ''}/${
+    subject.groups?.join(',') ?? ''
+  }/${subject.serviceAccount ?? ''}`;
 }
 
 export function hasAppAccesInNamespace(
@@ -730,19 +725,17 @@ export function getStatusesForUseCases(
 }
 
 /**
- * Get permissions by fetching ClusterRoleBindings for
- * given user/group and aggregating permissions of the
- * ClusterRoles referenced.
+ * Get permissions by fetching ClusterRoleBindings for the
+ * given subject and aggregating permissions of the ClusterRoles
+ * referenced.
  * @param httpClientFactory
  * @param auth
- * @param user
- * @param groups
+ * @param subject
  */
 async function getPermissionsWithClusterRoleBindings(
   httpClientFactory: HttpClientFactory,
   auth: IOAuth2Provider,
-  user?: string,
-  groups?: string[]
+  subject: IPermissionsSubject
 ): Promise<IPermissionMap> {
   const clusterRoleBindingList = await rbacv1.getClusterRoleBindingList(
     httpClientFactory(),
@@ -765,8 +758,7 @@ async function getPermissionsWithClusterRoleBindings(
       rolesRulesMap: {},
       clusterRolesRulesMap,
     },
-    user,
-    groups
+    subject
   );
 
   return computePermissions([['', review]]);
@@ -909,29 +901,42 @@ export function computeResourceRulesFromRoles(
 
 /**
  * Create a review response object from Roles/ClusterRoles bound
- * to a given user/groups by aggregating resource rules from
- * each Role/ClusterRole.
+ * to given subjects by aggregating resource rules from each
+ * Role/ClusterRole.
  *
  * @param bindings
  * @param rulesMaps
- * @param user
- * @param groups
+ * @param subject
  */
 export function createRulesReviewResponseFromBindings(
   bindings: Bindings,
   rulesMaps: IRulesMaps,
-  user?: string,
-  groups?: string[]
+  subject: IPermissionsSubject
 ): authorizationv1.ISelfSubjectRulesReview {
   const resourceRules: authorizationv1.IResourceRule[] = [];
 
-  // Get all bindings bound to the user/groups.
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let serviceAccountNamespace: string | undefined;
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let serviceAccountName: string | undefined;
+  if (subject.serviceAccount) {
+    [serviceAccountNamespace, serviceAccountName] = subject.serviceAccount
+      .replace(Constants.SERVICE_ACCOUNT_PREFIX, '')
+      .split(':', 2);
+  }
+
+  // Get all bindings bound to the subject.
   for (const binding of bindings) {
     if (
       binding.subjects?.find(
-        (subject) =>
-          (isSubjectKindUser(subject) && subject.name === user) ||
-          (isSubjectKindGroup(subject) && groups?.includes(subject.name))
+        (boundSubject) =>
+          (isSubjectKindUser(boundSubject) &&
+            boundSubject.name === subject.user) ||
+          (isSubjectKindGroup(boundSubject) &&
+            subject.groups?.includes(boundSubject.name)) ||
+          (isSubjectKindServiceAccount(boundSubject) &&
+            boundSubject.namespace === serviceAccountNamespace &&
+            boundSubject.name === serviceAccountName)
       )
     ) {
       // Determine role rules map to use based on the Kind of

--- a/src/model/constants/index.ts
+++ b/src/model/constants/index.ts
@@ -99,4 +99,5 @@ export const Constants = {
   README_FILE: 'README.md',
 
   SERVICE_ACCOUNT_PREFIX: 'system:serviceaccount:',
+  SERVICE_ACCOUNTS_PREFIX: 'system:serviceaccounts:',
 };

--- a/src/model/constants/index.ts
+++ b/src/model/constants/index.ts
@@ -97,4 +97,6 @@ export const Constants = {
 
   // README FILE - What we expect the name of a README file to be.
   README_FILE: 'README.md',
+
+  SERVICE_ACCOUNT_PREFIX: 'system:serviceaccount:',
 };

--- a/src/model/services/mapi/rbacv1/key.ts
+++ b/src/model/services/mapi/rbacv1/key.ts
@@ -36,6 +36,10 @@ export function isSubjectKindGroup(subject: ISubject): boolean {
   return isSubjectKind(subject, SubjectKinds.Group);
 }
 
+export function isSubjectKindServiceAccount(subject: ISubject): boolean {
+  return isSubjectKind(subject, SubjectKinds.ServiceAccount);
+}
+
 function isSubjectKind(subject: ISubject, kind: SubjectKinds): boolean {
   return subject.kind === kind;
 }

--- a/test/mockHttpCalls/authorizationv1/selfSubjectAccessReviews.ts
+++ b/test/mockHttpCalls/authorizationv1/selfSubjectAccessReviews.ts
@@ -136,7 +136,7 @@ export const selfSubjectAccessReviewCanGetClusterRoles = {
   },
 };
 
-export const localSubjectAccssReviewCanListOrgs = {
+export const localSubjectAccessReviewCanListOrgs = {
   kind: 'LocalSubjectAccessReview',
   apiVersion: 'authorization.k8s.io/v1',
   metadata: {

--- a/test/mockHttpCalls/authorizationv1/selfSubjectAccessReviews.ts
+++ b/test/mockHttpCalls/authorizationv1/selfSubjectAccessReviews.ts
@@ -135,3 +135,24 @@ export const selfSubjectAccessReviewCanGetClusterRoles = {
     reason: 'RBAC: ',
   },
 };
+
+export const localSubjectAccssReviewCanListOrgs = {
+  kind: 'LocalSubjectAccessReview',
+  apiVersion: 'authorization.k8s.io/v1',
+  metadata: {
+    creationTimestamp: null,
+    namespace: 'default',
+  },
+  spec: {
+    resourceAttributes: {
+      namespace: 'default',
+      verb: 'list',
+      group: 'security.giantswarm.io',
+      resource: 'organizations',
+    },
+  },
+  status: {
+    allowed: true,
+    reason: 'RBAC: ',
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,10 +4414,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/jest@27.5.1":
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.1.tgz#2c8b6dc6ff85c33bcd07d0b62cb3d19ddfdb3ab9"
-  integrity sha512-fUy7YRpT+rHXto1YlL+J9rs0uLGyiqVt3ZOTQR+4ROc47yNl8WLdVLgUloBRhOxP1PZvguHl44T3H0wAWxahYQ==
+"@types/jest@27.5.2":
+  version "27.5.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.2.tgz#ec49d29d926500ffb9fd22b84262e862049c026c"
+  integrity sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==
   dependencies:
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7966,10 +7966,10 @@ core-js-pure@^3.8.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.19.1.tgz#edffc1fc7634000a55ba05e95b3f0fe9587a5aa4"
   integrity sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ==
 
-core-js@3.22.7:
-  version "3.22.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.7.tgz#8d6c37f630f6139b8732d10f2c114c3f1d00024f"
-  integrity sha512-Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg==
+core-js@3.22.8:
+  version "3.22.8"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.8.tgz#23f860b1fe60797cc4f704d76c93fea8a2f60631"
+  integrity sha512-UoGQ/cfzGYIuiq6Z7vWL1HfkE9U9IZ4Ub+0XSiJTCzvbZzgPA69oDF2f+lgJ6dFFLEdjW5O6svvoKzXX23xFkA==
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13251,10 +13251,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@12.4.3:
-  version "12.4.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.4.3.tgz#914fa468458364e14cc952145db552d87c8847b6"
-  integrity sha512-eH6SKOmdm/ZwCRMTZAmM3q3dPkpq6vco/BfrOw8iGun4Xs/thYegPD/MLIwKO+iPkzibkLJuQcRhRLXKvaKreg==
+lint-staged@12.5.0:
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.5.0.tgz#d6925747480ae0e380d13988522f9dd8ef9126e3"
+  integrity sha512-BKLUjWDsKquV/JuIcoQW4MSAI3ggwEImF1+sB4zaKvyVx1wBk3FsG7UK9bpnmBTN1pm7EH2BBcMwINJzCRv12g==
   dependencies:
     cli-truncate "^3.1.0"
     colorette "^2.0.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14261,15 +14261,15 @@ mime@1.6.0, mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
 mime@^2.3.1, mime@^2.4.4:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
-
-mime@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
-  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -18362,10 +18362,10 @@ superagent@3.8.3:
     qs "^6.5.1"
     readable-stream "^2.3.5"
 
-superagent@7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-7.1.3.tgz#783ff8330e7c2dad6ad8f0095edc772999273b6b"
-  integrity sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==
+superagent@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-7.1.6.tgz#64f303ed4e4aba1e9da319f134107a54cacdc9c6"
+  integrity sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==
   dependencies:
     component-emitter "^1.3.0"
     cookiejar "^2.1.3"
@@ -18374,7 +18374,7 @@ superagent@7.1.3:
     form-data "^4.0.0"
     formidable "^2.0.1"
     methods "^1.1.2"
-    mime "^2.5.0"
+    mime "2.6.0"
     qs "^6.10.3"
     readable-stream "^3.6.0"
     semver "^7.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18984,10 +18984,10 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
-underscore@1.13.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.3.tgz#54bc95f7648c5557897e5e968d0f76bc062c34ee"
-  integrity sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==
+underscore@1.13.4:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.4.tgz#7886b46bbdf07f768e0052f1828e1dcab40c0dee"
+  integrity sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==
 
 unfetch@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17715,13 +17715,13 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sockjs@^0.3.21:
-  version "0.3.21"
-  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.21.tgz#b34ffb98e796930b60a0cfa11904d6a339a7d417"
-  integrity sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==
+sockjs@^0.3.24:
+  version "0.3.24"
+  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
+  integrity sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==
   dependencies:
     faye-websocket "^0.11.3"
-    uuid "^3.4.0"
+    uuid "^8.3.2"
     websocket-driver "^0.7.4"
 
 socks-proxy-agent@^6.0.0:
@@ -18517,15 +18517,15 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
-terser-webpack-plugin@5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz#0320dcc270ad5372c1e8993fabbd927929773e54"
-  integrity sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==
+terser-webpack-plugin@5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz#8033db876dd5875487213e87c627bca323e5ed90"
+  integrity sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==
   dependencies:
+    "@jridgewell/trace-mapping" "^0.3.7"
     jest-worker "^27.4.5"
     schema-utils "^3.1.1"
     serialize-javascript "^6.0.0"
-    source-map "^0.6.1"
     terser "^5.7.2"
 
 terser-webpack-plugin@^1.4.3:
@@ -19344,12 +19344,12 @@ uuid-browser@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid-browser/-/uuid-browser-3.1.0.tgz#0f05a40aef74f9e5951e20efbf44b11871e56410"
   integrity sha1-DwWkCu90+eWVHiDvv0SxGHHlZBA=
 
-uuid@8.3.2:
+uuid@8.3.2, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -19623,10 +19623,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.0.tgz#737dbf44335bb8bde68f8f39127fc401c97a1557"
-  integrity sha512-+Nlb39iQSOSsFv0lWUuUTim3jDQO8nhK3E68f//J2r5rIcp4lULHXz2oZ0UVdEeWXEh5lSzYUlzarZhDAeAVQw==
+webpack-dev-server@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.1.tgz#184607b0287c791aeaa45e58e8fe75fcb4d7e2a8"
+  integrity sha512-CTMfu2UMdR/4OOZVHRpdy84pNopOuigVIsRbGX3LVDMWNP8EUgC5mUBMErbwBlHTEX99ejZJpVqrir6EXAEajA==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"
@@ -19652,7 +19652,7 @@ webpack-dev-server@4.9.0:
     schema-utils "^4.0.0"
     selfsigned "^2.0.1"
     serve-index "^1.9.1"
-    sockjs "^0.3.21"
+    sockjs "^0.3.24"
     spdy "^4.0.2"
     webpack-dev-middleware "^5.3.1"
     ws "^8.4.2"
@@ -19747,7 +19747,37 @@ webpack@4:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@5.72.1, "webpack@>=4.43.0 <6.0.0":
+webpack@5.73.0:
+  version "5.73.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.73.0.tgz#bbd17738f8a53ee5760ea2f59dce7f3431d35d38"
+  integrity sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==
+  dependencies:
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^0.0.51"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.9.3"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.9"
+    json-parse-even-better-errors "^2.3.1"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.3.1"
+    webpack-sources "^3.2.3"
+
+"webpack@>=4.43.0 <6.0.0":
   version "5.72.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.72.1.tgz#3500fc834b4e9ba573b9f430b2c0a61e1bb57d13"
   integrity sha512-dXG5zXCLspQR4krZVR6QgajnZOjW2K/djHvdcRaDQvsjV9z9vaW6+ja5dZOYbqBBjF6kGXka/2ZyxNdc+8Jung==


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1122.

This PR adds the functionality to inspect permissions for a service account:
<img width="1195" alt="Screen Shot 2022-06-01 at 17 44 49" src="https://user-images.githubusercontent.com/62935115/171462280-96e75ad2-3f4d-48d4-b77f-01f463339c76.png">
The service account prefix remains in place, similar to the customer groups prefix:
<img width="600" alt="Screen Shot 2022-06-01 at 19 13 21" src="https://user-images.githubusercontent.com/62935115/171462626-c1f69f24-3611-4ef1-a502-7edb5d57cf3e.png">

The "Inspect Permissions" CLI guide also adapts similarly for service accounts as it does for users and groups:
<img width="1195" alt="Screen Shot 2022-06-01 at 17 45 20" src="https://user-images.githubusercontent.com/62935115/171462266-a92d959a-b8a9-4028-a0b8-c6301ed35cf5.png">