### PR TITLE
Combine the display of multiple CLI guides into one component

### DIFF
--- a/src/components/MAPI/apps/AppList/AppDetail.tsx
+++ b/src/components/MAPI/apps/AppList/AppDetail.tsx
@@ -1,6 +1,5 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { push, replace } from 'connected-react-router';
-import { Box } from 'grommet';
 import AppInstallModal from 'MAPI/apps/AppInstallModal';
 import { extractErrorMessage } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
@@ -20,6 +19,7 @@ import useSWR, { useSWRConfig } from 'swr';
 import { IVersion } from 'UI/Controls/VersionPicker/VersionPickerUtils';
 import AppDetailPage from 'UI/Display/Apps/AppDetailNew/AppDetailPage';
 import AppInstallationSelectedCluster from 'UI/Display/MAPI/apps/AppInstallationSelectedCluster';
+import CLIGuidesList from 'UI/Display/MAPI/CLIGuide/CLIGuidesList';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
@@ -335,7 +335,7 @@ const AppDetail: React.FC<React.PropsWithChildren<{}>> = () => {
             }
           />
           {selectedEntry && (
-            <Box margin={{ top: 'medium' }} direction='column' gap='small'>
+            <CLIGuidesList margin={{ top: 'medium' }}>
               <InspectAppGuide
                 appName={selectedEntry.spec.appName}
                 catalogName={selectedEntry.spec.catalog.name}
@@ -354,7 +354,7 @@ const AppDetail: React.FC<React.PropsWithChildren<{}>> = () => {
                   appsPermissions.canCreate && appsPermissions.canConfigure
                 }
               />
-            </Box>
+            </CLIGuidesList>
           )}
         </>
       </Breadcrumb>

--- a/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListItem.tsx
@@ -14,6 +14,7 @@ import React, {
 import styled from 'styled-components';
 import useSWR, { useSWRConfig } from 'swr';
 import Date from 'UI/Display/Date';
+import CLIGuidesList from 'UI/Display/MAPI/CLIGuide/CLIGuidesList';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 import Truncated from 'UI/Util/Truncated';
 import ErrorReporter from 'utils/errors/ErrorReporter';
@@ -271,11 +272,8 @@ const ClusterDetailAppListItem: React.FC<
           />
         </StyledBox>
         {app && catalogNamespace && (
-          <Box
-            margin={{ top: 'medium' }}
-            direction='column'
-            gap='small'
-            pad='xsmall'
+          <CLIGuidesList
+            margin={{ top: 'medium', horizontal: 'xsmall', bottom: 'xsmall' }}
           >
             <InspectInstalledAppGuide
               appName={app.metadata.name}
@@ -300,7 +298,7 @@ const ClusterDetailAppListItem: React.FC<
               namespace={app.metadata.namespace!}
               canUninstallApps={appsPermissions?.canDelete}
             />
-          </Box>
+          </CLIGuidesList>
         )}
       </Box>
     </AccordionPanel>

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailOverview.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useRouteMatch } from 'react-router';
 import styled from 'styled-components';
 import useSWR from 'swr';
