### PR TITLE
Update how we determine UI loading state

### DIFF
--- a/src/components/MAPI/apps/AppList/index.tsx
+++ b/src/components/MAPI/apps/AppList/index.tsx
@@ -75,7 +75,7 @@ const AppList: React.FC<React.PropsWithChildren<{}>> = () => {
   const {
     data: catalogList,
     error: catalogListError,
-    isValidating: catalogListIsValidating,
+    isLoading: catalogListIsLoading,
   } = useSWR<applicationv1alpha1.ICatalogList, GenericResponseError>(
     catalogListForOrganizationsKey,
     () =>
@@ -103,9 +103,6 @@ const AppList: React.FC<React.PropsWithChildren<{}>> = () => {
       ErrorReporter.getInstance().notify(catalogListError);
     }
   }, [catalogListError]);
-
-  const catalogListIsLoading =
-    typeof catalogList === 'undefined' && catalogListIsValidating;
 
   const {
     selectedCatalogs,
@@ -171,7 +168,7 @@ const AppList: React.FC<React.PropsWithChildren<{}>> = () => {
   const {
     data: appCatalogEntryList,
     error: appCatalogEntryListError,
-    isValidating: appCatalogEntryListIsValidating,
+    isLoading: appCatalogEntryListIsLoading,
   } = useSWR<applicationv1alpha1.IAppCatalogEntryList, GenericResponseError>(
     appCatalogEntryListKey,
     () =>
@@ -199,10 +196,7 @@ const AppList: React.FC<React.PropsWithChildren<{}>> = () => {
     }
   }, [appCatalogEntryListError]);
 
-  const appCatalogEntryListIsLoading =
-    catalogListIsLoading ||
-    (typeof appCatalogEntryList === 'undefined' &&
-      appCatalogEntryListIsValidating);
+  const isLoading = catalogListIsLoading || appCatalogEntryListIsLoading;
 
   const selectedClusterID = useSelector(
     (state: IState) => state.main.selectedClusterID
@@ -315,7 +309,7 @@ const AppList: React.FC<React.PropsWithChildren<{}>> = () => {
           extractErrorMessage(appCatalogEntryListError)
         )}
         facetsIsLoading={catalogListIsLoading}
-        appsIsLoading={appCatalogEntryListIsLoading}
+        appsIsLoading={isLoading}
         selectedClusterBanner={
           selectedClusterID ? (
             <AppInstallationSelectedCluster

--- a/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
+++ b/src/components/MAPI/apps/ClusterDetailAppListWidgetVersionInspector.tsx
@@ -86,15 +86,18 @@ const ClusterDetailAppListWidgetVersionInspector: React.FC<
     );
   }, [app, appCatalogEntryListGetOptions, canListAppCatalogEntries]);
 
