### PR TITLE
Future-proof code accessing Catalog.spec.storage

### DIFF
--- a/src/model/stores/appcatalog/actions.tsx
+++ b/src/model/stores/appcatalog/actions.tsx
@@ -144,7 +144,15 @@ export function catalogLoadIndex(
 }
 
 async function loadIndexForCatalog(catalog: IAppCatalog): Promise<IAppCatalog> {
-  const indexURL = normalizeAppCatalogIndexURL(catalog.spec.storage.URL);
+  const helmRepositoryURL = catalog.spec.repositories.find(repo => repo.type == 'helm');
+  if (typeof helmRepositoryURL === undefined) {
+    return Promise.reject(
+        new Error(
+          `Could not find repository of type "helm" in for catalog ${catalog.metadata.namespace}/${catalog.metadata.name}`
+        )
+    );
+  }
+  const indexURL = normalizeAppCatalogIndexURL(helmRepositoryURL);
 
   const response = await fetch(indexURL, { mode: 'cors' });
   if (response.status !== StatusCodes.Ok) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21782

Catalog CRs will be extended with a new field `.spec.repositories` containing an array of catalog sources in contrast to a single source defined in `.spec.storage`. Since catalog sources can have various types now (`helm`, `oci`, etc.) we need to find `helm` source if it exists in the array.

