### PR TITLE
Fix bug in cluster deletion confirmation form

### DIFF
--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailDeleteAction.tsx
@@ -106,6 +106,8 @@ const ClusterDetailDeleteAction: React.FC<
       return;
     }
 
+    if (!debouncedIsNameConfirmed) return;
+
     onDelete();
     hideConfirmation();
   };

--- a/src/components/UI/Display/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailDeleteAction.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailDeleteAction.tsx
@@ -126,6 +126,9 @@ describe('ClusterDetailDeleteAction', () => {
     const nameInput = screen.getByLabelText('Cluster name');
     expect(nameInput).toBeInTheDocument();
 
+    fireEvent.keyDown(nameInput, { key: 'enter', keyCode: 13 });
+    expect(onDeleteMockFn).not.toHaveBeenCalled();
+
     fireEvent.change(nameInput, { target: { value: 'at3s' } });
     expect(deleteButton).toBeDisabled();
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the cluster deletion form's confirmation step, where a user was able to bypass inputting the cluster name as confirmation for deletion, by pressing the "Enter" key.

This is fixed by not just relying on the "Delete" button being disabled, but also adding an additional check in the deletion handler function to check if the input name matches the cluster name.

### Any background context you can provide?

Reported internally: https://gigantic.slack.com/archives/C02FJACQ3D4/p1666270256211769