### PR TITLE
Add "Use web UI" use case to permissions overview

### DIFF
--- a/src/components/MAPI/permissions/PermissionsOverview/PermissionsOverview.tsx
+++ b/src/components/MAPI/permissions/PermissionsOverview/PermissionsOverview.tsx
@@ -91,31 +91,33 @@ const PermissionsOverview: React.FC<IPermissionsOverviewProps> = ({
     return useCases.filter((useCase) => !isGlobalUseCase(useCase));
   }, [useCases]);
 
-  const shouldDisplayUseCases =
+  const shouldDisplayUseCaseStatuses =
     useCases !== null &&
     (subjectType === SubjectTypes.Myself || subjectName !== '');
 
-  return shouldDisplayUseCases ? (
+  return (
     <>
-      <Tabs activeIndex={activeTab} onActive={setActiveTab}>
-        <Tab title='Global'>
-          <PermissionsUseCases
-            useCases={globalUseCases}
-            useCasesStatuses={useCasesStatuses}
-            activeIndexes={globalActiveIndexes}
-            onActive={setGlobalActiveIndexes}
-          />
-        </Tab>
-        <Tab title='For organizations'>
-          <PermissionsUseCases
-            useCases={organizationsUseCases}
-            useCasesStatuses={useCasesStatuses}
-            organizations={sortedOrganizations}
-            activeIndexes={organizationsActiveIndexes}
-            onActive={setOrganizationsActiveIndexes}
-          />
-        </Tab>
-      </Tabs>
+      {shouldDisplayUseCaseStatuses ? (
+        <Tabs activeIndex={activeTab} onActive={setActiveTab}>
+          <Tab title='Global'>
+            <PermissionsUseCases
+              useCases={globalUseCases}
+              useCasesStatuses={useCasesStatuses}
+              activeIndexes={globalActiveIndexes}
+              onActive={setGlobalActiveIndexes}
+            />
+          </Tab>
+          <Tab title='For organizations'>
+            <PermissionsUseCases
+              useCases={organizationsUseCases}
+              useCasesStatuses={useCasesStatuses}
+              organizations={sortedOrganizations}
+              activeIndexes={organizationsActiveIndexes}
+              onActive={setOrganizationsActiveIndexes}
+            />
+          </Tab>
+        </Tabs>
+      ) : null}
       <InspectPermissionsGuide
         forOrganizations={activeTab === 1}
         subjectType={subjectType}
@@ -123,7 +125,7 @@ const PermissionsOverview: React.FC<IPermissionsOverviewProps> = ({
         animation={{ type: 'fadeIn', duration: 300 }}
       />
     </>
-  ) : null;
+  );
 };
 
 export default PermissionsOverview;

--- a/src/components/MAPI/permissions/PermissionsOverview/PermissionsOverview.tsx
+++ b/src/components/MAPI/permissions/PermissionsOverview/PermissionsOverview.tsx
@@ -53,7 +53,10 @@ const PermissionsOverview: React.FC<IPermissionsOverviewProps> = ({
     );
 
     if (shouldDisplayAppAccessUseCase) {
-      const appAccessStatus = getStatusForAppAccessUseCase(permissions);
+      const appAccessStatus = getStatusForAppAccessUseCase(
+        permissions,
+        sortedOrganizations
+      );
       statuses = { ...statuses, ...appAccessStatus };
     }
 

--- a/src/components/MAPI/permissions/PermissionsOverview/__tests__/PermissionsOverview.tsx
+++ b/src/components/MAPI/permissions/PermissionsOverview/__tests__/PermissionsOverview.tsx
@@ -545,6 +545,12 @@ describe('PermissionsOverview', () => {
         screen.getByLabelText('access control permission status')
       ).getByText('Partial')
     ).toBeInTheDocument();
+
+    // displays app (web UI) access use case
+    const interfacesCategory = await screen.findByText('interfaces');
+    fireEvent.click(interfacesCategory);
+
+    expect(await screen.findByText('Use web UI')).toBeInTheDocument();
   });
 
   it('allows inspecting permissions for groups', async () => {
@@ -648,6 +654,12 @@ describe('PermissionsOverview', () => {
         screen.getByLabelText('access control permission status')
       ).getByText('Yes')
     ).toBeInTheDocument();
+
+    // displays app (web UI) access use case
+    const interfacesCategory = await screen.findByText('interfaces');
+    fireEvent.click(interfacesCategory);
+
+    expect(await screen.findByText('Use web UI')).toBeInTheDocument();
   });
 
   it('allows inspecting permissions for service accounts', async () => {
@@ -752,5 +764,8 @@ describe('PermissionsOverview', () => {
         screen.getByLabelText('access control permission status')
       ).getByText('No')
     ).toBeInTheDocument();
+
+    // does not display category for app access use case
+    expect(screen.queryByLabelText('interfaces')).not.toBeInTheDocument();
   });
 });

