### PR TITLE
Display longer cluster names

### DIFF
--- a/src/components/Apps/AppDetail/InstallAppModal/ClusterPicker.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/ClusterPicker.tsx
@@ -4,6 +4,7 @@ import React, { FC } from 'react';
 import styled from 'styled-components';
 import ClusterIDLabel, {
   ClusterIDLabelType,
+  MAX_VARIANT_LENGTH,
 } from 'UI/Display/Cluster/ClusterIDLabel';
 import TextInput from 'UI/Inputs/TextInput';
 
@@ -47,6 +48,14 @@ const NoSearchResults = styled.div`
   margin-top: 50px;
 `;
 
+const NAME_CHAR_WIDTH = 7.5;
+
+function getNameColumnWidth(nameLength: number) {
+  const charCount = Math.min(nameLength, MAX_VARIANT_LENGTH);
+
+  return charCount * NAME_CHAR_WIDTH;
+}
+
 interface IClusterPickerCluster
   extends Pick<IBaseCluster, 'id' | 'name' | 'owner'> {
   isAvailable: boolean;
@@ -80,6 +89,10 @@ const ClusterPicker: FC<React.PropsWithChildren<IClusterPicker>> = (props) => {
 
     (e.target as HTMLElement).click();
   };
+
+  const nameLengths = props.clusters.map((cluster) => cluster.id.length);
+  const longestNameLength = nameLengths ? Math.max(...nameLengths) : 0;
+  const nameColumnWidth = getNameColumnWidth(longestNameLength);
 
   return (
     <Box height={{ min: 'fit-content' }}>
@@ -130,6 +143,7 @@ const ClusterPicker: FC<React.PropsWithChildren<IClusterPicker>> = (props) => {
                       ? ClusterIDLabelType.ID
                       : ClusterIDLabelType.Name
                   }
+                  width={nameColumnWidth}
                 />
                 <ClusterTitle>{cluster.name}</ClusterTitle>
                 <ClusterNotice>

--- a/src/components/MAPI/clusters/ClusterList/ClusterList.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterList.tsx
@@ -7,6 +7,7 @@ import {
   TransitionGroup,
 } from 'react-transition-group';
 import styled from 'styled-components';
+import { MAX_VARIANT_LENGTH } from 'UI/Display/Cluster/ClusterIDLabel';
 import ClusterListEmptyPlaceholder from 'UI/Display/MAPI/clusters/ClusterList/ClusterListEmptyPlaceholder';
 
 import { IProviderClusterForCluster } from '../utils';
@@ -126,6 +127,15 @@ const AnimatedItem = styled(ClusterListItem)`
     }
   }
 `;
+
+const NAME_CHAR_WIDTH = 9;
+
+function getNameColumnWidth(nameLength: number) {
+  const charCount = Math.min(nameLength, MAX_VARIANT_LENGTH);
+
+  return charCount * NAME_CHAR_WIDTH;
+}
+
 interface IClusterListProps {
   isLoading: boolean;
   hasNoClusters: boolean;
@@ -178,6 +188,12 @@ const ClusterList: React.FC<React.PropsWithChildren<IClusterListProps>> = (
       : ITEM_TIMEOUT,
   };
 
+  const nameLengths = clustersWithProviderClusters?.map(
+    ({ cluster }) => cluster.metadata.name.length
+  );
+  const longestNameLength = nameLengths ? Math.max(...nameLengths) : 0;
+  const nameColumnWidth = getNameColumnWidth(longestNameLength);
+
   return (
     <SwitchTransition>
       <CSSTransition
@@ -220,6 +236,7 @@ const ClusterList: React.FC<React.PropsWithChildren<IClusterListProps>> = (
                         canListReleases={canListReleases}
                         canListCPNodes={canListCPNodes}
                         margin={{ bottom: 'medium' }}
+                        nameColumnWidth={nameColumnWidth}
                       />
                     </CSSTransition>
                   )

--- a/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
+++ b/src/components/MAPI/clusters/ClusterList/ClusterListItem.tsx
@@ -68,6 +68,7 @@ interface IClusterListItemProps
   canCreateClusters?: boolean;
   canListReleases?: boolean;
   canListCPNodes?: boolean;
+  nameColumnWidth?: number;
 }
 
 const ClusterListItem: React.FC<
@@ -82,6 +83,7 @@ const ClusterListItem: React.FC<
   canListReleases,
   canListCPNodes,
   className,
+  nameColumnWidth,
   ...props
 }) => {
   const name = cluster?.metadata.name;
@@ -235,6 +237,7 @@ const ClusterListItem: React.FC<
                   clusterID={value}
                   variant={ClusterIDLabelType.Name}
                   copyEnabled={true}
+                  width={nameColumnWidth}
                 />
               </Text>
             )}

--- a/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
+++ b/src/components/UI/Display/Cluster/ClusterIDLabel/index.tsx
@@ -2,8 +2,12 @@ import { Keyboard } from 'grommet';
 import React from 'react';
 import styled from 'styled-components';
 import { Tooltip, TooltipContainer } from 'UI/Display/Tooltip';
+import Truncated from 'UI/Util/Truncated';
 import CachingColorHash from 'utils/cachingColorHash';
