### PR TITLE
Fix YAMLException error parsing for app installation

### DIFF
--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppForm.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppForm.tsx
@@ -52,6 +52,14 @@ const InstallAppForm: React.FC<
     onChangeSecretsYAML?.(e.target.files);
   };
 
+  const handleValuesYAMLFileInputClicked = () => {
+    onChangeValuesYAML?.(null);
+  };
+
+  const handleSecretsYAMLFileInputClicked = () => {
+    onChangeSecretsYAML?.(null);
+  };
+
   const updateVersion = (newVersion?: string) => {
     if (typeof newVersion === 'undefined') return;
 
@@ -141,6 +149,7 @@ const InstallAppForm: React.FC<
         label='User level config values YAML'
         id='user-level-config'
         onChange={updateValuesYAML}
+        onClick={handleValuesYAMLFileInputClicked}
         error={valuesYAMLError}
       />
 
@@ -149,6 +158,7 @@ const InstallAppForm: React.FC<
         label='User level secret values YAML'
         id='user-level-secret'
         onChange={updateSecretsYAML}
+        onClick={handleSecretsYAMLFileInputClicked}
         error={secretsYAMLError}
       />
     </Box>

--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -106,10 +106,14 @@ const InstallAppModal: React.FC<
     if (page > 0) {
       setPage(page - 1);
     }
+    setValuesYAMLError('');
+    setSecretsYAMLError('');
   };
 
   const onClose = () => {
     setVisible(false);
+    setValuesYAMLError('');
+    setSecretsYAMLError('');
   };
 
   const openModal = () => {

--- a/src/components/MAPI/apps/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/AppInstallModal.tsx
@@ -144,11 +144,15 @@ const AppInstallModal: React.FC<
     if (page > 0) {
       setPage(page - 1);
     }
+    setValuesYAMLError('');
+    setSecretsYAMLError('');
   };
 
   const onClose = () => {
     setVisible(false);
     setQuery('');
+    setValuesYAMLError('');
+    setSecretsYAMLError('');
   };
 
   const selectedClusterID = useSelector(

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -857,28 +857,7 @@ export function compareApps(
 
 export function formatYAMLError(err: unknown): string {
   if (err instanceof YAMLException) {
-    interface IYAMLExceptionInternals extends YAMLException {
-      mark: {
-        buffer: string;
-        column: number;
-        line: number;
-        name: string;
-        position: number;
-        snippet: string;
-      };
-      reason: string;
-    }
-
-    const { reason, mark } = err as IYAMLExceptionInternals;
-    let { line, column } = mark;
-    /**
-     * Lines and columns are counted from 1, but the library
-     * counts from 0.
-     */
-    line++;
-    column++;
-
-    return `YAML parse error: ${reason} (${line}:${column})`;
+    return err.toString(true).replace(/^YAMLException/, 'YAML parse error');
   }
 
   return String(err);

--- a/src/components/UI/Inputs/FileInput/index.tsx
+++ b/src/components/UI/Inputs/FileInput/index.tsx
@@ -1,5 +1,5 @@
 import { FormField, FormFieldProps, TextInput as Input } from 'grommet';
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { setMultipleRefs } from 'utils/componentUtils';
 
 interface IFileInputProps
@@ -64,17 +64,21 @@ const FileInput = React.forwardRef<HTMLInputElement, IFileInputProps>(
       pad,
       children,
       value,
+      onClick,
       ...props
     },
     ref
   ) => {
     const inputRef = useRef<HTMLInputElement | null>(null);
 
-    useEffect(() => {
-      if (inputRef.current) {
-        inputRef.current.files = value!;
+    const handleFileInputClicked = (
+      e: React.MouseEvent<HTMLInputElement, MouseEvent>
+    ) => {
+      if (inputRef.current !== null) {
+        inputRef.current.value = '';
+        if (onClick) onClick(e);
       }
-    }, [value]);
+    };
 
     return (
       <FormField
@@ -97,6 +101,7 @@ const FileInput = React.forwardRef<HTMLInputElement, IFileInputProps>(
           disabled={disabled}
           required={required}
           name={name}
+          onClick={handleFileInputClicked}
           {...props}
           ref={setMultipleRefs(inputRef, ref)}
         />


### PR DESCRIPTION
### What does this PR do?
This PR fixes the `TypeError` encountered when we try to parse `YAMLException`s, by replacing manual formatting with the [`toString` method](https://github.com/nodeca/js-yaml/blob/0d3ca7a27b03a6c974790a30a89e456007d62976/lib/exception.js#L50) available on the `YAMLException class`.

It also fixes not being able to upload a file with the same name (but with different contents), and resets the errors when the user navigates away from the app installation form.

### Any background context you can provide?
Closes https://github.com/giantswarm/roadmap/issues/1499.
