### PR TITLE
Test schema for JSON schema form

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -127,6 +127,11 @@ enum FormDataPreviewFormat {
   Yaml,
 }
 
+// TODO: replace test schema URL with the correct one
+// after merging prototype branch into the main branch
+const testSchemaURL =
+  'https://raw.githubusercontent.com/giantswarm/happa/cluster-app-creation-form-prototype/src/components/UI/JSONSchemaForm/test.schema.json';
+
 const Prompt: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
   return <Line prompt={false} text={children} />;
 };
@@ -275,7 +280,20 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
   return (
     <Box width={{ max: '100%', width: 'large' }} gap='medium' margin='auto'>
       <Box direction='row' gap='medium'>
-        <InputGroup label='Schema'>
+        <InputGroup
+          label='Schema'
+          info={
+            <a
+              target='_blank'
+              rel='noopener noreferrer'
+              href={selectedProvider ? schemaURL : testSchemaURL}
+            >
+              <Text color='text-weak' size='small'>
+                Open schema in new tab <i className='fa fa-open-in-new' />
+              </Text>
+            </a>
+          }
+        >
           <Select
             value={selectedSchema}
             onChange={handleSelectedSchemaChange}

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -114,7 +114,36 @@ const uiSchemaProviderVSphere: Record<string, GenericObjectType> = {
 };
 
 const uiSchemaTestSchema: Record<string, GenericObjectType> = {
-  0: {},
+  0: {
+    'ui:options': {
+      order: [
+        'stringFields',
+        'numericFields',
+        'booleanFields',
+        'objectFields',
+        'arrayFields',
+        '*',
+      ],
+    },
+    stringFields: {
+      'ui:options': {
+        order: [
+          'string',
+          'stringEnum',
+          'stringCustomLabels',
+          'stringLength',
+          'stringFormat',
+          'stringPattern',
+          '*',
+        ],
+      },
+    },
+    arrayFields: {
+      'ui:options': {
+        order: ['arrayOfStrings', 'arrayOfObjects', 'arrayMinMaxItems', '*'],
+      },
+    },
+  },
 };
 
 export const prototypeProviders = [

--- a/src/components/UI/JSONSchemaForm/FieldTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/FieldTemplate/index.tsx
@@ -12,8 +12,11 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
   children,
   label,
   schema,
+  required,
 }) => {
   const { type, description } = schema;
+
+  const displayLabel = `${label}${required ? '*' : ''}`;
 
   const isRootItem = id === 'root';
   const isArrayItem = /(_\d+)$/.test(id);
@@ -25,7 +28,7 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
   if (type === 'object' && isArrayItem) {
     return (
       <ObjectFormField
-        label={label}
+        label={displayLabel}
         help={description}
         error={errors}
         isArrayItem={isArrayItem}
@@ -37,7 +40,11 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
 
   if (type === 'array' || type === 'object') {
     return (
-      <AccordionFormField label={label} help={description} error={errors}>
+      <AccordionFormField
+        label={displayLabel}
+        help={description}
+        error={errors}
+      >
         {children}
       </AccordionFormField>
     );
@@ -45,7 +52,7 @@ const FieldTemplate: React.FC<FieldTemplateProps> = ({
 
   return (
     <FormField
-      label={label}
+      label={displayLabel}
       help={description}
       error={rawErrors ? errors : undefined}
       htmlFor={id}

--- a/src/components/UI/JSONSchemaForm/test.schema.json
+++ b/src/components/UI/JSONSchemaForm/test.schema.json
@@ -2,138 +2,168 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
-        "string": {
-            "type": "string",
-            "title": "String",
-            "description": "String field with title and description."
-        },
-        "number": {
-            "type": "number",
-            "title": "Number",
-            "description": "Number field with title and description."
-        },
-        "integer": {
-            "type": "integer",
-            "title": "Integer",
-            "description": "Integer field with title and description."
-        },
-        "boolean": {
-            "type": "boolean",
-            "title": "Boolean",
-            "description": "Boolean field with title and description."
-        },
-        "stringEnum": {
-            "type": "string",
-            "title": "String enum",
-            "description": "String field with enumerated values.",
-            "enum": [
-                "firstValue",
-                "secondValue",
-                "thirdValue"
-            ]
-        },
-        "stringCustomLabels": {
-            "type": "string",
-            "title": "String enum with custom labels",
-            "description": "String field with enumerated values and custom labels.",
-            "oneOf": [
-                {"const": "firstValue", "title": "First Value"},
-                {"const": "secondValue", "title": "Second Value"},
-                {"const": "thirdValue", "title": "Third Value"}
-            ]
-        },
-        "stringLength": {
-            "type": "string",
-            "title": "String with min/max length",
-            "description": "String field with minLength and maxLength validation. Submit the form to see validation errors.",
-            "minLength": 2,
-            "maxLength": 5
-        },
-        "stringPattern": {
-            "type": "string",
-            "title": "String with pattern",
-            "description": "String field with pattern validation. Submit the form to see validation errors.",
-            "pattern": "^[a-z0-9]{10,20}$"
-        },
-        "stringFormat": {
-            "type": "string",
-            "title": "String with format",
-            "description": "String field with specific format (email, uri, date, ipv4, etc.).",
-            "format": "ipv4"
-        },
-        "integerEnum": {
-            "type": "integer",
-            "title": "Integer enum",
-            "description": "Integer field with enumerated values and custom labels.",
-            "oneOf": [
-                {"const": 1, "title": "One"},
-                {"const": 2, "title": "Two"},
-                {"const": 3, "title": "Three"}
-             ]
-        },
-        "integerLimit": {
-            "type": "number",
-            "title": "Number with min/max values",
-            "description": "Number field with minimum and maximum values validation. Submit the form to see validation errors.",
-            "minimum": 2,
-            "maximum": 5
-        },
-        "object": {
+        "stringFields": {
             "type": "object",
-            "title": "Object",
+            "title": "String fields",
             "properties": {
-                "name": {
-                    "type": "string"
+                "string": {
+                    "type": "string",
+                    "title": "String",
+                    "description": "String field with title and description."
                 },
-                "age": {
-                    "type": "integer"
+                "stringEnum": {
+                    "type": "string",
+                    "title": "String enum",
+                    "description": "String field with enumerated values.",
+                    "enum": [
+                        "firstValue",
+                        "secondValue",
+                        "thirdValue"
+                    ]
+                },
+                "stringCustomLabels": {
+                    "type": "string",
+                    "title": "String enum with custom labels",
+                    "description": "String field with enumerated values and custom labels.",
+                    "oneOf": [
+                        {"const": "firstValue", "title": "First Value"},
+                        {"const": "secondValue", "title": "Second Value"},
+                        {"const": "thirdValue", "title": "Third Value"}
+                    ]
+                },
+                "stringLength": {
+                    "type": "string",
+                    "title": "String with min/max length",
+                    "description": "String field with minLength and maxLength validation. Submit the form to see validation errors.",
+                    "minLength": 2,
+                    "maxLength": 5
+                },
+                "stringPattern": {
+                    "type": "string",
+                    "title": "String with pattern",
+                    "description": "String field with pattern validation. Submit the form to see validation errors.",
+                    "pattern": "^[a-z0-9]{10,20}$"
+                },
+                "stringFormat": {
+                    "type": "string",
+                    "title": "String with format",
+                    "description": "String field with specific format (email, uri, date, ipv4, etc.).",
+                    "format": "ipv4"
                 }
             }
         },
-        "objectRequired": {
+        "numericFields": {
             "type": "object",
-            "title": "Object with required",
-            "description": "Object field with required properties. Submit the form to see validation errors.",
+            "title": "Numeric fields",
             "properties": {
-                "name": {
-                    "type": "string"
+                "number": {
+                    "type": "number",
+                    "title": "Number",
+                    "description": "Number field with title and description."
                 },
-                "age": {
-                    "type": "number"
+                "numberLimit": {
+                    "type": "number",
+                    "title": "Number with min/max values",
+                    "description": "Number field with minimum and maximum values validation. Submit the form to see validation errors.",
+                    "minimum": 2,
+                    "maximum": 5
+                },
+                "integer": {
+                    "type": "integer",
+                    "title": "Integer",
+                    "description": "Integer field with title and description."
+                },
+                "integerEnum": {
+                    "type": "integer",
+                    "title": "Integer enum",
+                    "description": "Integer field with enumerated values and custom labels.",
+                    "oneOf": [
+                        {"const": 1, "title": "One"},
+                        {"const": 2, "title": "Two"},
+                        {"const": 3, "title": "Three"}
+                     ]
                 }
-            },
-            "required": ["name"]
-        },
-        "arrayOfStrings": {
-            "type": "array",
-            "title": "Array of strings",
-            "items": {
-                "type": "string"
             }
         },
-        "arrayOfObjects": {
-            "type": "array",
-            "title": "Array of objects",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
+        "booleanFields": {
+            "type": "object",
+            "title": "Boolean fields",
+            "properties": {
+                "boolean": {
+                    "type": "boolean",
+                    "title": "Boolean",
+                    "description": "Boolean field with title and description."
+                }
+            }
+        },
+        "objectFields": {
+            "type": "object",
+            "title": "Object fields",
+            "properties": {
+                "object": {
+                    "type": "object",
+                    "title": "Object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "age": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "objectRequired": {
+                    "type": "object",
+                    "title": "Object with required",
+                    "description": "Object field with required properties. Submit the form to see validation errors.",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "age": {
+                            "type": "number"
+                        }
                     },
-                    "age": {
-                        "type": "number"
+                    "required": ["name"]
+                }
+            }
+        },
+        "arrayFields": {
+            "type": "object",
+            "title": "Array fields",
+            "properties": {
+                "arrayOfStrings": {
+                    "type": "array",
+                    "title": "Array of strings",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "arrayOfObjects": {
+                    "type": "array",
+                    "title": "Array of objects",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "age": {
+                                "type": "number"
+                            }
+                        }
+                    }
+                },
+                "arrayMinMaxItems": {
+                    "type": "array",
+                    "title": "Array with min/max items",
+                    "description": "Array with the minimum and maximum number of items",
+                    "minItems": 1,
+                    "maxItems": 2,
+                    "items": {
+                        "type": "string"
                     }
                 }
-            }
-        },
-        "arrayMinItems": {
-            "type": "array",
-            "title": "Array with min/max items",
-            "description": "Array with the minimum and maximum number of items",
-            "minItems": 1,
-            "maxItems": 2,
-            "items": {
-                "type": "string"
             }
         }
     }

--- a/src/components/UI/JSONSchemaForm/test.schema.json
+++ b/src/components/UI/JSONSchemaForm/test.schema.json
@@ -1,0 +1,140 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "string": {
+            "type": "string",
+            "title": "String",
+            "description": "String field with title and description."
+        },
+        "number": {
+            "type": "number",
+            "title": "Number",
+            "description": "Number field with title and description."
+        },
+        "integer": {
+            "type": "integer",
+            "title": "Integer",
+            "description": "Integer field with title and description."
+        },
+        "boolean": {
+            "type": "boolean",
+            "title": "Boolean",
+            "description": "Boolean field with title and description."
+        },
+        "stringEnum": {
+            "type": "string",
+            "title": "String enum",
+            "description": "String field with enumerated values.",
+            "enum": [
+                "firstValue",
+                "secondValue",
+                "thirdValue"
+            ]
+        },
+        "stringCustomLabels": {
+            "type": "string",
+            "title": "String enum with custom labels",
+            "description": "String field with enumerated values and custom labels.",
+            "oneOf": [
+                {"const": "firstValue", "title": "First Value"},
+                {"const": "secondValue", "title": "Second Value"},
+                {"const": "thirdValue", "title": "Third Value"}
+            ]
+        },
+        "stringLength": {
+            "type": "string",
+            "title": "String with min/max length",
+            "description": "String field with minLength and maxLength validation. Submit the form to see validation errors.",
+            "minLength": 2,
+            "maxLength": 5
+        },
+        "stringPattern": {
+            "type": "string",
+            "title": "String with pattern",
+            "description": "String field with pattern validation. Submit the form to see validation errors.",
+            "pattern": "^[a-z0-9]{10,20}$"
+        },
+        "stringFormat": {
+            "type": "string",
+            "title": "String with format",
+            "description": "String field with specific format (email, uri, date, ipv4, etc.).",
+            "format": "ipv4"
+        },
+        "integerEnum": {
+            "type": "integer",
+            "title": "Integer enum",
+            "description": "Integer field with enumerated values and custom labels.",
+            "oneOf": [
+                {"const": 1, "title": "One"},
+                {"const": 2, "title": "Two"},
+                {"const": 3, "title": "Three"}
+             ]
+        },
+        "integerLimit": {
+            "type": "number",
+            "title": "Number with min/max values",
+            "description": "Number field with minimum and maximum values validation. Submit the form to see validation errors.",
+            "minimum": 2,
+            "maximum": 5
+        },
+        "object": {
+            "type": "object",
+            "title": "Object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                }
+            }
+        },
+        "objectRequired": {
+            "type": "object",
+            "title": "Object with required",
+            "description": "Object field with required properties. Submit the form to see validation errors.",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "number"
+                }
+            },
+            "required": ["name"]
+        },
+        "arrayOfStrings": {
+            "type": "array",
+            "title": "Array of strings",
+            "items": {
+                "type": "string"
+            }
+        },
+        "arrayOfObjects": {
+            "type": "array",
+            "title": "Array of objects",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "age": {
+                        "type": "number"
+                    }
+                }
+            }
+        },
+        "arrayMinItems": {
+            "type": "array",
+            "title": "Array with min/max items",
+            "description": "Array with the minimum and maximum number of items",
+            "minItems": 1,
+            "maxItems": 2,
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/src/components/UI/JSONSchemaForm/test.schema.json
+++ b/src/components/UI/JSONSchemaForm/test.schema.json
@@ -1,170 +1,190 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "type": "object",
     "properties": {
+        "arrayFields": {
+            "properties": {
+                "arrayMinMaxItems": {
+                    "description": "Array with the minimum and maximum number of items",
+                    "items": {
+                        "type": "string"
+                    },
+                    "maxItems": 2,
+                    "minItems": 1,
+                    "title": "Array with min/max items",
+                    "type": "array"
+                },
+                "arrayOfObjects": {
+                    "items": {
+                        "properties": {
+                            "age": {
+                                "type": "number"
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "title": "Array of objects",
+                    "type": "array"
+                },
+                "arrayOfStrings": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Array of strings",
+                    "type": "array"
+                }
+            },
+            "title": "Array fields",
+            "type": "object"
+        },
+        "booleanFields": {
+            "properties": {
+                "boolean": {
+                    "description": "Boolean field with title and description.",
+                    "title": "Boolean",
+                    "type": "boolean"
+                }
+            },
+            "title": "Boolean fields",
+            "type": "object"
+        },
+        "numericFields": {
+            "properties": {
+                "integer": {
+                    "description": "Integer field with title and description.",
+                    "title": "Integer",
+                    "type": "integer"
+                },
+                "integerEnum": {
+                    "description": "Integer field with enumerated values and custom labels.",
+                    "oneOf": [
+                        {
+                            "const": 1,
+                            "title": "One"
+                        },
+                        {
+                            "const": 2,
+                            "title": "Two"
+                        },
+                        {
+                            "const": 3,
+                            "title": "Three"
+                        }
+                    ],
+                    "title": "Integer enum",
+                    "type": "integer"
+                },
+                "number": {
+                    "description": "Number field with title and description.",
+                    "title": "Number",
+                    "type": "number"
+                },
+                "numberLimit": {
+                    "description": "Number field with minimum and maximum values validation. Submit the form to see validation errors.",
+                    "maximum": 5,
+                    "minimum": 2,
+                    "title": "Number with min/max values",
+                    "type": "number"
+                }
+            },
+            "title": "Numeric fields",
+            "type": "object"
+        },
+        "objectFields": {
+            "properties": {
+                "object": {
+                    "properties": {
+                        "age": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "title": "Object",
+                    "type": "object"
+                },
+                "objectRequired": {
+                    "description": "Object field with required properties. Submit the form to see validation errors.",
+                    "properties": {
+                        "age": {
+                            "type": "number"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "title": "Object with required",
+                    "type": "object"
+                }
+            },
+            "title": "Object fields",
+            "type": "object"
+        },
         "stringFields": {
-            "type": "object",
-            "title": "String fields",
             "properties": {
                 "string": {
-                    "type": "string",
+                    "description": "String field with title and description.",
                     "title": "String",
-                    "description": "String field with title and description."
+                    "type": "string"
+                },
+                "stringCustomLabels": {
+                    "description": "String field with enumerated values and custom labels.",
+                    "oneOf": [
+                        {
+                            "const": "firstValue",
+                            "title": "First Value"
+                        },
+                        {
+                            "const": "secondValue",
+                            "title": "Second Value"
+                        },
+                        {
+                            "const": "thirdValue",
+                            "title": "Third Value"
+                        }
+                    ],
+                    "title": "String enum with custom labels",
+                    "type": "string"
                 },
                 "stringEnum": {
-                    "type": "string",
-                    "title": "String enum",
                     "description": "String field with enumerated values.",
                     "enum": [
                         "firstValue",
                         "secondValue",
                         "thirdValue"
-                    ]
-                },
-                "stringCustomLabels": {
-                    "type": "string",
-                    "title": "String enum with custom labels",
-                    "description": "String field with enumerated values and custom labels.",
-                    "oneOf": [
-                        {"const": "firstValue", "title": "First Value"},
-                        {"const": "secondValue", "title": "Second Value"},
-                        {"const": "thirdValue", "title": "Third Value"}
-                    ]
-                },
-                "stringLength": {
-                    "type": "string",
-                    "title": "String with min/max length",
-                    "description": "String field with minLength and maxLength validation. Submit the form to see validation errors.",
-                    "minLength": 2,
-                    "maxLength": 5
-                },
-                "stringPattern": {
-                    "type": "string",
-                    "title": "String with pattern",
-                    "description": "String field with pattern validation. Submit the form to see validation errors.",
-                    "pattern": "^[a-z0-9]{10,20}$"
+                    ],
+                    "title": "String enum",
+                    "type": "string"
                 },
                 "stringFormat": {
-                    "type": "string",
-                    "title": "String with format",
                     "description": "String field with specific format (email, uri, date, ipv4, etc.).",
-                    "format": "ipv4"
+                    "format": "ipv4",
+                    "title": "String with format",
+                    "type": "string"
+                },
+                "stringLength": {
+                    "description": "String field with minLength and maxLength validation. Submit the form to see validation errors.",
+                    "maxLength": 5,
+                    "minLength": 2,
+                    "title": "String with min/max length",
+                    "type": "string"
+                },
+                "stringPattern": {
+                    "description": "String field with pattern validation. Submit the form to see validation errors.",
+                    "pattern": "^[a-z0-9]{10,20}$",
+                    "title": "String with pattern",
+                    "type": "string"
                 }
-            }
-        },
-        "numericFields": {
-            "type": "object",
-            "title": "Numeric fields",
-            "properties": {
-                "number": {
-                    "type": "number",
-                    "title": "Number",
-                    "description": "Number field with title and description."
-                },
-                "numberLimit": {
-                    "type": "number",
-                    "title": "Number with min/max values",
-                    "description": "Number field with minimum and maximum values validation. Submit the form to see validation errors.",
-                    "minimum": 2,
-                    "maximum": 5
-                },
-                "integer": {
-                    "type": "integer",
-                    "title": "Integer",
-                    "description": "Integer field with title and description."
-                },
-                "integerEnum": {
-                    "type": "integer",
-                    "title": "Integer enum",
-                    "description": "Integer field with enumerated values and custom labels.",
-                    "oneOf": [
-                        {"const": 1, "title": "One"},
-                        {"const": 2, "title": "Two"},
-                        {"const": 3, "title": "Three"}
-                     ]
-                }
-            }
-        },
-        "booleanFields": {
-            "type": "object",
-            "title": "Boolean fields",
-            "properties": {
-                "boolean": {
-                    "type": "boolean",
-                    "title": "Boolean",
-                    "description": "Boolean field with title and description."
-                }
-            }
-        },
-        "objectFields": {
-            "type": "object",
-            "title": "Object fields",
-            "properties": {
-                "object": {
-                    "type": "object",
-                    "title": "Object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "age": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "objectRequired": {
-                    "type": "object",
-                    "title": "Object with required",
-                    "description": "Object field with required properties. Submit the form to see validation errors.",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "age": {
-                            "type": "number"
-                        }
-                    },
-                    "required": ["name"]
-                }
-            }
-        },
-        "arrayFields": {
-            "type": "object",
-            "title": "Array fields",
-            "properties": {
-                "arrayOfStrings": {
-                    "type": "array",
-                    "title": "Array of strings",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "arrayOfObjects": {
-                    "type": "array",
-                    "title": "Array of objects",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "age": {
-                                "type": "number"
-                            }
-                        }
-                    }
-                },
-                "arrayMinMaxItems": {
-                    "type": "array",
-                    "title": "Array with min/max items",
-                    "description": "Array with the minimum and maximum number of items",
-                    "minItems": 1,
-                    "maxItems": 2,
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
+            },
+            "title": "String fields",
+            "type": "object"
         }
-    }
+    },
+    "type": "object"
 }


### PR DESCRIPTION
### What does this PR do?

- test schema with all the supported features was added to the json schema form prototype;
- `asterisk` sign was added to the required fields labels.

### How does it look like?

Test schema is selected:
<img width="674" alt="Screenshot 2023-01-18 at 16 09 44" src="https://user-images.githubusercontent.com/445309/213179972-17eaa972-7e58-4883-8f51-df3d3aafb43e.png">

Provider schema is selected:
<img width="674" alt="Screenshot 2023-01-18 at 16 09 52" src="https://user-images.githubusercontent.com/445309/213180002-c10839d7-d84e-4b22-bc2d-a20e992506ea.png">

Asterisk sign in the required field label:
<img width="674" alt="Screenshot 2023-01-18 at 15 54 12" src="https://user-images.githubusercontent.com/445309/213177166-c8ca6edb-c0d1-4401-a49f-14671c262eff.png">

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1181.
