### PR TITLE
Support displaying installed apps for CAPA

### DIFF
--- a/src/model/services/mapi/applicationv1alpha1/key.ts
+++ b/src/model/services/mapi/applicationv1alpha1/key.ts
@@ -69,10 +69,10 @@ export function getDefaultAppNameForProvider(
   provider: PropertiesOf<typeof Providers>
 ) {
   switch (provider) {
-    case Providers.GCP:
-      return 'default-apps-gcp';
+    case Providers.CAPA:
+      return 'default-apps-aws';
     default:
-      return undefined;
+      return `default-apps-${provider}`;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR makes a small change to add support for properly displaying installed apps for CAPA - previously default apps were showing up as user-installed apps.

As we don't currently have tests for apps in organization namespaces, I added an item to our CAPA todo list for that rather than add some here. I thought it made more sense to approach that holistically.

### Any background context you can provide?
Closes https://github.com/giantswarm/roadmap/issues/1501