+import CLIGuideList from 'UI/Display/MAPI/CLIGuide/CLIGuidesList';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
@@ -132,11 +133,8 @@ const ClusterDetailOverview: React.FC<React.PropsWithChildren<{}>> = () => {
       <ClusterDetailWidgetCreated cluster={cluster} basis='100%' />
 
       {cluster && (
-        <Box
+        <CLIGuideList
           margin={{ top: 'large' }}
-          direction='column'
-          gap='small'
-          basis='100%'
           animation={{ type: 'fadeIn', duration: 300 }}
         >
           <InspectClusterGuide
@@ -168,7 +166,7 @@ const ClusterDetailOverview: React.FC<React.PropsWithChildren<{}>> = () => {
             provider={provider}
             canUpdateCluster={canUpdateCluster}
           />
-        </Box>
+        </CLIGuideList>
       )}
     </StyledBox>
   );

--- a/src/components/MAPI/organizations/AccessControl/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/index.tsx
@@ -10,6 +10,7 @@ import AccessControlRoleDescription from 'UI/Display/MAPI/AccessControl/AccessCo
 import AccessControlRoleDetail from 'UI/Display/MAPI/AccessControl/AccessControlRoleDetail';
 import AccessControlRoleList from 'UI/Display/MAPI/AccessControl/AccessControlRoleList';
 import * as ui from 'UI/Display/MAPI/AccessControl/types';
+import CLIGuidesList from 'UI/Display/MAPI/CLIGuide/CLIGuidesList';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 
@@ -212,14 +213,14 @@ const AccessControl: React.FC<React.PropsWithChildren<IAccessControlProps>> = ({
             permissions={permissions}
           />
         </Box>
-        <Box margin={{ top: 'large' }} direction='column' gap='small'>
+        <CLIGuidesList margin={{ top: 'large' }}>
           <ListRolesGuide namespace={organizationNamespace} />
           <InspectRoleGuide namespace={organizationNamespace} />
           <BindRolesToSubjectsGuide
             namespace={organizationNamespace}
             canBindRoles={canBindRolesToSubjects(permissions)}
           />
-        </Box>
+        </CLIGuidesList>
       </Box>
     </DocumentTitle>
   );

--- a/src/components/MAPI/organizations/OrganizationDetailGeneral/index.tsx
+++ b/src/components/MAPI/organizations/OrganizationDetailGeneral/index.tsx
@@ -1,5 +1,4 @@
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
-import { Box } from 'grommet';
 import { usePermissionsForClusters } from 'MAPI/clusters/permissions/usePermissionsForClusters';
 import { usePermissionsForCPNodes } from 'MAPI/clusters/permissions/usePermissionsForCPNodes';
 import { usePermissionsForReleases } from 'MAPI/releases/permissions/usePermissionsForReleases';
@@ -21,6 +20,7 @@ import { IState } from 'model/stores/state';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useSWR from 'swr';
+import CLIGuidesList from 'UI/Display/MAPI/CLIGuide/CLIGuidesList';
 import OrganizationDetailPage from 'UI/Display/Organizations/OrganizationDetailPage';
 import * as ui from 'UI/Display/Organizations/types';
 import ErrorReporter from 'utils/errors/ErrorReporter';
@@ -226,13 +226,13 @@ const OrganizationDetailGeneral: React.FC<
           typeof appsSummary === 'undefined' && appsSummaryIsValidating
         }
       />
-      <Box margin={{ top: 'large' }} direction='column' gap='small'>
+      <CLIGuidesList margin={{ top: 'large' }}>
         <GetOrganizationDetailsGuide organizationName={organizationName} />
         <DeleteOrganizationGuide
           organizationName={organizationName}
           canDeleteOrganization={orgPermissions.canDelete}
         />
-      </Box>
+      </CLIGuidesList>
     </>
   );
 };

--- a/src/components/MAPI/organizations/OrganizationList.tsx
+++ b/src/components/MAPI/organizations/OrganizationList.tsx
@@ -17,6 +17,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import DocumentTitle from 'shared/DocumentTitle';
 import useSWR, { useSWRConfig } from 'swr';
 import Button from 'UI/Controls/Button';
+import CLIGuidesList from 'UI/Display/MAPI/CLIGuide/CLIGuidesList';
 import OrganizationListPage from 'UI/Display/Organizations/OrganizationListPage';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
@@ -184,12 +185,12 @@ const OrganizationIndex: React.FC<React.PropsWithChildren<unknown>> = () => {
         )}
       </Box>
 
-      <Box margin={{ top: 'large' }} direction='column' gap='small'>
+      <CLIGuidesList margin={{ top: 'large' }}>
         <ListOrganizationsGuide />
         <CreateOrganizationGuide
           canCreateOrganizations={canCreateOrganizations}
         />
-      </Box>
+      </CLIGuidesList>
     </DocumentTitle>
   );
 };

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -37,6 +37,7 @@ import { CODE_CHAR_WIDTH, CODE_PADDING } from 'styles';
 import BaseTransition from 'styles/transitions/BaseTransition';
 import useSWR from 'swr';
 import Button from 'UI/Controls/Button';
+import CLIGuidesList from 'UI/Display/MAPI/CLIGuide/CLIGuidesList';
 import { NodePoolGridRow } from 'UI/Display/MAPI/workernodes/styles';
 import WorkerNodesNodePoolListPlaceholder from 'UI/Display/MAPI/workernodes/WorkerNodesNodePoolListPlaceholder';
 import ErrorReporter from 'utils/errors/ErrorReporter';
