### PR TITLE
Revert "Remove infrastructure.giantswarm.io/v1alpha2 types and checks"

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProvider.tsx
@@ -3,6 +3,7 @@ import { ProviderCluster } from 'MAPI/types';
 import * as capav1beta1 from 'model/services/mapi/capav1beta1';
 import * as capgv1beta1 from 'model/services/mapi/capgv1beta1';
 import * as capzv1beta1 from 'model/services/mapi/capzv1beta1';
+import * as infrav1alpha2 from 'model/services/mapi/infrastructurev1alpha2';
 import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
 import React from 'react';
 import ClusterDetailWidget from 'UI/Display/MAPI/clusters/ClusterDetail/ClusterDetailWidget';
@@ -51,8 +52,10 @@ const ClusterDetailWidgetProvider: React.FC<
           <ClusterDetailWidgetProviderAzure
             providerCluster={providerCluster as capzv1beta1.IAzureCluster}
           />
-        ) : kind === infrav1alpha3.AWSCluster &&
-          apiVersion === infrav1alpha3.ApiVersion ? (
+        ) : (kind === infrav1alpha2.AWSCluster &&
+            apiVersion === infrav1alpha2.ApiVersion) ||
+          (kind === infrav1alpha3.AWSCluster &&
+            apiVersion === infrav1alpha3.ApiVersion) ? (
           <ClusterDetailWidgetProviderAWS
             providerCluster={providerCluster as infrav1alpha3.IAWSCluster}
           />

--- a/src/components/MAPI/clusters/CreateCluster/patches.ts
+++ b/src/components/MAPI/clusters/CreateCluster/patches.ts
@@ -3,6 +3,7 @@ import { determineRandomAZs, getSupportedAvailabilityZones } from 'MAPI/utils';
 import { Constants } from 'model/constants';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as capzv1beta1 from 'model/services/mapi/capzv1beta1';
+import * as infrav1alpha2 from 'model/services/mapi/infrastructurev1alpha2';
 import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
 import { compare } from 'utils/semver';
 
@@ -43,8 +44,10 @@ export function withClusterReleaseVersion(
   return (cluster, providerCluster, controlPlaneNodes) => {
     const hasNonNamespacedResources =
       providerCluster &&
-      providerCluster.kind === infrav1alpha3.AWSCluster &&
-      providerCluster.apiVersion === infrav1alpha3.ApiVersion &&
+      ((providerCluster.kind === infrav1alpha2.AWSCluster &&
+        providerCluster.apiVersion === infrav1alpha2.ApiVersion) ||
+        (providerCluster.kind === infrav1alpha3.AWSCluster &&
+          providerCluster.apiVersion === infrav1alpha3.ApiVersion)) &&
       compare(newVersion, Constants.AWS_NAMESPACED_CLUSTERS_VERSION) < 0;
     const defaultNamespace = 'default';
 
@@ -111,8 +114,10 @@ export function withClusterDescription(newDescription: string): ClusterPatch {
 
     if (
       providerCluster &&
-      providerCluster.kind === infrav1alpha3.AWSCluster &&
-      providerCluster.apiVersion === infrav1alpha3.ApiVersion &&
+      ((providerCluster.kind === infrav1alpha2.AWSCluster &&
+        providerCluster.apiVersion === infrav1alpha2.ApiVersion) ||
+        (providerCluster.kind === infrav1alpha3.AWSCluster &&
+          providerCluster.apiVersion === infrav1alpha3.ApiVersion)) &&
       providerCluster.spec
     ) {
       providerCluster.spec.cluster.description = newDescription;
@@ -144,7 +149,10 @@ export function withClusterControlPlaneNodesCount(count: number): ClusterPatch {
     const supportedAZs = getSupportedAvailabilityZones().all;
 
     for (const controlPlaneNode of controlPlaneNodes) {
-      if (controlPlaneNode.apiVersion !== infrav1alpha3.ApiVersion) {
+      if (
+        controlPlaneNode.apiVersion !== infrav1alpha2.ApiVersion &&
+        controlPlaneNode.apiVersion !== infrav1alpha3.ApiVersion
+      ) {
         continue;
       }
 

--- a/src/components/MAPI/clusters/utils.ts
+++ b/src/components/MAPI/clusters/utils.ts
@@ -22,6 +22,7 @@ import * as capgv1beta1 from 'model/services/mapi/capgv1beta1';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as capzv1beta1 from 'model/services/mapi/capzv1beta1';
 import * as corev1 from 'model/services/mapi/corev1';
+import * as infrav1alpha2 from 'model/services/mapi/infrastructurev1alpha2';
 import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
 import * as metav1 from 'model/services/mapi/metav1';
 import * as releasev1alpha1 from 'model/services/mapi/releasev1alpha1';
@@ -313,6 +314,8 @@ export function createDefaultCluster(config: {
   const { kind, apiVersion } = config.providerCluster;
   switch (true) {
     case kind === capzv1beta1.AzureCluster:
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion:
       return createDefaultV1Alpha3Cluster(config);
@@ -372,6 +375,8 @@ export function createDefaultControlPlaneNodes(config: {
   switch (true) {
     case kind === capzv1beta1.AzureCluster:
       return [createDefaultAzureMachine(config)];
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion: {
       const name = generateUID(5);
@@ -652,6 +657,8 @@ export async function createCluster(
       break;
     }
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion: {
       // AWS cluster
@@ -736,13 +743,13 @@ export async function createCluster(
                 return infrav1alpha3.createAWSControlPlane(
                   httpClientFactory(),
                   auth,
-                  n
+                  n as infrav1alpha3.IAWSControlPlane
                 );
               case infrav1alpha3.G8sControlPlane:
                 return infrav1alpha3.createG8sControlPlane(
                   httpClientFactory(),
                   auth,
-                  n
+                  n as infrav1alpha3.IG8sControlPlane
                 );
               default:
                 return Promise.reject(
@@ -919,6 +926,8 @@ export function getClusterConditions(
       statuses.isUpgrading = isClusterUpgrading(cluster);
       break;
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion: {
       if (!providerCluster) break;

--- a/src/components/MAPI/types.ts
+++ b/src/components/MAPI/types.ts
@@ -5,10 +5,13 @@ import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
 import * as capzv1beta1 from 'model/services/mapi/capzv1beta1';
 import * as gscorev1alpha1 from 'model/services/mapi/gscorev1alpha1';
+import * as infrav1alpha2 from 'model/services/mapi/infrastructurev1alpha2';
 import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
 
 export type ControlPlaneNode =
   | capzv1beta1.IAzureMachine
+  | infrav1alpha2.IAWSControlPlane
+  | infrav1alpha2.IG8sControlPlane
   | infrav1alpha3.IAWSControlPlane
   | infrav1alpha3.IG8sControlPlane
   | capav1beta1.IAWSMachineTemplate
@@ -17,6 +20,8 @@ export type ControlPlaneNode =
 
 export type ControlPlaneNodeList =
   | capzv1beta1.IAzureMachineList
+  | infrav1alpha2.IAWSControlPlaneList
+  | infrav1alpha2.IG8sControlPlaneList
   | infrav1alpha3.IAWSControlPlaneList
   | infrav1alpha3.IG8sControlPlaneList
   | capav1beta1.IAWSMachineTemplateList
@@ -29,6 +34,7 @@ export type ClusterList = capiv1beta1.IClusterList;
 
 export type ProviderCluster =
   | capzv1beta1.IAzureCluster
+  | infrav1alpha2.IAWSCluster
   | infrav1alpha3.IAWSCluster
   | capav1beta1.IAWSCluster
   | capgv1beta1.IGCPCluster
@@ -36,6 +42,7 @@ export type ProviderCluster =
 
 export type ProviderClusterList =
   | capzv1beta1.IAzureClusterList
+  | infrav1alpha2.IAWSClusterList
   | infrav1alpha3.IAWSClusterList
   | capav1beta1.IAWSClusterList
   | capgv1beta1.IGCPClusterList;
@@ -53,6 +60,7 @@ export type NodePoolList =
 export type ProviderNodePool =
   | capzexpv1alpha3.IAzureMachinePool
   | capzv1beta1.IAzureMachinePool
+  | infrav1alpha2.IAWSMachineDeployment
   | infrav1alpha3.IAWSMachineDeployment
   | capav1beta1.IAWSMachinePool
   | capgv1beta1.IGCPMachineTemplate
@@ -61,6 +69,7 @@ export type ProviderNodePool =
 export type ProviderNodePoolList =
   | capzexpv1alpha3.IAzureMachinePoolList
   | capzv1beta1.IAzureMachinePoolList
+  | infrav1alpha2.IAWSMachineDeploymentList
   | infrav1alpha3.IAWSMachineDeploymentList
   | capav1beta1.IAWSMachinePoolList
   | capgv1beta1.IGCPMachineTemplateList;

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -7,6 +7,7 @@ import * as capiexpv1alpha3 from 'model/services/mapi/capiv1alpha3/exp';
 import * as capiv1beta1 from 'model/services/mapi/capiv1beta1';
 import * as capzexpv1alpha3 from 'model/services/mapi/capzv1alpha3/exp';
 import * as capzv1beta1 from 'model/services/mapi/capzv1beta1';
+import * as infrav1alpha2 from 'model/services/mapi/infrastructurev1alpha2';
 import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
 import * as metav1 from 'model/services/mapi/metav1';
 import * as securityv1alpha1 from 'model/services/mapi/securityv1alpha1';
@@ -188,6 +189,8 @@ export async function fetchNodePoolListForCluster(
 
       break;
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion:
       list = await capiv1beta1.getMachineDeploymentList(
@@ -262,6 +265,8 @@ export function fetchNodePoolListForClusterKey(
         namespace,
       });
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion:
       return capiv1beta1.getMachineDeploymentListKey({
@@ -647,6 +652,8 @@ export async function fetchControlPlaneNodesForCluster(
       return cpNodes.items;
     }
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion: {
       const [awsCP, g8sCP] = await Promise.allSettled([
@@ -731,6 +738,8 @@ export function fetchControlPlaneNodesForClusterKey(
         namespace: cluster.metadata.namespace,
       });
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion:
       return infrav1alpha3.getAWSControlPlaneListKey({
@@ -786,6 +795,8 @@ export async function fetchProviderClusterForCluster(
         infrastructureRef.name
       );
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion:
       return infrav1alpha3.getAWSCluster(
@@ -825,6 +836,8 @@ export function fetchProviderClusterForClusterKey(cluster: Cluster) {
         infrastructureRef.name
       );
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion:
       return infrav1alpha3.getAWSClusterKey(
@@ -1209,6 +1222,8 @@ export function getClusterDescription(
 
   const { kind, apiVersion } = infrastructureRef;
   switch (true) {
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion:
       return (
@@ -1249,6 +1264,8 @@ export function getProviderClusterLocation(
         (providerCluster as capzv1beta1.IAzureCluster).spec?.location ?? ''
       );
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion: {
       const region = (providerCluster as infrav1alpha3.IAWSCluster).spec
@@ -1489,6 +1506,8 @@ export function supportsClientCertificates(cluster: Cluster): boolean {
     case kind === capzv1beta1.AzureCluster:
       return true;
 
+    case kind === infrav1alpha2.AWSCluster &&
+      apiVersion === infrav1alpha2.ApiVersion:
     case kind === infrav1alpha3.AWSCluster &&
       apiVersion === infrav1alpha3.ApiVersion: {
       const releaseVersion = getClusterReleaseVersion(cluster);

--- a/src/components/MAPI/workernodes/utils.ts
+++ b/src/components/MAPI/workernodes/utils.ts
@@ -153,7 +153,7 @@ export async function updateNodePoolDescription(
       providerNodePool = await infrav1alpha3.updateAWSMachineDeployment(
         client,
         auth,
-        providerNodePool
+        providerNodePool as infrav1alpha3.IAWSMachineDeployment
       );
 
       mutate(
@@ -637,7 +637,7 @@ export async function updateNodePoolScaling(
       providerNodePool = await infrav1alpha3.updateAWSMachineDeployment(
         client,
         auth,
-        providerNodePool
+        providerNodePool as infrav1alpha3.IAWSMachineDeployment
       );
 
       mutate(

--- a/src/model/services/mapi/infrastructurev1alpha2/index.ts
+++ b/src/model/services/mapi/infrastructurev1alpha2/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/model/services/mapi/infrastructurev1alpha2/types.ts
+++ b/src/model/services/mapi/infrastructurev1alpha2/types.ts
@@ -1,0 +1,59 @@
+import * as infrav1alpha3 from 'model/services/mapi/infrastructurev1alpha3';
+
+export const ApiVersion = 'infrastructure.giantswarm.io/v1alpha2';
+
+export const AWSCluster = 'AWSCluster';
+
+export interface IAWSCluster
+  extends Omit<infrav1alpha3.IAWSCluster, 'apiVersion'> {
+  apiVersion: typeof ApiVersion;
+}
+
+export const AWSClusterList = 'AWSClusterList';
+
+export interface IAWSClusterList
+  extends Omit<infrav1alpha3.IAWSClusterList, 'apiVersion'> {
+  apiVersion: typeof ApiVersion;
+}
+
+export const AWSControlPlane = 'AWSControlPlane';
+
+export interface IAWSControlPlane
+  extends Omit<infrav1alpha3.IAWSControlPlane, 'apiVersion'> {
+  apiVersion: typeof ApiVersion;
+}
+
+export const AWSControlPlaneList = 'AWSControlPlaneList';
+
+export interface IAWSControlPlaneList
+  extends Omit<infrav1alpha3.IAWSControlPlaneList, 'apiVersion'> {
+  apiVersion: typeof ApiVersion;
+}
+
+export const G8sControlPlane = 'G8sControlPlane';
+
+export interface IG8sControlPlane
+  extends Omit<infrav1alpha3.IG8sControlPlane, 'apiVersion'> {
+  apiVersion: typeof ApiVersion;
+}
+
+export const G8sControlPlaneList = 'G8sControlPlaneList';
+
+export interface IG8sControlPlaneList
+  extends Omit<infrav1alpha3.IG8sControlPlaneList, 'apiVersion'> {
+  apiVersion: typeof ApiVersion;
+}
+
+export const AWSMachineDeployment = 'AWSMachineDeployment';
+
+export interface IAWSMachineDeployment
+  extends Omit<infrav1alpha3.IAWSMachineDeployment, 'apiVersion'> {
+  apiVersion: typeof ApiVersion;
+}
+
+export const AWSMachineDeploymentList = 'AWSMachineDeploymentList';
+
+export interface IAWSMachineDeploymentList
+  extends Omit<infrav1alpha3.IAWSMachineDeploymentList, 'apiVersion'> {
+  apiVersion: typeof ApiVersion;
+}


### PR DESCRIPTION
Reverts giantswarm/happa#3875

While there aren't any more clusters using `awsclusters` from API group `infrastructure.giantswarm.io/v1alpha2`, there are still infrastructure references that haven't been updated to the use the new API version. This unfortunately breaks happa's checks for the API version, and we need to revert the changes of the linked PR.