### PR TITLE
Cluster app form fields suggestions

### DIFF
--- a/src/components/UI/JSONSchemaForm/BaseInputTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/BaseInputTemplate/index.tsx
@@ -25,9 +25,16 @@ const BaseInputTemplate: React.FC<WidgetProps> = ({
     }
   };
 
+  const handleSuggestionSelect = (e: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    suggestion: any;
+  }) => {
+    onChange(e.suggestion);
+  };
+
   const inputProps = getInputProps(schema, type as string, options);
 
-  const { description } = schema;
+  const { description, examples } = schema;
 
   const isArrayItem = /(_\d+)$/.test(id);
   const simplifiedView = isArrayItem && !description;
@@ -62,12 +69,14 @@ const BaseInputTemplate: React.FC<WidgetProps> = ({
       id={id}
       label={displayLabel}
       help={description}
-      value={value}
+      suggestions={examples as string[]}
+      value={value ?? ''}
       placeholder={placeholder}
       disabled={disabled}
       readOnly={readonly}
       margin={margin}
       onChange={handleChange}
+      onSuggestionSelect={handleSuggestionSelect}
       {...inputProps}
     />
   );

--- a/src/components/UI/JSONSchemaForm/BaseInputTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/BaseInputTemplate/index.tsx
@@ -25,10 +25,7 @@ const BaseInputTemplate: React.FC<WidgetProps> = ({
     }
   };
 
-  const handleSuggestionSelect = (e: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    suggestion: any;
-  }) => {
+  const handleSuggestionSelect = (e: { suggestion: string }) => {
     onChange(e.suggestion);
   };
 

--- a/src/components/UI/JSONSchemaForm/SelectWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/SelectWidget/index.tsx
@@ -14,9 +14,13 @@ const SelectWidget: React.FC<WidgetProps> = ({
     onChange(option.value);
   };
 
-  const selectedOption = options.enumOptions?.find(
-    (option) => option.value === value
-  );
+  const enumOptions =
+    options.enumOptions?.map((option) => ({
+      label: option.label,
+      value: option.value,
+    })) || [];
+
+  const selectedOption = enumOptions.find((option) => option.value === value);
 
   const { description } = schema;
 
@@ -30,7 +34,7 @@ const SelectWidget: React.FC<WidgetProps> = ({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         handleChange(e.option);
       }}
-      options={options.enumOptions || []}
+      options={enumOptions}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?
In this PR:
- support for displaying schema examples was added;
- `SelectWidget` was improved to support `oneOf` schema property. It will allow us to provide custom labels for select values, e.g.:
```
"servicePriorityLabel": {
    "type": "string",
    "oneOf": [
        {"const": "lowest", "title": "Lowest"},
        {"const": "medium", "title": "Medium"},
        {"const": "highest", "title": "Highest"}
     ]
}
```

### How does it look like?
Displaying schema examples:
<img width="697" alt="Screenshot 2022-12-20 at 16 59 15" src="https://user-images.githubusercontent.com/445309/208914941-5cbc221b-0de8-4859-a07f-382d193db0ed.png">


### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1181.