@@ -640,11 +641,8 @@ const ClusterDetailWorkerNodes: React.FC<
               )}
             </Box>
             {cluster && providerCluster && (
-              <Box
+              <CLIGuidesList
                 margin={{ top: 'large' }}
-                direction='column'
-                gap='small'
-                basis='100%'
                 animation={{ type: 'fadeIn', duration: 300 }}
               >
                 <ListNodePoolsGuide
@@ -671,7 +669,7 @@ const ClusterDetailWorkerNodes: React.FC<
                     usesNonExpMachinePools={usesNonExpMachinePools}
                   />
                 )}
-              </Box>
+              </CLIGuidesList>
             )}
           </Box>
         </Breadcrumb>

--- a/src/components/UI/Display/MAPI/CLIGuide/CLIGuidesList.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/CLIGuidesList.tsx
@@ -1,0 +1,88 @@
+import {
+  Accordion,
+  AccordionPanel,
+  Box,
+  Text,
+  ThemeContext,
+  ThemeType,
+} from 'grommet';
+import { normalizeColor } from 'grommet/utils';
+import React, { useState } from 'react';
+import { css } from 'styled-components';
+
+const customTheme: ThemeType = {
+  icon: {
+    // @ts-expect-error
+    extend: css`
+      fill: ${({ theme }) => normalizeColor('text-weak', theme)};
+      stroke: ${({ theme }) => normalizeColor('text-weak', theme)};
+    `,
+  },
+};
+
+interface ICLIGuidesListProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof Accordion>, 'title'> {
+  title?: string;
+}
+
+const CLIGuidesList: React.FC<React.PropsWithChildren<ICLIGuidesListProps>> = ({
+  children,
+  title = 'Use the Management API to …',
+  ...props
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <ThemeContext.Extend value={customTheme}>
+      <Accordion
+        onActive={(indices: number[]) => setIsExpanded(indices.length > 0)}
+        basis='100%'
+        round='xsmall'
+        background={isExpanded ? 'accent-strong' : 'background-strong'}
+        {...props}
+      >
+        <AccordionPanel
+          label={
+            <Box
+              direction='row'
+              align='center'
+              pad='small'
+              gap='xsmall'
+              round='xsmall'
+              background={isExpanded ? 'accent-strong' : 'background-strong'}
+            >
+              <Text
+                className='fa fa-shell'
+                role='presentation'
+                aria-hidden={true}
+                color='text-weak'
+              />
+              <Text weight='bold' color='text-weak'>
+                {title}
+              </Text>
+            </Box>
+          }
+        >
+          <Box
+            basis='100%'
+            margin={{ bottom: 'xsmall' }}
+            pad='12px'
+            gap='small'
+          >
+            {children &&
+              React.Children.map(
+                children,
+                (child) =>
+                  child &&
+                  React.cloneElement(child as React.ReactElement, {
+                    inList: true,
+                  })
+              )}
+          </Box>
+        </AccordionPanel>
+      </Accordion>
+    </ThemeContext.Extend>
+  );
+};
+
+export default CLIGuidesList;

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/__snapshots__/index.tsx.snap
@@ -38,7 +38,7 @@ exports[`CLIGuide renders the contents when open 1`] = `
               <span
                 class="StyledText-sc-1sadyjn-0 hLeSgE"
               >
-                Get something from somewhere
+                Get something from somewhere via the Management API
               </span>
             </div>
             <div
@@ -120,7 +120,223 @@ exports[`CLIGuide renders without crashing 1`] = `
               <span
                 class="StyledText-sc-1sadyjn-0 hLeSgE"
               >
