### PR TITLE
Fix cluster apps sorting

### DIFF
--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -768,7 +768,7 @@ export function compareApps(
     return -1;
   }
 
-  return a.metadata.name.localeCompare(b.metadata.name);
+  return a.spec.name.localeCompare(b.spec.name);
 }
 
 export function formatYAMLError(err: unknown): string {


### PR DESCRIPTION
Relates to [giantswarm/roadmap/issues/1057](https://github.com/giantswarm/roadmap/issues/1057).

Recently we started to display an original app name - `.spec.name` along with the name that can be customised - `.metadata.name`. The list sorting logic stayed the same, we sort by `.metadata.name` which can cause a situation like this:

<img width="1205" alt="Screenshot 2022-08-09 at 13 58 29" src="https://user-images.githubusercontent.com/445309/183662180-7b1a7c4c-aeb3-452a-b67e-62205b9716d4.png">

In this PR sorting logic was fixed:
<img width="1205" alt="Screenshot 2022-08-09 at 15 47 30" src="https://user-images.githubusercontent.com/445309/183662666-1352baee-45ca-4faa-bc84-3a6035b37666.png">

