### PR TITLE
Display details for CAPA clusters

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetVersions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetVersions.tsx
@@ -142,3 +142,45 @@ describe('ClusterDetailWidgetVersions on GCP', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('ClusterDetailWidgetVersions on CAPA', () => {
+  const provider = window.config.info.general.provider;
+
+  beforeAll(() => {
+    window.config.info.general.provider = Providers.CAPA;
+    (usePermissionsForCPNodes as jest.Mock).mockReturnValue(defaultPermissions);
+  });
+  afterAll(() => {
+    window.config.info.general.provider = provider;
+  });
+
+  it('displays the cluster app version', () => {
+    render(
+      getComponent({
+        cluster: capiv1beta1Mocks.randomClusterCAPA1,
+      })
+    );
+
+    expect(
+      screen.getByLabelText('Cluster app version: 0.9.2')
+    ).toBeInTheDocument();
+  });
+
+  it(`displays a link to the cluster app version's release notes`, () => {
+    render(
+      getComponent({
+        cluster: capiv1beta1Mocks.randomClusterCAPA1,
+      })
+    );
+
+    const releaseNotesLink = screen.getByLabelText(
+      'Cluster app version 0.9.2 release notes'
+    );
+    expect(releaseNotesLink).toBeInTheDocument();
+
+    expect(releaseNotesLink).toHaveAttribute(
+      'href',
+      'https://github.com/giantswarm/cluster-aws/releases/tag/v0.9.2'
+    );
+  });
+});

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -17,6 +17,7 @@ import {
 import { IProviderNodePoolForNodePool } from 'MAPI/workernodes/utils';
 import { GenericResponse } from 'model/clients/GenericResponse';
 import { Constants, Providers } from 'model/constants';
+import * as capav1beta1 from 'model/services/mapi/capav1beta1';
 import * as capgv1beta1 from 'model/services/mapi/capgv1beta1';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
@@ -959,6 +960,8 @@ export function getClusterConditions(
 
   const { kind, apiVersion } = infrastructureRef;
   switch (true) {
+    case kind === capav1beta1.AWSCluster &&
+      apiVersion === capav1beta1.ApiVersion:
     case kind === capgv1beta1.GCPCluster:
       statuses.isConditionUnknown =
         typeof cluster.status === 'undefined' ||

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -17,7 +17,6 @@ import {
 import { IProviderNodePoolForNodePool } from 'MAPI/workernodes/utils';
 import { GenericResponse } from 'model/clients/GenericResponse';
 import { Constants, Providers } from 'model/constants';
-import * as capav1beta1 from 'model/services/mapi/capav1beta1';
 import * as capgv1beta1 from 'model/services/mapi/capgv1beta1';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
@@ -960,18 +959,6 @@ export function getClusterConditions(
 
   const { kind, apiVersion } = infrastructureRef;
   switch (true) {
-    case kind === capav1beta1.AWSCluster &&
-      apiVersion === capav1beta1.ApiVersion:
-    case kind === capgv1beta1.GCPCluster:
-      statuses.isConditionUnknown =
-        typeof cluster.status === 'undefined' ||
-        typeof cluster.status.conditions === 'undefined';
-      statuses.isCreating = capiv1beta1.isConditionFalse(
-        cluster,
-        capiv1beta1.conditionTypeControlPlaneInitialized
-      );
-      break;
-
     case kind === capzv1beta1.AzureCluster:
       statuses.isConditionUnknown =
         typeof cluster.status === 'undefined' ||
@@ -999,6 +986,15 @@ export function getClusterConditions(
       );
       break;
     }
+    default:
+      statuses.isConditionUnknown =
+        typeof cluster.status === 'undefined' ||
+        typeof cluster.status.conditions === 'undefined';
+      statuses.isCreating = capiv1beta1.isConditionFalse(
+        cluster,
+        capiv1beta1.conditionTypeControlPlaneInitialized
+      );
+      break;
   }
 
   return statuses;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1093,6 +1093,8 @@ export function getClusterDescription(
 
   const { kind, apiVersion } = infrastructureRef;
   switch (true) {
+    case kind === capav1beta1.AWSCluster &&
+      apiVersion === capav1beta1.ApiVersion:
     case kind === capgv1beta1.GCPCluster:
     case kind === capzv1beta1.AzureCluster:
       return (

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1093,15 +1093,6 @@ export function getClusterDescription(
 
   const { kind, apiVersion } = infrastructureRef;
   switch (true) {
-    case kind === capav1beta1.AWSCluster &&
-      apiVersion === capav1beta1.ApiVersion:
-    case kind === capgv1beta1.GCPCluster:
-    case kind === capzv1beta1.AzureCluster:
-      return (
-        cluster.metadata.annotations?.[
-          capiv1beta1.annotationClusterDescription
-        ] || defaultValue
-      );
     case kind === infrav1alpha2.AWSCluster &&
       apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
@@ -1115,7 +1106,11 @@ export function getClusterDescription(
         defaultValue
       );
     default:
-      return defaultValue;
+      return (
+        cluster.metadata.annotations?.[
+          capiv1beta1.annotationClusterDescription
+        ] || defaultValue
+      );
   }
 }
 

--- a/test/mockHttpCalls/capiv1beta1/clusters.ts
+++ b/test/mockHttpCalls/capiv1beta1/clusters.ts
@@ -188,7 +188,7 @@ export const randomClusterCAPA2: capiv1beta1.ICluster = {
     labels: {
       app: 'cluster-aws',
       'app.kubernetes.io/managed-by': 'Helm',
-      'app.kubernetes.io/version': '0.9.2',
+      'app.kubernetes.io/version': '0.9.3',
       'application.giantswarm.io/team': 'hydra',
       'cluster-apps-operator.giantswarm.io/watching': '',
       'cluster.x-k8s.io/cluster-name': 'fdsa1',


### PR DESCRIPTION
### What does this PR do?

This PR adds support for displaying a description and a status for CAPA clusters. Only `Cluster creating…` status is supported for now.

### How does it look like?

<img width="1199" alt="Screenshot 2022-10-05 at 19 05 02" src="https://user-images.githubusercontent.com/445309/194108485-b5dd71e1-9a56-40dd-804f-2baa613ee01c.png">

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/1474.