### PR TITLE
Add validation errors to json schema form

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/ClusterNameWidget.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/ClusterNameWidget.tsx
@@ -1,31 +1,16 @@
 import { WidgetProps } from '@rjsf/utils';
-import { FormField } from 'grommet';
 import React from 'react';
 import ClusterIDLabel, {
   ClusterIDLabelType,
 } from 'UI/Display/Cluster/ClusterIDLabel';
 
-const ClusterNameWidget: React.FC<WidgetProps> = ({
-  id,
-  label,
-  schema,
-  value,
-}) => {
-  const { description } = schema;
-
+const ClusterNameWidget: React.FC<WidgetProps> = ({ value }) => {
   return (
-    <FormField
-      htmlFor={id}
-      label={label}
-      help={description}
-      contentProps={{ border: false }}
-    >
-      <ClusterIDLabel
-        clusterID={value}
-        variant={ClusterIDLabelType.Name}
-        aria-label={`Cluster name: ${value}`}
-      />
-    </FormField>
+    <ClusterIDLabel
+      clusterID={value}
+      variant={ClusterIDLabelType.Name}
+      aria-label={`Cluster name: ${value}`}
+    />
   );
 };
 

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -285,11 +285,12 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
               uiSchema={uiSchema}
               validator={validator}
               formData={formData}
+              showErrorList='bottom'
               onSubmit={handleCreation}
               onChange={handleFormDataChange}
               key={formDataKey.current}
             >
-              <Box margin={{ top: 'medium' }}>
+              <Box margin={{ vertical: 'medium' }}>
                 <Box direction='row' gap='small'>
                   <Button primary={true} type='submit' loading={isCreating}>
                     Create cluster

--- a/src/components/UI/JSONSchemaForm/AccordionFormField/index.tsx
+++ b/src/components/UI/JSONSchemaForm/AccordionFormField/index.tsx
@@ -1,0 +1,67 @@
+import { Accordion, AccordionPanel, Box, Text } from 'grommet';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+const Icon = styled(Text)<{ isActive?: boolean }>`
+  transform: rotate(${({ isActive }) => (isActive ? '0deg' : '-90deg')});
+  transform-origin: center center;
+  transition: 0.15s ease-out;
+  font-size: 28px;
+  line-height: 20px;
+  margin-left: -6px;
+`;
+
+interface AccordionFormFieldProps {
+  label: string;
+  help?: string;
+  error?: React.ReactNode;
+}
+
+const AccordionFormField: React.FC<
+  React.PropsWithChildren<AccordionFormFieldProps>
+> = ({ label, help, error, children }) => {
+  const [activeIndexes, setActiveIndexes] = useState<number[]>([]);
+
+  return (
+    <Accordion
+      activeIndex={activeIndexes}
+      onActive={setActiveIndexes}
+      animate={false}
+    >
+      <AccordionPanel
+        header={
+          <Box>
+            <Box direction='row' align='center' margin={{ vertical: 'small' }}>
+              <Icon
+                className='fa fa-chevron-down'
+                isActive={activeIndexes.includes(0)}
+                role='presentation'
+                aria-hidden='true'
+              />
+              <Text weight='bold'>{label}</Text>
+            </Box>
+            {help && (
+              <Text size='small' color='text-weak' margin={{ bottom: 'small' }}>
+                {help}
+              </Text>
+            )}
+            {error && <Box margin={{ bottom: 'small' }}>{error}</Box>}
+          </Box>
+        }
+      >
+        <Box
+          border='all'
+          pad={{ vertical: 'small', horizontal: 'medium' }}
+          round='xsmall'
+          margin={{
+            bottom: 'medium',
+          }}
+        >
+          {children}
+        </Box>
+      </AccordionPanel>
+    </Accordion>
+  );
+};
+
+export default AccordionFormField;

--- a/src/components/UI/JSONSchemaForm/ArrayFieldTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ArrayFieldTemplate/index.tsx
@@ -1,20 +1,11 @@
 import { ArrayFieldTemplateProps } from '@rjsf/utils';
-import { Accordion, AccordionPanel, Box, Text } from 'grommet';
-import React, { useState } from 'react';
+import { Box } from 'grommet';
+import React from 'react';
 import styled from 'styled-components';
 import Button from 'UI/Controls/Button';
 
 const StyledButton = styled(Button)`
   height: 40px;
-`;
-
-const Icon = styled(Text)<{ isActive?: boolean }>`
-  transform: rotate(${({ isActive }) => (isActive ? '0deg' : '-90deg')});
-  transform-origin: center center;
-  transition: 0.15s ease-out;
-  font-size: 28px;
-  line-height: 20px;
-  margin-left: -6px;
 `;
 
 const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
@@ -24,10 +15,6 @@ const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
   schema,
   onAddClick,
 }) => {
-  const [activeIndexes, setActiveIndexes] = useState<number[]>([]);
-
-  const { description } = schema;
-
   const itemsAreObjects =
     schema.items &&
     typeof schema.items !== 'boolean' &&
@@ -35,68 +22,35 @@ const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
     schema.items.type === 'object';
 
   return (
-    <Accordion
-      activeIndex={activeIndexes}
-      onActive={setActiveIndexes}
-      animate={false}
-    >
-      <AccordionPanel
-        header={
-          <Box>
-            <Box direction='row' align='center' margin={{ vertical: 'small' }}>
-              <Icon
-                className='fa fa-chevron-down'
-                isActive={activeIndexes.includes(0)}
-                role='presentation'
-                aria-hidden='true'
-              />
-              <Text weight='bold'>{title}</Text>
-            </Box>
-            {description && (
-              <Text size='small' color='text-weak' margin={{ bottom: 'small' }}>
-                {description}
-              </Text>
-            )}
-          </Box>
-        }
+    <>
+      <Box
+        gap={itemsAreObjects ? 'large' : 'none'}
+        border={itemsAreObjects ? 'between' : false}
       >
-        <Box
+        {items.map((element) => (
+          <Box key={element.key} direction='row' gap='small'>
+            <Box fill>{element.children}</Box>
+            <StyledButton
+              icon={<i className='fa fa-delete' />}
+              onClick={element.onDropIndexClick(element.index)}
+              margin={{ top: 'small' }}
+            />
+          </Box>
+        ))}
+      </Box>
+      {canAdd && (
+        <Button
+          icon={<i className='fa fa-add-circle' />}
+          onClick={onAddClick}
           margin={{
+            top: items.length > 0 ? 'medium' : 'small',
             bottom: 'small',
           }}
-          border='all'
-          pad={{ top: 'small', bottom: 'medium', horizontal: 'medium' }}
-          round='xsmall'
         >
-          <Box
-            gap={itemsAreObjects ? 'large' : 'none'}
-            border={itemsAreObjects ? 'between' : false}
-          >
-            {items.map((element) => (
-              <Box key={element.key} direction='row' gap='small'>
-                <Box fill>{element.children}</Box>
-                <StyledButton
-                  icon={<i className='fa fa-delete' />}
-                  onClick={element.onDropIndexClick(element.index)}
-                  margin={{ top: 'small' }}
-                />
-              </Box>
-            ))}
-          </Box>
-          {canAdd && (
-            <Button
-              icon={<i className='fa fa-add-circle' />}
-              onClick={onAddClick}
-              margin={{
-                top: items.length > 0 ? 'medium' : 'small',
-              }}
-            >
-              Add {title} item
-            </Button>
-          )}
-        </Box>
-      </AccordionPanel>
-    </Accordion>
+          Add {title} item
+        </Button>
+      )}
+    </>
   );
 };
 

