### PR TITLE
GCP cluster status and description

### DIFF
--- a/src/components/MAPI/clusters/ClusterList/__tests__/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/__tests__/ClusterListItem.tsx
@@ -629,13 +629,6 @@ describe('ClusterListItem on GCP', () => {
   });
 
   it('displays cluster status', async () => {
-    (usePermissionsForNodePools as jest.Mock).mockReturnValue(
-      defaultPermissions
-    );
-    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
-      defaultPermissions
-    );
-
     render(
       getComponent({
         cluster: {

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -932,6 +932,16 @@ export function getClusterConditions(
   }
 
   switch (infrastructureRef.kind) {
+    case capgv1beta1.GCPCluster:
+      statuses.isConditionUnknown =
+        typeof cluster.status === 'undefined' ||
+        typeof cluster.status.conditions === 'undefined';
+      statuses.isCreating = capiv1beta1.isConditionFalse(
+        cluster,
+        capiv1beta1.conditionTypeControlPlaneInitialized
+      );
+      break;
+
     case capzv1beta1.AzureCluster:
       statuses.isConditionUnknown =
         typeof cluster.status === 'undefined' ||

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1035,6 +1035,7 @@ export function getClusterDescription(
   }
 
   switch (infrastructureRef.kind) {
+    case capgv1beta1.GCPCluster:
     case capzv1beta1.AzureCluster:
       return (
         cluster.metadata.annotations?.[

--- a/src/model/services/mapi/capiv1beta1/key.ts
+++ b/src/model/services/mapi/capiv1beta1/key.ts
@@ -37,6 +37,7 @@ export const annotationCGroupV1 = 'node.giantswarm.io/cgroupv1';
 export const conditionTypeReady = 'Ready';
 export const conditionTypeCreating = 'Creating';
 export const conditionTypeUpgrading = 'Upgrading';
+export const conditionTypeControlPlaneInitialized = 'ControlPlaneInitialized';
 
 export const conditionReasonCreationCompleted = 'CreationCompleted';
 export const conditionReasonExistingObject = 'ExistingObject';

--- a/test/mockHttpCalls/infrastructurev1alpha3/awsClusters.ts
+++ b/test/mockHttpCalls/infrastructurev1alpha3/awsClusters.ts
@@ -61,6 +61,10 @@ export const randomAWSCluster1: infrav1alpha3.IAWSCluster = {
     cluster: {
       conditions: [
         {
+          condition: 'Created',
+          lastTransitionTime: '2022-03-29T06:41:52Z',
+        },
+        {
           condition: 'Creating',
           lastTransitionTime: '2022-03-29T06:40:52Z',
         },


### PR DESCRIPTION
Closes [giantswarm/roadmap/issues/1226](https://github.com/giantswarm/roadmap/issues/1226).

This PR adds support for displaying a description and a status for CAPG clusters. Only `Cluster creating…` status is supported by now.

<img width="857" alt="Screenshot 2022-07-15 at 14 03 33" src="https://user-images.githubusercontent.com/445309/179211199-5c75df0c-f4c3-4460-ad11-9d3daa36a8f2.png">



