### PR TITLE
Add service priority select box into create cluster form

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterServicePriority.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterServicePriority.tsx
@@ -1,0 +1,59 @@
+import { Box } from 'grommet';
+import { getClusterServicePriority } from 'MAPI/utils';
+import React from 'react';
+import InputGroup from 'UI/Inputs/InputGroup';
+import Select from 'UI/Inputs/Select';
+import { toTitleCase } from 'utils/helpers';
+
+import { IClusterPropertyProps, withClusterServicePriority } from './patches';
+
+interface ICreateClusterServicePriorityProps
+  extends IClusterPropertyProps,
+    Omit<
+      React.ComponentPropsWithoutRef<typeof InputGroup>,
+      'onChange' | 'id'
+    > {}
+
+const CreateClusterServicePriority: React.FC<
+  React.PropsWithChildren<ICreateClusterServicePriorityProps>
+> = ({
+  id,
+  cluster,
+  providerCluster,
+  onChange,
+  readOnly,
+  disabled,
+  ...props
+}) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({
+      isValid: true,
+      patch: withClusterServicePriority(e.target.value),
+    });
+  };
+
+  const value = getClusterServicePriority(cluster);
+
+  return (
+    <InputGroup
+      htmlFor={id}
+      label='Service priority'
+      help="Specifies the cluster's priority, relative to other clusters."
+      {...props}
+    >
+      <Box width='200px'>
+        <Select
+          value={value}
+          id={id}
+          onChange={handleChange}
+          options={['highest', 'medium', 'lowest']}
+          labelKey={toTitleCase}
+          readOnly={readOnly}
+          disabled={disabled}
+        />
+      </Box>
+    </InputGroup>
+  );
+};
+
+export default CreateClusterServicePriority;

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterServicePriority.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterServicePriority.tsx
@@ -1,5 +1,5 @@
 import { Box } from 'grommet';
-import { getClusterServicePriority } from 'MAPI/utils';
+import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import React from 'react';
 import InputGroup from 'UI/Inputs/InputGroup';
 import Select from 'UI/Inputs/Select';
@@ -32,7 +32,7 @@ const CreateClusterServicePriority: React.FC<
     });
   };
 
