### PR TITLE
Add custom json schema form wrapper

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -1,4 +1,4 @@
-import Form, { IChangeEvent } from '@rjsf/core';
+import { IChangeEvent } from '@rjsf/core';
 import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
@@ -16,6 +16,7 @@ import useSWR from 'swr';
 import Button from 'UI/Controls/Button';
 import InputGroup from 'UI/Inputs/InputGroup';
 import Select from 'UI/Inputs/Select';
+import JSONSchemaForm from 'UI/JSONSchemaForm';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
@@ -217,7 +218,7 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
             branch.
           </Text>
         ) : (
-          <Form
+          <JSONSchemaForm
             schema={appSchema}
             validator={validator}
             onSubmit={handleCreation}
@@ -233,7 +234,7 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
                 )}
               </Box>
             </Box>
-          </Form>
+          </JSONSchemaForm>
         ))}
     </Box>
   );

--- a/src/components/UI/JSONSchemaForm/ArrayFieldTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ArrayFieldTemplate/index.tsx
@@ -1,0 +1,40 @@
+import { ArrayFieldTemplateProps } from '@rjsf/utils';
+import { Box } from 'grommet';
+import React from 'react';
+import Button from 'UI/Controls/Button';
+import InputGroup from 'UI/Inputs/InputGroup';
+
+const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
+  items,
+  canAdd,
+  title,
+  onAddClick,
+}) => {
+  return (
+    <InputGroup label={title}>
+      <div>
+        {items.map((element) => (
+          <Box key={element.key} direction='row'>
+            <Box fill={true}>{element.children}</Box>
+            <Button
+              icon={<i className='fa fa-delete' />}
+              onClick={element.onDropIndexClick(element.index)}
+            >
+              Delete
+            </Button>
+          </Box>
+        ))}
+        {canAdd && (
+          <Button
+            icon={<i className='fa fa-add-circle' />}
+            onClick={onAddClick}
+          >
+            Add
+          </Button>
+        )}
+      </div>
+    </InputGroup>
+  );
+};
+
+export default ArrayFieldTemplate;

--- a/src/components/UI/JSONSchemaForm/BaseInputTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/BaseInputTemplate/index.tsx
@@ -1,0 +1,48 @@
+import { getInputProps, WidgetProps } from '@rjsf/utils';
+import React from 'react';
+import TextInput from 'UI/Inputs/TextInput';
+
+const BaseInputTemplate: React.FC<WidgetProps> = (props) => {
+  const {
+    schema,
+    // id,
+    options,
+    label,
+    value,
+    type,
+    placeholder,
+    required,
+    disabled,
+    readonly,
+    autofocus,
+    onChange,
+    onBlur,
+    onFocus,
+    rawErrors,
+    hideError,
+    uiSchema,
+    registry,
+    formContext,
+    ...rest
+  } = props;
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value === '' ? options.emptyValue || '' : e.target.value);
+  };
+
+  // const inputProps = { ...rest, ...getInputProps(schema, type, options) };]
+  const inputProps = getInputProps(schema, type, options);
+
+  return (
+    <TextInput
+      // id={id}
+      // value={value}
+      placeholder={placeholder}
+      disabled={disabled}
+      readOnly={readonly}
+      onChange={handleChange}
+      {...inputProps}
+    />
+  );
+};
+
+export default BaseInputTemplate;

--- a/src/components/UI/JSONSchemaForm/CheckboxWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/CheckboxWidget/index.tsx
@@ -1,0 +1,13 @@
+import { WidgetProps } from '@rjsf/utils';
+import React from 'react';
+import CheckBoxInput from 'UI/Inputs/CheckBoxInput';
+
+const CheckboxWidget: React.FC<WidgetProps> = ({ label, onChange }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.checked);
+  };
+
+  return <CheckBoxInput label={label} onChange={handleChange} />;
+};
+
+export default CheckboxWidget;

