### PR TITLE
Make node pool management read-only for GCP

### DIFF
--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1249,13 +1249,17 @@ export function isCAPZCluster(cluster: Cluster): boolean {
   return compare(releaseVersion, Constants.AZURE_CAPZ_VERSION) >= 0;
 }
 
-export function isCAPGCluster(cluster: Cluster): boolean {
+function isCAPGCluster(cluster: Cluster): boolean {
   return cluster.spec?.infrastructureRef?.kind === capgv1beta1.GCPCluster;
 }
 
 export function isNodePoolMngmtReadOnly(cluster: Cluster): boolean {
   // TODO: remove isCAPGCluster check once node pool mgmt for GCP is supported
   return isCAPZCluster(cluster) || isCAPGCluster(cluster);
+}
+
+export function supportsNodePoolAutoscaling(cluster: Cluster): boolean {
+  return !isCAPGCluster(cluster);
 }
 
 export function supportsNonExpMachinePools(cluster: Cluster): boolean {

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -12,6 +12,7 @@ import { HttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
 import { compare } from 'utils/semver';
 
+import { hasClusterAppLabel } from './clusters/utils';
 import {
   Cluster,
   ClusterList,
@@ -1254,8 +1255,7 @@ function isCAPGCluster(cluster: Cluster): boolean {
 }
 
 export function isNodePoolMngmtReadOnly(cluster: Cluster): boolean {
-  // TODO: remove isCAPGCluster check once node pool mgmt for GCP is supported
-  return isCAPZCluster(cluster) || isCAPGCluster(cluster);
+  return isCAPZCluster(cluster) || hasClusterAppLabel(cluster);
 }
 
 export function supportsNodePoolAutoscaling(cluster: Cluster): boolean {

--- a/src/components/MAPI/workernodes/ClusterDetailWidgetWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWidgetWorkerNodes.tsx
@@ -9,6 +9,7 @@ import {
   fetchProviderNodePoolsForNodePoolsKey,
   getMachineTypes,
   IProviderNodePoolForNodePoolName,
+  isNodePoolMngmtReadOnly,
 } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import { OrganizationsRoutes } from 'model/constants/routes';
@@ -146,6 +147,8 @@ const ClusterDetailWidgetWorkerNodes: React.FC<
   const hasNoNodePools =
     typeof workerNodePoolsCount === 'number' && workerNodePoolsCount === 0;
 
+  const isReadOnly = cluster && isNodePoolMngmtReadOnly(cluster);
+
   const workerNodesPath = useMemo(
     () =>
       RoutePath.createUsablePath(
@@ -182,11 +185,11 @@ const ClusterDetailWidgetWorkerNodes: React.FC<
         >
           <Box>
             <Text margin={{ bottom: 'small' }}>No node pools</Text>
-            {canCreate && (
+            {canCreate && !isReadOnly && (
               <Text size='small'>Create node pools to run workloads.</Text>
             )}
           </Box>
-          {canCreate && (
+          {canCreate && !isReadOnly && (
             <StyledLink
               to={{
                 pathname: workerNodesPath,

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -138,9 +138,10 @@ function getNameColumnWidth(nameLength: number) {
 const Header = styled(Box)<{
   additionalColumnsCount?: number;
   nameColumnWidth?: number;
+  displayMenuColumn?: boolean;
 }>`
-  ${({ additionalColumnsCount, nameColumnWidth }) =>
-    NodePoolGridRow(additionalColumnsCount, nameColumnWidth)}
+  ${({ additionalColumnsCount, nameColumnWidth, displayMenuColumn }) =>
+    NodePoolGridRow(additionalColumnsCount, nameColumnWidth, displayMenuColumn)}
 
   text-transform: uppercase;
   color: #ccc;
@@ -149,9 +150,10 @@ const Header = styled(Box)<{
 const ColumnInfo = styled(Box)<{
   additionalColumnsCount?: number;
   nameColumnWidth?: number;
+  displayMenuColumn?: boolean;
 }>`
-  ${({ additionalColumnsCount, nameColumnWidth }) =>
-    NodePoolGridRow(additionalColumnsCount, nameColumnWidth)}
+  ${({ additionalColumnsCount, nameColumnWidth, displayMenuColumn }) =>
+    NodePoolGridRow(additionalColumnsCount, nameColumnWidth, displayMenuColumn)}
 
   padding-bottom: 0;
   margin-bottom: -5px;
@@ -476,7 +478,7 @@ const ClusterDetailWorkerNodes: React.FC<
               </Text>
             </Box>
 
-            {!hasNoNodePools && (
+            {!hasNoNodePools && cluster && (
               <Box>
                 <ColumnInfo
                   additionalColumnsCount={
@@ -485,6 +487,7 @@ const ClusterDetailWorkerNodes: React.FC<
                     (hideNodePoolAutoscalingColumns ? 0 : 2)
                   }
                   nameColumnWidth={nameColumnWidth}
+                  displayMenuColumn={!isReadOnly}
                   margin={{ top: 'xsmall' }}
                 >
                   <NodesInfo
@@ -509,6 +512,7 @@ const ClusterDetailWorkerNodes: React.FC<
                     (hideNodePoolAutoscalingColumns ? 0 : 2)
                   }
                   nameColumnWidth={nameColumnWidth}
+                  displayMenuColumn={!isReadOnly}
                   height='xxsmall'
                 >
                   <Box

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -630,6 +630,7 @@ const ClusterDetailWorkerNodes: React.FC<
               {!hasNoNodePools &&
                 cluster &&
                 providerCluster &&
+                !isReadOnly &&
                 !isCreateFormOpen && (
                   <Box
                     animation={{ type: 'fadeIn', duration: 300 }}
@@ -640,10 +641,7 @@ const ClusterDetailWorkerNodes: React.FC<
                     <Button
                       onClick={handleOpenCreateForm}
                       disabled={
-                        !cluster ||
-                        !providerCluster ||
-                        isReadOnly ||
-                        !canCreateNodePools
+                        !cluster || !providerCluster || !canCreateNodePools
                       }
                       unauthorized={!canCreateNodePools}
                     >
@@ -667,7 +665,7 @@ const ClusterDetailWorkerNodes: React.FC<
                 <WorkerNodesNodePoolListPlaceholder
                   animation={{ type: 'fadeIn', duration: 300 }}
                   onCreateButtonClick={handleOpenCreateForm}
-                  disabled={isReadOnly}
+                  readOnly={isReadOnly}
                   canCreateNodePools={canCreateNodePools}
                 />
               )}

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -15,9 +15,9 @@ import {
   fetchProviderNodePoolsForNodePools,
   fetchProviderNodePoolsForNodePoolsKey,
   IProviderNodePoolForNodePoolName,
-  isCAPGCluster,
   isCAPIProvider,
   isNodePoolMngmtReadOnly,
+  supportsNodePoolAutoscaling,
   supportsNonExpMachinePools,
   supportsReleases,
 } from 'MAPI/utils';
@@ -455,7 +455,8 @@ const ClusterDetailWorkerNodes: React.FC<
     }, [cluster]);
 
     const displayCGroupsColumn = !isCAPIProvider(provider);
-    const hideNodePoolAutoscalingColumns = cluster && isCAPGCluster(cluster);
+    const hideNodePoolAutoscalingColumns =
+      cluster && !supportsNodePoolAutoscaling(cluster);
 
     return (
       <DocumentTitle title={`Worker Nodes | ${clusterId}`}>

--- a/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
+++ b/src/components/MAPI/workernodes/WorkerNodesNodePoolItem.tsx
@@ -55,9 +55,10 @@ function formatAvailabilityZonesLabel(
 const Row = styled(Box)<{
   additionalColumnsCount?: number;
   nameColumnWidth?: number;
+  displayMenuColumn?: boolean;
 }>`
-  ${({ additionalColumnsCount, nameColumnWidth }) =>
-    NodePoolGridRow(additionalColumnsCount, nameColumnWidth)}
+  ${({ additionalColumnsCount, nameColumnWidth, displayMenuColumn }) =>
+    NodePoolGridRow(additionalColumnsCount, nameColumnWidth, displayMenuColumn)}
 `;
 
 const StyledViewAndEditName = styled(ViewAndEditName)`
@@ -245,6 +246,7 @@ const WorkerNodesNodePoolItem: React.FC<
           (hideNodePoolAutoscaling ? 0 : 2)
         }
         nameColumnWidth={nameColumnWidth}
+        displayMenuColumn={!readOnly}
       >
         <Box align='flex-start'>
           <OptionalValue
@@ -420,15 +422,17 @@ const WorkerNodesNodePoolItem: React.FC<
               </Box>
             ))}
 
-            <Box align='center'>
-              <WorkerNodesNodePoolActions
-                onDeleteClick={onDelete}
-                onScaleClick={onScale}
-                disabled={readOnly}
-                canUpdateNodePools={canUpdateNodePools}
-                canDeleteNodePools={canDeleteNodePools}
-              />
-            </Box>
+            {!readOnly && (
+              <Box align='center'>
+                <WorkerNodesNodePoolActions
+                  onDeleteClick={onDelete}
+                  onScaleClick={onScale}
+                  disabled={readOnly}
+                  canUpdateNodePools={canUpdateNodePools}
+                  canDeleteNodePools={canDeleteNodePools}
+                />
+              </Box>
+            )}
           </>
         )}
       </Row>

--- a/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolListPlaceholder.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/WorkerNodesNodePoolListPlaceholder.tsx
@@ -5,13 +5,13 @@ import Button from 'UI/Controls/Button';
 interface IWorkerNodesNodePoolListPlaceholderProps
   extends React.ComponentPropsWithoutRef<typeof Box> {
   onCreateButtonClick?: () => void;
-  disabled?: boolean;
+  readOnly?: boolean;
   canCreateNodePools?: boolean;
 }
 
 const WorkerNodesNodePoolListPlaceholder: React.FC<
   React.PropsWithChildren<IWorkerNodesNodePoolListPlaceholderProps>
-> = ({ onCreateButtonClick, disabled, canCreateNodePools, ...props }) => {
+> = ({ onCreateButtonClick, readOnly, canCreateNodePools, ...props }) => {
   return (
     <Box
       background='background-back'
@@ -20,27 +20,32 @@ const WorkerNodesNodePoolListPlaceholder: React.FC<
       gap='medium'
       {...props}
     >
-      <Box>
-        <Text color='text-weak'>
-          {canCreateNodePools
-            ? 'Add at least one node pool to the cluster so you could run workloads'
-            : 'For creating a node pool, you need additional permissions. Please talk to your administrator.'}
-        </Text>
-      </Box>
-      <Box>
-        <Button
-          onClick={onCreateButtonClick}
-          disabled={disabled}
-          unauthorized={!canCreateNodePools}
-        >
-          <i
-            className='fa fa-add-circle'
-            role='presentation'
-            aria-hidden={true}
-          />{' '}
-          Add node pool
-        </Button>
-      </Box>
+      {readOnly ? (
+        <Text color='text-weak'>No node pools.</Text>
+      ) : (
+        <>
+          <Box>
+            <Text color='text-weak'>
+              {canCreateNodePools
+                ? 'Add at least one node pool to the cluster so you could run workloads'
+                : 'For creating a node pool, you need additional permissions. Please talk to your administrator.'}
+            </Text>
+          </Box>
+          <Box>
+            <Button
+              onClick={onCreateButtonClick}
+              unauthorized={!canCreateNodePools}
+            >
+              <i
+                className='fa fa-add-circle'
+                role='presentation'
+                aria-hidden={true}
+              />{' '}
+              Add node pool
+            </Button>
+          </Box>
+        </>
+      )}
     </Box>
   );
 };

--- a/src/components/UI/Display/MAPI/workernodes/styles.tsx
+++ b/src/components/UI/Display/MAPI/workernodes/styles.tsx
@@ -2,7 +2,8 @@ import { css } from 'styled-components';
 
 export const NodePoolGridRow = (
   extraColumnCount: number = 0,
-  nameColumnWidth: number = 0
+  nameColumnWidth: number = 0,
+  displayMenuColumn: boolean = true
 ) => css`
   display: grid;
   grid-gap: 0 ${({ theme }) => theme.global.edgeSize.small};
@@ -13,7 +14,7 @@ export const NodePoolGridRow = (
     3fr
     repeat(2, 2fr)
     ${extraColumnCount ? `repeat(${extraColumnCount}, 2fr)` : ''}
-    1fr;
+    ${displayMenuColumn ? '1fr' : ''};
   grid-template-rows: ${({ theme }) => theme.global.size.xxsmall};
   justify-content: space-between;
   place-items: center normal;


### PR DESCRIPTION
### What does this PR do?

This PR makes node pool management "read-only" for node pools belonging to clusters that are managed by an app (i.e. it has the `app: cluster-PROVIDER` label). Node pool creation, deletion, and updating an existing node pool's description and scaling are disabled.

### What is the effect of this change to users?

Users on GCP installations will not be able to add/edit/delete node pool resources from the web UI. Users on vintage installations should notice no change.

### How does it look like?
- the "Add node pool" button and any placeholder messages prompting users to create node pools when the cluster doesn't have any node pools is hidden
- the node pool list item menu button is hidden
- node pool description is displayed as uneditable text
<img width="1223" alt="Screen Shot 2022-09-08 at 16 17 17" src="https://user-images.githubusercontent.com/62935115/189146048-6d91c416-a35f-4aa4-98f5-e16655480ccd.png">

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/1382, which is a task towards our first milestone of providing a read-only web UI for GCP.

The changes here are meant to be temporary in the sense that they will be in place until cluster management via apps is implemented for the web UI.

### What is needed from the reviewers?
The UI changes can be verified by checking out this branch and starting local development against a GCP installation (e.g. `gohan`), or alternatively by using `opsctl deploy`. 
