### PR TITLE
Add support for determining permissions for CAPG resources

### DIFF
--- a/src/components/MAPI/apps/permissions/usePermissionsForClusterApps.ts
+++ b/src/components/MAPI/apps/permissions/usePermissionsForClusterApps.ts
@@ -1,0 +1,67 @@
+import { usePermissions } from 'MAPI/permissions/usePermissions';
+import { hasPermission } from 'MAPI/permissions/utils';
+import { Providers } from 'model/constants';
+
+export function usePermissionsForClusterApps(
+  _provider: PropertiesOf<typeof Providers>,
+  namespace: string
+) {
+  const { data: permissions } = usePermissions();
+
+  const computed = {
+    canGet: false,
+    canList: false,
+    canUpdate: false,
+    canCreate: false,
+    canDelete: false,
+  };
+
+  if (!permissions) return computed;
+
+  computed.canCreate =
+    hasPermission(
+      permissions,
+      namespace,
+      'create',
+      'application.giantswarm.io',
+      'apps'
+    ) && hasPermission(permissions, namespace, 'create', '', 'configmaps');
+
+  computed.canDelete =
+    hasPermission(
+      permissions,
+      namespace,
+      'delete',
+      'application.giantswarm.io',
+      'apps'
+    ) && hasPermission(permissions, namespace, 'delete', '', 'configmaps');
+
+  computed.canUpdate =
+    hasPermission(
+      permissions,
+      namespace,
+      'update',
+      'application.giantswarm.io',
+      'apps'
+    ) && hasPermission(permissions, namespace, 'update', '', 'configmaps');
+
+  computed.canGet =
+    hasPermission(
+      permissions,
+      namespace,
+      'get',
+      'application.giantswarm.io',
+      'apps'
+    ) && hasPermission(permissions, namespace, 'get', '', 'configmaps');
+
+  computed.canList =
+    hasPermission(
+      permissions,
+      namespace,
+      'list',
+      'application.giantswarm.io',
+      'apps'
+    ) && hasPermission(permissions, namespace, 'list', '', 'configmaps');
+
+  return computed;
+}

--- a/src/components/MAPI/clusters/permissions/usePermissionsForCPNodes.ts
+++ b/src/components/MAPI/clusters/permissions/usePermissionsForCPNodes.ts
@@ -1,3 +1,4 @@
+import { usePermissionsForClusterApps } from 'MAPI/apps/permissions/usePermissionsForClusterApps';
 import { usePermissions } from 'MAPI/permissions/usePermissions';
 import { hasPermission } from 'MAPI/permissions/utils';
 import { Providers } from 'model/constants';
