### PR TITLE
Fix app details UI bugs

### DIFF
--- a/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
+++ b/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
@@ -124,10 +124,12 @@ const Detail = styled.div`
 
 const Keyword = styled.span`
   margin-right: 10px;
+  margin-bottom: 10px;
   font-family: Inconsolata, monospace;
   background-color: ${({ theme }) => theme.colors.darkBlueDarker2};
   padding: 5px 8px;
   border-radius: 5px;
+  display: inline-block;
 `;
 
 const VersionPickerRow = styled.div`
@@ -379,9 +381,11 @@ const AppDetail: React.FC<React.PropsWithChildren<IAppDetailPageProps>> = (
           {props.keywords!.length > 0 && (
             <Detail>
               <small>KEYWORDS</small>
-              {props.keywords!.map((k) => (
-                <Keyword key={k}>{k}</Keyword>
-              ))}
+              <span>
+                {props.keywords!.map((k) => (
+                  <Keyword key={k}>{k}</Keyword>
+                ))}
+              </span>
             </Detail>
           )}
         </Details>

--- a/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
+++ b/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
@@ -81,7 +81,7 @@ const Readme = styled.div`
   margin-right: 25px;
   flex-shrink: 0;
   padding: 20px;
-  overflow-x: scroll;
+  overflow-x: auto;
 
   .markdown pre {
     background-color: ${(props) => props.theme.colors.darkBlueDarker6};


### PR DESCRIPTION
### What does this PR do?

Fixes 2 UI bugs in the app details page:
- horizontal scrollbar displayed automatically when user is using a mouse
- app keywords not wrapping

### What is the effect of this change to users?
Users should no longer see the horizontal scrollbar displayed automatically when using a mouse, and should only see it if there is horizontal overflow content.

App keywords should also wrap automatically.
**Before:**
<img width="500" alt="Screen Shot 2022-09-16 at 15 16 42" src="https://user-images.githubusercontent.com/62935115/190649792-0e49d8d4-ca7a-4040-929a-9ff016091270.png">
**After:**
<img width="300" alt="Screen Shot 2022-09-16 at 15 30 40" src="https://user-images.githubusercontent.com/62935115/190650610-55df3116-e7e9-486a-9aab-3bd3211c61a5.png">


### Any background context you can provide?
Closes https://github.com/giantswarm/roadmap/issues/1000 and https://github.com/giantswarm/roadmap/issues/1405