### PR TITLE
Fix uploading a file with the same name for configuring an installed app

### DIFF
--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload.tsx
@@ -18,6 +18,7 @@ const YAMLFileUpload: React.FC<
 
   const handleUploadClick = () => {
     if (fileInput.current !== null) {
+      fileInput.current.value = '';
       fileInput.current.click();
     }
   };

--- a/src/components/Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload.tsx
+++ b/src/components/Cluster/ClusterDetail/AppDetailsModal/YAMLFileUpload.tsx
@@ -24,7 +24,7 @@ const YAMLFileUpload: React.FC<
   };
 
   const fileInputOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.files || e.target.files.length < 0) return;
+    if (!e.target.files || e.target.files.length === 0) return;
 
     setFileUploading(true);
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1212.

This PR fixes a bug with uploading files to configure an installed app. When users re-upload a file with the same name, the `onChange` event is not fired. This is because the `<input />` element's value is set to the file's path, and the value has not changed (even if the file contents have).

To circumvent this, we reset the value of `<input />` to an empty string whenever the "Upload/Replace values/secret values" button is clicked.

This PR also fixes a related bug where we try to index an empty array of files - in this case it makes more sense to exit early if there are no files to upload.