@@ -6,6 +7,12 @@ export function usePermissionsForCPNodes(
   provider: PropertiesOf<typeof Providers>,
   namespace: string
 ) {
+  const {
+    canCreate: canCreateClusterApps,
+    canDelete: canDeleteClusterApps,
+    canUpdate: canUpdateClusterApps,
+  } = usePermissionsForClusterApps(provider, namespace);
+
   const { data: permissions } = usePermissions();
 
   const computed = {
@@ -142,6 +149,45 @@ export function usePermissionsForCPNodes(
         'infrastructure.cluster.x-k8s.io',
         'azuremachines'
       );
+
+      break;
+
+    case Providers.GCP:
+      computed.canCreate = canCreateClusterApps;
+      computed.canDelete = canDeleteClusterApps;
+      computed.canUpdate = canUpdateClusterApps;
+
+      computed.canGet =
+        hasPermission(
+          permissions,
+          namespace,
+          'get',
+          'cluster.x-k8s.io',
+          'machines'
+        ) &&
+        hasPermission(
+          permissions,
+          namespace,
+          'get',
+          'infrastructure.cluster.x-k8s.io',
+          'gcpmachinetemplates'
+        );
+
+      computed.canList =
+        hasPermission(
+          permissions,
+          namespace,
+          'list',
+          'cluster.x-k8s.io',
+          'machines'
+        ) &&
+        hasPermission(
+          permissions,
+          namespace,
+          'list',
+          'infrastructure.cluster.x-k8s.io',
+          'gcpmachinetemplates'
+        );
 
       break;
   }

--- a/src/components/MAPI/clusters/permissions/usePermissionsForClusters.ts
+++ b/src/components/MAPI/clusters/permissions/usePermissionsForClusters.ts
@@ -1,13 +1,21 @@
+import { usePermissionsForClusterApps } from 'MAPI/apps/permissions/usePermissionsForClusterApps';
 import { usePermissions } from 'MAPI/permissions/usePermissions';
 import { hasPermission } from 'MAPI/permissions/utils';
 import { Providers } from 'model/constants';
 
 import { usePermissionsForCPNodes } from './usePermissionsForCPNodes';
 
+// eslint-disable-next-line complexity
 export function usePermissionsForClusters(
   provider: PropertiesOf<typeof Providers>,
   namespace: string
 ) {
+  const {
+    canCreate: canCreateClusterApps,
+    canDelete: canDeleteClusterApps,
+    canUpdate: canUpdateClusterApps,
+  } = usePermissionsForClusterApps(provider, namespace);
+
   const { canCreate: canCreateCPNodes, canDelete: canDeleteCPNodes } =
     usePermissionsForCPNodes(provider, namespace);
 
@@ -190,6 +198,45 @@ export function usePermissionsForClusters(
           'list',
           'infrastructure.cluster.x-k8s.io',
           'azureclusters'
+        );
+
+      break;
+
+    case Providers.GCP:
+      computed.canCreate = canCreateClusterApps;
+      computed.canDelete = canDeleteClusterApps;
+      computed.canUpdate = canUpdateClusterApps;
+
+      computed.canGet =
+        hasPermission(
+          permissions,
+          namespace,
+          'get',
+          'cluster.x-k8s.io',
+          'clusters'
+        ) &&
+        hasPermission(
+          permissions,
+          namespace,
+          'get',
+          'infrastructure.cluster.x-k8s.io',
+          'gcpclusters'
+        );
+
+      computed.canList =
+        hasPermission(
+          permissions,
+          namespace,
+          'list',
+          'cluster.x-k8s.io',
+          'clusters'
+        ) &&
+        hasPermission(
+          permissions,
+          namespace,
+          'list',
+          'infrastructure.cluster.x-k8s.io',
+          'gcpclusters'
         );
 
       break;

--- a/src/components/MAPI/workernodes/permissions/usePermissionsForNodePools.ts
+++ b/src/components/MAPI/workernodes/permissions/usePermissionsForNodePools.ts
@@ -1,3 +1,4 @@
+import { usePermissionsForClusterApps } from 'MAPI/apps/permissions/usePermissionsForClusterApps';
 import { usePermissions } from 'MAPI/permissions/usePermissions';
 import { hasPermission } from 'MAPI/permissions/utils';
 import { Providers } from 'model/constants';
@@ -9,6 +10,11 @@ export function usePermissionsForNodePools(
   provider: PropertiesOf<typeof Providers>,
   namespace: string
 ) {
+  const { canUpdate: canUpdateClusterApps } = usePermissionsForClusterApps(
+    provider,
+    namespace
+  );
+
   const { canCreate: canCreateSparks } = usePermissionsForSparks(
     provider,
     namespace
@@ -225,6 +231,46 @@ export function usePermissionsForNodePools(
           'list',
           'exp.infrastructure.cluster.x-k8s.io',
           'azuremachinepools'
+        );
+
+      break;
+
+    case Providers.GCP:
+      // Node pools are mutated through the cluster app's ConfigMap
+      computed.canCreate = canUpdateClusterApps;
+      computed.canDelete = canUpdateClusterApps;
+      computed.canUpdate = canUpdateClusterApps;
+
+      computed.canGet =
+        hasPermission(
+          permissions,
+          namespace,
+          'get',
+          'cluster.x-k8s.io',
+          'machinedeployments'
+        ) &&
+        hasPermission(
+          permissions,
+          namespace,
+          'get',
+          'infrastructure.cluster.x-k8s.io',
+          'gcpmachinetemplates'
+        );
+
+      computed.canList =
+        hasPermission(
+          permissions,
+          namespace,
+          'list',
+          'cluster.x-k8s.io',
+          'machinedeployments'
+        ) &&
+        hasPermission(
+          permissions,
+          namespace,
+          'list',
+          'infrastructure.cluster.x-k8s.io',
+          'gcpmachinetemplates'
         );
 
       break;

--- a/src/model/constants/providers.ts
+++ b/src/model/constants/providers.ts
@@ -3,3 +3,5 @@ export const AWS = 'aws';
 export const AZURE = 'azure';
 
 export const KVM = 'kvm';
+
+export const GCP = 'gcp';


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1214 (towards https://github.com/giantswarm/roadmap/issues/1192).

This PR adds support for determining permissions to CAPG resources, specifically clusters, control plane nodes, and node pools.

For permissions to `get` and `list` resources, this is accomplished in a similar way as we do for existing providers.

For mutating actions (`create`, `update`, `delete`), a new permissions hook is added for determining permissions to cluster apps (Apps and ConfigMaps). Cluster management should be done via cluster apps, so it makes sense to check for permissions to these resources rather than the resulting resources. The [`values.yaml`](https://github.com/giantswarm/cluster-gcp/blob/main/helm/cluster-gcp/values.yaml) file for the `cluster-gcp` app provides more information about what is configurable.