-                Get something from somewhere
+                Get something from somewhere via the Management API
+              </span>
+            </div>
+            <div
+              class="StyledBox-sc-13pk1d4-0 xKDIh"
+            >
+              <svg
+                aria-label="FormDown"
+                class="StyledIcon-sc-ofa7kd-0 bwOwIm"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 9-6 6-6-6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="StyledBox-sc-13pk1d4-0 iNDmPr"
+        >
+          <div
+            aria-hidden="true"
+            class="StyledBox-sc-13pk1d4-0 iNDmPr Collapsible__AnimatedBox-sc-15kniua-0 cxsREl"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CLIGuidesList renders the contents when open 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 fxRgDK"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-12xd2cf-0 lixbyN"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 kflmHi"
+      role="tablist"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 hFkNOm"
+      >
+        <button
+          aria-expanded="true"
+          aria-selected="true"
+          class="StyledButtonKind-sc-1vhfpnt-0 bICtWz"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 dsfsDz"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 ewtkHK"
+            >
+              <span
+                aria-hidden="true"
+                class="StyledText-sc-1sadyjn-0 gxPAiZ fa fa-shell"
+                role="presentation"
+              />
+              <div
+                class="StyledBox__StyledBoxGap-sc-13pk1d4-1 bnQbNj"
+              />
+              <span
+                class="StyledText-sc-1sadyjn-0 hxuJKP"
+              >
+                Use the API to …
+              </span>
+            </div>
+            <div
+              class="StyledBox-sc-13pk1d4-0 xKDIh"
+            >
+              <svg
+                aria-label="FormUp"
+                class="StyledIcon-sc-ofa7kd-0 bwOwIm"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m18 15-6-6-6 6"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+          </div>
+        </button>
+        <div
+          class="StyledBox-sc-13pk1d4-0 iNDmPr"
+          style=""
+        >
+          <div
+            aria-hidden="false"
+            class="StyledBox-sc-13pk1d4-0 iNDmPr Collapsible__AnimatedBox-sc-15kniua-0 fBjAck"
+            open=""
+            style="max-height: 0;"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 kAkXMK"
+            >
+              <div
+                class="StyledBox-sc-13pk1d4-0 bPoCLd CLIGuide__StyledAccordion-sc-1q6mc5x-0 czGaBT"
+                role="tablist"
+              >
+                <div
+                  class="StyledBox-sc-13pk1d4-0 hFkNOm"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-selected="false"
+                    class="StyledButtonKind-sc-1vhfpnt-0 bICtWz"
+                    role="tab"
+                    type="button"
+                  >
+                    <div
+                      class="StyledBox-sc-13pk1d4-0 dsfsDz"
+                    >
+                      <div
+                        class="StyledBox-sc-13pk1d4-0 kKfTPQ"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="StyledText-sc-1sadyjn-0 gNWhMe fa fa-shell"
+                          role="presentation"
+                        />
+                        <div
+                          class="StyledBox__StyledBoxGap-sc-13pk1d4-1 bnQbNj"
+                        />
+                        <span
+                          class="StyledText-sc-1sadyjn-0 hLeSgE"
+                        >
+                          Get something from somewhere
+                        </span>
+                      </div>
+                      <div
+                        class="StyledBox-sc-13pk1d4-0 xKDIh"
+                      >
+                        <svg
+                          aria-label="FormDown"
+                          class="StyledIcon-sc-ofa7kd-0 bwOwIm"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="m18 9-6 6-6-6"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </button>
+                  <div
+                    class="StyledBox-sc-13pk1d4-0 iNDmPr"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="StyledBox-sc-13pk1d4-0 iNDmPr Collapsible__AnimatedBox-sc-15kniua-0 cxsREl"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CLIGuidesList renders without crashing 1`] = `
+<div
+  class="StyledGrommet-sc-19lkkz7-0 fxRgDK"
+>
+  <div
+    class="ThemeProvider__AppWrapper-sc-12xd2cf-0 lixbyN"
+  >
+    <div
+      class="StyledBox-sc-13pk1d4-0 bcgQUq"
+      role="tablist"
+    >
+      <div
+        class="StyledBox-sc-13pk1d4-0 hFkNOm"
+      >
+        <button
+          aria-expanded="false"
+          aria-selected="false"
+          class="StyledButtonKind-sc-1vhfpnt-0 bICtWz"
+          role="tab"
+          type="button"
+        >
+          <div
+            class="StyledBox-sc-13pk1d4-0 dsfsDz"
+          >
+            <div
+              class="StyledBox-sc-13pk1d4-0 lgRgkK"
+            >
+              <span
+                aria-hidden="true"
+                class="StyledText-sc-1sadyjn-0 gxPAiZ fa fa-shell"
+                role="presentation"
+              />
+              <div
+                class="StyledBox__StyledBoxGap-sc-13pk1d4-1 bnQbNj"
+              />
+              <span
+                class="StyledText-sc-1sadyjn-0 hxuJKP"
+              >
+                Use the API to …
               </span>
             </div>
             <div

--- a/src/components/UI/Display/MAPI/CLIGuide/__tests__/index.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/__tests__/index.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, screen } from '@testing-library/react';
+import * as React from 'react';
 import { renderWithTheme } from 'test/renderUtils';
 
 import CLIGuide from '..';
