### PR TITLE
Display cluster app and Kubernetes version information in Organizations > General tab

### DIFF
--- a/src/components/MAPI/organizations/OrganizationDetailGeneral/__tests__/index.tsx
+++ b/src/components/MAPI/organizations/OrganizationDetailGeneral/__tests__/index.tsx
@@ -830,6 +830,12 @@ describe('OrganizationDetailGeneral on GCP', () => {
 
     nock(window.config.mapiEndpoint)
       .get(
+        `/apis/cluster.x-k8s.io/v1beta1/namespaces/org-org1/machines/?labelSelector=cluster.x-k8s.io%2Fcluster-name%3D${capiv1beta1Mocks.randomClusterListGCP.items[0].metadata.name}%2Ccluster.x-k8s.io%2Fcontrol-plane%3D`
+      )
+      .reply(StatusCodes.Ok, capiv1beta1Mocks.randomClusterGCP1MachineList);
+
+    nock(window.config.mapiEndpoint)
+      .get(
         `/apis/infrastructure.cluster.x-k8s.io/v1beta1/namespaces/org-org1/gcpmachinetemplates/?labelSelector=cluster.x-k8s.io%2Fcluster-name%3D${capiv1beta1Mocks.randomClusterListGCP.items[0].metadata.name}%2Ccluster.x-k8s.io%2Frole%3Dcontrol-plane`
       )
       .reply(
@@ -892,6 +898,24 @@ describe('OrganizationDetailGeneral on GCP', () => {
     await waitFor(() =>
       expect(screen.getByLabelText('CPU in worker nodes')).toHaveTextContent(
         '12'
+      )
+    );
+
+    // Releases.
+    expect(screen.queryByText('Releases')).not.toBeInTheDocument();
+
+    // Versions.
+    await waitFor(() =>
+      expect(screen.getByText('Versions')).toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText('Cluster app version')).toHaveTextContent(
+        '0.15.1, 0.15.2'
+      )
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText('Kubernetes version')).toHaveTextContent(
+        '1.22'
       )
     );
   });

--- a/src/components/MAPI/organizations/OrganizationDetailGeneral/index.tsx
+++ b/src/components/MAPI/organizations/OrganizationDetailGeneral/index.tsx
@@ -7,6 +7,7 @@ import {
   extractErrorMessage,
   fetchClusterList,
   fetchClusterListKey,
+  supportsReleases,
 } from 'MAPI/utils';
 import { usePermissionsForNodePools } from 'MAPI/workernodes/permissions/usePermissionsForNodePools';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
@@ -165,10 +166,12 @@ const OrganizationDetailGeneral: React.FC<
   }, [clustersSummaryError]);
 
   const releasesPermissions = usePermissionsForReleases(provider, 'default');
+  const isReleasesSupportedByProvider = supportsReleases(provider);
 
