### PR TITLE
Display original app name

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetCatalog.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetCatalog.tsx
@@ -90,7 +90,7 @@ const ClusterDetailAppListWidgetCatalog: React.FC<
   const isManaged = catalog ? isAppCatalogVisibleToUsers(catalog) : false;
 
   return (
-    <ClusterDetailAppListWidget title='Catalog' {...props}>
+    <ClusterDetailAppListWidget title='Catalog' titleColor='text' {...props}>
       <OptionalValue value={catalogTitle} loaderWidth={150}>
         {(value) => (
           <CatalogLabel

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetInstalledAs.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetInstalledAs.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ClusterDetailAppListWidget from 'UI/Display/MAPI/apps/ClusterDetailAppListWidget';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 
-interface IClusterDetailAppListWidgetNamespaceProps
+interface IClusterDetailAppListWidgetInstalledAsProps
   extends Omit<
     React.ComponentPropsWithoutRef<typeof ClusterDetailAppListWidget>,
     'title'
@@ -12,22 +12,22 @@ interface IClusterDetailAppListWidgetNamespaceProps
   app?: applicationv1alpha1.IApp;
 }
 
-const ClusterDetailAppListWidgetNamespace: React.FC<
-  React.PropsWithChildren<IClusterDetailAppListWidgetNamespaceProps>
+const ClusterDetailAppListWidgetInstalledAs: React.FC<
+  React.PropsWithChildren<IClusterDetailAppListWidgetInstalledAsProps>
 > = ({ app, ...props }) => {
   return (
     <ClusterDetailAppListWidget
-      title='Target namespace'
+      title='Installed as'
       titleColor='text'
       {...props}
     >
-      <OptionalValue value={app?.spec.namespace} loaderWidth={100}>
+      <OptionalValue value={app?.metadata.name} loaderWidth={100}>
         {(value) => (
-          <Text aria-label={`App target namespace: ${value}`}>{value}</Text>
+          <Text aria-label={`App installed as: ${value}`}>{value}</Text>
         )}
       </OptionalValue>
     </ClusterDetailAppListWidget>
   );
 };
 
-export default ClusterDetailAppListWidgetNamespace;
+export default ClusterDetailAppListWidgetInstalledAs;

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetName.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetName.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ClusterDetailAppListWidget from 'UI/Display/MAPI/apps/ClusterDetailAppListWidget';
 import OptionalValue from 'UI/Display/OptionalValue/OptionalValue';
 
-interface IClusterDetailAppListWidgetNamespaceProps
+interface IClusterDetailAppListWidgetNameProps
   extends Omit<
     React.ComponentPropsWithoutRef<typeof ClusterDetailAppListWidget>,
     'title'
@@ -12,22 +12,16 @@ interface IClusterDetailAppListWidgetNamespaceProps
   app?: applicationv1alpha1.IApp;
 }
 
-const ClusterDetailAppListWidgetNamespace: React.FC<
-  React.PropsWithChildren<IClusterDetailAppListWidgetNamespaceProps>
+const ClusterDetailAppListWidgetName: React.FC<
+  React.PropsWithChildren<IClusterDetailAppListWidgetNameProps>
 > = ({ app, ...props }) => {
   return (
-    <ClusterDetailAppListWidget
-      title='Target namespace'
-      titleColor='text'
-      {...props}
-    >
-      <OptionalValue value={app?.spec.namespace} loaderWidth={100}>
-        {(value) => (
-          <Text aria-label={`App target namespace: ${value}`}>{value}</Text>
-        )}
+    <ClusterDetailAppListWidget title='App name' titleColor='text' {...props}>
+      <OptionalValue value={app?.spec.name} loaderWidth={100}>
+        {(value) => <Text aria-label={`App name: ${value}`}>{value}</Text>}
       </OptionalValue>
     </ClusterDetailAppListWidget>
   );
 };
 
-export default ClusterDetailAppListWidgetNamespace;
+export default ClusterDetailAppListWidgetName;

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetStatus.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetStatus.tsx
@@ -20,7 +20,7 @@ const ClusterDetailAppListWidgetStatus: React.FC<
   if (app?.status?.release.status) status = app.status.release.status;
 
   return (
-    <ClusterDetailAppListWidget title='Status' {...props}>
+    <ClusterDetailAppListWidget title='Status' titleColor='text' {...props}>
       <OptionalValue value={status} loaderWidth={100}>
         {(value) => <Text aria-label={`App status: ${value}`}>{value}</Text>}
       </OptionalValue>

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersion.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersion.tsx
@@ -92,6 +92,7 @@ const ClusterDetailAppListWidgetVersion: React.FC<
   return (
     <ClusterDetailAppListWidget
       title='Version'
+      titleColor='text'
       contentProps={{
         direction: 'row',
         gap: 'small',

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListItem.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListItem.tsx
@@ -26,7 +26,8 @@ import { usePermissionsForCatalogs } from '../permissions/usePermissionsForCatal
 
 function generateApp(
   name: string = 'some-app',
-  version: string = '1.2.1'
+  version: string = '1.2.1',
+  installedAs: string = 'some-app-alias'
 ): applicationv1alpha1.IApp {
   const namespace = capiv1beta1Mocks.randomCluster1.metadata.name;
 
@@ -48,7 +49,7 @@ function generateApp(
         'giantswarm.io/organization': 'org1',
         'giantswarm.io/service-type': 'managed',
       },
-      name,
+      name: installedAs,
       namespace,
       resourceVersion: '294675096',
       selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${name}`,
@@ -149,6 +150,29 @@ describe('ClusterDetailAppListItem', () => {
       defaultPermissions
     );
     render(getComponent({}));
+  });
+
+  it('displays app name and alias', async () => {
+    (usePermissionsForCatalogs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+    (usePermissionsForAppCatalogEntries as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+
+    render(
+      getComponent({
+        app: generateApp(),
+      })
+    );
+
+    const appNameWidget = await screen.findByLabelText('App name');
+    expect(within(appNameWidget).getByText('some-app')).toBeInTheDocument();
+
+    const appInstalledAsWidget = await screen.findByLabelText('Installed as');
+    expect(
+      within(appInstalledAsWidget).getByText('some-app-alias')
+    ).toBeInTheDocument();
   });
 
   it('displays various information about the supported app versions', async () => {
@@ -278,7 +302,7 @@ describe('ClusterDetailAppListItem', () => {
       defaultPermissions
     );
 
-    let app = generateApp('coredns', '1.2.0');
+    let app = generateApp('coredns', '1.2.0', 'coredns');
     const newVersion = '1.3.0';
 
     nock(window.config.mapiEndpoint)
@@ -350,7 +374,7 @@ describe('ClusterDetailAppListItem', () => {
       defaultPermissions
     );
 
-    let app = generateApp('coredns', '1.3.0');
+    let app = generateApp('coredns', '1.3.0', 'coredns');
     const newVersion = '1.2.0';
 
     nock(window.config.mapiEndpoint)
@@ -422,7 +446,7 @@ describe('ClusterDetailAppListItem', () => {
       defaultPermissions
     );
 
-    const app = generateApp('coredns', '1.2.0');
+    const app = generateApp('coredns', '1.2.0', 'coredns');
     const newVersion = '1.3.0';
 
     nock(window.config.mapiEndpoint)

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetInstalledAs.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetInstalledAs.tsx
@@ -1,0 +1,102 @@
+import { screen } from '@testing-library/react';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import * as capiv1beta1Mocks from 'test/mockHttpCalls/capiv1beta1';
+import { renderWithTheme } from 'test/renderUtils';
+
+import ClusterDetailAppListWidgetInstalledAs from '../ClusterDetailAppListWidgetInstalledAs';
+
+function generateApp(
+  name: string = 'some-app',
+  version: string = '1.2.1',
+  installedAs: string = 'some-app-alias'
+): applicationv1alpha1.IApp {
+  const namespace = capiv1beta1Mocks.randomCluster1.metadata.name;
+
+  return {
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'App',
+    metadata: {
+      annotations: {
+        'chart-operator.giantswarm.io/force-helm-upgrade': 'true',
+      },
+      creationTimestamp: new Date().toISOString(),
+      finalizers: ['operatorkit.giantswarm.io/app-operator-app'],
+      generation: 1,
+      labels: {
+        app: name,
+        'app-operator.giantswarm.io/version': '3.2.1',
+        'giantswarm.io/cluster': namespace,
+        'giantswarm.io/managed-by': 'Helm',
+        'giantswarm.io/organization': 'org1',
+        'giantswarm.io/service-type': 'managed',
+      },
+      name: installedAs,
+      namespace,
+      resourceVersion: '294675096',
+      selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${name}`,
+      uid: '859c4eb1-ece4-4eca-85b2-a4a456b6ae81',
+    },
+    spec: {
+      catalog: 'default',
+      config: {
+        configMap: {
+          name: `${namespace}-cluster-values`,
+          namespace,
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      kubeConfig: {
+        context: {
+          name: `${namespace}-kubeconfig`,
+        },
+        inCluster: false,
+        secret: {
+          name: `${namespace}-kubeconfig`,
+          namespace,
+        },
+      },
+      name,
+      namespace: 'giantswarm',
+      userConfig: {
+        configMap: {
+          name: '',
+          namespace: '',
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      version,
+    },
+    status: {
+      appVersion: '0.4.1',
+      release: {
+        lastDeployed: '2021-04-27T16:21:37Z',
+        status,
+      },
+      version,
+    },
+  };
+}
+
+describe('ClusterDetailAppListWidgetInstalledAs', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(ClusterDetailAppListWidgetInstalledAs, {});
+  });
+
+  it('displays the app installed as name', () => {
+    const app = generateApp();
+
+    renderWithTheme(ClusterDetailAppListWidgetInstalledAs, {
+      app,
+    });
+
+    expect(
+      screen.getByLabelText('App installed as: some-app-alias')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetName.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailAppListWidgetName.tsx
@@ -1,0 +1,100 @@
+import { screen } from '@testing-library/react';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import * as capiv1beta1Mocks from 'test/mockHttpCalls/capiv1beta1';
+import { renderWithTheme } from 'test/renderUtils';
+
+import ClusterDetailAppListWidgetName from '../ClusterDetailAppListWidgetName';
+
+function generateApp(
+  name: string = 'some-app',
+  version: string = '1.2.1',
+  installedAs: string = 'some-app-alias'
+): applicationv1alpha1.IApp {
+  const namespace = capiv1beta1Mocks.randomCluster1.metadata.name;
+
+  return {
+    apiVersion: 'application.giantswarm.io/v1alpha1',
+    kind: 'App',
+    metadata: {
+      annotations: {
+        'chart-operator.giantswarm.io/force-helm-upgrade': 'true',
+      },
+      creationTimestamp: new Date().toISOString(),
+      finalizers: ['operatorkit.giantswarm.io/app-operator-app'],
+      generation: 1,
+      labels: {
+        app: name,
+        'app-operator.giantswarm.io/version': '3.2.1',
+        'giantswarm.io/cluster': namespace,
+        'giantswarm.io/managed-by': 'Helm',
+        'giantswarm.io/organization': 'org1',
+        'giantswarm.io/service-type': 'managed',
+      },
+      name: installedAs,
+      namespace,
+      resourceVersion: '294675096',
+      selfLink: `/apis/application.giantswarm.io/v1alpha1/namespaces/${namespace}/apps/${name}`,
+      uid: '859c4eb1-ece4-4eca-85b2-a4a456b6ae81',
+    },
+    spec: {
+      catalog: 'default',
+      config: {
+        configMap: {
+          name: `${namespace}-cluster-values`,
+          namespace,
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      kubeConfig: {
+        context: {
+          name: `${namespace}-kubeconfig`,
+        },
+        inCluster: false,
+        secret: {
+          name: `${namespace}-kubeconfig`,
+          namespace,
+        },
+      },
+      name,
+      namespace: 'giantswarm',
+      userConfig: {
+        configMap: {
+          name: '',
+          namespace: '',
+        },
+        secret: {
+          name: '',
+          namespace: '',
+        },
+      },
+      version,
+    },
+    status: {
+      appVersion: '0.4.1',
+      release: {
+        lastDeployed: '2021-04-27T16:21:37Z',
+        status,
+      },
+      version,
+    },
+  };
+}
+
+describe('ClusterDetailAppListWidgetName', () => {
+  it('renders without crashing', () => {
+    renderWithTheme(ClusterDetailAppListWidgetName, {});
+  });
+
+  it('displays the app name', () => {
+    const app = generateApp();
+
+    renderWithTheme(ClusterDetailAppListWidgetName, {
+      app,
+    });
+
+    expect(screen.getByLabelText('App name: some-app')).toBeInTheDocument();
+  });
+});

--- a/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/__tests__/__snapshots__/index.tsx.snap
@@ -9,10 +9,10 @@ exports[`ClusterDetailAppListWidget renders a simple widget 1`] = `
   >
     <div
       aria-label="Some widget"
-      class="StyledBox-sc-13pk1d4-0 dKbXbi"
+      class="StyledBox-sc-13pk1d4-0 bCeIlK"
     >
       <div
-        class="StyledBox-sc-13pk1d4-0 iNDmPr"
+        class="StyledBox-sc-13pk1d4-0 iHJggX"
       >
         <span
           class="StyledText-sc-1sadyjn-0 lfzAuU ClusterDetailAppListWidget__Title-sc-1uv4dc5-0 cOsBqW"

--- a/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/index.tsx
+++ b/src/components/UI/Display/MAPI/apps/ClusterDetailAppListWidget/index.tsx
@@ -9,16 +9,30 @@ const Title = styled(Text)`
 interface IClusterDetailAppListWidgetProps
   extends React.ComponentPropsWithoutRef<typeof Box> {
   title: string;
+  titleWidth?: string;
+  titleColor?: string;
   contentProps?: React.ComponentPropsWithoutRef<typeof Box>;
 }
 
 const ClusterDetailAppListWidget: React.FC<
   React.PropsWithChildren<IClusterDetailAppListWidgetProps>
-> = ({ title, children, contentProps, ...props }) => {
+> = ({
+  title,
+  titleWidth,
+  titleColor = 'text-weak',
+  children,
+  contentProps,
+  ...props
+}) => {
   return (
-    <Box pad='xsmall' direction='column' aria-label={title} {...props}>
-      <Box>
-        <Title color='text-weak' size='small'>
+    <Box
+      pad={{ horizontal: 'xsmall' }}
+      direction='column'
+      aria-label={title}
+      {...props}
+    >
+      <Box width={{ min: titleWidth }} margin={{ right: 'medium' }}>
+        <Title color={titleColor} size='small'>
           {title}
         </Title>
       </Box>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -247,6 +247,10 @@ const theme = deepMerge(generate(16), {
         dark: COLORS.shade6,
         light: COLORS.shade6,
       },
+      'border-xweak': {
+        dark: COLORS.darkBlueLighter3,
+        light: COLORS.darkBlueLighter3,
+      },
       control: {
         dark: 'border',
         light: 'border',


### PR DESCRIPTION
Closes [giantswarm/roadmap/issues/1057](https://github.com/giantswarm/roadmap/issues/1057).

In this PR application's original name was added to the information displayed about an installed application.  For the "original name" - `.spec.name` field of the App resource is used. `.metadata.name` field, that was previously displayed as an app name, is now displayed as "Installed as". In the collapsed view, "Installed as" name is displayed only if it's different from the original name.

App item is collapsed:
<img width="1211" alt="Screenshot 2022-07-22 at 12 51 07" src="https://user-images.githubusercontent.com/445309/180421853-b8da791e-da06-4ecd-8130-8843a8b506a7.png">

App item is expanded:
<img width="1211" alt="Screenshot 2022-07-22 at 12 51 25" src="https://user-images.githubusercontent.com/445309/180421870-a3653f3a-4a4b-4279-996e-3b79eb709f5b.png">