+import { getTruncationParams } from 'utils/helpers';
 import useCopyToClipboard from 'utils/hooks/useCopyToClipboard';
+
+export const MAX_VARIANT_LENGTH = 10;
 
 const colorHash = new CachingColorHash();
 
@@ -33,11 +37,15 @@ const Wrapper = styled.span`
   }
 `;
 
-const Label = styled.span<{ clusterID: string }>`
+const Label = styled.span<{ clusterID: string; width?: number }>`
   background-color: ${(props) => colorHash.calculateColor(props.clusterID)};
   font-family: ${(props) => props.theme.fontFamilies.console};
   padding: 0.2em 0.4em;
   border-radius: 0.2em;
+  display: inline-block;
+  box-sizing: content-box;
+  width: ${({ width }) => (width ? `${width}px` : 'auto')};
+  text-align: center;
 `;
 
 export enum ClusterIDLabelType {
@@ -49,11 +57,12 @@ interface IClusterIDLabelProps extends React.ComponentPropsWithoutRef<'span'> {
   clusterID: string;
   copyEnabled?: boolean;
   variant?: ClusterIDLabelType;
+  width?: number;
 }
 
 const ClusterIDLabel: React.FC<
   React.PropsWithChildren<IClusterIDLabelProps>
-> = ({ clusterID, copyEnabled, variant, ...props }) => {
+> = ({ clusterID, copyEnabled, variant, width, ...props }) => {
   const [hasContentInClipboard, setClipboardContent] = useCopyToClipboard();
 
   const copyToClipboard = (e: React.MouseEvent<HTMLElement>) => {
@@ -63,18 +72,16 @@ const ClusterIDLabel: React.FC<
     setClipboardContent(clusterID);
   };
 
-  let label = clusterID.substring(0, 5);
-  if (label !== clusterID) {
-    label = `${clusterID.substring(0, 4)}…`;
-  }
-
   const labelComponent = (
-    <Label clusterID={clusterID}>
-      <TooltipContainer
-        content={<Tooltip>{`Cluster ${variant}: ${clusterID}`}</Tooltip>}
+    <Label clusterID={clusterID} width={width}>
+      <Truncated
+        aria-label={clusterID}
+        {...getTruncationParams(MAX_VARIANT_LENGTH)}
+        tooltip={`Cluster ${variant}: ${clusterID}`}
+        showTooltip={true}
       >
-        <span aria-label={clusterID}>{label}</span>
-      </TooltipContainer>
+        {clusterID}
+      </Truncated>
     </Label>
   );
 

--- a/src/components/UI/Util/Truncated.tsx
+++ b/src/components/UI/Util/Truncated.tsx
@@ -11,7 +11,9 @@ interface ITruncatedProps
   numEnd?: number;
   numStart?: number;
   replacer?: string;
+  tooltip?: string;
   tooltipPlacement?: 'top' | 'bottom';
+  showTooltip?: boolean;
 }
 
 const Wrapper = styled.span``;
@@ -26,7 +28,9 @@ const Truncated: React.FC<React.PropsWithChildren<ITruncatedProps>> = ({
   numEnd,
   numStart,
   replacer,
+  tooltip,
   tooltipPlacement,
+  showTooltip = false,
   ...rest
 }) => {
   let str = String(children);
@@ -35,7 +39,7 @@ const Truncated: React.FC<React.PropsWithChildren<ITruncatedProps>> = ({
   str = truncate(str, replacer as string, numStart as number, numEnd as number);
 
   // Skip the tooltip if the content was not truncated
-  const skipTooltip = str === children;
+  const skipTooltip = str === children && !showTooltip;
 
   return (
     <Wrapper {...rest}>
@@ -48,7 +52,7 @@ const Truncated: React.FC<React.PropsWithChildren<ITruncatedProps>> = ({
               placement={tooltipPlacement ?? 'top'}
               width={{ max: 'none' }}
             >
-              {String(children)}
+              {tooltip ?? String(children)}
             </Tooltip>
           }
         >


### PR DESCRIPTION
### What does this PR do?

In this PR cluster name truncation limit was increased to 10 characters. In list views, if there are clusters with various name length, cluster label width is set to fit the longest name. 

### How does it look like?
Cluster list:
<img width="1206" alt="Screenshot 2022-11-11 at 16 08 35" src="https://user-images.githubusercontent.com/445309/201347581-a444f051-91cc-4912-808e-16535d317095.png">

App installation modal > cluster selection list:
<img width="651" alt="Screenshot 2022-11-11 at 16 09 55" src="https://user-images.githubusercontent.com/445309/201347602-ad8604e6-014b-41fc-9f8f-ab829467adcd.png">

When cluster name is longer that 10 characters.
Cluster list:
<img width="1198" alt="Screenshot 2022-11-11 at 16 11 33" src="https://user-images.githubusercontent.com/445309/201348133-d6474a3f-a619-43a1-81be-6a673590fac4.png">

App installation modal > cluster selection list:
<img width="651" alt="Screenshot 2022-11-11 at 16 10 59" src="https://user-images.githubusercontent.com/445309/201348170-a296f3bc-833c-402f-96e9-824ceec69459.png">

### Any background context you can provide?
Closes https://github.com/giantswarm/roadmap/issues/1538.
