### PR TITLE
Update cluster creation message for GCP

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/index.tsx
@@ -428,7 +428,7 @@ describe('ClusterDetail', () => {
     expect(clusterStatus).toBeInTheDocument();
     expect(
       within(clusterStatus).getByText(
-        'The cluster is currently being created. This step usually takes about 15 minutes.'
+        'The cluster is currently being created. This step usually takes about 5 minutes.'
       )
     ).toBeInTheDocument();
   });

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -326,11 +326,11 @@ const ClusterDetail: React.FC<React.PropsWithChildren<{}>> = () => {
     ? capiv1beta1.getKubernetesAPIEndpointURL(cluster)
     : undefined;
 
-  const { status: clusterStatus, clusterUpdateSchedule } = useClusterStatus(
-    cluster,
-    providerCluster,
-    releaseList?.items
-  );
+  const {
+    status: clusterStatus,
+    clusterUpdateSchedule,
+    clusterCreationDuration,
+  } = useClusterStatus(cluster, providerCluster, releaseList?.items);
 
   const updateDescription = async (newValue: string) => {
     if (!cluster) return;
@@ -417,6 +417,7 @@ const ClusterDetail: React.FC<React.PropsWithChildren<{}>> = () => {
             >
               <ClusterStatusComponent
                 status={clusterStatus}
+                clusterCreationDuration={clusterCreationDuration}
                 clusterUpdateSchedule={clusterUpdateSchedule}
                 inheritColor={true}
                 showFullMessage={true}

--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -86,7 +86,11 @@ const ClusterListItem: React.FC<
 }) => {
   const name = cluster?.metadata.name;
 
-  const { status: clusterStatus, clusterUpdateSchedule } = useClusterStatus(
+  const {
+    status: clusterStatus,
+    clusterUpdateSchedule,
+    clusterCreationDuration,
+  } = useClusterStatus(
     cluster,
     providerCluster === null ? undefined : providerCluster,
     releases
@@ -252,6 +256,7 @@ const ClusterListItem: React.FC<
               {clusterStatus && (
                 <ClusterStatus
                   status={clusterStatus}
+                  clusterCreationDuration={clusterCreationDuration}
                   clusterUpdateSchedule={clusterUpdateSchedule}
                 />
               )}

--- a/src/components/MAPI/clusters/ClusterStatus/ClusterStatus.tsx
+++ b/src/components/MAPI/clusters/ClusterStatus/ClusterStatus.tsx
@@ -11,6 +11,7 @@ import {
 interface IClusterStatusProps
   extends React.ComponentPropsWithoutRef<typeof Box> {
   status: ClusterStatusType;
+  clusterCreationDuration?: string;
   clusterUpdateSchedule?: IClusterUpdateSchedule;
   inheritColor?: boolean;
   showFullMessage?: boolean;
@@ -18,6 +19,7 @@ interface IClusterStatusProps
 
 const ClusterStatus: React.FC<React.PropsWithChildren<IClusterStatusProps>> = ({
   status,
+  clusterCreationDuration,
   clusterUpdateSchedule,
   inheritColor,
   showFullMessage,
@@ -33,8 +35,7 @@ const ClusterStatus: React.FC<React.PropsWithChildren<IClusterStatusProps>> = ({
       color = 'text-weak';
       iconClassName = 'fa fa-change-in-progress';
       message = 'Cluster creating…';
-      fullMessage =
-        'The cluster is currently being created. This step usually takes about 15 minutes.';
+      fullMessage = `The cluster is currently being created. This step usually takes about ${clusterCreationDuration}.`;
       break;
 
     case ClusterStatusType.UpgradeInProgress:

--- a/src/components/MAPI/clusters/CreateCluster/index.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/index.tsx
@@ -37,6 +37,7 @@ import {
   createDefaultControlPlaneNodes,
   createDefaultProviderCluster,
   findLatestReleaseVersion,
+  getClusterCreationDuration,
 } from '../utils';
 import CreateClusterControlPlaneNodeAZs from './CreateClusterControlPlaneNodeAZs';
 import CreateClusterControlPlaneNodesCount from './CreateClusterControlPlaneNodesCount';
@@ -330,6 +331,7 @@ const CreateCluster: React.FC<React.PropsWithChildren<ICreateClusterProps>> = (
   }, [state.controlPlaneNodes]);
   const labels = filterLabels(capiv1beta1.getClusterLabels(state.cluster));
   const servicePriority = capiv1beta1.getClusterServicePriority(state.cluster);
+  const clusterCreationDuration = getClusterCreationDuration(state.cluster);
 
   return (
     <Breadcrumb data={{ title: 'CREATE CLUSTER', pathname: match.url }}>
@@ -418,8 +420,8 @@ const CreateCluster: React.FC<React.PropsWithChildren<ICreateClusterProps>> = (
               </Box>
               <Box margin={{ top: 'medium' }} gap='small'>
                 <Text color='text-weak'>
-                  It will take around 15 minutes for the control plane to become
-                  available.
+                  {`It will take around ${clusterCreationDuration} for the control plane to become
+                  available.`}
                 </Text>
                 <Text>
                   <i

--- a/src/components/MAPI/clusters/hooks/useClusterStatus.ts
+++ b/src/components/MAPI/clusters/hooks/useClusterStatus.ts
@@ -11,6 +11,7 @@ import { useSelector } from 'react-redux';
 import {
   ClusterStatus,
   getClusterConditions,
+  getClusterCreationDuration,
   getClusterUpdateSchedule,
   IClusterUpdateSchedule,
   isClusterUpgradable,
@@ -20,7 +21,11 @@ export function useClusterStatus(
   cluster?: capiv1beta1.ICluster,
   providerCluster?: ProviderCluster,
   releases?: releasev1alpha1.IRelease[]
-): { status?: ClusterStatus; clusterUpdateSchedule?: IClusterUpdateSchedule } {
+): {
+  status?: ClusterStatus;
+  clusterUpdateSchedule?: IClusterUpdateSchedule;
+  clusterCreationDuration?: string;
+} {
   const isAdmin = useSelector(getUserIsAdmin);
   const isImpersonatingNonAdmin = useSelector(getIsImpersonatingNonAdmin);
   const provider = window.config.info.general.provider;
@@ -51,7 +56,10 @@ export function useClusterStatus(
 
     case isConditionUnknown:
     case isCreating:
-      return { status: ClusterStatus.CreationInProgress };
+      return {
+        status: ClusterStatus.CreationInProgress,
+        clusterCreationDuration: getClusterCreationDuration(cluster),
+      };
 
     case isUpgrading:
       return { status: ClusterStatus.UpgradeInProgress };

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -18,6 +18,7 @@ import {
 import { IProviderNodePoolForNodePool } from 'MAPI/workernodes/utils';
 import { GenericResponse } from 'model/clients/GenericResponse';
 import { Constants, Providers } from 'model/constants';
+import * as capgv1beta1 from 'model/services/mapi/capgv1beta1';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as capzv1beta1 from 'model/services/mapi/capzv1beta1';
 import * as corev1 from 'model/services/mapi/corev1';
@@ -1148,7 +1149,7 @@ export function fetchControlPlaneNodesK8sVersionsKey(
 }
 
 export function getClusterCreationDuration(cluster: Cluster): string {
-  if (cluster.spec?.infrastructureRef?.kind === 'GCPCluster') {
+  if (cluster.spec?.infrastructureRef?.kind === capgv1beta1.GCPCluster) {
     return '5 minutes';
   }
 

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -1146,3 +1146,11 @@ export function fetchControlPlaneNodesK8sVersionsKey(
 ): string {
   return `fetchControlPlaneNodesK8sVersions/${cluster.metadata.namespace}/${cluster.metadata.name}`;
 }
+
+export function getClusterCreationDuration(cluster: Cluster): string {
+  if (cluster.spec?.infrastructureRef?.kind === 'GCPCluster') {
+    return '5 minutes';
+  }
+
+  return '15 minutes';
+}

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -213,11 +213,11 @@ const ClusterDetailWidgetRelease: React.FC<
     );
   }, [releaseList, targetVersion]);
 
-  const { status: clusterStatus, clusterUpdateSchedule } = useClusterStatus(
-    cluster,
-    providerCluster,
-    releaseList?.items
-  );
+  const {
+    status: clusterStatus,
+    clusterUpdateSchedule,
+    clusterCreationDuration,
+  } = useClusterStatus(cluster, providerCluster, releaseList?.items);
 
   const [upgradeModalVisible, setUpgradeModalVisible] = useState(false);
 
@@ -404,6 +404,7 @@ const ClusterDetailWidgetRelease: React.FC<
           clusterStatus === ClusterStatus.UpgradeScheduled) && (
           <ClusterStatusComponent
             status={clusterStatus}
+            clusterCreationDuration={clusterCreationDuration}
             clusterUpdateSchedule={clusterUpdateSchedule}
             margin={{ left: 'small' }}
           />


### PR DESCRIPTION
### What does this PR do?

This PR updates the cluster creation message displayed for GCP clusters to inform users that the creation process usually takes 5 minutes instead of 15 minutes.

### What is the effect of this change to users?
Users should now see a more accurate representation of the cluster creation duration.

### How does it look like?
<img width="360" alt="Screenshot 2022-11-02 at 15 30 39" src="https://user-images.githubusercontent.com/62935115/199516980-125b8934-40d4-4320-8cc7-8cec15f3664b.png">
<img width="555" alt="Screenshot 2022-11-02 at 15 30 13" src="https://user-images.githubusercontent.com/62935115/199516983-b89367f8-24be-452e-997a-028aee5f61f4.png">

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/1438.