### PR TITLE
Push to gcp app collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,18 @@ workflows:
             tags:
               only: /^v.*/
 
+      - architect/push-to-app-collection:
+          name: push-to-gcp-app-collection
+          app_name: "happa"
+          app_collection_repo: "gcp-app-collection"
+          requires:
+            - push-happa-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
       # FE Docs
 
       - build-fe-docs:


### PR DESCRIPTION
We want to push happa to gcp app collection so that we have always the latest release available..
