### PR TITLE
Change web UI release notes link

### DIFF
--- a/src/components/Footer/FooterUtils.tsx
+++ b/src/components/Footer/FooterUtils.tsx
@@ -36,7 +36,7 @@ export function getReleaseURL(version: string): string {
       return `https://github.com/giantswarm/happa/commit/${semverVersion.getPreRelease()}`;
     }
 
-    return `https://docs.giantswarm.io/changes/web-ui/happa/v${version}/`;
+    return `https://github.com/giantswarm/happa/releases/tag/v${version}/`;
   } catch (err) {
     ErrorReporter.getInstance().notify(err as Error);
 


### PR DESCRIPTION
### What does this PR do?

This PR changes the release notes link to point to the happa releases page for the version, replacing the link to the docs releases page.

### What is the effect of this change to users?
When clicking on the "release notes" link in the footer, users should be directed to happa's releases page for the specified version.

### Any background context you can provide?

No tracking issue, reported internally on Slack. Due to our documentation page's workflow, sometimes the link does not point to an existing page. This ensures that the the link always points to an existing page with the release notes.