-  const { data: appCatalogEntryList, error: appCatalogEntryListError } = useSWR<
-    applicationv1alpha1.IAppCatalogEntryList,
-    GenericResponseError
-  >(appCatalogEntryListKey, () =>
-    applicationv1alpha1.getAppCatalogEntryList(
-      appCatalogEntryListClient.current,
-      auth,
-      appCatalogEntryListGetOptions
-    )
+  const {
+    data: appCatalogEntryList,
+    error: appCatalogEntryListError,
+    isLoading: appCatalogEntryListIsLoading,
+  } = useSWR<applicationv1alpha1.IAppCatalogEntryList, GenericResponseError>(
+    appCatalogEntryListKey,
+    () =>
+      applicationv1alpha1.getAppCatalogEntryList(
+        appCatalogEntryListClient.current,
+        auth,
+        appCatalogEntryListGetOptions
+      )
   );
 
   useEffect(() => {
@@ -114,9 +117,7 @@ const ClusterDetailAppListWidgetVersionInspector: React.FC<
 
   const isLoading =
     typeof app === 'undefined' ||
-    (canListAppCatalogEntries &&
-      typeof appCatalogEntryList === 'undefined' &&
-      typeof appCatalogEntryListError === 'undefined');
+    (canListAppCatalogEntries && appCatalogEntryListIsLoading);
 
   const currentEntry = useMemo(() => {
     if (!appCatalogEntryList || !currentVersion) return undefined;

--- a/src/components/MAPI/apps/ClusterDetailApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailApps.tsx
@@ -94,7 +94,7 @@ const ClusterDetailApps: React.FC<
   const {
     data: appList,
     error: appListError,
-    isValidating: appListIsValidating,
+    isLoading: appListIsLoading,
   } = useSWR<applicationv1alpha1.IAppList, GenericResponseError>(
     appListKey,
     () =>
@@ -114,11 +114,6 @@ const ClusterDetailApps: React.FC<
       },
     }
   );
-  const appListIsLoading =
-    typeof appsPermissions.canList === 'undefined' ||
-    (appListIsValidating &&
-      typeof appList === 'undefined' &&
-      typeof appListError === 'undefined');
 
   useEffect(() => {
     if (appListError) {
@@ -126,7 +121,10 @@ const ClusterDetailApps: React.FC<
     }
   }, [appListError]);
 
-  const isLoading = appListIsLoading || typeof appsNamespace === 'undefined';
+  const isLoading =
+    typeof appsPermissions.canList === 'undefined' ||
+    appListIsLoading ||
+    typeof appsNamespace === 'undefined';
 
   const dispatch = useDispatch();
 

--- a/src/components/MAPI/apps/ClusterDetailIngress.tsx
+++ b/src/components/MAPI/apps/ClusterDetailIngress.tsx
@@ -102,15 +102,14 @@ const ClusterDetailIngress: React.FC<
   const {
     data: appList,
     error: appListError,
-    isValidating: appListIsValidating,
+    isLoading: appListIsLoading,
   } = useSWR<applicationv1alpha1.IAppList, GenericResponseError>(
     appListKey,
     () => applicationv1alpha1.getAppList(appListClient, auth, appListGetOptions)
   );
 
-  const appListIsLoading =
-    typeof appsPermissions.canList === 'undefined' ||
-    (typeof appList === 'undefined' && appListIsValidating && !appListError);
+  const isLoading =
+    typeof appsPermissions.canList === 'undefined' || appListIsLoading;
 
   useEffect(() => {
     if (appListError) {
@@ -141,14 +140,14 @@ const ClusterDetailIngress: React.FC<
         }}
       >
         <IngressWrapper {...rest}>
-          {appListIsLoading && (
+          {isLoading && (
             <Box direction='row' align='center' gap='small'>
               <StyledLoadingIndicator loading={true} />
               <Text color='text-weak'>Loading ingress information…</Text>
             </Box>
           )}
 
-          {!appListIsLoading && !appListError && (
+          {!isLoading && !appListError && (
             <Box margin={{ bottom: 'medium' }}>
               {hasIngress ? (
                 <Text>
@@ -166,7 +165,7 @@ const ClusterDetailIngress: React.FC<
             </Box>
           )}
 
-          {hasIngress && !appListIsLoading && !appListError && (
+          {hasIngress && !isLoading && !appListError && (
             <Instructions
               provider={provider}
               k8sEndpoint={k8sEndpoint}
@@ -175,7 +174,7 @@ const ClusterDetailIngress: React.FC<
             />
           )}
 
-          {!hasIngress && !appListIsLoading && !appListError && (
+          {!hasIngress && !isLoading && !appListError && (
             <InstallIngressButton
               clusterID={clusterId}
               appsNamespace={appsNamespace!}

--- a/src/components/MAPI/apps/ClusterDetailWidgetApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailWidgetApps.tsx
@@ -84,7 +84,7 @@ const ClusterDetailWidgetApps: React.FC<
   const {
     data: appList,
     error: appListError,
-    isValidating: appListIsValidating,
+    isLoading: appListIsLoading,
   } = useSWR<applicationv1alpha1.IAppList, GenericResponseError>(
     appListKey,
     () =>
@@ -101,11 +101,7 @@ const ClusterDetailWidgetApps: React.FC<
     }
   }, [appListError]);
 
-  const appListIsLoading =
-    typeof canListApps === 'undefined' ||
-    (appListIsValidating &&
-      typeof appList === 'undefined' &&
-      typeof appListError === 'undefined');
+  const isLoading = typeof canListApps === 'undefined' || appListIsLoading;
 
   const userInstalledApps = useMemo(() => {
     if (typeof appList === 'undefined') {
@@ -127,7 +123,7 @@ const ClusterDetailWidgetApps: React.FC<
       };
     }
 
-    if (appListIsLoading) {
+    if (isLoading) {
       return {
         apps: undefined,
         notDeployed: undefined,
@@ -137,7 +133,7 @@ const ClusterDetailWidgetApps: React.FC<
     const apps = appList?.items ?? [];
 
     return computeAppsCategorizedCounters(apps);
-  }, [appList, appListError, appListIsLoading, insufficientPermissionsForApps]);
+  }, [appList, appListError, isLoading, insufficientPermissionsForApps]);
 
   const hasNoApps =
     typeof appCounters.apps === 'number' && appCounters.apps === 0;

--- a/src/components/MAPI/apps/InstallIngressButton.tsx
+++ b/src/components/MAPI/apps/InstallIngressButton.tsx
@@ -88,7 +88,7 @@ const InstallIngressButton: React.FC<
 
   const {
     data: appList,
-    isValidating: appListIsValidating,
+    isLoading: appListIsLoading,
     error: appListError,
     mutate: mutateAppList,
   } = useSWR<applicationv1alpha1.IAppList, GenericResponseError>(
@@ -126,7 +126,7 @@ const InstallIngressButton: React.FC<
   const {
     data: ingressAppToInstall,
     error: ingressAppToInstallError,
-    isValidating: ingressAppToInstallIsValidating,
+    isLoading: ingressAppToInstallIsLoading,
   } = useSWR<applicationv1alpha1.IAppCatalogEntry | null, GenericResponseError>(
     ingressAppCatalogEntryKey,
     () => getIngressAppCatalogEntry(appCatalogEntryClient.current, auth)
@@ -165,12 +165,10 @@ const InstallIngressButton: React.FC<
     case !errorMessage && isInstalling:
       isLoading = true;
       break;
-    case !errorMessage && typeof appList === 'undefined' && appListIsValidating:
+    case appListIsLoading:
       isLoading = true;
       break;
-    case !errorMessage &&
-      typeof ingressAppToInstall === 'undefined' &&
-      ingressAppToInstallIsValidating:
+    case ingressAppToInstallIsLoading:
       isLoading = true;
       break;
   }

--- a/src/components/MAPI/apps/permissions/usePermissionsForApps/usePermissionsForAppConfigsInClusterNamespace.ts
+++ b/src/components/MAPI/apps/permissions/usePermissionsForApps/usePermissionsForAppConfigsInClusterNamespace.ts
@@ -31,7 +31,7 @@ export function usePermissionsForAppConfigsInClusterNamespace(
   const {
     data: configMapsAccess,
     error: configMapsError,
-    isValidating: configMapsIsValidating,
+    isLoading: configMapsIsLoading,
   } = useSWR<Record<typeof verbs[number], boolean>, GenericResponseError>(
     fetchAccessForResourceKey(namespace, verbs, '', 'configmaps'),
     () =>
@@ -51,7 +51,7 @@ export function usePermissionsForAppConfigsInClusterNamespace(
   const {
     data: secretsAccess,
     error: secretsError,
-    isValidating: secretsIsValidating,
+    isLoading: secretsIsLoading,
   } = useSWR<Record<typeof verbs[number], boolean>, GenericResponseError>(
     fetchAccessForResourceKey(namespace, verbs, '', 'secrets'),
     () =>
@@ -80,16 +80,6 @@ export function usePermissionsForAppConfigsInClusterNamespace(
       );
     }
   }, [configMapsError, secretsError]);
-
-  const configMapsIsLoading =
-    typeof configMapsAccess === 'undefined' &&
-    typeof configMapsError === 'undefined' &&
-    configMapsIsValidating;
-
-  const secretsIsLoading =
-    typeof secretsAccess === 'undefined' &&
-    typeof secretsError === 'undefined' &&
-    secretsIsValidating;
 
   if (configMapsIsLoading || secretsIsLoading) return computed;
 

--- a/src/components/MAPI/apps/permissions/usePermissionsForApps/usePermissionsForAppsInClusterNamespace.ts
+++ b/src/components/MAPI/apps/permissions/usePermissionsForApps/usePermissionsForAppsInClusterNamespace.ts
@@ -37,7 +37,7 @@ export function usePermissionsForAppsInClusterNamespace(
   const {
     data: appAccess,
     error,
-    isValidating,
+    isLoading,
   } = useSWR<Record<typeof verbs[number], boolean>, GenericResponseError>(
     fetchAccessForResourceKey(namespace, verbs, group, resource),
     () =>
@@ -71,11 +71,6 @@ export function usePermissionsForAppsInClusterNamespace(
     provider,
     namespace
   );
-
-  const isLoading =
-    typeof appAccess === 'undefined' &&
-    typeof error === 'undefined' &&
-    isValidating;
 
   if (isLoading) {
     computed.canGet = undefined;

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailActions.tsx
@@ -55,11 +55,13 @@ const ClusterDetailActions: React.FC<
   const orgClient = useRef(clientFactory());
 
   // The error is handled in the parent component.
-  const { data: org, error: orgError } = useSWR<
-    securityv1alpha1.IOrganization,
-    GenericResponseError
-  >(securityv1alpha1.getOrganizationKey(orgId), () =>
-    securityv1alpha1.getOrganization(orgClient.current, auth, orgId)
+  const {
+    data: org,
+    error: orgError,
+    isLoading: orgIsLoading,
+  } = useSWR<securityv1alpha1.IOrganization, GenericResponseError>(
+    securityv1alpha1.getOrganizationKey(orgId),
+    () => securityv1alpha1.getOrganization(orgClient.current, auth, orgId)
   );
 
   const namespace = org?.status?.namespace;
@@ -73,10 +75,11 @@ const ClusterDetailActions: React.FC<
       : null;
 
   // The error is handled in the parent component.
-  const { data: cluster, error: clusterError } = useSWR<
-    Cluster,
-    GenericResponseError
-  >(clusterKey, () =>
+  const {
+    data: cluster,
+    error: clusterError,
+    isLoading: clusterIsLoading,
+  } = useSWR<Cluster, GenericResponseError>(clusterKey, () =>
     fetchCluster(clientFactory, auth, provider, namespace!, clusterId)
   );
   const isClusterApp = cluster ? hasClusterAppLabel(cluster) : undefined;
@@ -86,10 +89,11 @@ const ClusterDetailActions: React.FC<
     : null;
 
   // The error is handled in the parent component.
-  const { data: providerCluster, error: providerClusterError } = useSWR<
-    ProviderCluster,
-    GenericResponseError
-  >(providerClusterKey, () =>
+  const {
+    data: providerCluster,
+    error: providerClusterError,
+    isLoading: providerClusterIsLoading,
+  } = useSWR<ProviderCluster, GenericResponseError>(providerClusterKey, () =>
     fetchProviderClusterForCluster(clientFactory, auth, cluster!)
   );
 
@@ -103,16 +107,19 @@ const ClusterDetailActions: React.FC<
       ? fetchNodePoolListForClusterKey(cluster, cluster.metadata.namespace)
       : null;
 
-  const { data: nodePoolList, error: nodePoolListError } = useSWR<
-    NodePoolList,
-    GenericResponseError
-  >(nodePoolListForClusterKey, () =>
-    fetchNodePoolListForCluster(
-      clientFactory,
-      auth,
-      cluster,
-      cluster!.metadata.namespace
-    )
+  const {
+    data: nodePoolList,
+    error: nodePoolListError,
+    isLoading: nodePoolListIsLoading,
+  } = useSWR<NodePoolList, GenericResponseError>(
+    nodePoolListForClusterKey,
+    () =>
+      fetchNodePoolListForCluster(
+        clientFactory,
+        auth,
+        cluster,
+        cluster!.metadata.namespace
+      )
   );
 
   useEffect(() => {
@@ -167,15 +174,18 @@ const ClusterDetailActions: React.FC<
     ? applicationv1alpha1.getAppListKey(appListGetOptions)
     : null;
 
-  const { data: appList, error: appListError } = useSWR<
-    applicationv1alpha1.IAppList,
-    GenericResponseError
-  >(appListKey, () =>
-    applicationv1alpha1.getAppList(
-      appListClient.current,
-      auth,
-      appListGetOptions
-    )
+  const {
+    data: appList,
+    error: appListError,
+    isLoading: appListIsLoading,
+  } = useSWR<applicationv1alpha1.IAppList, GenericResponseError>(
+    appListKey,
+    () =>
+      applicationv1alpha1.getAppList(
+        appListClient.current,
+        auth,
+        appListGetOptions
+      )
   );
 
   useEffect(() => {
@@ -212,16 +222,11 @@ const ClusterDetailActions: React.FC<
     typeof nodePoolListError !== 'undefined';
 
   const isLoadingResources =
-    typeof org === 'undefined' &&
-    typeof orgError === 'undefined' &&
-    typeof cluster === 'undefined' &&
-    typeof clusterError === 'undefined' &&
-    typeof providerCluster === 'undefined' &&
-    typeof providerClusterError === 'undefined' &&
-    typeof nodePoolList === 'undefined' &&
-    typeof nodePoolListError === 'undefined' &&
-    typeof appList === 'undefined' &&
-    typeof appListError === 'undefined';
+    orgIsLoading &&
+    clusterIsLoading &&
+    providerClusterIsLoading &&
+    nodePoolListIsLoading &&
+    appListIsLoading;
 
   const [isDeleting, setIsDeleting] = useState(false);
 

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetControlPlaneNodes.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetControlPlaneNodes.tsx
@@ -88,17 +88,14 @@ const ClusterDetailWidgetControlPlaneNodes: React.FC<
   const {
     data: controlPlaneNodes,
     error: controlPlaneNodesError,
-    isValidating: controlPlaneNodesIsValidating,
+    isLoading: controlPlaneNodesIsLoading,
   } = useSWR<ControlPlaneNode[], GenericResponseError>(
     controlPlaneNodesKey,
     () => fetchControlPlaneNodesForCluster(clientFactory, auth, cluster!)
   );
 
   const isLoading =
-    typeof cluster === 'undefined' ||
-    (typeof controlPlaneNodes === 'undefined' &&
-      typeof controlPlaneNodesError === 'undefined' &&
-      controlPlaneNodesIsValidating);
+    typeof cluster === 'undefined' || controlPlaneNodesIsLoading;
 
   useEffect(() => {
     if (controlPlaneNodesError) {

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProviderAWS.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProviderAWS.tsx
@@ -57,8 +57,8 @@ const ClusterDetailWidgetProviderAWS: React.FC<
 
   const {
     data: credentialList,
-    isLoading: credentialListIsLoading,
     error: credentialListError,
+    isLoading: credentialListIsLoading,
   } = useSWR<legacyCredentials.ICredentialList, GenericResponseError>(
     credentialListKey,
     () =>

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProviderAWS.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProviderAWS.tsx
@@ -57,7 +57,7 @@ const ClusterDetailWidgetProviderAWS: React.FC<
 
   const {
     data: credentialList,
-    isValidating: credentialListIsValidating,
+    isLoading: credentialListIsLoading,
     error: credentialListError,
   } = useSWR<legacyCredentials.ICredentialList, GenericResponseError>(
     credentialListKey,
@@ -81,9 +81,6 @@ const ClusterDetailWidgetProviderAWS: React.FC<
       ErrorReporter.getInstance().notify(credentialListError);
     }
   }, [credentialListError, orgId]);
-
-  const credentialListIsLoading =
-    typeof credentialList === 'undefined' && credentialListIsValidating;
 
   const credentials = credentialListIsLoading
     ? undefined

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProviderAzure.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProviderAzure.tsx
@@ -52,8 +52,8 @@ const ClusterDetailWidgetProviderAzure: React.FC<
 
   const {
     data: credentialList,
-    isValidating: credentialListIsValidating,
     error: credentialListError,
+    isLoading: credentialListIsLoading,
   } = useSWR<legacyCredentials.ICredentialList, GenericResponseError>(
     credentialListKey,
     () =>
@@ -76,9 +76,6 @@ const ClusterDetailWidgetProviderAzure: React.FC<
       ErrorReporter.getInstance().notify(credentialListError);
     }
   }, [credentialListError, orgId]);
-
-  const credentialListIsLoading =
-    typeof credentialList === 'undefined' && credentialListIsValidating;
 
   const credentials = credentialListIsLoading
     ? undefined

--- a/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProviderCAPA.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/ClusterDetailWidgetProviderCAPA.tsx
@@ -50,8 +50,8 @@ const ClusterDetailWidgetProviderCAPA: React.FC<
 
   const {
     data: roleIdentity,
-    isValidating: roleIdentityIsValidating,
     error: roleIdentityError,
+    isLoading: roleIdentityIsLoading,
   } = useSWR<capav1beta1.IAWSClusterRoleIdentity, GenericResponseError>(
     roleIdentityKey,
     () =>
@@ -74,9 +74,6 @@ const ClusterDetailWidgetProviderCAPA: React.FC<
       ErrorReporter.getInstance().notify(roleIdentityError);
     }
   }, [roleIdentityError]);
-
-  const roleIdentityIsLoading =
-    typeof roleIdentity === 'undefined' && roleIdentityIsValidating;
 
   const accountID = roleIdentityIsLoading
     ? undefined

--- a/src/components/MAPI/clusters/ClusterDetail/index.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/index.tsx
@@ -299,7 +299,7 @@ const ClusterDetail: React.FC<React.PropsWithChildren<{}>> = () => {
   const {
     data: providerCluster,
     error: providerClusterError,
-    isValidating: providerClusterIsValidating,
+    isLoading: providerClusterIsLoading,
   } = useSWR<ProviderCluster, GenericResponseError>(providerClusterKey, () =>
     fetchProviderClusterForCluster(clientFactory, auth, cluster!)
   );
@@ -309,11 +309,6 @@ const ClusterDetail: React.FC<React.PropsWithChildren<{}>> = () => {
       ErrorReporter.getInstance().notify(providerClusterError);
     }
   }, [providerClusterError]);
-
-  const providerClusterIsLoading =
-    typeof providerCluster === 'undefined' &&
-    typeof providerClusterError === 'undefined' &&
-    providerClusterIsValidating;
 
   const clusterDescription = useMemo(() => {
     if (!cluster || providerClusterIsLoading) return undefined;

--- a/src/components/MAPI/clusters/Clusters.tsx
+++ b/src/components/MAPI/clusters/Clusters.tsx
@@ -69,10 +69,11 @@ const Clusters: React.FC<React.PropsWithChildren<{}>> = () => {
     ? fetchClusterListKey(provider, namespace, selectedOrg)
     : null;
 
-  const { data: clusterList, error: clusterListError } = useSWR<
-    ClusterListType,
-    GenericResponseError
-  >(clusterListKey, () =>
+  const {
+    data: clusterList,
+    error: clusterListError,
+    isLoading: clusterListIsLoading,
+  } = useSWR<ClusterListType, GenericResponseError>(clusterListKey, () =>
     fetchClusterList(clientFactory, auth, provider, namespace, selectedOrg)
   );
 
@@ -86,11 +87,14 @@ const Clusters: React.FC<React.PropsWithChildren<{}>> = () => {
     ? fetchProviderClustersForClustersKey(clusterList.items)
     : null;
 
-  const { data: providerClusterList, error: providerClusterListError } = useSWR<
-    IProviderClusterForClusterName[],
-    GenericResponseError
-  >(providerClusterKey, () =>
-    fetchProviderClustersForClusters(clientFactory, auth, clusterList!.items)
+  const {
+    data: providerClusterList,
+    error: providerClusterListError,
+    isLoading: providerClusterListIsLoading,
+  } = useSWR<IProviderClusterForClusterName[], GenericResponseError>(
+    providerClusterKey,
+    () =>
+      fetchProviderClustersForClusters(clientFactory, auth, clusterList!.items)
   );
 
   useEffect(() => {
@@ -108,7 +112,7 @@ const Clusters: React.FC<React.PropsWithChildren<{}>> = () => {
 
   const clustersRef = useRef<IProviderClusterForCluster[]>();
   const sortedClustersWithProviderClusters = useMemo(() => {
-    if (!clusterList?.items && !providerClusterList) {
+    if (clusterListIsLoading || providerClusterListIsLoading) {
       clustersRef.current = undefined;
     }
 
@@ -120,12 +124,14 @@ const Clusters: React.FC<React.PropsWithChildren<{}>> = () => {
     }
 
     return clustersRef.current;
-  }, [clusterList?.items, providerClusterList]);
+  }, [
+    clusterList?.items,
+    clusterListIsLoading,
+    providerClusterList,
+    providerClusterListIsLoading,
+  ]);
 
-  const clusterListIsLoading =
-    sortedClustersWithProviderClusters === undefined &&
-    clusterListError === undefined &&
-    providerClusterListError === undefined;
+  const isLoading = sortedClustersWithProviderClusters === undefined;
 
   const newClusterPath = useMemo(() => {
     if (!selectedOrg) return '';
@@ -142,7 +148,7 @@ const Clusters: React.FC<React.PropsWithChildren<{}>> = () => {
   const hasNoClusters =
     hasOrgs &&
     namespace !== undefined &&
-    !clusterListIsLoading &&
+    !isLoading &&
     sortedClustersWithProviderClusters?.length === 0;
 
   const hasError =
@@ -240,7 +246,7 @@ const Clusters: React.FC<React.PropsWithChildren<{}>> = () => {
             <ClusterListErrorPlaceholder organizationName={selectedOrgName!} />
           ) : (
             <ClusterList
-              isLoading={clusterListIsLoading}
+              isLoading={isLoading}
               hasNoClusters={hasNoClusters}
               orgID={selectedOrgID!}
               orgName={selectedOrgName!}

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterRelease.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterRelease.tsx
@@ -39,7 +39,7 @@ const CreateClusterRelease: React.FC<
   const {
     data: releaseList,
     error: releaseListError,
-    isValidating: releaseIsValidating,
+    isLoading: releaseListIsLoading,
   } = useSWR<releasev1alpha1.IReleaseList, GenericResponseError>(
     releasev1alpha1.getReleaseListKey(),
     () => releasev1alpha1.getReleaseList(releaseListClient, auth)
@@ -50,11 +50,6 @@ const CreateClusterRelease: React.FC<
       ErrorReporter.getInstance().notify(releaseListError);
     }
   }, [releaseListError]);
-
-  const releaseIsLoading =
-    releaseIsValidating &&
-    typeof releaseList === 'undefined' &&
-    typeof releaseListError === 'undefined';
 
   const releases = useMemo(() => {
     if (!releaseList) return {};
@@ -118,7 +113,7 @@ const CreateClusterRelease: React.FC<
         releases={releases}
         isAdmin={isAdmin && !isImpersonatingNonAdmin}
         errorMessage={extractErrorMessage(releaseListError)}
-        isLoading={releaseIsLoading}
+        isLoading={releaseListIsLoading}
         selectRelease={handleChange}
         selectedRelease={value}
       />

--- a/src/components/MAPI/clusters/GettingStarted/GettingStartedInstallIngress.tsx
+++ b/src/components/MAPI/clusters/GettingStarted/GettingStartedInstallIngress.tsx
@@ -30,10 +30,13 @@ const GettingStartedInstallIngress: React.FC<
 
   const orgClient = useHttpClient();
   const orgKey = securityv1alpha1.getOrganizationKey(orgId);
-  const { data: org, error: orgError } = useSWR<
-    securityv1alpha1.IOrganization,
-    GenericResponseError
-  >(orgKey, () => securityv1alpha1.getOrganization(orgClient, auth, orgId));
+  const {
+    data: org,
+    error: orgError,
+    isLoading: orgIsLoading,
+  } = useSWR<securityv1alpha1.IOrganization, GenericResponseError>(orgKey, () =>
+    securityv1alpha1.getOrganization(orgClient, auth, orgId)
+  );
 
   useEffect(() => {
     if (orgError) {
@@ -60,10 +63,11 @@ const GettingStartedInstallIngress: React.FC<
       ? fetchClusterKey(provider, namespace, clusterId)
       : null;
 
-  const { data: cluster, error: clusterError } = useSWR<
-    Cluster,
-    GenericResponseError
-  >(clusterKey, () =>
+  const {
+    data: cluster,
+    error: clusterError,
+    isLoading: clusterIsLoading,
+  } = useSWR<Cluster, GenericResponseError>(clusterKey, () =>
     fetchCluster(clientFactory, auth, provider, namespace!, clusterId)
   );
 
@@ -92,11 +96,7 @@ const GettingStartedInstallIngress: React.FC<
   const hasError =
     typeof orgError !== 'undefined' || typeof clusterError !== 'undefined';
 
-  const isLoadingResources =
-    typeof org === 'undefined' &&
-    typeof orgError === 'undefined' &&
-    typeof cluster === 'undefined' &&
-    typeof clusterError === 'undefined';
+  const isLoadingResources = orgIsLoading && clusterIsLoading;
 
   return (
     <Breadcrumb

--- a/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
+++ b/src/components/MAPI/keypairs/ClusterDetailKeyPairs.tsx
@@ -114,17 +114,12 @@ const ClusterDetailKeyPairs: React.FC<
   const {
     data: keyPairList,
     error: keyPairListError,
-    isValidating: keyPairListIsValidating,
+    isLoading: keyPairListIsLoading,
   } = useSWR<legacyKeyPairs.IKeyPairList, GenericResponseError>(
     keyPairListKey,
     () =>
       legacyKeyPairs.getKeyPairList(keyPairListClient.current, auth, clusterId)
   );
-
-  const keyPairListIsLoading =
-    typeof keyPairList === 'undefined' &&
-    typeof keyPairListError === 'undefined' &&
-    keyPairListIsValidating;
 
   useEffect(() => {
     if (keyPairListError) {

--- a/src/components/MAPI/organizations/AccessControl/index.tsx
+++ b/src/components/MAPI/organizations/AccessControl/index.tsx
@@ -47,7 +47,7 @@ const AccessControl: React.FC<React.PropsWithChildren<IAccessControlProps>> = ({
 
   const clientFactory = useHttpClientFactory();
   const auth = useAuthProvider();
-  const { data, mutate, error, isValidating } = useSWR<
+  const { data, mutate, error, isLoading } = useSWR<
     ui.IAccessControlRoleItem[],
     GenericResponseError
   >(getRoleItemsKey(permissions, organizationNamespace), () =>
@@ -66,11 +66,7 @@ const AccessControl: React.FC<React.PropsWithChildren<IAccessControlProps>> = ({
     [data, activeRoleName]
   );
 
-  const rolesIsLoading =
-    typeof data === 'undefined' && typeof error === 'undefined' && isValidating;
-
-  const activeRoleIsLoading =
-    rolesIsLoading && typeof activeRole === 'undefined';
+  const activeRoleIsLoading = isLoading && typeof activeRole === 'undefined';
 
   useLayoutEffect(() => {
     if (!activeRole && data && data.length > 0) {
@@ -193,7 +189,7 @@ const AccessControl: React.FC<React.PropsWithChildren<IAccessControlProps>> = ({
             }}
             basis='1/4'
             roles={data ?? []}
-            isLoading={rolesIsLoading}
+            isLoading={isLoading}
             activeRoleName={activeRoleName}
             setActiveRoleName={setActiveRoleName}
             errorMessage={extractErrorMessage(error)}

--- a/src/components/MAPI/organizations/OrganizationDetailGeneral/index.tsx
+++ b/src/components/MAPI/organizations/OrganizationDetailGeneral/index.tsx
@@ -72,7 +72,7 @@ const OrganizationDetailGeneral: React.FC<
   const {
     data: clusterList,
     error: clusterListError,
-    isValidating: clusterListIsValidating,
+    isLoading: clusterListIsLoading,
   } = useSWR<ClusterList, GenericResponseError>(clusterListKey, () =>
     fetchClusterList(
       clientFactory,
@@ -146,8 +146,8 @@ const OrganizationDetailGeneral: React.FC<
 
   const {
     data: clustersSummary,
-    isValidating: clustersSummaryIsValidating,
     error: clustersSummaryError,
+    isLoading: clustersSummaryIsLoading,
   } = useSWR<ui.IOrganizationDetailClustersSummary, GenericResponseError>(
     () => fetchClustersSummaryKey(clusterList?.items),
     () =>
@@ -176,8 +176,8 @@ const OrganizationDetailGeneral: React.FC<
 
   const {
     data: releasesSummary,
-    isValidating: releasesSummaryIsValidating,
     error: releasesSummaryError,
+    isLoading: releasesSummaryIsLoading,
   } = useSWR<ui.IOrganizationDetailReleasesSummary, GenericResponseError>(
     releasesSummaryKey,
     () => fetchReleasesSummary(clientFactory, auth, clusterList!.items)
@@ -201,8 +201,8 @@ const OrganizationDetailGeneral: React.FC<
 
   const {
     data: versionsSummary,
-    isValidating: versionsSummaryIsValidating,
     error: versionsSummaryError,
+    isLoading: versionsSummaryIsLoading,
   } = useSWR<ui.IOrganizationDetailVersionsSummary, GenericResponseError>(
     versionsSummaryKey,
     () => fetchVersionsSummary(clientFactory, auth, clusterList!.items)
@@ -223,24 +223,14 @@ const OrganizationDetailGeneral: React.FC<
         canDeleteOrganizations={orgPermissions.canDelete}
         readOnly={isManagedByGitOps}
         clusterCount={clusterList?.items.length}
-        clusterCountLoading={
-          typeof clusterList === 'undefined' &&
-          typeof clusterListError === 'undefined' &&
-          clusterListIsValidating
-        }
+        clusterCountLoading={clusterListIsLoading}
         clustersSummary={clustersSummary}
-        clustersSummaryLoading={
-          typeof clustersSummary === 'undefined' && clustersSummaryIsValidating
-        }
+        clustersSummaryLoading={clustersSummaryIsLoading}
         releasesSummary={releasesSummary}
-        releasesSummaryLoading={
-          typeof releasesSummary === 'undefined' && releasesSummaryIsValidating
-        }
+        releasesSummaryLoading={releasesSummaryIsLoading}
         isReleasesSupported={isReleasesSupportedByProvider}
         versionsSummary={versionsSummary}
-        versionsSummaryLoading={
-          typeof versionsSummary === 'undefined' && versionsSummaryIsValidating
-        }
+        versionsSummaryLoading={versionsSummaryIsLoading}
         hasClusterApp={hasClusterApp}
       />
       <CLIGuidesList margin={{ top: 'large' }}>

--- a/src/components/MAPI/permissions/usePermissions.ts
+++ b/src/components/MAPI/permissions/usePermissions.ts
@@ -35,16 +35,13 @@ export function usePermissions() {
     firstLoadComplete && user?.type === LoggedInUserTypes.MAPI
       ? usePermissionsKey
       : null;
-  const { data, error, isValidating } = useSWR<
+  const { data, error, isLoading } = useSWR<
     IPermissionMap,
     GenericResponseError
   >(key, () => fetchPermissions(httpClientFactory, auth, organizations), {
     refreshInterval: Constants.PERMISSIONS_REFRESH_INTERVAL,
     revalidateIfStale: false,
   });
-
-  const isLoading =
-    typeof data === 'undefined' && typeof error === 'undefined' && isValidating;
 
   useEffect(() => {
     if (error) {

--- a/src/components/MAPI/permissions/useSubjectPermissions.ts
+++ b/src/components/MAPI/permissions/useSubjectPermissions.ts
@@ -25,15 +25,12 @@ export function useSubjectPermissions(subject?: IPermissionsSubject) {
 
   const key = subject ? fetchPermissionsForSubjectKey(subject) : null;
 
-  const { data, error, isValidating } = useSWR<
+  const { data, error, isLoading } = useSWR<
     IPermissionMap,
     GenericResponseError
   >(key, () =>
     fetchPermissionsForSubject(httpClientFactory, auth, organizations, subject!)
   );
-
-  const isLoading =
-    typeof data === 'undefined' && typeof error === 'undefined' && isValidating;
 
   useEffect(() => {
     if (error) {

--- a/src/components/MAPI/permissions/useUseCasesPermissions.ts
+++ b/src/components/MAPI/permissions/useUseCasesPermissions.ts
@@ -98,7 +98,7 @@ export function useUseCasesPermissions(
   const {
     data: permissionsAtClusterScope,
     error: permissionsAtClusterScopeError,
-    isValidating: permissionsAtClusterScopeIsValidating,
+    isLoading: permissionsAtClusterScopeIsLoading,
   } = useSWR<IPermissionMap, GenericResponseError>(
     permissionsAtClusterScopeKey,
     () =>
@@ -123,11 +123,6 @@ export function useUseCasesPermissions(
       ErrorReporter.getInstance().notify(permissionsAtClusterScopeError);
     }
   }, [permissionsAtClusterScopeError]);
-
-  const permissionsAtClusterScopeIsLoading =
-    typeof permissionsAtClusterScope === 'undefined' &&
-    typeof permissionsAtClusterScopeError === 'undefined' &&
-    permissionsAtClusterScopeIsValidating;
 
   const error = namespacePermissionsError || permissionsAtClusterScopeError;
   const isLoading =

--- a/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
+++ b/src/components/MAPI/releases/ClusterDetailWidgetRelease.tsx
@@ -244,17 +244,14 @@ const ClusterDetailWidgetRelease: React.FC<
   const {
     data: controlPlaneNodes,
     error: controlPlaneNodesError,
-    isValidating: controlPlaneNodesIsValidating,
+    isLoading: controlPlaneNodesIsLoading,
   } = useSWR<ControlPlaneNode[], GenericResponseError>(
     controlPlaneNodesKey,
     () => fetchControlPlaneNodesForCluster(clientFactory, auth, cluster!)
   );
 
-  const controlPlaneNodesIsLoading =
-    typeof cluster === 'undefined' ||
-    (typeof controlPlaneNodes === 'undefined' &&
-      typeof controlPlaneNodesError === 'undefined' &&
-      controlPlaneNodesIsValidating);
+  const isLoading =
+    typeof cluster === 'undefined' || controlPlaneNodesIsLoading;
 
   useEffect(() => {
     if (controlPlaneNodesError) {
@@ -263,7 +260,7 @@ const ClusterDetailWidgetRelease: React.FC<
   }, [controlPlaneNodesError]);
 
   const controlPlaneNodesStats = useMemo(() => {
-    if (controlPlaneNodesIsLoading) {
+    if (isLoading) {
       return {
         totalCount: undefined,
         readyCount: undefined,
@@ -280,7 +277,7 @@ const ClusterDetailWidgetRelease: React.FC<
     }
 
     return clusterDetailUtils.computeControlPlaneNodesStats(controlPlaneNodes);
-  }, [canListControlPlaneNodes, controlPlaneNodes, controlPlaneNodesIsLoading]);
+  }, [canListControlPlaneNodes, controlPlaneNodes, isLoading]);
 
   const handleUpgradeModalClose = () => {
     setUpgradeModalVisible(false);

--- a/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
+++ b/src/components/MAPI/workernodes/ClusterDetailWorkerNodes.tsx
@@ -306,11 +306,10 @@ const ClusterDetailWorkerNodes: React.FC<
         ? fetchClusterKey(provider, namespace, clusterId)
         : null;
 
-    const {
-      data: cluster,
-      error: clusterError,
-      isValidating: clusterIsValidating,
-    } = useSWR<Cluster, GenericResponseError>(clusterKey, () =>
+    const { data: cluster, isLoading: clusterIsLoading } = useSWR<
+      Cluster,
+      GenericResponseError
+    >(clusterKey, () =>
       fetchCluster(clientFactory, auth, provider, namespace!, clusterId)
     );
 
@@ -346,7 +345,7 @@ const ClusterDetailWorkerNodes: React.FC<
     const {
       data: nodePoolList,
       error: nodePoolListError,
-      isValidating: nodePoolListIsValidating,
+      isLoading: nodePoolListIsLoading,
     } = useSWR<NodePoolList, GenericResponseError>(
       nodePoolListForClusterKey,
       () =>
@@ -358,13 +357,7 @@ const ClusterDetailWorkerNodes: React.FC<
         )
     );
 
-    const nodePoolListIsLoading =
-      (typeof cluster === 'undefined' &&
-        typeof clusterError === 'undefined' &&
-        clusterIsValidating) ||
-      (typeof nodePoolList === 'undefined' &&
-        typeof nodePoolListError === 'undefined' &&
-        nodePoolListIsValidating);
+    const isLoading = clusterIsLoading || nodePoolListIsLoading;
 
     useEffect(() => {
       if (nodePoolListError) {
@@ -597,7 +590,7 @@ const ClusterDetailWorkerNodes: React.FC<
                   <Box />
                 </Header>
                 <Box margin={{ top: 'xsmall' }}>
-                  {nodePoolListIsLoading &&
+                  {isLoading &&
                     LOADING_COMPONENTS.map((_, idx) => (
                       <WorkerNodesNodePoolItem
                         key={idx}
@@ -612,7 +605,7 @@ const ClusterDetailWorkerNodes: React.FC<
 
                   <AnimationWrapper>
                     <TransitionGroup>
-                      {!nodePoolListIsLoading &&
+                      {!isLoading &&
                         nodePoolsWithProviderNodePools.map(
                           ({ nodePool, providerNodePool }) => (
                             <BaseTransition


### PR DESCRIPTION
### What does this PR do?

This PR updates the UI loading logic in components to use the new `isLoading` state returned by the `useSWR` hook with swr `v2`. Previously we determined initial loading state by the condition that the component is validating (`true` for initial load and whenever revalidation happens) and in addition that data and error are both `undefined` (to rule out revalidation).

For more explanation for this state, please see [here](https://swr.vercel.app/blog/swr-v2#isloading) and [here](https://swr.vercel.app/docs/advanced/understanding#combining-with-isloading-and-isvalidating-for-better-ux).

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/1807.