-  const value = getClusterServicePriority(cluster);
+  const value = capiv1beta1.getClusterServicePriority(cluster);
 
   return (
     <InputGroup

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -42,6 +42,7 @@ import CreateClusterControlPlaneNodesCount from './CreateClusterControlPlaneNode
 import CreateClusterDescription from './CreateClusterDescription';
 import CreateClusterName from './CreateClusterName';
 import CreateClusterRelease from './CreateClusterRelease';
+import CreateClusterServicePriority from './CreateClusterServicePriority';
 import {
   ClusterPatch,
   IClusterPropertyValue,
@@ -52,6 +53,7 @@ enum ClusterPropertyField {
   Name,
   Description,
   Release,
+  ServicePriority,
   ControlPlaneNodeAZs,
   ControlPlaneNodesCount,
 }
@@ -112,7 +114,12 @@ function makeInitialState(
 ): IClusterState {
   const name = generateUID(5);
 
-  const resourceConfig = { ...config, name, releaseVersion: '' };
+  const resourceConfig = {
+    ...config,
+    name,
+    releaseVersion: '',
+    servicePriority: 'highest',
+  };
   const providerCluster = createDefaultProviderCluster(
     provider,
     resourceConfig
@@ -128,6 +135,7 @@ function makeInitialState(
     validationResults: {
       [ClusterPropertyField.Name]: true,
       [ClusterPropertyField.Description]: true,
+      [ClusterPropertyField.ServicePriority]: true,
       [ClusterPropertyField.Release]: true,
       [ClusterPropertyField.ControlPlaneNodeAZs]: true,
       [ClusterPropertyField.ControlPlaneNodesCount]: true,
@@ -363,7 +371,13 @@ const CreateCluster: React.FC<React.PropsWithChildren<ICreateClusterProps>> = (
               onChange={handleChange(ClusterPropertyField.Release)}
               orgNamespace={state.orgNamespace}
             />
-
+            <CreateClusterServicePriority
+              id={`cluster-${ClusterPropertyField.ServicePriority}`}
+              cluster={state.cluster}
+              providerCluster={state.providerCluster}
+              controlPlaneNodes={state.controlPlaneNodes}
+              onChange={handleChange(ClusterPropertyField.ServicePriority)}
+            />
             {provider === Providers.AZURE && (
               <CreateClusterControlPlaneNodeAZs
                 id={`cluster-${ClusterPropertyField.ControlPlaneNodeAZs}`}
@@ -375,7 +389,6 @@ const CreateCluster: React.FC<React.PropsWithChildren<ICreateClusterProps>> = (
                 )}
               />
             )}
-
             {provider === Providers.AWS && (
               <CreateClusterControlPlaneNodesCount
                 id={`cluster-${ClusterPropertyField.ControlPlaneNodesCount}`}
@@ -387,7 +400,6 @@ const CreateCluster: React.FC<React.PropsWithChildren<ICreateClusterProps>> = (
                 )}
               />
             )}
-
             <Box margin={{ top: 'medium' }}>
               <Box direction='row' gap='small'>
                 <Button

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -118,7 +118,6 @@ function makeInitialState(
     ...config,
     name,
     releaseVersion: '',
-    servicePriority: 'highest',
   };
   const providerCluster = createDefaultProviderCluster(
     provider,

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -116,6 +116,15 @@ export function withClusterDescription(newDescription: string): ClusterPatch {
   };
 }
 
+export function withClusterServicePriority(
+  servicePriority: string
+): ClusterPatch {
+  return (cluster) => {
+    cluster.metadata.labels ??= {};
+    cluster.metadata.labels[capiv1beta1.labelServicePriority] = servicePriority;
+  };
+}
+
 export function withClusterControlPlaneNodeAZs(zones?: string[]): ClusterPatch {
   return (_, _p, controlPlaneNodes) => {
     for (const controlPlaneNode of controlPlaneNodes) {

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -246,7 +246,6 @@ export function createDefaultProviderCluster(
     name: string;
     organization: string;
     releaseVersion: string;
-    servicePriority: string;
   }
 ) {
   switch (provider) {
@@ -264,7 +263,6 @@ function createDefaultAzureCluster(config: {
   name: string;
   organization: string;
   releaseVersion: string;
-  servicePriority: string;
 }): capzv1beta1.IAzureCluster {
   return {
     apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
@@ -277,7 +275,6 @@ function createDefaultAzureCluster(config: {
         [capiv1beta1.labelClusterName]: config.name,
         [capiv1beta1.labelOrganization]: config.organization,
         [capiv1beta1.labelReleaseVersion]: config.releaseVersion,
-        [capiv1beta1.labelServicePriority]: config.servicePriority,
       },
     },
     spec: {
@@ -308,7 +305,6 @@ function createDefaultAWSCluster(config: {
   name: string;
   organization: string;
   releaseVersion: string;
-  servicePriority: string;
 }): infrav1alpha3.IAWSCluster {
   return {
     apiVersion: 'infrastructure.giantswarm.io/v1alpha3',
@@ -321,7 +317,6 @@ function createDefaultAWSCluster(config: {
         [capiv1beta1.labelClusterName]: config.name,
         [infrav1alpha3.labelOrganization]: config.organization,
         [infrav1alpha3.labelReleaseVersion]: config.releaseVersion,
-        [capiv1beta1.labelServicePriority]: config.servicePriority,
       },
     },
     spec: {
@@ -386,8 +381,6 @@ function createDefaultV1Alpha3Cluster(config: {
     config.providerCluster!.metadata.labels![capiv1beta1.labelOrganization];
   const releaseVersion =
     config.providerCluster!.metadata.labels![capiv1beta1.labelReleaseVersion];
-  const servicePriority =
-    config.providerCluster!.metadata.labels![capiv1beta1.labelServicePriority];
 
   return {
     apiVersion: 'cluster.x-k8s.io/v1beta1',
@@ -400,7 +393,8 @@ function createDefaultV1Alpha3Cluster(config: {
         [capiv1beta1.labelClusterName]: name,
         [capiv1beta1.labelOrganization]: organization,
         [capiv1beta1.labelReleaseVersion]: releaseVersion,
-        [capiv1beta1.labelServicePriority]: servicePriority,
+        [capiv1beta1.labelServicePriority]:
+          Constants.DEFAULT_CLUSTER_SERVICE_PRIORITY,
       },
       annotations: {
         [capiv1beta1.annotationClusterDescription]:

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -246,6 +246,7 @@ export function createDefaultProviderCluster(
     name: string;
     organization: string;
     releaseVersion: string;
+    servicePriority: string;
   }
 ) {
   switch (provider) {
@@ -263,6 +264,7 @@ function createDefaultAzureCluster(config: {
   name: string;
   organization: string;
   releaseVersion: string;
+  servicePriority: string;
 }): capzv1beta1.IAzureCluster {
   return {
     apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
@@ -275,6 +277,7 @@ function createDefaultAzureCluster(config: {
         [capiv1beta1.labelClusterName]: config.name,
         [capiv1beta1.labelOrganization]: config.organization,
         [capiv1beta1.labelReleaseVersion]: config.releaseVersion,
+        [capiv1beta1.labelServicePriority]: config.servicePriority,
       },
     },
     spec: {
@@ -305,6 +308,7 @@ function createDefaultAWSCluster(config: {
   name: string;
   organization: string;
   releaseVersion: string;
+  servicePriority: string;
 }): infrav1alpha3.IAWSCluster {
   return {
     apiVersion: 'infrastructure.giantswarm.io/v1alpha3',
@@ -317,6 +321,7 @@ function createDefaultAWSCluster(config: {
         [capiv1beta1.labelClusterName]: config.name,
         [infrav1alpha3.labelOrganization]: config.organization,
         [infrav1alpha3.labelReleaseVersion]: config.releaseVersion,
+        [capiv1beta1.labelServicePriority]: config.servicePriority,
       },
     },
     spec: {
@@ -381,6 +386,8 @@ function createDefaultV1Alpha3Cluster(config: {
     config.providerCluster!.metadata.labels![capiv1beta1.labelOrganization];
   const releaseVersion =
     config.providerCluster!.metadata.labels![capiv1beta1.labelReleaseVersion];
+  const servicePriority =
+    config.providerCluster!.metadata.labels![capiv1beta1.labelServicePriority];
 
   return {
     apiVersion: 'cluster.x-k8s.io/v1beta1',
@@ -393,6 +400,7 @@ function createDefaultV1Alpha3Cluster(config: {
         [capiv1beta1.labelClusterName]: name,
         [capiv1beta1.labelOrganization]: organization,
         [capiv1beta1.labelReleaseVersion]: releaseVersion,
+        [capiv1beta1.labelServicePriority]: servicePriority,
       },
       annotations: {
         [capiv1beta1.annotationClusterDescription]:
@@ -1045,7 +1053,7 @@ export function getClusterLabelsWithDisplayInfo(
 
 function getClusterLabelKeyDisplayInfo(key: string) {
   switch (key) {
-    case 'giantswarm.io/service-priority':
+    case capiv1beta1.labelServicePriority:
       return { displayKey: 'Service priority' };
 
     default:
@@ -1055,19 +1063,19 @@ function getClusterLabelKeyDisplayInfo(key: string) {
 
 function getClusterLabelValueDisplayInfo(key: string, value: string) {
   switch (`${key}:${value}`) {
-    case 'giantswarm.io/service-priority:highest':
+    case `${capiv1beta1.labelServicePriority}:highest`:
       return {
         displayValue: 'Highest',
         textColor: theme.colors.darkBlueDarker2,
         backgroundColor: theme.colors.brown1,
       };
-    case 'giantswarm.io/service-priority:medium':
+    case `${capiv1beta1.labelServicePriority}:medium`:
       return {
         displayValue: 'Medium',
         textColor: theme.colors.darkBlueDarker2,
         backgroundColor: theme.colors.yellow2,
       };
-    case 'giantswarm.io/service-priority:lowest':
+    case `${capiv1beta1.labelServicePriority}:lowest`:
       return {
         displayValue: 'Lowest',
         textColor: theme.colors.white4,
@@ -1081,7 +1089,7 @@ function getClusterLabelValueDisplayInfo(key: string, value: string) {
 
 function isSpecialPurposeLabel(key: string) {
   switch (key) {
-    case 'giantswarm.io/service-priority':
+    case capiv1beta1.labelServicePriority:
       return true;
     default:
       return false;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -909,12 +909,6 @@ export function getClusterDescription(
   }
 }
 
-export function getClusterServicePriority(cluster: Cluster): string {
-  const labels = capiv1beta1.getClusterLabels(cluster);
-
-  return labels[capiv1beta1.labelServicePriority];
-}
-
 export function getProviderClusterLocation(
   providerCluster: ProviderCluster
 ): string | undefined {

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -909,6 +909,12 @@ export function getClusterDescription(
   }
 }
 
+export function getClusterServicePriority(cluster: Cluster): string {
+  const labels = capiv1beta1.getClusterLabels(cluster);
+
+  return labels[capiv1beta1.labelServicePriority];
+}
+
 export function getProviderClusterLocation(
   providerCluster: ProviderCluster
 ): string | undefined {

--- a/src/model/constants/index.ts
+++ b/src/model/constants/index.ts
@@ -1,3 +1,5 @@
+import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
+
 import * as AppConstants from './apps';
 import * as AuthorizationTypes from './authorizationTypes';
 import { CSSBreakpoints } from './cssBreakpoints';
@@ -26,6 +28,7 @@ export const Constants = {
   DEFAULT_NODEPOOL_NAME: 'Unnamed node pool',
   DEFAULT_NODEPOOL_DESCRIPTION: 'Please add description',
   DEFAULT_CLUSTER_DESCRIPTION: 'Please add description',
+  DEFAULT_CLUSTER_SERVICE_PRIORITY: 'highest',
   AZURE_NODEPOOL_DEFAULT_VM_SIZE: 'Standard_D4s_v3',
   AZURE_CONTROL_PLANE_DEFAULT_VM_SIZE: 'Standard_D4s_v3',
   AWS_CONTROL_PLANE_DEFAULT_INSTANCE_TYPE: 'm5.xlarge',
@@ -79,7 +82,7 @@ export const Constants = {
     'cluster.x-k8s.io/cluster-name',
     'cluster.x-k8s.io/watch-filter',
   ],
-  ALLOWED_CLUSTER_LABEL_KEYS: ['giantswarm.io/service-priority'],
+  ALLOWED_CLUSTER_LABEL_KEYS: [capiv1beta1.labelServicePriority],
 
   // Cluster & node pool name length restrictions
   MIN_NAME_LENGTH: 3,

--- a/src/model/services/mapi/capiv1beta1/key.ts
+++ b/src/model/services/mapi/capiv1beta1/key.ts
@@ -62,6 +62,12 @@ export function getClusterLabels(cluster: ICluster): IClusterLabelMap {
   return cluster.metadata.labels;
 }
 
+export function getClusterServicePriority(cluster: ICluster): string {
+  const labels = getClusterLabels(cluster);
+
+  return labels[labelServicePriority];
+}
+
 export function getMachinePoolDescription(machinePool: IMachinePool): string {
   let name =
     machinePool.metadata.annotations?.[annotationMachinePoolDescription];

--- a/src/model/services/mapi/capiv1beta1/key.ts
+++ b/src/model/services/mapi/capiv1beta1/key.ts
@@ -11,6 +11,7 @@ export const labelMachineControlPlane = 'cluster.x-k8s.io/control-plane';
 export const labelMachinePool = 'giantswarm.io/machine-pool';
 export const labelClusterOperator = 'cluster-operator.giantswarm.io/version';
 export const labelAzureOperatorVersion = 'azure-operator.giantswarm.io/version';
+export const labelServicePriority = 'giantswarm.io/service-priority';
 
 export const annotationClusterDescription = 'cluster.giantswarm.io/description';
 export const annotationUpdateScheduleTargetRelease =


### PR DESCRIPTION
The ability to set service priority has been introduced to the create cluster form in this PR. The service priority is set to `highest` by default.

<img width="825" alt="Screenshot 2022-06-09 at 17 36 04" src="https://user-images.githubusercontent.com/445309/172873844-c31a891d-63db-440e-8bc4-fc5856441c92.png">

