### PR TITLE
Align style of keywords and cluster labels

### DIFF
--- a/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
+++ b/src/components/UI/Display/Apps/AppDetailNew/AppDetailPage.tsx
@@ -125,11 +125,14 @@ const Detail = styled.div`
 const Keyword = styled.span`
   margin-right: 10px;
   margin-bottom: 10px;
-  font-family: Inconsolata, monospace;
+  font-size: 13px;
   background-color: ${({ theme }) => theme.colors.darkBlueDarker2};
   padding: 5px 8px;
   border-radius: 5px;
   display: inline-block;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
 `;
 
 const VersionPickerRow = styled.div`


### PR DESCRIPTION
### What does this PR do?

App keywords and cluster labels are logically similar. This PR changes the styles of the keyword component to the styles of cluster labels.

### What is the effect of this change to users?

Users will see logically similar components also visually similar.

### How does it look like?
**Before**:
Keywords (left), cluster labels (right)
![image](https://user-images.githubusercontent.com/61459260/198574928-de93005b-ac40-4c99-8a09-e70dbd70c39d.png)
**After**:
Keywords (left), cluster labels (right)
![image](https://user-images.githubusercontent.com/61459260/198575164-a576c91e-6685-4a94-a646-37b88330b8b4.png)


### Any background context you can provide?

closes https://github.com/giantswarm/roadmap/issues/1191

### What is needed from the reviewers?

As you can see it is not possible to use the background color of the cluster label component for the keyword component, because then the background color of the keyword component would be indistinguishable from the background.
It would be possible to change the background color of the cluster label component to the background color of the keyword component. 
I did not do that, because I think changing the color of the cluster labels is less visually appealing. Do you agree?

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

Added `kind/ux-enhancement`