### PR TITLE
Resolve external schema references

### DIFF
--- a/src/components/MAPI/apps/__tests__/utils.ts
+++ b/src/components/MAPI/apps/__tests__/utils.ts
@@ -276,8 +276,11 @@ describe('utils', () => {
           someProperty: {
             $ref: 'https://schema.giantswarm.io/someProperty/v0.0.1',
           },
-          anotherProprty: {
-            $ref: 'https://schema.giantswarm.io/anotherProperty/v0.0.1',
+          anotherProperty: {
+            type: 'array',
+            items: {
+              $ref: 'https://schema.giantswarm.io/anotherProperty/v0.0.1',
+            },
           },
         },
       };
@@ -302,18 +305,8 @@ describe('utils', () => {
       const externalSchema2 = {
         $id: 'https://schema.giantswarm.io/anotherProperty/v0.0.1',
         $schema: 'https://json-schema.org/draft/2020-12/schema',
-        description: 'Another test property.',
-        properties: {
-          name: {
-            description: 'Another property name.',
-            examples: ['example'],
-            title: 'Name',
-            type: 'string',
-          },
-        },
-        required: ['name'],
         title: 'Another property for testing puroses',
-        type: 'object',
+        type: 'string',
       };
 
       nock('https://schema.giantswarm.io')
@@ -345,17 +338,7 @@ describe('utils', () => {
           'https:schema.giantswarm.ioanotherPropertyv0.0.1': {
             $id: '/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
-            description: 'Another test property.',
-            properties: {
-              name: {
-                description: 'Another property name.',
-                examples: ['example'],
-                title: 'Name',
-                type: 'string',
-              },
-            },
-            required: ['name'],
-            type: 'object',
+            type: 'string',
           },
         },
       });
@@ -424,7 +407,9 @@ describe('utils', () => {
         type: 'object',
         properties: {
           someProperty: {
-            $ref: 'https://schema.giantswarm.io/someProperty/v0.0.1',
+            anyOf: [
+              { $ref: 'https://schema.giantswarm.io/someProperty/v0.0.1' },
+            ],
           },
         },
       };

--- a/src/components/MAPI/apps/__tests__/utils.ts
+++ b/src/components/MAPI/apps/__tests__/utils.ts
@@ -319,8 +319,8 @@ describe('utils', () => {
 
       expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
         $defs: {
-          'https:schema.giantswarm.iosomePropertyv0.0.1': {
-            $id: '/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+          'https://schema.giantswarm.io/someProperty/v0.0.1': {
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
             description: 'Some test property.',
             properties: {
@@ -335,8 +335,8 @@ describe('utils', () => {
             title: 'Some property for testing purposes',
             type: 'object',
           },
-          'https:schema.giantswarm.ioanotherPropertyv0.0.1': {
-            $id: '/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+          'https://schema.giantswarm.io/anotherProperty/v0.0.1': {
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1anotherProperty~1v0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
             title: 'Another property for testing purposes',
             type: 'string',
@@ -346,12 +346,12 @@ describe('utils', () => {
         type: 'object',
         properties: {
           someProperty: {
-            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $ref: '#/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
           },
           anotherProperty: {
             type: 'array',
             items: {
-              $ref: '#/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+              $ref: '#/$defs/https:~1~1schema.giantswarm.io~1anotherProperty~1v0.0.1',
             },
           },
         },
@@ -395,9 +395,9 @@ describe('utils', () => {
 
       expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
         $defs: {
-          'https:schema.giantswarm.iosomePropertyv0.0.1': {
+          'https://schema.giantswarm.io/someProperty/v0.0.1': {
             $schema: 'https://json-schema.org/draft/2020-12/schema',
-            $id: '/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
             description: 'Some test property.',
             properties: {
               name: {
@@ -416,10 +416,10 @@ describe('utils', () => {
         type: 'object',
         properties: {
           someProperty: {
-            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $ref: '#/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
           },
           someProperty2: {
-            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $ref: '#/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
           },
         },
       });
@@ -466,9 +466,9 @@ describe('utils', () => {
 
       expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
         $defs: {
-          'https:schema.giantswarm.iosomePropertyv0.0.1': {
+          'https://schema.giantswarm.io/someProperty/v0.0.1': {
             $schema: 'https://json-schema.org/draft/2020-12/schema',
-            $id: '/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
             $defs: {
               name: {
                 description: 'Some property name.',
@@ -480,7 +480,7 @@ describe('utils', () => {
             description: 'Some test property.',
             properties: {
               name: {
-                $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1/$defs/name',
+                $ref: '#/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1/$defs/name',
               },
             },
             required: ['name'],
@@ -493,7 +493,9 @@ describe('utils', () => {
         properties: {
           someProperty: {
             anyOf: [
-              { $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1' },
+              {
+                $ref: '#/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
+              },
             ],
           },
         },
@@ -572,8 +574,8 @@ describe('utils', () => {
 
       expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
         $defs: {
-          'https:schema.giantswarm.iosomePropertyv0.0.1': {
-            $id: '/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+          'https://schema.giantswarm.io/someProperty/v0.0.1': {
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
             description: 'Some test property.',
             properties: {
@@ -586,7 +588,7 @@ describe('utils', () => {
               anotherProperty: {
                 type: 'array',
                 items: {
-                  $ref: '#/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+                  $ref: '#/$defs/https:~1~1schema.giantswarm.io~1anotherProperty~1v0.0.1',
                 },
               },
             },
@@ -594,15 +596,15 @@ describe('utils', () => {
             title: 'Some property for testing purposes',
             type: 'object',
           },
-          'https:schema.giantswarm.ioanotherPropertyv0.0.1': {
-            $id: '/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+          'https://schema.giantswarm.io/anotherProperty/v0.0.1': {
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1anotherProperty~1v0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
             description: 'Another test property.',
             properties: {
               aProperty: {
                 allOf: [
                   {
-                    $ref: '#/$defs/https:schema.giantswarm.ioyetAnotherPropertyv0.0.1',
+                    $ref: '#/$defs/https:~1~1schema.giantswarm.io~1yetAnotherProperty~1v0.0.1',
                   },
                 ],
               },
@@ -610,8 +612,8 @@ describe('utils', () => {
             title: 'Another property for testing purposes',
             type: 'object',
           },
-          'https:schema.giantswarm.ioyetAnotherPropertyv0.0.1': {
-            $id: '/$defs/https:schema.giantswarm.ioyetAnotherPropertyv0.0.1',
+          'https://schema.giantswarm.io/yetAnotherProperty/v0.0.1': {
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1yetAnotherProperty~1v0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
             title: 'Yet another property for testing purposes',
             type: 'string',
@@ -621,7 +623,7 @@ describe('utils', () => {
         type: 'object',
         properties: {
           someProperty: {
-            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $ref: '#/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
           },
         },
       });
@@ -690,8 +692,8 @@ describe('utils', () => {
 
       expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
         $defs: {
-          'https:schema.giantswarm.iosomePropertyv0.0.1': {
-            $id: '/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+          'https://schema.giantswarm.io/someProperty/v0.0.1': {
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
             description: 'Some test property.',
             properties: {
@@ -704,7 +706,7 @@ describe('utils', () => {
               anotherProperty: {
                 type: 'array',
                 items: {
-                  $ref: '#/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+                  $ref: '#/$defs/https:~1~1schema.giantswarm.io~1anotherProperty~1v0.0.1',
                 },
               },
             },
@@ -712,15 +714,15 @@ describe('utils', () => {
             title: 'Some property for testing purposes',
             type: 'object',
           },
-          'https:schema.giantswarm.ioanotherPropertyv0.0.1': {
-            $id: '/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+          'https://schema.giantswarm.io/anotherProperty/v0.0.1': {
+            $id: '/$defs/https:~1~1schema.giantswarm.io~1anotherProperty~1v0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
             description: 'Another test property.',
             properties: {
               aProperty: {
                 allOf: [
                   {
-                    $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+                    $ref: '#/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
                   },
                 ],
               },
@@ -733,7 +735,7 @@ describe('utils', () => {
         type: 'object',
         properties: {
           someProperty: {
-            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $ref: '#/$defs/https:~1~1schema.giantswarm.io~1someProperty~1v0.0.1',
           },
         },
       });

--- a/src/components/MAPI/apps/__tests__/utils.ts
+++ b/src/components/MAPI/apps/__tests__/utils.ts
@@ -318,7 +318,6 @@ describe('utils', () => {
         .reply(StatusCodes.Ok, externalSchema2);
 
       expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
-        ...schema,
         $defs: {
           'https:schema.giantswarm.iosomePropertyv0.0.1': {
             $id: '/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
@@ -341,6 +340,19 @@ describe('utils', () => {
             $schema: 'https://json-schema.org/draft/2020-12/schema',
             title: 'Another property for testing purposes',
             type: 'string',
+          },
+        },
+        $schema: 'http://json-schema.org/schema#',
+        type: 'object',
+        properties: {
+          someProperty: {
+            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+          },
+          anotherProperty: {
+            type: 'array',
+            items: {
+              $ref: '#/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+            },
           },
         },
       });
@@ -382,7 +394,6 @@ describe('utils', () => {
         .reply(StatusCodes.Ok, externalSchema);
 
       expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
-        ...schema,
         $defs: {
           'https:schema.giantswarm.iosomePropertyv0.0.1': {
             $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -399,6 +410,16 @@ describe('utils', () => {
             required: ['name'],
             title: 'Some property for testing purposes',
             type: 'object',
+          },
+        },
+        $schema: 'http://json-schema.org/schema#',
+        type: 'object',
+        properties: {
+          someProperty: {
+            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+          },
+          someProperty2: {
+            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
           },
         },
       });
@@ -444,7 +465,6 @@ describe('utils', () => {
         .reply(StatusCodes.Ok, externalSchema);
 
       expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
-        ...schema,
         $defs: {
           'https:schema.giantswarm.iosomePropertyv0.0.1': {
             $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -466,6 +486,254 @@ describe('utils', () => {
             required: ['name'],
             title: 'Some property for testing purposes',
             type: 'object',
+          },
+        },
+        $schema: 'http://json-schema.org/schema#',
+        type: 'object',
+        properties: {
+          someProperty: {
+            anyOf: [
+              { $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1' },
+            ],
+          },
+        },
+      });
+    });
+
+    it('resolves external schema references with external schema references', async () => {
+      const schema: RJSFSchema = {
+        $schema: 'http://json-schema.org/schema#',
+        type: 'object',
+        properties: {
+          someProperty: {
+            $ref: 'https://schema.giantswarm.io/someProperty/v0.0.1',
+          },
+        },
+      };
+
+      const externalSchema1 = {
+        $id: 'https://schema.giantswarm.io/someProperty/v0.0.1',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        description: 'Some test property.',
+        properties: {
+          name: {
+            description: 'Some property name.',
+            examples: ['example'],
+            title: 'Name',
+            type: 'string',
+          },
+          anotherProperty: {
+            type: 'array',
+            items: {
+              $ref: 'https://schema.giantswarm.io/anotherProperty/v0.0.1',
+            },
+          },
+        },
+        required: ['name'],
+        title: 'Some property for testing purposes',
+        type: 'object',
+      };
+
+      const externalSchema2 = {
+        $id: 'https://schema.giantswarm.io/anotherProperty/v0.0.1',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        description: 'Another test property.',
+        properties: {
+          aProperty: {
+            allOf: [
+              {
+                $ref: 'https://schema.giantswarm.io/yetAnotherProperty/v0.0.1',
+              },
+            ],
+          },
+        },
+        title: 'Another property for testing purposes',
+        type: 'object',
+      };
+
+      const externalSchema3 = {
+        $id: 'https://schema.giantswarm.io/yetAnotherProperty/v0.0.1',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        title: 'Yet another property for testing purposes',
+        type: 'string',
+      };
+
+      nock('https://schema.giantswarm.io')
+        .get('/someProperty/v0.0.1')
+        .reply(StatusCodes.Ok, externalSchema1);
+
+      nock('https://schema.giantswarm.io')
+        .get('/anotherProperty/v0.0.1')
+        .reply(StatusCodes.Ok, externalSchema2);
+
+      nock('https://schema.giantswarm.io')
+        .get('/yetAnotherProperty/v0.0.1')
+        .reply(StatusCodes.Ok, externalSchema3);
+
+      expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
+        $defs: {
+          'https:schema.giantswarm.iosomePropertyv0.0.1': {
+            $id: '/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            description: 'Some test property.',
+            properties: {
+              name: {
+                description: 'Some property name.',
+                examples: ['example'],
+                title: 'Name',
+                type: 'string',
+              },
+              anotherProperty: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+                },
+              },
+            },
+            required: ['name'],
+            title: 'Some property for testing purposes',
+            type: 'object',
+          },
+          'https:schema.giantswarm.ioanotherPropertyv0.0.1': {
+            $id: '/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            description: 'Another test property.',
+            properties: {
+              aProperty: {
+                allOf: [
+                  {
+                    $ref: '#/$defs/https:schema.giantswarm.ioyetAnotherPropertyv0.0.1',
+                  },
+                ],
+              },
+            },
+            title: 'Another property for testing purposes',
+            type: 'object',
+          },
+          'https:schema.giantswarm.ioyetAnotherPropertyv0.0.1': {
+            $id: '/$defs/https:schema.giantswarm.ioyetAnotherPropertyv0.0.1',
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            title: 'Yet another property for testing purposes',
+            type: 'string',
+          },
+        },
+        $schema: 'http://json-schema.org/schema#',
+        type: 'object',
+        properties: {
+          someProperty: {
+            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+          },
+        },
+      });
+    });
+
+    it('resolves external schema references with circular external schema references', async () => {
+      const schema: RJSFSchema = {
+        $schema: 'http://json-schema.org/schema#',
+        type: 'object',
+        properties: {
+          someProperty: {
+            $ref: 'https://schema.giantswarm.io/someProperty/v0.0.1',
+          },
+        },
+      };
+
+      // externalSchema1 refers to externalSchema2
+      const externalSchema1 = {
+        $id: 'https://schema.giantswarm.io/someProperty/v0.0.1',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        description: 'Some test property.',
+        properties: {
+          name: {
+            description: 'Some property name.',
+            examples: ['example'],
+            title: 'Name',
+            type: 'string',
+          },
+          anotherProperty: {
+            type: 'array',
+            items: {
+              $ref: 'https://schema.giantswarm.io/anotherProperty/v0.0.1',
+            },
+          },
+        },
+        required: ['name'],
+        title: 'Some property for testing purposes',
+        type: 'object',
+      };
+
+      // externalSchema2 refers to externalSchema1
+      const externalSchema2 = {
+        $id: 'https://schema.giantswarm.io/anotherProperty/v0.0.1',
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        description: 'Another test property.',
+        properties: {
+          aProperty: {
+            allOf: [
+              {
+                $ref: 'https://schema.giantswarm.io/someProperty/v0.0.1',
+              },
+            ],
+          },
+        },
+        title: 'Another property for testing purposes',
+        type: 'object',
+      };
+
+      nock('https://schema.giantswarm.io')
+        .get('/someProperty/v0.0.1')
+        .reply(StatusCodes.Ok, externalSchema1);
+
+      nock('https://schema.giantswarm.io')
+        .get('/anotherProperty/v0.0.1')
+        .reply(StatusCodes.Ok, externalSchema2);
+
+      expect(await resolveExternalSchemaRef(clientFactory(), schema)).toEqual({
+        $defs: {
+          'https:schema.giantswarm.iosomePropertyv0.0.1': {
+            $id: '/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            description: 'Some test property.',
+            properties: {
+              name: {
+                description: 'Some property name.',
+                examples: ['example'],
+                title: 'Name',
+                type: 'string',
+              },
+              anotherProperty: {
+                type: 'array',
+                items: {
+                  $ref: '#/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+                },
+              },
+            },
+            required: ['name'],
+            title: 'Some property for testing purposes',
+            type: 'object',
+          },
+          'https:schema.giantswarm.ioanotherPropertyv0.0.1': {
+            $id: '/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            description: 'Another test property.',
+            properties: {
+              aProperty: {
+                allOf: [
+                  {
+                    $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
+                  },
+                ],
+              },
+            },
+            title: 'Another property for testing purposes',
+            type: 'object',
+          },
+        },
+        $schema: 'http://json-schema.org/schema#',
+        type: 'object',
+        properties: {
+          someProperty: {
+            $ref: '#/$defs/https:schema.giantswarm.iosomePropertyv0.0.1',
           },
         },
       });

--- a/src/components/MAPI/apps/__tests__/utils.ts
+++ b/src/components/MAPI/apps/__tests__/utils.ts
@@ -298,14 +298,14 @@ describe('utils', () => {
           },
         },
         required: ['name'],
-        title: 'Some property for testing puroses',
+        title: 'Some property for testing purposes',
         type: 'object',
       };
 
       const externalSchema2 = {
         $id: 'https://schema.giantswarm.io/anotherProperty/v0.0.1',
         $schema: 'https://json-schema.org/draft/2020-12/schema',
-        title: 'Another property for testing puroses',
+        title: 'Another property for testing purposes',
         type: 'string',
       };
 
@@ -333,11 +333,13 @@ describe('utils', () => {
               },
             },
             required: ['name'],
+            title: 'Some property for testing purposes',
             type: 'object',
           },
           'https:schema.giantswarm.ioanotherPropertyv0.0.1': {
             $id: '/$defs/https:schema.giantswarm.ioanotherPropertyv0.0.1',
             $schema: 'https://json-schema.org/draft/2020-12/schema',
+            title: 'Another property for testing purposes',
             type: 'string',
           },
         },
@@ -371,7 +373,7 @@ describe('utils', () => {
           },
         },
         required: ['name'],
-        title: 'Some property for testing puroses',
+        title: 'Some property for testing purposes',
         type: 'object',
       };
 
@@ -395,6 +397,7 @@ describe('utils', () => {
               },
             },
             required: ['name'],
+            title: 'Some property for testing purposes',
             type: 'object',
           },
         },
@@ -432,7 +435,7 @@ describe('utils', () => {
           },
         },
         required: ['name'],
-        title: 'Some property for testing puroses',
+        title: 'Some property for testing purposes',
         type: 'object',
       };
 
@@ -461,6 +464,7 @@ describe('utils', () => {
               },
             },
             required: ['name'],
+            title: 'Some property for testing purposes',
             type: 'object',
           },
         },

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -1360,9 +1360,9 @@ export function fetchAppCatalogEntrySchemaKey(url?: string) {
 }
 
 function hashURLToJSONRef(url: string): string {
-  // URLs can contain the '/', '#', and '$' characters,
-  // which have special meaning in JSON $ref,
-  return url.replace(/#|$|\//g, '');
+  // URLs contain the '/' character, which has to be escaped
+  // when used in JSON pointers
+  return url.replaceAll('/', '~1');
 }
 
 /**
@@ -1471,7 +1471,7 @@ async function processExternalSchema(
 
         const patchedSchema = patchExternalSchema(url, fetchedSchema);
 
-        patchedDefs[hashURLToJSONRef(url)] = patchedSchema;
+        patchedDefs[url] = patchedSchema;
 
         const [patchedSchemaForNewUrls, newUrls] =
           parseSchemaForURLs(patchedSchema);
@@ -1479,12 +1479,12 @@ async function processExternalSchema(
         for (const newUrl of newUrls) {
           // if we haven't already processed the schema from a new URL,
           // add it to the list of URLs to fetch from
-          if (!patchedDefs[hashURLToJSONRef(newUrl)]) {
+          if (!patchedDefs[newUrl]) {
             urls.add(newUrl);
           }
 
           // update stored schema
-          patchedDefs[hashURLToJSONRef(url)] = patchedSchemaForNewUrls;
+          patchedDefs[url] = patchedSchemaForNewUrls;
         }
       }
     }

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -1429,10 +1429,6 @@ export async function resolveExternalSchemaRef(
           processRefs
         );
 
-        // delete external schema title to avoid overwriting parent schema's name
-        // for the field
-        delete patchedDef.title;
-
         // update $id so relative $refs within the subschema are handled correctly
         patchedDef.$id = `/$defs/${hashURLToJSONRef(response.value.url)}`;
 

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -1361,7 +1361,7 @@ export function fetchAppCatalogEntrySchemaKey(url?: string) {
 
 function hashURLToJSONRef(url: string): string {
   // URLs contain the '/' character, which has to be escaped
-  // when used in JSON pointers
+  // when used in JSON pointers. See https://www.rfc-editor.org/rfc/rfc6901#section-4
   return url.replaceAll('/', '~1');
 }
 

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -1410,6 +1410,10 @@ export async function resolveExternalSchemaRef(
     const patchedDefs: Record<string, RJSFSchema> = {};
 
     for (const response of responses) {
+      if (response.status === 'rejected') {
+        throw response.reason;
+      }
+
       if (response.status === 'fulfilled') {
         const processRefs = (obj: RJSFSchema) => {
           const ref: string | undefined = obj.$ref;

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -9,7 +9,7 @@ import {
   fetchAppCatalogEntrySchema,
   fetchAppCatalogEntrySchemaKey,
 } from 'MAPI/apps/utils';
-import { generateUID } from 'MAPI/utils';
+import { extractErrorMessage, generateUID } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import { IHttpClient } from 'model/clients/HttpClient';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -23,6 +23,7 @@ import RadioInput from 'UI/Inputs/RadioInput';
 import Select from 'UI/Inputs/Select';
 import JSONSchemaForm from 'UI/JSONSchemaForm';
 import ErrorReporter from 'utils/errors/ErrorReporter';
+import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
 
@@ -178,6 +179,12 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
 
   useEffect(() => {
     if (appSchemaError) {
+      new FlashMessage(
+        'Something went wrong while trying to fetch external app schema.',
+        messageType.ERROR,
+        messageTTL.LONG,
+        extractErrorMessage(appSchemaError)
+      );
       ErrorReporter.getInstance().notify(appSchemaError);
     }
   }, [appSchemaError]);
@@ -265,6 +272,7 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
         </Wrapper>
       )}
       {!appSchemaIsLoading &&
+        typeof appSchemaError === 'undefined' &&
         (typeof appSchema === 'undefined' ? (
           <Text>
             No <code>values.schema.json</code> file found for the selected

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -8,7 +8,7 @@ import yaml from 'js-yaml';
 import {
   fetchAppCatalogEntrySchema,
   fetchAppCatalogEntrySchemaKey,
-} from 'MAPI/apps/AppList/utils';
+} from 'MAPI/apps/utils';
 import { generateUID } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import { IHttpClient } from 'model/clients/HttpClient';

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -513,6 +513,8 @@ export function traverseJSONSchemaObject(
     )) {
       traverseJSONSchemaObject(value as Record<string, unknown>, processFn);
     }
+  } else if (obj.type === 'array' && typeof obj.items === 'object') {
+    traverseJSONSchemaObject(obj.items, processFn);
   } else {
     processFn(obj);
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { RJSFSchema } from '@rjsf/utils';
 import compareAsc from 'date-fns/fp/compareAsc';
 import format from 'date-fns/fp/format';
 import formatDistance from 'date-fns/fp/formatDistance';
@@ -476,4 +477,45 @@ export function getHumanReadableMemory(size: number, minDecimals: number = 0) {
 
 export function isIPAddress(s: string): boolean {
   return ipRegex().test(s);
+}
+
+/**
+ * Determines whether a given string is a valid URL of https/http protocol
+ * @param str
+ */
+export function isValidURL(str: string): boolean {
+  try {
+    const url = new URL(str);
+
+    return url.protocol === 'https:' || url.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Traverses a JSON schema object recursively via the schema's "properties" field
+ * @param obj
+ * @param processFn
+ * @returns obj
+ */
+export function traverseJSONSchemaObject(
+  obj: RJSFSchema,
+  processFn: (obj: RJSFSchema) => void
+): Record<string, unknown> {
+  if (
+    obj.type === 'object' &&
+    obj.properties &&
+    typeof obj.properties === 'object'
+  ) {
+    for (const value of Object.values(
+      obj.properties as Record<string, unknown>
+    )) {
+      traverseJSONSchemaObject(value as Record<string, unknown>, processFn);
+    }
+  } else {
+    processFn(obj);
+  }
+
+  return obj;
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds basic support for resolving external schema references. This feature is currently and unfortunately not supported by `react-json-schema-form`, so we implement our own external schema resolution, which functions as follows:
- we collect all `$ref` from a cluster app schema that references a URL of http/https protocol (e.g. `$ref: https://giantswarm.schema.io/someSchema`)
- we fetch the schema from each URL and patch the original (parent) schema, so that the `$ref` now references a relative schema defined in the parent schema's `$def`

The tests accompanying this PR might shed some more light on the resolution behaviour.

Caveats:
~~- we don't currently handle external schema that reference other external schema - we only fetch from the URLs found in the parent schema~~
- currently we throw an error if any of the external schema cannot be fetched. We can choose handle this with more nuance in the future (e.g. proceeding with an incomplete schema, but notifying the user).

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1181.

### What is needed from the reviewers?

This PR can be tested using provider `GCP`'s `main` branch.  Expanding and adding items to `machineDeployments.customNodeLabels` used to break the form due to external schema referenced. Now that should no longer be the case, and the schema from https://schema.giantswarm.io/labelvalue/v0.0.1 should be used for a `customerNodeLabels` item.

<img width="400" alt="Screenshot 2022-12-21 at 14 15 20" src="https://user-images.githubusercontent.com/62935115/208919041-d36ea35c-30ca-44f6-aaa4-45f48d7f3315.png">