-  const releasesSummaryKey = releasesPermissions.canGet
-    ? () => fetchReleasesSummaryKey(clusterList?.items)
-    : null;
+  const releasesSummaryKey =
+    releasesPermissions.canGet && isReleasesSupportedByProvider
+      ? () => fetchReleasesSummaryKey(clusterList?.items)
+      : null;
 
   const {
     data: releasesSummary,
@@ -221,6 +224,7 @@ const OrganizationDetailGeneral: React.FC<
         releasesSummaryLoading={
           typeof releasesSummary === 'undefined' && releasesSummaryIsValidating
         }
+        isReleasesSupported={isReleasesSupportedByProvider}
         appsSummary={appsSummary}
         appsSummaryLoading={
           typeof appsSummary === 'undefined' && appsSummaryIsValidating

--- a/src/components/UI/Display/Organizations/OrganizationDetailPage.tsx
+++ b/src/components/UI/Display/Organizations/OrganizationDetailPage.tsx
@@ -36,6 +36,7 @@ interface IOrganizationDetailPageProps {
   clustersSummaryLoading?: boolean;
   releasesSummary?: IOrganizationDetailReleasesSummary;
   releasesSummaryLoading?: boolean;
+  isReleasesSupported?: boolean;
   appsSummary?: IOrganizationDetailAppsSummary;
   appsSummaryLoading?: boolean;
 }
@@ -53,6 +54,7 @@ const OrganizationDetailPage: React.FC<
   clustersSummaryLoading,
   releasesSummary,
   releasesSummaryLoading,
+  isReleasesSupported,
   appsSummary,
   appsSummaryLoading,
 }) => {
@@ -129,64 +131,66 @@ const OrganizationDetailPage: React.FC<
           </Box>
         </Box>
       </Box>
-      <Box direction='row' gap='large'>
-        <Box width='small'>
-          <Text weight='bold' size='large' margin='none'>
-            Releases
-          </Text>
-        </Box>
-        <Box direction='row' gap='small'>
-          <Box width='medium' direction='column' gap='xsmall'>
-            <Text>Oldest release</Text>
-            <Text>Newest release</Text>
-            <Text>Releases in use</Text>
+      {isReleasesSupported && (
+        <Box direction='row' gap='large'>
+          <Box width='small'>
+            <Text weight='bold' size='large' margin='none'>
+              Releases
+            </Text>
           </Box>
-          <Box direction='column' gap='xsmall'>
-            <Box direction='row' gap='small'>
+          <Box direction='row' gap='small'>
+            <Box width='medium' direction='column' gap='xsmall'>
+              <Text>Oldest release</Text>
+              <Text>Newest release</Text>
+              <Text>Releases in use</Text>
+            </Box>
+            <Box direction='column' gap='xsmall'>
+              <Box direction='row' gap='small'>
+                <OrganizationDetailStatistic
+                  isLoading={releasesSummaryLoading}
+                  aria-label='Oldest release'
+                >
+                  {releasesSummary?.oldestReleaseVersion}
+                </OrganizationDetailStatistic>
+                <OrganizationDetailStatistic
+                  isLoading={releasesSummaryLoading}
+                  aria-label='Oldest release Kubernetes version'
+                >
+                  <KubernetesVersionLabel
+                    version={oldestReleaseK8sVersion}
+                    eolDate={oldestReleaseK8sVersionEOLDate}
+                    hidePatchVersion={true}
+                  />
+                </OrganizationDetailStatistic>
+              </Box>
+              <Box direction='row' gap='small'>
+                <OrganizationDetailStatistic
+                  isLoading={releasesSummaryLoading}
+                  aria-label='Newest release'
+                >
+                  {releasesSummary?.newestReleaseVersion}
+                </OrganizationDetailStatistic>
+                <OrganizationDetailStatistic
+                  isLoading={releasesSummaryLoading}
+                  aria-label='Newest release Kubernetes version'
+                >
+                  <KubernetesVersionLabel
+                    version={newestReleaseK8sVersion}
+                    eolDate={newestReleaseK8sVersionEOLDate}
+                    hidePatchVersion={true}
+                  />
+                </OrganizationDetailStatistic>
+              </Box>
               <OrganizationDetailStatistic
                 isLoading={releasesSummaryLoading}
-                aria-label='Oldest release'
+                aria-label='Releases in use'
               >
-                {releasesSummary?.oldestReleaseVersion}
-              </OrganizationDetailStatistic>
-              <OrganizationDetailStatistic
-                isLoading={releasesSummaryLoading}
-                aria-label='Oldest release Kubernetes version'
-              >
-                <KubernetesVersionLabel
-                  version={oldestReleaseK8sVersion}
-                  eolDate={oldestReleaseK8sVersionEOLDate}
-                  hidePatchVersion={true}
-                />
+                {releasesSummary?.releasesInUseCount}
               </OrganizationDetailStatistic>
             </Box>
-            <Box direction='row' gap='small'>
-              <OrganizationDetailStatistic
-                isLoading={releasesSummaryLoading}
-                aria-label='Newest release'
-              >
-                {releasesSummary?.newestReleaseVersion}
-              </OrganizationDetailStatistic>
-              <OrganizationDetailStatistic
-                isLoading={releasesSummaryLoading}
-                aria-label='Newest release Kubernetes version'
-              >
-                <KubernetesVersionLabel
-                  version={newestReleaseK8sVersion}
-                  eolDate={newestReleaseK8sVersionEOLDate}
-                  hidePatchVersion={true}
-                />
-              </OrganizationDetailStatistic>
-            </Box>
-            <OrganizationDetailStatistic
-              isLoading={releasesSummaryLoading}
-              aria-label='Releases in use'
-            >
-              {releasesSummary?.releasesInUseCount}
-            </OrganizationDetailStatistic>
           </Box>
         </Box>
-      </Box>
+      )}
       <Box direction='row' gap='large'>
         <Box width='small'>
           <Text weight='bold' size='large' margin='none'>

--- a/src/components/UI/Display/Organizations/OrganizationDetailPage.tsx
+++ b/src/components/UI/Display/Organizations/OrganizationDetailPage.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from 'grommet';
 import OrganizationDetailDelete from 'MAPI/organizations/OrganizationDetailDelete';
 import React from 'react';
+import Truncated from 'UI/Util/Truncated';
 import { getK8sVersionEOLDate } from 'utils/config';
 import { getHumanReadableMemory } from 'utils/helpers';
 
@@ -10,6 +11,7 @@ import {
   IOrganizationDetailAppsSummary,
   IOrganizationDetailClustersSummary,
   IOrganizationDetailReleasesSummary,
+  IOrganizationDetailVersionsSummary,
 } from './types';
 
 function formatMemory(value?: number): string | undefined {
@@ -25,6 +27,131 @@ function formatCPU(value?: number): number | undefined {
   return Math.round(value);
 }
 
+function formatClusterAppVersionsInfo(
+  versionsSummary: IOrganizationDetailVersionsSummary
+): React.ReactNode {
+  const {
+    oldestClusterAppVersion,
+    newestClusterAppVersion,
+    clusterAppVersionsInUseCount,
+  } = versionsSummary;
+
+  if (
+    typeof oldestClusterAppVersion === 'undefined' ||
+    typeof newestClusterAppVersion === 'undefined' ||
+    typeof clusterAppVersionsInUseCount === 'undefined'
+  ) {
+    return undefined;
+  }
+
+  switch (clusterAppVersionsInUseCount) {
+    case 0:
+      return undefined;
+    case 1:
+      return (
+        <Truncated numStart={8} numEnd={3}>
+          {newestClusterAppVersion}
+        </Truncated>
+      );
+    case 2:
+      return (
+        <>
+          <Truncated numStart={8} numEnd={3}>
+            {oldestClusterAppVersion}
+          </Truncated>
+          ,{' '}
+          <Truncated numStart={8} numEnd={3}>
+            {newestClusterAppVersion}
+          </Truncated>
+        </>
+      );
+    default:
+      return (
+        <>
+          {clusterAppVersionsInUseCount} versions in use, oldest{' '}
+          <Truncated numStart={8} numEnd={3}>
+            {oldestClusterAppVersion}
+          </Truncated>
+          , newest{' '}
+          <Truncated numStart={8} numEnd={3}>
+            {newestClusterAppVersion}
+          </Truncated>
+        </>
+      );
+  }
+}
+
+function formatK8sVersionsInfo(
+  versionsSummary: IOrganizationDetailVersionsSummary
+): React.ReactNode {
+  const { oldestK8sVersion, newestK8sVersion, k8sVersionsInUseCount } =
+    versionsSummary;
+
+  if (
+    typeof oldestK8sVersion === 'undefined' ||
+    typeof newestK8sVersion === 'undefined' ||
+    typeof k8sVersionsInUseCount === 'undefined'
+  ) {
+    return undefined;
+  }
+
+  const oldestReleaseK8sVersionEOLDate =
+    getK8sVersionEOLDate(oldestK8sVersion) ?? undefined;
+  const newestReleaseK8sVersionEOLDate =
+    getK8sVersionEOLDate(newestK8sVersion) ?? undefined;
+
+  switch (k8sVersionsInUseCount) {
+    case 0:
+      return undefined;
+    case 1:
+      return (
+        <KubernetesVersionLabel
+          version={newestK8sVersion}
+          eolDate={newestReleaseK8sVersionEOLDate}
+          hidePatchVersion={true}
+          hideIcon={true}
+        />
+      );
+    case 2:
+      return (
+        <>
+          <KubernetesVersionLabel
+            version={oldestK8sVersion}
+            eolDate={oldestReleaseK8sVersionEOLDate}
+            hidePatchVersion={true}
+            hideIcon={true}
+          />
+          ,{' '}
+          <KubernetesVersionLabel
+            version={newestK8sVersion}
+            eolDate={newestReleaseK8sVersionEOLDate}
+            hidePatchVersion={true}
+            hideIcon={true}
+          />
+        </>
+      );
+    default:
+      return (
+        <>
+          {k8sVersionsInUseCount} versions in use, oldest{' '}
+          <KubernetesVersionLabel
+            version={oldestK8sVersion}
+            eolDate={oldestReleaseK8sVersionEOLDate}
+            hidePatchVersion={true}
+            hideIcon={true}
+          />
+          , newest{' '}
+          <KubernetesVersionLabel
+            version={newestK8sVersion}
+            eolDate={newestReleaseK8sVersionEOLDate}
+            hidePatchVersion={true}
+            hideIcon={true}
+          />
+        </>
+      );
+  }
+}
+
 interface IOrganizationDetailPageProps {
   organizationName: string;
   organizationNamespace: string;
@@ -37,6 +164,9 @@ interface IOrganizationDetailPageProps {
   releasesSummary?: IOrganizationDetailReleasesSummary;
   releasesSummaryLoading?: boolean;
   isReleasesSupported?: boolean;
+  versionsSummary?: IOrganizationDetailVersionsSummary;
+  versionsSummaryLoading?: boolean;
+  hasClusterApp?: boolean;
   appsSummary?: IOrganizationDetailAppsSummary;
   appsSummaryLoading?: boolean;
 }
@@ -55,6 +185,9 @@ const OrganizationDetailPage: React.FC<
   releasesSummary,
   releasesSummaryLoading,
   isReleasesSupported,
+  versionsSummary,
+  versionsSummaryLoading,
+  hasClusterApp,
   appsSummary,
   appsSummaryLoading,
 }) => {
@@ -131,6 +264,39 @@ const OrganizationDetailPage: React.FC<
           </Box>
         </Box>
       </Box>
+      {hasClusterApp && (
+        <Box direction='row' gap='large'>
+          <Box width='small'>
+            <Text weight='bold' size='large' margin='none'>
+              Versions
+            </Text>
+          </Box>
+          <Box direction='row' gap='small'>
+            <Box width='medium' direction='column' gap='xsmall'>
+              <Text>Cluster app</Text>
+              <Text>Kubernetes</Text>
+            </Box>
+            <Box direction='column' gap='xsmall'>
+              <OrganizationDetailStatistic
+                isLoading={versionsSummaryLoading}
+                aria-label='Cluster app version'
+              >
+                {versionsSummary
+                  ? formatClusterAppVersionsInfo(versionsSummary)
+                  : undefined}
+              </OrganizationDetailStatistic>
+              <OrganizationDetailStatistic
+                isLoading={versionsSummaryLoading}
+                aria-label='Kubernetes version'
+              >
+                {versionsSummary
+                  ? formatK8sVersionsInfo(versionsSummary)
+                  : undefined}
+              </OrganizationDetailStatistic>
+            </Box>
+          </Box>
+        </Box>
+      )}
       {isReleasesSupported && (
         <Box direction='row' gap='large'>
           <Box width='small'>

--- a/src/components/UI/Display/Organizations/types.ts
+++ b/src/components/UI/Display/Organizations/types.ts
@@ -19,3 +19,12 @@ export interface IOrganizationDetailAppsSummary {
   appsInUseCount?: number;
   appDeploymentsCount?: number;
 }
+
+export interface IOrganizationDetailVersionsSummary {
+  oldestClusterAppVersion?: string;
+  newestClusterAppVersion?: string;
+  clusterAppVersionsInUseCount?: number;
+  oldestK8sVersion?: string;
+  newestK8sVersion?: string;
+  k8sVersionsInUseCount?: number;
+}

--- a/test/mockHttpCalls/capiv1beta1/clusters.ts
+++ b/test/mockHttpCalls/capiv1beta1/clusters.ts
@@ -207,7 +207,7 @@ export const randomClusterGCP2: capiv1beta1.ICluster = {
     labels: {
       app: 'cluster-gcp',
       'app.kubernetes.io/managed-by': 'Helm',
-      'app.kubernetes.io/version': '0.15.1',
+      'app.kubernetes.io/version': '0.15.2',
       'application.giantswarm.io/team': 'phoenix',
       'cluster-apps-operator.giantswarm.io/watching': '',
       'cluster.x-k8s.io/cluster-name': 'g9h9j',


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1246.

This PR displays information about cluster app and Kubernetes version in the Organizations > General tab. This section is only displayed if at least one cluster in the organization is created from a cluster app. We also don't display the 'Releases' section if the provider does not support releases.

For example, when there is one cluster app and Kubernetes version in use:
<img width="500" alt="Screen Shot 2022-08-09 at 17 10 33" src="https://user-images.githubusercontent.com/62935115/183702093-0d90046f-ba8a-4234-9242-90a17a20c2cc.png">

When there are 2 different versions in use, we enumerate the versions:
<img width="500" alt="Screen Shot 2022-08-09 at 17 19 17" src="https://user-images.githubusercontent.com/62935115/183702087-694989bd-5ee3-4818-a8d4-cf7b2158ebb5.png">

When there are 3 or more versions in use, we display the number of versions in use, as well as the oldest and newest versions:
<img width="700" alt="Screen Shot 2022-08-09 at 17 17 18" src="https://user-images.githubusercontent.com/62935115/183702092-fe5aadc2-6dd0-41a2-a2af-28efe2e30fb2.png">

Kubernetes versions are also displayed using a similar logic, and the EOL date is displayed on mouseover in a tooltip.