### PR TITLE
Fix login: create SelfSubjectAccessReview in correct namespace

### DIFF
--- a/src/components/__tests__/Layout.tsx
+++ b/src/components/__tests__/Layout.tsx
@@ -90,7 +90,6 @@ describe('Layout', () => {
         kind: 'SelfSubjectAccessReview',
         spec: {
           resourceAttributes: {
-            namespace: 'default',
             verb: 'list',
             group: 'security.giantswarm.io',
             resource: 'organizations',

--- a/src/model/stores/organization/actions.tsx
+++ b/src/model/stores/organization/actions.tsx
@@ -106,7 +106,6 @@ export function organizationsLoadMAPI(
       let canList = false;
       const request: authorizationv1.ISelfSubjectAccessReviewSpec = {
         resourceAttributes: {
-          namespace: 'default',
           verb: 'list',
           group: 'security.giantswarm.io',
           resource: 'organizations',


### PR DESCRIPTION
Background https://gigantic.slack.com/archives/C02FJACQ3D4/p1660053452432869.

While helping a customer with a happa login issue, it was noticed and reported that the `SelfSubjectAccessReview` we create during login to check if the user has access to list Organizations is performed in the `default` namespace. This is incorrect - Organizations are not namespaced resources, and the `SelfSubjectAccessReview` should instead be created outside of namespaces/at the cluster scope (i.e. omitting the namespace field).

This was returning false positives for access, which then leads to requests for listing organizations to be wrongly made.