--- a/src/components/UI/JSONSchemaForm/BaseInputTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/BaseInputTemplate/index.tsx
@@ -5,7 +5,6 @@ import TextInput from 'UI/Inputs/TextInput';
 
 const BaseInputTemplate: React.FC<WidgetProps> = ({
   id,
-  label,
   schema,
   options,
   value,
@@ -13,6 +12,7 @@ const BaseInputTemplate: React.FC<WidgetProps> = ({
   placeholder,
   disabled,
   readonly,
+  required,
   onChange,
 }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,47 +31,36 @@ const BaseInputTemplate: React.FC<WidgetProps> = ({
 
   const inputProps = getInputProps(schema, type as string, options);
 
-  const { description, examples } = schema;
+  const { examples } = schema;
 
-  const isArrayItem = /(_\d+)$/.test(id);
-  const simplifiedView = isArrayItem && !description;
-
-  const displayLabel = simplifiedView ? '' : label;
-
-  const margin = {
-    top: simplifiedView ? 'small' : 'none',
-    bottom: 'small',
-  };
-
-  return inputProps.type === 'number' ? (
+  return schema.type === 'integer' ? (
     <NumberPicker
       id={id}
-      label={displayLabel}
-      help={description}
+      error={null}
       value={value}
       placeholder={placeholder}
       disabled={disabled}
       readOnly={readonly}
+      required={required}
       min={inputProps.min}
       max={inputProps.max}
       step={inputProps.step}
-      margin={margin}
+      margin={{ bottom: 'none' }}
       contentProps={{
-        width: { max: inputProps.type === 'number' ? 'small' : 'auto' },
+        width: { max: 'small' },
       }}
       onChange={handleNumberChange}
     />
   ) : (
     <TextInput
       id={id}
-      label={displayLabel}
-      help={description}
       suggestions={examples as string[]}
       value={value ?? ''}
       placeholder={placeholder}
       disabled={disabled}
       readOnly={readonly}
-      margin={margin}
+      required={required}
+      margin={{ bottom: 'none' }}
       onChange={handleChange}
       onSuggestionSelect={handleSuggestionSelect}
       {...inputProps}

--- a/src/components/UI/JSONSchemaForm/CheckboxWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/CheckboxWidget/index.tsx
@@ -2,26 +2,12 @@ import { WidgetProps } from '@rjsf/utils';
 import React from 'react';
 import CheckBoxInput from 'UI/Inputs/CheckBoxInput';
 
-const CheckboxWidget: React.FC<WidgetProps> = ({
-  id,
-  label,
-  schema,
-  onChange,
-}) => {
+const CheckboxWidget: React.FC<WidgetProps> = ({ id, onChange }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.checked);
   };
 
-  const { description } = schema;
-
-  return (
-    <CheckBoxInput
-      id={id}
-      help={description}
-      fieldLabel={label}
-      onChange={handleChange}
-    />
-  );
+  return <CheckBoxInput id={id} onChange={handleChange} />;
 };
 
 export default CheckboxWidget;

--- a/src/components/UI/JSONSchemaForm/ErrorListTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ErrorListTemplate/index.tsx
@@ -1,0 +1,22 @@
+import { ErrorListProps } from '@rjsf/utils';
+import { Box, Paragraph } from 'grommet';
+import React from 'react';
+import { FlashMessageType } from 'styles';
+import FlashMessage from 'UI/Display/FlashMessage';
+
+const ErrorListTemplate: React.FC<ErrorListProps> = ({ errors }) => {
+  return (
+    <FlashMessage type={FlashMessageType.Danger}>
+      <Paragraph size='xlarge'>Errors</Paragraph>
+      <Box>
+        {errors.map((error, idx) => (
+          <Paragraph key={idx} fill>
+            {error.stack}
+          </Paragraph>
+        ))}
+      </Box>
+    </FlashMessage>
+  );
+};
+
+export default ErrorListTemplate;

--- a/src/components/UI/JSONSchemaForm/FieldErrorTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/FieldErrorTemplate/index.tsx
@@ -1,0 +1,21 @@
+import { FieldErrorProps } from '@rjsf/utils';
+import { Text } from 'grommet';
+import React from 'react';
+
+const FieldErrorTemplate: React.FC<FieldErrorProps> = ({ errors }) => {
+  if (typeof errors === 'undefined') {
+    return null;
+  }
+
+  return (
+    <>
+      {errors.map((error, idx) => (
+        <Text key={idx} size='small' color='text-error'>
+          {error}
+        </Text>
+      ))}
+    </>
+  );
+};
+
+export default FieldErrorTemplate;

--- a/src/components/UI/JSONSchemaForm/FieldTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/FieldTemplate/index.tsx
@@ -1,17 +1,58 @@
 import { FieldTemplateProps } from '@rjsf/utils';
+import { FormField } from 'grommet';
 import React from 'react';
 
+import AccordionFormField from '../AccordionFormField';
+import ObjectFormField from '../ObjectFormField';
+
 const FieldTemplate: React.FC<FieldTemplateProps> = ({
-  help,
+  id,
   errors,
+  rawErrors,
   children,
+  label,
+  schema,
 }) => {
+  const { type, description } = schema;
+
+  const isRootItem = id === 'root';
+  const isArrayItem = /(_\d+)$/.test(id);
+
+  if (isRootItem) {
+    return children;
+  }
+
+  if (type === 'object' && isArrayItem) {
+    return (
+      <ObjectFormField
+        label={label}
+        help={description}
+        error={errors}
+        isArrayItem={isArrayItem}
+      >
+        {children}
+      </ObjectFormField>
+    );
+  }
+
+  if (type === 'array' || type === 'object') {
+    return (
+      <AccordionFormField label={label} help={description} error={errors}>
+        {children}
+      </AccordionFormField>
+    );
+  }
+
   return (
-    <div>
+    <FormField
+      label={label}
+      help={description}
+      error={rawErrors ? errors : undefined}
+      htmlFor={id}
+      contentProps={{ border: false }}
+    >
       {children}
-      {errors}
-      {help}
-    </div>
+    </FormField>
   );
 };
 

--- a/src/components/UI/JSONSchemaForm/ObjectFieldTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ObjectFieldTemplate/index.tsx
@@ -1,85 +1,15 @@
 import { ObjectFieldTemplateProps } from '@rjsf/utils';
-import { Accordion, AccordionPanel, Box, FormField, Text } from 'grommet';
-import React, { useState } from 'react';
-import styled from 'styled-components';
-
-const Icon = styled(Text)<{ isActive?: boolean }>`
-  transform: rotate(${({ isActive }) => (isActive ? '0deg' : '-90deg')});
-  transform-origin: center center;
-  transition: 0.15s ease-out;
-  font-size: 28px;
-  line-height: 20px;
-  margin-left: -6px;
-`;
+import React from 'react';
 
 const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
-  idSchema,
-  schema,
-  title,
   properties,
 }) => {
-  const [activeIndexes, setActiveIndexes] = useState<number[]>([]);
-
-  const isRootItem = title === '';
-  const isArrayItem = /(_\d+)$/.test(idSchema.$id);
-
-  const { description } = schema;
-
-  if (isRootItem || isArrayItem) {
-    return (
-      <FormField
-        label={title !== '' ? title : undefined}
-        help={title !== '' && description ? description : undefined}
-        contentProps={{ border: false }}
-        margin={{ bottom: isArrayItem ? 'none' : 'small' }}
-      >
-        {properties.map((element) => (
-          <div key={element.name}>{element.content}</div>
-        ))}
-      </FormField>
-    );
-  }
-
   return (
-    <Accordion
-      activeIndex={activeIndexes}
-      onActive={setActiveIndexes}
-      animate={false}
-    >
-      <AccordionPanel
-        header={
-          <Box>
-            <Box direction='row' align='center' margin={{ vertical: 'small' }}>
-              <Icon
-                className='fa fa-chevron-down'
-                isActive={activeIndexes.includes(0)}
-                role='presentation'
-                aria-hidden='true'
-              />
-              <Text weight='bold'>{title}</Text>
-            </Box>
-            {description && (
-              <Text size='small' color='text-weak' margin={{ bottom: 'small' }}>
-                {description}
-              </Text>
-            )}
-          </Box>
-        }
-      >
-        <Box
-          margin={{
-            bottom: 'medium',
-          }}
-          border='all'
-          pad={{ vertical: 'small', horizontal: 'medium' }}
-          round='xsmall'
-        >
-          {properties.map((element) => (
-            <div key={element.name}>{element.content}</div>
-          ))}
-        </Box>
-      </AccordionPanel>
-    </Accordion>
+    <>
+      {properties.map((element) => (
+        <div key={element.name}>{element.content}</div>
+      ))}
+    </>
   );
 };
 

--- a/src/components/UI/JSONSchemaForm/ObjectFormField/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ObjectFormField/index.tsx
@@ -1,0 +1,32 @@
+import { Box, Text } from 'grommet';
+import React from 'react';
+
+interface ObjectFormFieldProps {
+  label: string;
+  isArrayItem: boolean;
+  help?: string;
+  error?: React.ReactNode;
+}
+
+const ObjectFormField: React.FC<
+  React.PropsWithChildren<ObjectFormFieldProps>
+> = ({ label, isArrayItem, help, error, children }) => {
+  return (
+    <Box margin={{ bottom: isArrayItem ? 'none' : 'small' }}>
+      <Text as='label' weight='bold' margin={{ vertical: 'small' }}>
+        {label}
+      </Text>
+      {help && (
+        <Box margin={{ bottom: 'small' }}>
+          <Text color='text-weak' size='small'>
+            {help}
+          </Text>
+        </Box>
+      )}
+      {error && <Box margin={{ bottom: 'small' }}>{error}</Box>}
+      {children}
+    </Box>
+  );
+};
+
+export default ObjectFormField;

--- a/src/components/UI/JSONSchemaForm/SelectWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/SelectWidget/index.tsx
@@ -4,9 +4,7 @@ import Select from 'UI/Inputs/Select';
 
 const SelectWidget: React.FC<WidgetProps> = ({
   id,
-  label,
   options,
-  schema,
   value,
   onChange,
 }) => {
@@ -22,14 +20,10 @@ const SelectWidget: React.FC<WidgetProps> = ({
 
   const selectedOption = enumOptions.find((option) => option.value === value);
 
-  const { description } = schema;
-
   return (
     <Select
       id={id}
-      label={label}
       value={selectedOption}
-      help={description}
       onChange={(e) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         handleChange(e.option);

--- a/src/components/UI/JSONSchemaForm/ToggleWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ToggleWidget/index.tsx
@@ -2,27 +2,12 @@ import { WidgetProps } from '@rjsf/utils';
 import React from 'react';
 import CheckBoxInput from 'UI/Inputs/CheckBoxInput';
 
-const ToggleWidget: React.FC<WidgetProps> = ({
-  id,
-  label,
-  schema,
-  onChange,
-}) => {
+const ToggleWidget: React.FC<WidgetProps> = ({ id, onChange }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.checked);
   };
 
-  const { description } = schema;
-
-  return (
-    <CheckBoxInput
-      id={id}
-      help={description}
-      toggle={true}
-      fieldLabel={label}
-      onChange={handleChange}
-    />
-  );
+  return <CheckBoxInput id={id} toggle={true} onChange={handleChange} />;
 };
 
 export default ToggleWidget;

--- a/src/components/UI/JSONSchemaForm/index.tsx
+++ b/src/components/UI/JSONSchemaForm/index.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import ArrayFieldTemplate from './ArrayFieldTemplate';
 import BaseInputTemplate from './BaseInputTemplate';
 import CheckboxWidget from './CheckboxWidget';
+import ErrorListTemplate from './ErrorListTemplate';
+import FieldErrorTemplate from './FieldErrorTemplate';
 import FieldTemplate from './FieldTemplate';
 import ObjectFieldTemplate from './ObjectFieldTemplate';
 import SelectWidget from './SelectWidget';
@@ -18,7 +20,9 @@ const customWidgets = {
 const customTemplates = {
   ArrayFieldTemplate,
   BaseInputTemplate,
+  ErrorListTemplate,
   FieldTemplate,
+  FieldErrorTemplate,
   ObjectFieldTemplate,
 };
 
@@ -28,6 +32,7 @@ const JSONSchemaForm: React.FC<FormProps> = (props) => {
       fields={customFields}
       widgets={customWidgets}
       templates={customTemplates}
+      noHtml5Validate
       {...props}
     />
   );


### PR DESCRIPTION
### What does this PR do?

- Validation errors were added to the json schema form.
- `ArrayFieldTemplate` and `ObjectFieldTemplate` were refactored to share the accordion logic.

### How does it look like?

Form field errors:
<img width="674" alt="Screenshot 2023-01-12 at 18 44 23" src="https://user-images.githubusercontent.com/445309/212115255-8d5c9923-2135-4d71-9ca6-8afb751c7b89.png">

Form errors:
<img width="674" alt="Screenshot 2023-01-12 at 18 44 49" src="https://user-images.githubusercontent.com/445309/212115294-0a0442f5-b886-4971-8a34-ea78fe929cd0.png">

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1181.