--- a/src/components/MAPI/permissions/guides/InspectPermissionsGuide.tsx
+++ b/src/components/MAPI/permissions/guides/InspectPermissionsGuide.tsx
@@ -1,6 +1,7 @@
 import { Text } from 'grommet';
 import LoginGuideStep from 'MAPI/guides/LoginGuideStep';
 import { getCurrentInstallationContextName } from 'MAPI/guides/utils';
+import { Constants } from 'model/constants';
 import * as docs from 'model/constants/docs';
 import React from 'react';
 import CLIGuide from 'UI/Display/MAPI/CLIGuide';
@@ -17,6 +18,7 @@ interface IInspectPermissionsGuideProps
   subjectType?: SubjectTypes;
 }
 
+// eslint-disable-next-line complexity
 const InspectPermissionsGuide: React.FC<IInspectPermissionsGuideProps> = ({
   forOrganizations,
   subjectName,
@@ -24,6 +26,17 @@ const InspectPermissionsGuide: React.FC<IInspectPermissionsGuideProps> = ({
   ...props
 }) => {
   const context = getCurrentInstallationContextName();
+
+  const subjectNamePlaceholder =
+    subjectType === SubjectTypes.User
+      ? 'USER'
+      : subjectType === SubjectTypes.Group
+      ? 'customer:GROUP'
+      : subjectType === SubjectTypes.ServiceAccount
+      ? `${Constants.SERVICE_ACCOUNTS_PREFIX}SERVICE_ACCOUNT`
+      : '';
+
+  const displayedSubjectName = subjectName || subjectNamePlaceholder;
 
   const currentSubjectType =
     subjectType === SubjectTypes.User
@@ -37,15 +50,15 @@ const InspectPermissionsGuide: React.FC<IInspectPermissionsGuideProps> = ({
   const currentSubjectPossessive =
     subjectType === SubjectTypes.User ? (
       <>
-        user <code>{subjectName}</code> has
+        user <code>{displayedSubjectName}</code> has
       </>
     ) : subjectType === SubjectTypes.Group ? (
       <>
-        a member of group <code>{subjectName}</code> has
+        a member of group <code>{displayedSubjectName}</code> has
       </>
     ) : subjectType === SubjectTypes.ServiceAccount ? (
       <>
-        service account <code>{subjectName}</code> has
+        service account <code>{displayedSubjectName}</code> has
       </>
     ) : (
       `you have`
@@ -54,9 +67,9 @@ const InspectPermissionsGuide: React.FC<IInspectPermissionsGuideProps> = ({
   const impersonationFlags =
     subjectType === SubjectTypes.User ||
     subjectType === SubjectTypes.ServiceAccount
-      ? ` \\\n  --as ${subjectName}`
+      ? ` \\\n  --as ${displayedSubjectName}`
       : subjectType === SubjectTypes.Group
-      ? ` \\\n  --as example@acme.org --as-group ${subjectName}`
+      ? ` \\\n  --as example@acme.org --as-group ${displayedSubjectName}`
       : '';
 
   return (

--- a/src/components/MAPI/permissions/utils.ts
+++ b/src/components/MAPI/permissions/utils.ts
@@ -516,6 +516,28 @@ export function hasAppAccess(
   );
 }
 
+export const appAccessUseCase: IPermissionsUseCase = {
+  name: 'Use web UI',
+  description: 'Has the minimum permissions required to access this web UI',
+  category: 'interfaces',
+  scope: { cluster: true },
+  permissions: [],
+};
+
+export function getStatusForAppAccessUseCase(
+  permissions: IPermissionMap
+): PermissionsUseCaseStatuses {
+  const orgNamespaces = Object.keys(permissions).filter(
+    (ns) => ns !== 'default' && ns !== 'giantswarm' && ns !== ''
+  );
+
+  return {
+    [appAccessUseCase.name]: {
+      '': orgNamespaces.some((ns) => hasAppAccesInNamespace(permissions, ns)),
+    },
+  };
+}
+
 export function hasAccessToInspectPermissions(
   permissions: IPermissionMap
 ): boolean {

--- a/src/components/MAPI/permissions/utils.ts
+++ b/src/components/MAPI/permissions/utils.ts
@@ -525,10 +525,11 @@ export const appAccessUseCase: IPermissionsUseCase = {
 };
 
 export function getStatusForAppAccessUseCase(
-  permissions: IPermissionMap
+  permissions: IPermissionMap,
+  organizations: IOrganization[]
 ): PermissionsUseCaseStatuses {
-  const orgNamespaces = Object.keys(permissions).filter(
-    (ns) => ns !== 'default' && ns !== 'giantswarm' && ns !== ''
+  const orgNamespaces = organizations.map(
+    (o) => o.namespace ?? getNamespaceFromOrgName(o.id)
   );
 
   return {


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1185.

This PR adds the "Use web UI" use case to the list of use cases displayed in the permissions overview page. This use case is only evaluated and displayed for User and Group subject types (it doesn't make sense to display it for Service Accounts, and is redundant when inspecting permissions for yourself).

<img width="400" alt="Screen Shot 2022-06-28 at 16 09 13" src="https://user-images.githubusercontent.com/62935115/176200893-bb65eff4-b342-41d5-989a-a0b0bfda007d.png">

