### PR TITLE
Don't fetch cluster-service StorageConfigs for CAPI providers

### DIFF
--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
@@ -38,7 +38,11 @@ import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 import CreateKeyPairGuide from '../clusters/guides/CreateKeyPairGuide';
 import ClusterDetailKeyPairDetailsModal from './ClusterDetailKeyPairDetailsModal';
 import { usePermissionsForKeyPairs } from './permissions/usePermissionsForKeyPairs';
-import { getKeyPairExpirationDate, isKeyPairExpiringSoon } from './utils';
+import {
+  getKeyPairExpirationDate,
+  isKeyPairExpiringSoon,
+  supportsLegacyKeyPairs,
+} from './utils';
 
 const LOADING_COMPONENTS = new Array(4).fill(0);
 
@@ -100,9 +104,12 @@ const ClusterDetailKeyPairs: React.FC<
   const { canGet: canGetKeyPairs, canCreate: canCreateKeyPairs } =
     usePermissionsForKeyPairs(provider, namespace ?? '');
 
-  const keyPairListKey = canGetKeyPairs
-    ? legacyKeyPairs.getKeyPairListKey(clusterId)
-    : null;
+  const isLegacyKeyPairsSupported = supportsLegacyKeyPairs(provider);
+
+  const keyPairListKey =
+    isLegacyKeyPairsSupported && canGetKeyPairs
+      ? legacyKeyPairs.getKeyPairListKey(clusterId)
+      : null;
 
   const {
     data: keyPairList,
@@ -134,7 +141,8 @@ const ClusterDetailKeyPairs: React.FC<
 
   const displayKeyPairsPlaceholder =
     !canGetKeyPairs ||
-    (!keyPairListIsLoading && keyPairList?.items.length === 0);
+    (!keyPairListIsLoading && keyPairList?.items.length === 0) ||
+    !isLegacyKeyPairsSupported;
 
   const [selectedKeyPairSerial, setSelectedKeyPairSerial] = useState('');
 

--- a/src/components/MAPI/keypairs/ClusterDetailWidgetKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailWidgetKeyPairs.tsx
@@ -16,7 +16,7 @@ import ErrorReporter from 'utils/errors/ErrorReporter';
 import { useHttpClient } from 'utils/hooks/useHttpClient';
 
 import { usePermissionsForKeyPairs } from './permissions/usePermissionsForKeyPairs';
-import { isKeyPairActive } from './utils';
+import { isKeyPairActive, supportsLegacyKeyPairs } from './utils';
 
 const StyledLink = styled.a`
   color: ${({ theme }) => normalizeColor('input-highlight', theme)};
@@ -50,9 +50,12 @@ const ClusterDetailWidgetKeyPairs: React.FC<
     namespace ?? ''
   );
 
-  const keyPairListKey = canGet
-    ? legacyKeyPairs.getKeyPairListKey(clusterId)
-    : null;
+  const isLegacyKeyPairsSupported = supportsLegacyKeyPairs(provider);
+
+  const keyPairListKey =
+    isLegacyKeyPairsSupported && canGet
+      ? legacyKeyPairs.getKeyPairListKey(clusterId)
+      : null;
 
   const { data: keyPairList, error: keyPairListError } = useSWR<
     legacyKeyPairs.IKeyPairList,
@@ -76,7 +79,8 @@ const ClusterDetailWidgetKeyPairs: React.FC<
 
   const hasNoKeyPairs =
     !canGet ||
-    (typeof activeKeyPairsCount === 'number' && activeKeyPairsCount === 0);
+    (typeof activeKeyPairsCount === 'number' && activeKeyPairsCount === 0) ||
+    !isLegacyKeyPairsSupported;
 
   return (
     <ClusterDetailWidget

--- a/src/components/MAPI/keypairs/utils.ts
+++ b/src/components/MAPI/keypairs/utils.ts
@@ -2,6 +2,8 @@ import add from 'date-fns/fp/add';
 import compareAsc from 'date-fns/fp/compareAsc';
 import differenceInHours from 'date-fns/fp/differenceInHours';
 import toDate from 'date-fns-tz/toDate';
+import { isCAPIProvider } from 'MAPI/utils';
+import { Providers } from 'model/constants';
 import * as keypairs from 'model/services/mapi/legacy/keypairs';
 
 export function getKeyPairExpirationDate(keyPair: keypairs.IKeyPair) {
@@ -26,4 +28,10 @@ export function isKeyPairExpiringSoon(keyPair: keypairs.IKeyPair) {
 
   // eslint-disable-next-line no-magic-numbers
   return differenceInHours(now)(expirationDate) < 24;
+}
+
+export function supportsLegacyKeyPairs(
+  provider: PropertiesOf<typeof Providers>
+): boolean {
+  return !isCAPIProvider(provider);
 }

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1297,7 +1297,7 @@ export function supportsClientCertificates(cluster: Cluster): boolean {
     }
 
     default:
-      return false;
+      return true;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR ensures that we don't try to fetch cluster-service StorageConfigs for CAPI providers.

### What is the effect of this change to users?
Currently, users on GCP are seeing this error message when navigating to the "Client certificates" tab in cluster details:
<img width="329" alt="Screen Shot 2022-09-09 at 11 40 10" src="https://user-images.githubusercontent.com/62935115/189321127-a570669b-7bb0-4fa4-9203-7f5b4c93ac0d.png">

With the changes of this PR, we check whether the provider supports client certificates from cluster-service before fetching them. The providers that support them should be the non-CAPI (vintage) providers (AWS and Azure).

### How does it look like?

Users should no longer see the flash error message, and also shouldn't see failed network requests fetching cluster-service StorageConfigs in the browser's console.

Users should also be able to see the MAPI CLI guide for creating a client certificate displayed in the "Client certificates" tab.

### Any background context you can provide?

Towards our [roadmap item](https://github.com/giantswarm/roadmap/issues/1192) of supporting GCP in the web UI.