--- a/src/components/UI/JSONSchemaForm/ObjectFieldTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ObjectFieldTemplate/index.tsx
@@ -1,0 +1,22 @@
+import { ObjectFieldTemplateProps } from '@rjsf/utils';
+import React from 'react';
+import InputGroup from 'UI/Inputs/InputGroup';
+
+const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
+  title,
+  properties,
+}) => {
+  const children = properties.map((element) => (
+    <div key={element.name} className='property-wrapper'>
+      {element.content}
+    </div>
+  ));
+
+  return properties.length === 1 || title === '' ? (
+    children
+  ) : (
+    <InputGroup label={title}>{children}</InputGroup>
+  );
+};
+
+export default ObjectFieldTemplate;

--- a/src/components/UI/JSONSchemaForm/SelectWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/SelectWidget/index.tsx
@@ -1,0 +1,25 @@
+import { EnumOptionsType, WidgetProps } from '@rjsf/utils';
+import React from 'react';
+import Select from 'UI/Inputs/Select';
+
+const SelectWidget: React.FC<WidgetProps> = ({ options, value, onChange }) => {
+  const handleChange = (option: EnumOptionsType) => {
+    onChange(option.value);
+  };
+
+  const selectedOption = options.enumOptions?.find(
+    (option) => option.value === value
+  );
+
+  return (
+    <Select
+      value={selectedOption}
+      onChange={(e) => {
+        handleChange(e.option);
+      }}
+      options={options.enumOptions || []}
+    />
+  );
+};
+
+export default SelectWidget;

--- a/src/components/UI/JSONSchemaForm/ToggleWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ToggleWidget/index.tsx
@@ -1,0 +1,13 @@
+import { WidgetProps } from '@rjsf/utils';
+import React from 'react';
+import CheckBoxInput from 'UI/Inputs/CheckBoxInput';
+
+const ToggleWidget: React.FC<WidgetProps> = ({ label, onChange }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.checked);
+  };
+
+  return <CheckBoxInput toggle={true} label={label} onChange={handleChange} />;
+};
+
+export default ToggleWidget;

--- a/src/components/UI/JSONSchemaForm/UpDownWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/UpDownWidget/index.tsx
@@ -1,0 +1,21 @@
+import { WidgetProps } from '@rjsf/utils';
+import React from 'react';
+import NumberPicker from 'UI/Inputs/NumberPicker';
+
+const UpDownWidget: React.FC<WidgetProps> = ({ onChange }) => {
+  const handleChange = ({
+    value,
+    valid,
+  }: {
+    value: number;
+    valid: boolean;
+  }) => {
+    if (valid) {
+      onChange(value);
+    }
+  };
+
+  return <NumberPicker onChange={handleChange} />;
+};
+
+export default UpDownWidget;

--- a/src/components/UI/JSONSchemaForm/index.tsx
+++ b/src/components/UI/JSONSchemaForm/index.tsx
@@ -1,0 +1,36 @@
+import Form, { FormProps } from '@rjsf/core';
+import React from 'react';
+
+import ArrayFieldTemplate from './ArrayFieldTemplate';
+import BaseInputTemplate from './BaseInputTemplate';
+import CheckboxWidget from './CheckboxWidget';
+import ObjectFieldTemplate from './ObjectFieldTemplate';
+import SelectWidget from './SelectWidget';
+import ToggleWidget from './ToggleWidget';
+import UpDownWidget from './UpDownWidget';
+
+const customFields = {};
+const customWidgets = {
+  checkbox: CheckboxWidget,
+  toggle: ToggleWidget,
+  updown: UpDownWidget,
+  select: SelectWidget,
+};
+const customTemplates = {
+  ArrayFieldTemplate,
+  BaseInputTemplate,
+  ObjectFieldTemplate,
+};
+
+const JSONSchemaForm: React.FC<FormProps> = (props) => {
+  return (
+    <Form
+      fields={customFields}
+      widgets={customWidgets}
+      templates={customTemplates}
+      {...props}
+    />
+  );
+};
+
+export default JSONSchemaForm;


### PR DESCRIPTION
### What does this PR do?

This PR introduces a custom wrapper around `react-jsonschema-form`'s  `<Form />` component that uses our own UI form inputs. The work is still in progress.

<img width="698" alt="Screenshot 2022-12-06 at 11 05 57" src="https://user-images.githubusercontent.com/445309/205855164-c615ec35-e79f-46e0-a097-9a557126e405.png">