### PR TITLE
Add support for fetching CAPA cluster resources

### DIFF
--- a/src/components/MAPI/clusters/permissions/usePermissionsForClusters.ts
+++ b/src/components/MAPI/clusters/permissions/usePermissionsForClusters.ts
@@ -202,6 +202,45 @@ export function usePermissionsForClusters(
 
       break;
 
+    case Providers.CAPA:
+      computed.canCreate = canCreateClusterApps;
+      computed.canDelete = canDeleteClusterApps;
+      computed.canUpdate = canUpdateClusterApps;
+
+      computed.canGet =
+        hasPermission(
+          permissions,
+          namespace,
+          'get',
+          'cluster.x-k8s.io',
+          'clusters'
+        ) &&
+        hasPermission(
+          permissions,
+          namespace,
+          'get',
+          'infrastructure.cluster.x-k8s.io',
+          'awsclusters'
+        );
+
+      computed.canList =
+        hasPermission(
+          permissions,
+          namespace,
+          'list',
+          'cluster.x-k8s.io',
+          'clusters'
+        ) &&
+        hasPermission(
+          permissions,
+          namespace,
+          'list',
+          'infrastructure.cluster.x-k8s.io',
+          'awsclusters'
+        );
+
+      break;
+
     case Providers.GCP:
       computed.canCreate = canCreateClusterApps;
       computed.canDelete = canDeleteClusterApps;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1,6 +1,7 @@
 import { GenericResponse } from 'model/clients/GenericResponse';
 import { Constants, Providers } from 'model/constants';
 import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import * as capav1beta1 from 'model/services/mapi/capav1beta1';
 import * as capgv1beta1 from 'model/services/mapi/capgv1beta1';
 import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
@@ -693,6 +694,15 @@ export async function fetchProviderClusterForCluster(
 
   const { kind, apiVersion } = infrastructureRef;
   switch (true) {
+    case kind === capav1beta1.AWSCluster &&
+      apiVersion === capav1beta1.ApiVersion:
+      return capav1beta1.getAWSCluster(
+        httpClientFactory(),
+        auth,
+        cluster.metadata.namespace!,
+        infrastructureRef.name
+      );
+
     case kind === capgv1beta1.GCPCluster:
       return capgv1beta1.getGCPCluster(
         httpClientFactory(),
@@ -731,6 +741,13 @@ export function fetchProviderClusterForClusterKey(cluster: Cluster) {
 
   const { kind, apiVersion } = infrastructureRef;
   switch (true) {
+    case kind === capav1beta1.AWSCluster &&
+      apiVersion === capav1beta1.ApiVersion:
+      return capav1beta1.getAWSClusterKey(
+        cluster.metadata.namespace!,
+        infrastructureRef.name
+      );
+
     case kind === capgv1beta1.GCPCluster:
       return capgv1beta1.getGCPClusterKey(
         cluster.metadata.namespace!,

--- a/src/model/constants/providers.ts
+++ b/src/model/constants/providers.ts
@@ -2,6 +2,8 @@ export const AWS = 'aws';
 
 export const AZURE = 'azure';
 
-export const KVM = 'kvm';
+export const CAPA = 'capa';
 
 export const GCP = 'gcp';
+
+export const KVM = 'kvm';

--- a/test/mockHttpCalls/capav1beta1/awsClusters.ts
+++ b/test/mockHttpCalls/capav1beta1/awsClusters.ts
@@ -1,0 +1,151 @@
+import * as capav1beta1 from 'model/services/mapi/capav1beta1';
+
+export const randomAWSCluster1: capav1beta1.IAWSCluster = {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
+  kind: 'AWSCluster',
+  metadata: {
+    annotations: {
+      'aws.giantswarm.io/dns-assign-additional-vpc': '',
+      'aws.giantswarm.io/dns-mode': 'private',
+      'meta.helm.sh/release-name': 'asdf1',
+      'meta.helm.sh/release-namespace': 'org-org1',
+    },
+    creationTimestamp: '2022-09-29T09:14:00Z',
+    finalizers: [],
+    labels: {
+      app: 'cluster-aws',
+      'app.kubernetes.io/managed-by': 'Helm',
+      'app.kubernetes.io/version': '0.9.2',
+      'application.giantswarm.io/team': 'hydra',
+      'cluster.x-k8s.io/cluster-name': 'asdf1',
+      'cluster.x-k8s.io/watch-filter': 'capi',
+      'giantswarm.io/cluster': 'asdf1',
+      'giantswarm.io/organization': 'giantswarm',
+      'helm.sh/chart': 'cluster-aws-0.9.2',
+      'release.giantswarm.io/version': '20.0.0-alpha1',
+    },
+    name: 'asdf1',
+    namespace: 'org-org1',
+    ownerReferences: [
+      {
+        apiVersion: 'cluster.x-k8s.io/v1beta1',
+        blockOwnerDeletion: true,
+        controller: true,
+        kind: 'Cluster',
+        name: 'asdf1',
+        uid: '',
+      },
+    ],
+  },
+  spec: {
+    controlPlaneEndpoint: {
+      host: 'asdf1-apiserver-123412345.eu-west-2.elb.amazonaws.com',
+      port: 6443,
+    },
+    controlPlaneLoadBalancer: {
+      crossZoneLoadBalancing: false,
+      scheme: 'internet-facing',
+    },
+    identityRef: {
+      kind: 'AWSClusterRoleIdentity',
+      name: 'default',
+    },
+    region: 'eu-west-2',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-09-29T09:14:00Z',
+        status: 'True',
+        type: 'Ready',
+      },
+    ],
+    failureDomains: {
+      'eu-west-2a': {
+        controlPlane: true,
+      },
+      'eu-west-2b': {
+        controlPlane: true,
+      },
+      'eu-west-2c': {
+        controlPlane: true,
+      },
+    },
+    ready: true,
+  },
+};
+
+export const randomAWSCluster2: capav1beta1.IAWSCluster = {
+  apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
+  kind: 'AWSCluster',
+  metadata: {
+    annotations: {
+      'aws.giantswarm.io/dns-assign-additional-vpc': '',
+      'aws.giantswarm.io/dns-mode': 'private',
+      'meta.helm.sh/release-name': 'fdsa1',
+      'meta.helm.sh/release-namespace': 'org-org1',
+    },
+    creationTimestamp: '2022-09-28T09:15:00Z',
+    finalizers: [],
+    labels: {
+      app: 'cluster-aws',
+      'app.kubernetes.io/managed-by': 'Helm',
+      'app.kubernetes.io/version': '0.9.2',
+      'application.giantswarm.io/team': 'hydra',
+      'cluster.x-k8s.io/cluster-name': 'fdsa1',
+      'cluster.x-k8s.io/watch-filter': 'capi',
+      'giantswarm.io/cluster': 'fdsa1',
+      'giantswarm.io/organization': 'giantswarm',
+      'helm.sh/chart': 'cluster-aws-0.9.2',
+      'release.giantswarm.io/version': '20.0.0-alpha1',
+    },
+    name: 'fdsa1',
+    namespace: 'org-org1',
+    ownerReferences: [
+      {
+        apiVersion: 'cluster.x-k8s.io/v1beta1',
+        blockOwnerDeletion: true,
+        controller: true,
+        kind: 'Cluster',
+        name: 'fdsa1',
+        uid: '',
+      },
+    ],
+  },
+  spec: {
+    controlPlaneEndpoint: {
+      host: 'fdsa1-apiserver-123412345.eu-west-2.elb.amazonaws.com',
+      port: 6443,
+    },
+    controlPlaneLoadBalancer: {
+      crossZoneLoadBalancing: false,
+      scheme: 'internet-facing',
+    },
+    identityRef: {
+      kind: 'AWSClusterRoleIdentity',
+      name: 'default',
+    },
+    region: 'eu-west-2',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-09-28T09:15:00Z',
+        status: 'True',
+        type: 'Ready',
+      },
+    ],
+    failureDomains: {
+      'eu-west-2a': {
+        controlPlane: true,
+      },
+      'eu-west-2b': {
+        controlPlane: true,
+      },
+      'eu-west-2c': {
+        controlPlane: true,
+      },
+    },
+    ready: true,
+  },
+};

--- a/test/mockHttpCalls/capav1beta1/index.ts
+++ b/test/mockHttpCalls/capav1beta1/index.ts
@@ -1,0 +1,1 @@
+export * from './awsClusters';

--- a/test/mockHttpCalls/capiv1beta1/clusters.ts
+++ b/test/mockHttpCalls/capiv1beta1/clusters.ts
@@ -88,6 +88,177 @@ export const randomClusterAWS2: capiv1beta1.ICluster = {
   },
 };
 
+export const randomClusterCAPA1: capiv1beta1.ICluster = {
+  apiVersion: 'cluster.x-k8s.io/v1beta1',
+  kind: 'Cluster',
+  metadata: {
+    annotations: {
+      'cluster.giantswarm.io/description': 'test capa cluster',
+      'meta.helm.sh/release-name': 'asdf1',
+      'meta.helm.sh/release-namespace': 'org-org1',
+      'network-topology.giantswarm.io/mode': 'None',
+    },
+    creationTimestamp: '2022-09-29T09:14:00Z',
+    finalizers: [],
+    labels: {
+      app: 'cluster-aws',
+      'app.kubernetes.io/managed-by': 'Helm',
+      'app.kubernetes.io/version': '0.9.2',
+      'application.giantswarm.io/team': 'hydra',
+      'cluster-apps-operator.giantswarm.io/watching': '',
+      'cluster.x-k8s.io/cluster-name': 'asdf1',
+      'cluster.x-k8s.io/watch-filter': 'capi',
+      'giantswarm.io/cluster': 'asdf1',
+      'giantswarm.io/organization': 'org1',
+      'helm.sh/chart': 'cluster-aws-0.9.2',
+      'release.giantswarm.io/version': '20.0.0-alpha1',
+    },
+    name: 'asdf1',
+    namespace: 'org-org1',
+  },
+  spec: {
+    controlPlaneEndpoint: {
+      host: 'asdf1-apiserver-123412345.eu-west-2.elb.amazonaws.com',
+      port: 6443,
+    },
+    controlPlaneRef: {
+      apiVersion: 'controlplane.cluster.x-k8s.io/v1beta1',
+      kind: 'KubeadmControlPlane',
+      name: 'asdf1',
+      namespace: 'org-org1',
+    },
+    infrastructureRef: {
+      apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
+      kind: 'AWSCluster',
+      name: 'asdf1',
+      namespace: 'org-org1',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-09-29T09:22:07Z',
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: '2022-09-29T09:19:19Z',
+        status: 'True',
+        type: 'ControlPlaneInitialized',
+      },
+      {
+        lastTransitionTime: '2022-09-29T09:22:07Z',
+        status: 'True',
+        type: 'ControlPlaneReady',
+      },
+      {
+        lastTransitionTime: '2022-09-29T09:17:04Z',
+        status: 'True',
+        type: 'InfrastructureReady',
+      },
+    ],
+    controlPlaneReady: true,
+    failureDomains: {
+      'eu-west-2a': {
+        controlPlane: true,
+      },
+      'eu-west-2b': {
+        controlPlane: true,
+      },
+      'eu-west-2c': {
+        controlPlane: true,
+      },
+    },
+    infrastructureReady: true,
+    phase: 'Provisioned',
+  },
+};
+
+export const randomClusterCAPA2: capiv1beta1.ICluster = {
+  apiVersion: 'cluster.x-k8s.io/v1beta1',
+  kind: 'Cluster',
+  metadata: {
+    annotations: {
+      'cluster.giantswarm.io/description': 'another test capa cluster',
+      'meta.helm.sh/release-name': 'fdsa1',
+      'meta.helm.sh/release-namespace': 'org-org1',
+    },
+    creationTimestamp: '2022-09-28T09:15:00Z',
+    finalizers: [],
+    labels: {
+      app: 'cluster-aws',
+      'app.kubernetes.io/managed-by': 'Helm',
+      'app.kubernetes.io/version': '0.9.2',
+      'application.giantswarm.io/team': 'hydra',
+      'cluster-apps-operator.giantswarm.io/watching': '',
+      'cluster.x-k8s.io/cluster-name': 'fdsa1',
+      'cluster.x-k8s.io/watch-filter': 'capi',
+      'giantswarm.io/cluster': 'fdsa1',
+      'giantswarm.io/organization': 'org1',
+      'helm.sh/chart': 'cluster-aws-0.9.2',
+      'release.giantswarm.io/version': '20.0.0-alpha1',
+    },
+    name: 'fdsa1',
+    namespace: 'org-org1',
+  },
+  spec: {
+    controlPlaneEndpoint: {
+      host: 'fdsa1-apiserver-123412345.eu-west-2.elb.amazonaws.com',
+      port: 6443,
+    },
+    controlPlaneRef: {
+      apiVersion: 'controlplane.cluster.x-k8s.io/v1beta1',
+      kind: 'KubeadmControlPlane',
+      name: 'fdsa1',
+      namespace: 'org-org1',
+    },
+    infrastructureRef: {
+      apiVersion: 'infrastructure.cluster.x-k8s.io/v1beta1',
+      kind: 'AWSCluster',
+      name: 'fdsa1',
+      namespace: 'org-org1',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: '2022-09-28T09:20:00Z',
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: '2022-09-28T09:19:00Z',
+        status: 'True',
+        type: 'ControlPlaneInitialized',
+      },
+      {
+        lastTransitionTime: '2022-09-28T09:22:00Z',
+        status: 'True',
+        type: 'ControlPlaneReady',
+      },
+      {
+        lastTransitionTime: '2022-09-28T00:17:00Z',
+        status: 'True',
+        type: 'InfrastructureReady',
+      },
+    ],
+    controlPlaneReady: true,
+    failureDomains: {
+      'eu-west-2a': {
+        controlPlane: true,
+      },
+      'eu-west-2b': {
+        controlPlane: true,
+      },
+      'eu-west-2c': {
+        controlPlane: true,
+      },
+    },
+    infrastructureReady: true,
+    phase: 'Provisioned',
+  },
+};
+
 export const randomClusterGCP1: capiv1beta1.ICluster = {
   apiVersion: 'cluster.x-k8s.io/v1beta1',
   kind: 'Cluster',
@@ -453,6 +624,15 @@ export const randomClusterListAWS: capiv1beta1.IClusterList = {
     selfLink: '/apis/cluster.x-k8s.io/v1beta1/clusters/',
   },
   items: [randomClusterAWS1, randomClusterAWS2],
+};
+
+export const randomClusterListCAPA: capiv1beta1.IClusterList = {
+  apiVersion: 'cluster.x-k8s.io/v1beta1',
+  kind: 'ClusterList',
+  metadata: {
+    selfLink: '/apis/cluster.x-k8s.io/v1beta1/clusters/',
+  },
+  items: [randomClusterCAPA1, randomClusterCAPA2],
 };
 
 export const randomClusterListGCP: capiv1beta1.IClusterList = {


### PR DESCRIPTION
### What does this PR do?

This PR adds support for fetching CAPA cluster resources, specifically by refactoring the `fetchProviderClusterforCluster` function to add a case for CAPA clusters. It also updates the permission hook for determining permissions to cluster resources, and adds some test mocks for CAPA clusters.

Hopefully this is sufficient enough to allow us to work concurrently on displaying cluster, node pools, and control planes details.

### What is the effect of this change to users?

On a CAPA installation, users should now be able to see clusters listed in the cluster list page instead.

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/1450.