### PR TITLE
Fix user invitation for organizations with migrated names

### DIFF
--- a/src/components/Users/Users.js
+++ b/src/components/Users/Users.js
@@ -2,7 +2,6 @@ import DocumentTitle from 'components/shared/DocumentTitle';
 import { push } from 'connected-react-router';
 import { MainRoutes, UsersRoutes } from 'model/constants/routes';
 import { getLoggedInUser } from 'model/stores/main/selectors';
-import { getOrganizationByID } from 'model/stores/organization/utils';
 import {
   invitationCreate,
   invitationsLoad,
@@ -133,23 +132,10 @@ class Users extends React.Component {
       },
     });
 
-    const organizations = Object.values(this.props.organizations.items);
-
-    const invitationOrgs = invitationForm.organizations.map((id) => {
-      const org = getOrganizationByID(id, organizations);
-
-      return org.name ?? org.id;
-    });
-
-    const invitation = {
-      ...invitationForm,
-      organizations: invitationOrgs,
-    };
-
     this.props
       .dispatch(usersLoad()) // Hack to ensure fresh Giant Swarm access token before inviting the user.
       .then(() => {
-        return this.props.dispatch(invitationCreate(invitation));
+        return this.props.dispatch(invitationCreate(invitationForm));
       })
       .then((result) => {
         this.setState({


### PR DESCRIPTION
### What does this PR do?

This PR fixes user invitations for organizations whose name on the `Organization` CR is different from the name in the `ui.giantswarm.io/original-organization-name` annotation (e.g. an organization with `abcde` on the `Organization` CR but `ABCDE` in the annotation).

We previously added logic to invite users using the latter, but since we've migrated organizations with mixed case names to use normalized names, we should instead invite users using the normalized name.

### Any background context you can provide?

Should fix https://gigantic.slack.com/archives/C02EVLE9W/p1668182297167749

### What is needed from the reviewers?
Can you think of situations where this might break (i.e. any installations where we should still invite users to organizations using the old mixed-case names)?