+import CLIGuidesList from '../CLIGuidesList';
 
 describe('CLIGuide', () => {
   it('renders without crashing', () => {
@@ -23,6 +25,31 @@ describe('CLIGuide', () => {
     );
 
     expect(await screen.findByText('Just some content')).toBeInTheDocument();
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('CLIGuidesList', () => {
+  it('renders without crashing', () => {
+    const { container } = renderWithTheme(CLIGuidesList, {
+      title: 'Use the API to …',
+      children: '',
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders the contents when open', async () => {
+    const { container } = renderWithTheme(CLIGuidesList, {
+      title: 'Use the API to …',
+      children: <CLIGuide title='Get something from somewhere' />,
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: /Use the API to …/ }));
+
+    expect(
+      await screen.findByText('Get something from somewhere')
+    ).toBeInTheDocument();
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/UI/Display/MAPI/CLIGuide/index.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/index.tsx
@@ -39,16 +39,28 @@ const customTheme: ThemeType = {
   },
 };
 
+function formatTitle(title: string, inList: boolean): string {
+  if (inList) {
+    return title.replace(/via the Management API/gi, '');
+  }
+
+  return title.endsWith('via the Management API')
+    ? title
+    : `${title} via the Management API`;
+}
+
 interface ICLIGuideProps
   extends Omit<React.ComponentPropsWithoutRef<typeof Accordion>, 'title'> {
   title: React.ReactNode;
   footer?: React.ReactNode;
+  inList?: boolean;
 }
 
 const CLIGuide: React.FC<React.PropsWithChildren<ICLIGuideProps>> = ({
   children,
   title,
   footer,
+  inList = false,
   ...props
 }) => {
   return (
@@ -67,7 +79,9 @@ const CLIGuide: React.FC<React.PropsWithChildren<ICLIGuideProps>> = ({
                 role='presentation'
                 aria-hidden={true}
               />
-              <Text weight='bold'>{title}</Text>
+              <Text weight='bold'>
+                {typeof title === 'string' ? formatTitle(title, inList) : title}
+              </Text>
             </Box>
           }
         >

--- a/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuide.stories.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuide.stories.tsx
@@ -6,6 +6,6 @@ export { Simple } from './Simple';
 export { AdditionalInfo } from './AdditionalInfo';
 
 export default {
-  title: 'Display/MAPI/CLIGuide',
+  title: 'Display/MAPI/CLIGuides/CLIGuide',
   component: CLIGuide,
 } as Meta;

--- a/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuidesList.stories.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuidesList.stories.tsx
@@ -1,0 +1,10 @@
+import { Meta } from '@storybook/react';
+
+import CLIGuidesList from '../CLIGuidesList';
+
+export { Simple } from './CLIGuidesList';
+
+export default {
+  title: 'Display/MAPI/CLIGuides/CLIGuidesList',
+  component: CLIGuidesList,
+} as Meta;

--- a/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuidesList.tsx
+++ b/src/components/UI/Display/MAPI/CLIGuide/stories/CLIGuidesList.tsx
@@ -1,0 +1,35 @@
+import { Story } from '@storybook/react';
+import React from 'react';
+
+import CLIGuide from '..';
+import CLIGuidesList from '../CLIGuidesList';
+import CLIGuideStep from '../CLIGuideStep';
+import CLIGuideStepList from '../CLIGuideStepList';
+
+export const Simple: Story<
+  React.ComponentPropsWithoutRef<typeof CLIGuidesList>
+> = (args) => {
+  return <CLIGuidesList {...args} />;
+};
+
+Simple.args = {
+  title: 'Use the API to …',
+  children: (
+    <CLIGuide title='Get some data from the somewhere'>
+      <CLIGuideStepList>
+        <CLIGuideStep
+          title='1. Make sure you are a boss'
+          command='some command --some-flag'
+        />
+        <CLIGuideStep
+          title='2. Maybe check again if you are still a boss'
+          command='some-other-cli checkboss'
+        />
+      </CLIGuideStepList>
+    </CLIGuide>
+  ),
+};
+
+Simple.argTypes = {
+  title: { control: { type: 'text' } },
+};


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1235.

This PR improves how we display multiple CLI guides by combining them into one component, with the goal of reducing visual noise for users. This is implemented wherever we display 2 or more CLI guides in conjunction.

**An example:**
Collapsed
<img width="1187" alt="Screen Shot 2022-07-19 at 09 36 02" src="https://user-images.githubusercontent.com/62935115/179731527-8ffb7132-0f2d-4696-9b4d-d5c474c23898.png">

Expanded
<img width="1187" alt="Screen Shot 2022-07-19 at 09 34 27" src="https://user-images.githubusercontent.com/62935115/179731627-4218cde4-5df7-4af0-9356-a7798e12899e.png">

