### PR TITLE
Provide more guidance in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,15 +4,15 @@
 
 ### What is the effect of this change to users?
 
-### Any background context you can provide?
-
-### What are the relevant issues?
-
-### What is needed from the reviewers?
-
 ### How does it look like?
 
 (Please add screenshots or screen recordings demonstrating the change.)
+
+### Any background context you can provide?
+
+(Please link public issues or summarize if not public.)
+
+### What is needed from the reviewers?
 
 ### Do the docs need to be updated?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,21 @@
-Please set a PR title that is informative for end users, as it will end up in the generated release notes.
+### What does this PR do?
 
-PR labels define how this PR is categorized in the release notes:
+(Please set a descriptive PR title. Use this space for additional explanations.)
 
-- **New features**: `kind/feature`
-- **Changes**: `kind/change`, `kind/bug`, `kind/removal`, `kind/ux-enhancement`, `kind/security`
+### What is the effect of this change to users?
 
-Using any of these labels will **exclude** this PR from the release notes: `dependencies`, `kind/dev-change`, `kind/refactor`
+### Any background context you can provide?
 
-Please replace this info with a description of your changes for reviewers and for people seeking for explanation of changes after the fact.
+### What are the relevant issues?
+
+### What is needed from the reviewers?
+
+### How does it look like?
+
+(Please add screenshots or screen recordings demonstrating the change.)
+
+### Do the docs need to be updated?
+
+### Should this change be mentioned in the release notes?
+
+If yes, please apply one of the following labels: `kind/feature`, `kind/change`, `kind/bug`, `kind/removal`, `kind/ux-enhancement`, `kind/security`


### PR DESCRIPTION
### What does this PR do?

Update the PR template, which should guide PR authors to provide more information, and enable better reviews.

### What is the effect of this change to users?

Users trying to understand changes, coming from release notes, might find more useful information looking into merged pull requests.

### Any background context you can provide?

I discussed recently with Puja how we can enhance the PR review process.

### What are the relevant issues?

There are no related issues I know of, yet.

### What is needed from the reviewers?

Please put yourself into the shoes of

1. a PR author: do you think the amount of information required will hinder work on happa? Do you think the quality of PRs will rise?
2. a PR reviewer: do you think the information provided would help you give better feedback on a PR?
3. a user: do you think the information provided helps to understand changes in happa?

### How does it look like?

You have it right in front of you. No screenshots required.

### Do the docs need to be updated?

None I can think of.

### Should this change be mentioned in the release notes?

No