### PR TITLE
Add support for fetching CAPG resources

### DIFF
--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -134,18 +134,6 @@ export async function fetchNodePoolListForCluster(
   let list: NodePoolList;
 
   switch (infrastructureRef.kind) {
-    case capgv1beta1.GCPCluster:
-      list = await capiv1beta1.getMachinePoolList(httpClientFactory(), auth, {
-        labelSelector: {
-          matchingLabels: {
-            [capiv1beta1.labelClusterName]: cluster.metadata.name,
-          },
-        },
-        namespace,
-      });
-
-      break;
-
     case capzv1beta1.AzureCluster:
       if (supportsNonExpMachinePools(cluster)) {
         list = await capiv1beta1.getMachinePoolList(httpClientFactory(), auth, {
@@ -173,6 +161,7 @@ export async function fetchNodePoolListForCluster(
 
       break;
 
+    case capgv1beta1.GCPCluster:
     case infrav1alpha3.AWSCluster:
       list = await capiv1beta1.getMachineDeploymentList(
         httpClientFactory(),
@@ -211,16 +200,6 @@ export function fetchNodePoolListForClusterKey(
   }
 
   switch (infrastructureRef.kind) {
-    case capgv1beta1.GCPCluster:
-      return capiv1beta1.getMachinePoolListKey({
-        labelSelector: {
-          matchingLabels: {
-            [capiv1beta1.labelClusterName]: cluster.metadata.name,
-          },
-        },
-        namespace,
-      });
-
     case capzv1beta1.AzureCluster:
       if (supportsNonExpMachinePools(cluster)) {
         return capiv1beta1.getMachinePoolListKey({
@@ -242,6 +221,7 @@ export function fetchNodePoolListForClusterKey(
         namespace,
       });
 
+    case capgv1beta1.GCPCluster:
     case infrav1alpha3.AWSCluster:
       return capiv1beta1.getMachineDeploymentListKey({
         labelSelector: {
@@ -273,7 +253,7 @@ export async function fetchProviderNodePoolForNodePool(
   const kind = infrastructureRef.kind;
 
   switch (true) {
-    case kind === capgv1beta1.GCPCluster:
+    case kind === capgv1beta1.GCPMachineTemplate:
       return capgv1beta1.getGCPMachineTemplate(
         httpClientFactory(),
         auth,

--- a/src/model/services/mapi/k8sUrl.ts
+++ b/src/model/services/mapi/k8sUrl.ts
@@ -275,7 +275,7 @@ function serializeFieldSelector(fieldSelector: IK8sFieldSelector): string {
 
 function serializeKeyValuePairs(from: Record<string, string>): string {
   return Object.entries(from).reduce<string>((acc, [labelKey, labelValue]) => {
-    if (!labelKey || !labelValue) return acc;
+    if (!labelKey) return acc;
 
     let newAcc = acc;
     if (acc.length > 0) {


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1215 (towards https://github.com/giantswarm/roadmap/issues/1192).

This PR adds support for fetching CAPG resources - clusters, control plane nodes, and node pools.