### PR TITLE
Use self hosted fonts for Roboto and Inconsolata

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,39 @@
-<link
-  rel="stylesheet"
-  href="//fonts.googleapis.com/css?family=Roboto:300,400,700,300italic|Inconsolata:400,700|Roboto+Condensed:400,700"
-  type="text/css"
-/>
+<style type="text/css">
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 300;
+  src: local(''), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-300.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-300.woff') format('woff');
+}
+@font-face {
+  font-family: 'Roboto';
+  font-style: italic;
+  font-weight: 300;
+  src: local(''), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-300italic.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-300italic.woff') format('woff');
+}
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: local(''), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-regular.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-regular.woff') format('woff');
+}
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  src: local(''), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-700.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-700.woff') format('woff');
+}
+@font-face {
+  font-family: 'Inconsolata';
+  font-style: normal;
+  font-weight: 400;
+  src: local(''), url('https://s.giantswarm.io/fonts/1/inconsolata-v30-latin-regular.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/inconsolata-v30-latin-regular.woff') format('woff');
+}
+@font-face {
+  font-family: 'Inconsolata';
+  font-style: normal;
+  font-weight: 700;
+  src: local(''), url('https://s.giantswarm.io/fonts/1/inconsolata-v30-latin-700.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/inconsolata-v30-latin-700.woff') format('woff');
+}
+</style>
 <script src="https://use.fortawesome.com/b5c7b73e.js"></script>

--- a/src/components/UI/Display/Documentation/Mermaid.tsx
+++ b/src/components/UI/Display/Documentation/Mermaid.tsx
@@ -8,7 +8,7 @@ const DEFAULT_CONFIG: mermaidAPI.Config = {
   securityLevel: 'strict',
   themeCSS:
     '.node rect { fill: #EFEFEF; } .cluster rect { fill: #FFFFFF; stroke: #000000}',
-  fontFamily: 'Roboto:300,300i,400,400i,700,700i',
+  fontFamily: 'Roboto:300,400,700',
   flowchart: {
     htmlLabels: false,
     useMaxWidth: true,

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -21,11 +21,44 @@
         background-color: #152531;
       }
     </style>
-    <link
-      rel="stylesheet"
-      href="//fonts.googleapis.com/css?family=Roboto:300,400,700,300italic|Inconsolata:400,700|Roboto+Condensed:400,700"
-      type="text/css"
-    />
+    <style type="text/css">
+    @font-face {
+      font-family: 'Roboto';
+      font-style: normal;
+      font-weight: 300;
+      src: local(''), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-300.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-300.woff') format('woff');
+    }
+    @font-face {
+      font-family: 'Roboto';
+      font-style: italic;
+      font-weight: 300;
+      src: local(''), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-300italic.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-300italic.woff') format('woff');
+    }
+    @font-face {
+      font-family: 'Roboto';
+      font-style: normal;
+      font-weight: 400;
+      src: local(''), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-regular.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-regular.woff') format('woff');
+    }
+    @font-face {
+      font-family: 'Roboto';
+      font-style: normal;
+      font-weight: 700;
+      src: local(''), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-700.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/roboto-v30-latin-ext_latin-700.woff') format('woff');
+    }
+    @font-face {
+      font-family: 'Inconsolata';
+      font-style: normal;
+      font-weight: 400;
+      src: local(''), url('https://s.giantswarm.io/fonts/1/inconsolata-v30-latin-regular.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/inconsolata-v30-latin-regular.woff') format('woff');
+    }
+    @font-face {
+      font-family: 'Inconsolata';
+      font-style: normal;
+      font-weight: 700;
+      src: local(''), url('https://s.giantswarm.io/fonts/1/inconsolata-v30-latin-700.woff2') format('woff2'), url('https://s.giantswarm.io/fonts/1/inconsolata-v30-latin-700.woff') format('woff');
+    }
+    </style>
     <script src="https://use.fortawesome.com/b5c7b73e.js"></script>
     <meta name="robots" content="noindex, nofollow" />
     <meta name="mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22146

Switches Roboto and Inconsolata to use our self-hosted files instead of Google's.