### PR TITLE
Fix submitted form data and form re-rendering

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -1,5 +1,5 @@
 import { IChangeEvent } from '@rjsf/core';
-import { getDefaultFormState, RJSFSchema, ValidatorType } from '@rjsf/utils';
+import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { Box, Text } from 'grommet';
@@ -10,13 +10,7 @@ import {
 } from 'MAPI/apps/AppList/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import { IHttpClient } from 'model/clients/HttpClient';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import useSWR from 'swr';
 import Button from 'UI/Controls/Button';
@@ -176,24 +170,13 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
   const appSchemaIsLoading =
     appSchema === undefined && appSchemaError === undefined;
 
-  const [formData, setFormData] = useState<RJSFSchema | undefined>(undefined);
+  const [formData, setFormData] = useState<RJSFSchema>({});
   const formDataKey = useRef<number | undefined>(undefined);
 
-  const resetFormData = useCallback(() => {
-    setFormData(
-      appSchema
-        ? getDefaultFormState<RJSFSchema, RJSFSchema>(
-            validator as ValidatorType<RJSFSchema>,
-            appSchema
-          )
-        : appSchema
-    );
+  const resetFormData = () => {
+    setFormData({});
     formDataKey.current = Date.now();
-  }, [appSchema]);
-
-  useEffect(() => {
-    resetFormData();
-  }, [selectedProvider, selectedBranch, resetFormData]);
+  };
 
   const handleSelectedProviderChange = (
     e: React.ChangeEvent<HTMLInputElement>
@@ -201,6 +184,14 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
     const newProvider = e.target.value as PrototypeProviders;
     setSelectedProvider(newProvider);
     setSelectedBranch(getDefaultRepoBranch(newProvider));
+    resetFormData();
+  };
+
+  const handleSelectedBranchChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setSelectedBranch(e.target.value);
+    resetFormData();
   };
 
   const handleFormDataChange = ({
@@ -237,9 +228,7 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
           <InputGroup label='Branch'>
             <Select
               value={selectedBranch}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setSelectedBranch(e.target.value)
-              }
+              onChange={handleSelectedBranchChange}
               options={repoBranches?.map((entry) => entry.name) ?? []}
             />
           </InputGroup>

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -171,8 +171,16 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
     setSelectedBranch(getDefaultRepoBranch(newProvider));
   };
 
+  const [formData, setFormData] = useState<RJSFSchema | undefined>(undefined);
+
+  const handleFormDataChange = ({
+    formData: data,
+  }: IChangeEvent<RJSFSchema>) => {
+    setFormData(data);
+  };
+
   const handleCreation = (
-    { formData }: IChangeEvent<RJSFSchema>,
+    _: IChangeEvent<RJSFSchema>,
     e: React.FormEvent<HTMLElement>
   ) => {
     e.preventDefault();
@@ -221,7 +229,9 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
           <JSONSchemaForm
             schema={appSchema}
             validator={validator}
+            formData={formData}
             onSubmit={handleCreation}
+            onChange={handleFormDataChange}
           >
             <Box margin={{ top: 'medium' }}>
               <Box direction='row' gap='small'>

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -14,6 +14,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import useSWR from 'swr';
 import Button from 'UI/Controls/Button';
+import { CodeBlock, Prompt } from 'UI/Display/Documentation/CodeBlock';
 import InputGroup from 'UI/Inputs/InputGroup';
 import Select from 'UI/Inputs/Select';
 import JSONSchemaForm from 'UI/JSONSchemaForm';
@@ -25,6 +26,12 @@ const Wrapper = styled.div`
   position: relative;
   margin: auto;
   text-align: center;
+`;
+
+const Styled = styled.div`
+  .codeblock--prompt-indicator {
+    display: none;
+  }
 `;
 
 type PrototypeProviders =
@@ -226,25 +233,37 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
             branch.
           </Text>
         ) : (
-          <JSONSchemaForm
-            schema={appSchema}
-            validator={validator}
-            formData={formData}
-            onSubmit={handleCreation}
-            onChange={handleFormDataChange}
-          >
-            <Box margin={{ top: 'medium' }}>
-              <Box direction='row' gap='small'>
-                <Button primary={true} type='submit' loading={isCreating}>
-                  Create cluster
-                </Button>
+          <>
+            <JSONSchemaForm
+              schema={appSchema}
+              validator={validator}
+              formData={formData}
+              onSubmit={handleCreation}
+              onChange={handleFormDataChange}
+            >
+              <Box margin={{ top: 'medium' }}>
+                <Box direction='row' gap='small'>
+                  <Button primary={true} type='submit' loading={isCreating}>
+                    Create cluster
+                  </Button>
 
-                {!isCreating && (
-                  <Button onClick={onCreationCancel}>Cancel</Button>
-                )}
+                  {!isCreating && (
+                    <Button onClick={onCreationCancel}>Cancel</Button>
+                  )}
+                </Box>
               </Box>
-            </Box>
-          </JSONSchemaForm>
+            </JSONSchemaForm>
+            {formData !== undefined && (
+              <Box margin={{ top: 'large' }} gap='small'>
+                <Text weight='bold'>Form data preview</Text>
+                <Styled>
+                  <CodeBlock>
+                    <Prompt>{JSON.stringify(formData, null, '\r  ')}</Prompt>
+                  </CodeBlock>
+                </Styled>
+              </Box>
+            )}
+          </>
         ))}
     </Box>
   );


### PR DESCRIPTION
This PR fixes the 2 bugs we discussed yesterday. Namely:
- submitted form data had missing fields
- form being re-rendered unnecessarily

I also added a live preview for the form data so we could more easily see what would be submitted:

JSON:
<img width="450" alt="Screenshot 2022-12-08 at 06 50 32" src="https://user-images.githubusercontent.com/62935115/206368661-77993a38-5055-488f-b357-34bb91299e35.png">

YAML:
<img width="450" alt="Screenshot 2022-12-08 at 06 50 24" src="https://user-images.githubusercontent.com/62935115/206368656-a0d8d670-a3f0-4564-868b-e740d1b6d2bd.png">