### PR TITLE
UI schema for cluster app creation form

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -229,9 +229,7 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
     useState<FormDataPreviewFormat>(FormDataPreviewFormat.Json);
 
   // TODO: replace when we use app version instead of branch name
-  const version = selectedBranch.includes('release-')
-    ? selectedBranch.replace('release-', '')
-    : 'v0.0.0';
+  const version = selectedBranch.replace('release-', '');
 
   const uiSchema = useMemo(
     () => getUiSchema(selectedProvider, version),

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -231,7 +231,9 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
     useState<FormDataPreviewFormat>(FormDataPreviewFormat.Json);
 
   // TODO: replace when we use app version instead of branch name
-  const version = selectedBranch.replace('release-', '');
+  const version = selectedBranch.startsWith('release-')
+    ? selectedBranch.replace('release-', '').replace('x', '0')
+    : 'v0.0.0';
 
   const uiSchema = useMemo(
     () => getUiSchema(selectedProvider, version),

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -228,14 +228,15 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
   const [formDataPreviewFormat, setFormDataPreviewFormat] =
     useState<FormDataPreviewFormat>(FormDataPreviewFormat.Json);
 
-  const uiSchema = useMemo(() => {
-    // TODO: replace when we use app version instead of branch name
-    const version = selectedBranch.includes('release-')
-      ? selectedBranch.replace('release-', '')
-      : 'v0.0.0';
+  // TODO: replace when we use app version instead of branch name
+  const version = selectedBranch.includes('release-')
+    ? selectedBranch.replace('release-', '')
+    : 'v0.0.0';
 
-    return getUiSchema(selectedProvider, version);
-  }, [selectedBranch, selectedProvider]);
+  const uiSchema = useMemo(
+    () => getUiSchema(selectedProvider, version),
+    [version, selectedProvider]
+  );
 
   return (
     <Box width={{ max: '100%', width: 'large' }} gap='medium' margin='auto'>

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -1,5 +1,5 @@
 import { IChangeEvent } from '@rjsf/core';
-import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { Box, Text } from 'grommet';
@@ -9,7 +9,7 @@ import {
   fetchAppCatalogEntrySchema,
   fetchAppCatalogEntrySchemaKey,
 } from 'MAPI/apps/utils';
-import { extractErrorMessage, generateUID } from 'MAPI/utils';
+import { extractErrorMessage } from 'MAPI/utils';
 import { GenericResponseError } from 'model/clients/GenericResponseError';
 import { IHttpClient } from 'model/clients/HttpClient';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -27,28 +27,18 @@ import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
 import { IOAuth2Provider } from 'utils/OAuth2/OAuth2';
 
-import ClusterNameWidget from './ClusterNameWidget';
+import {
+  getDefaultFormData,
+  getUiSchema,
+  PrototypeProviders,
+  prototypeProviders,
+} from './schemaUtils';
 
 const Wrapper = styled.div`
   position: relative;
   margin: auto;
   text-align: center;
 `;
-
-type PrototypeProviders =
-  | 'AWS'
-  | 'Cloud Director'
-  | 'GCP'
-  | 'Open Stack'
-  | 'VSphere';
-
-const prototypeProviders: PrototypeProviders[] = [
-  'AWS',
-  'Cloud Director',
-  'GCP',
-  'Open Stack',
-  'VSphere',
-];
 
 function getAppRepoName(provider: PrototypeProviders): string {
   switch (provider) {
@@ -76,10 +66,6 @@ function getAppCatalogEntrySchemaURL(
 
   return `https://raw.githubusercontent.com/giantswarm/${appRepoName}/${branchName}/helm/${appRepoName}/values.schema.json`;
 }
-
-const getDefaultFormData = () => ({
-  clusterName: generateUID(5),
-});
 
 interface IRepoBranchEntry {
   name: string;
@@ -124,67 +110,6 @@ const Prompt: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
 };
 
 Prompt.displayName = 'Prompt';
-
-type UiSchemaGenericKeys = 'CLUSTER_NAME' | 'CLUSTER_DESCRIPTION';
-
-type UiSchemaKeysMap = Record<UiSchemaGenericKeys, string>;
-
-function getUiSchemaKeysMap(
-  provider: PrototypeProviders,
-  version: string
-): UiSchemaKeysMap {
-  // select major version
-  const majorVersion = version.split('.')[0];
-
-  const uiSchemaKeysMapProviderDefault: Record<
-    string,
-    Record<UiSchemaGenericKeys, string>
-  > = {
-    v0: {
-      CLUSTER_NAME: 'clusterName',
-      CLUSTER_DESCRIPTION: 'clusterDescription',
-    },
-  };
-
-  switch (provider) {
-    default:
-      return uiSchemaKeysMapProviderDefault[majorVersion];
-  }
-}
-
-function generateUiSchemaForProvider(
-  provider: PrototypeProviders,
-  uiSchemaKeysMap: UiSchemaKeysMap
-): UiSchema {
-  const { CLUSTER_NAME, CLUSTER_DESCRIPTION } = uiSchemaKeysMap;
-
-  switch (provider) {
-    default:
-      return {
-        'ui:order': [CLUSTER_NAME, CLUSTER_DESCRIPTION, '*'],
-        [CLUSTER_NAME]: {
-          'ui:widget': ClusterNameWidget,
-        },
-      };
-  }
-}
-
-function getAppVersionFromBranchName(branchName: string) {
-  return branchName.includes('release-')
-    ? branchName.replace('release-', '')
-    : 'v0.0.0';
-}
-
-function getUiSchema(
-  provider: PrototypeProviders,
-  branchName: string
-): UiSchema {
-  // TODO: replace when we use app version instead of branch name
-  const version = getAppVersionFromBranchName(branchName);
-  const uiSchemaKeysMap = getUiSchemaKeysMap(provider, version);
-
-  return generateUiSchemaForProvider(provider, uiSchemaKeysMap);
-}
 
 interface ICreateClusterAppFormProps {
   namespace: string;
@@ -253,11 +178,13 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
   const appSchemaIsLoading =
     appSchema === undefined && appSchemaError === undefined;
 
-  const [formData, setFormData] = useState<RJSFSchema>(getDefaultFormData());
+  const [formData, setFormData] = useState<RJSFSchema>(
+    getDefaultFormData(selectedProvider)
+  );
   const formDataKey = useRef<number | undefined>(undefined);
 
-  const resetFormData = () => {
-    setFormData(getDefaultFormData());
+  const resetFormData = (newProvider: PrototypeProviders) => {
+    setFormData(getDefaultFormData(newProvider));
     formDataKey.current = Date.now();
   };
 
@@ -267,14 +194,14 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
     const newProvider = e.target.value as PrototypeProviders;
     setSelectedProvider(newProvider);
     setSelectedBranch(getDefaultRepoBranch(newProvider));
-    resetFormData();
+    resetFormData(newProvider);
   };
 
   const handleSelectedBranchChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     setSelectedBranch(e.target.value);
-    resetFormData();
+    resetFormData(selectedProvider);
   };
 
   const handleFormDataChange = ({
@@ -294,7 +221,7 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
 
     // eslint-disable-next-line no-console
     console.log(formData);
-    resetFormData();
+    resetFormData(selectedProvider);
   };
 
   const [formDataPreviewFormat, setFormDataPreviewFormat] =
@@ -313,7 +240,7 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
           <Select
             value={selectedProvider}
             onChange={handleSelectedProviderChange}
-            options={prototypeProviders}
+            options={prototypeProviders.slice()}
           />
         </InputGroup>
         <Box flex={{ grow: 1 }}>

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -229,7 +229,12 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
     useState<FormDataPreviewFormat>(FormDataPreviewFormat.Json);
 
   const uiSchema = useMemo(() => {
-    return getUiSchema(selectedProvider, selectedBranch);
+    // TODO: replace when we use app version instead of branch name
+    const version = selectedBranch.includes('release-')
+      ? selectedBranch.replace('release-', '')
+      : 'v0.0.0';
+
+    return getUiSchema(selectedProvider, version);
   }, [selectedBranch, selectedProvider]);
 
   return (

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -44,6 +44,8 @@ function getAppRepoName(provider: PrototypeProviders): string {
   switch (provider) {
     case 'AWS':
       return 'cluster-aws';
+    case 'Azure':
+      return 'cluster-azure';
     case 'Cloud Director':
       return 'cluster-cloud-director';
     case 'GCP':

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppForm.tsx
@@ -120,6 +120,7 @@ interface ICreateClusterAppFormProps {
 
 const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
   onCreationCancel,
+  organizationID,
 }) => {
   const [isCreating, _setIsCreating] = useState<boolean>(false);
 
@@ -179,12 +180,12 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
     appSchema === undefined && appSchemaError === undefined;
 
   const [formData, setFormData] = useState<RJSFSchema>(
-    getDefaultFormData(selectedProvider)
+    getDefaultFormData(selectedProvider, organizationID)
   );
   const formDataKey = useRef<number | undefined>(undefined);
 
   const resetFormData = (newProvider: PrototypeProviders) => {
-    setFormData(getDefaultFormData(newProvider));
+    setFormData(getDefaultFormData(newProvider, organizationID));
     formDataKey.current = Date.now();
   };
 
@@ -230,8 +231,6 @@ const CreateClusterAppForm: React.FC<ICreateClusterAppFormProps> = ({
   const uiSchema = useMemo(() => {
     return getUiSchema(selectedProvider, selectedBranch);
   }, [selectedBranch, selectedProvider]);
-
-  console.log(uiSchema);
 
   return (
     <Box width={{ max: '100%', width: 'large' }} gap='medium' margin='auto'>

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -53,11 +53,6 @@ const uiSchemaProviderCloudDirector: Record<string, GenericObjectType> = {
         '*',
       ],
     },
-    clusterName: {
-      'ui:options': {
-        widget: ClusterNameWidget,
-      },
-    },
   },
 };
 
@@ -133,17 +128,30 @@ export const getDefaultFormData = (
   organization: string
 ) => {
   switch (provider) {
-    case 'VSphere':
-      return {
-        cluster: {
-          name: generateUID(5),
-        },
-      };
-    default:
+    case 'AWS':
+    case 'Azure':
+    case 'GCP':
+    case 'Open Stack':
       return {
         clusterName: generateUID(5),
         organization,
       };
+
+    case 'Cloud Director':
+      return {
+        organization,
+      };
+
+    case 'VSphere':
+      return {
+        cluster: {
+          name: generateUID(5),
+          organization,
+        },
+      };
+
+    default:
+      return {};
   }
 };
 

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -4,25 +4,6 @@ import { compare } from 'utils/semver';
 
 import ClusterNameWidget from './ClusterNameWidget';
 
-const uiSchemaProviderDefault: Record<string, GenericObjectType> = {
-  v0: {
-    'ui:options': {
-      order: [
-        'clusterName',
-        'clusterDescription',
-        'organization',
-        'controlPlane',
-        '*',
-      ],
-    },
-    clusterName: {
-      'ui:options': {
-        widget: ClusterNameWidget,
-      },
-    },
-  },
-};
-
 const uiSchemaProviderAWS: Record<string, GenericObjectType> = {
   v0: {
     'ui:options': {
@@ -166,6 +147,15 @@ export const getDefaultFormData = (
   }
 };
 
+const uiSchemaForProvider: Record<PrototypeProviders, UiSchema> = {
+  AWS: uiSchemaProviderAWS,
+  Azure: uiSchemaProviderAzure,
+  'Cloud Director': uiSchemaProviderCloudDirector,
+  GCP: uiSchemaProviderGCP,
+  'Open Stack': uiSchemaProviderOpenStack,
+  VSphere: uiSchemaProviderVSphere,
+};
+
 export function getUiSchema(
   provider: PrototypeProviders,
   version: string
@@ -173,38 +163,7 @@ export function getUiSchema(
   // select major version
   const majorVersion = version.split('.')[0];
 
-  // eslint-disable-next-line @typescript-eslint/init-declarations
-  let uiSchema;
-
-  switch (provider) {
-    case 'AWS':
-      uiSchema = uiSchemaProviderAWS;
-      break;
-
-    case 'Azure':
-      uiSchema = uiSchemaProviderAzure;
-      break;
-
-    case 'Cloud Director':
-      uiSchema = uiSchemaProviderCloudDirector;
-      break;
-
-    case 'GCP':
-      uiSchema = uiSchemaProviderGCP;
-      break;
-
-    case 'Open Stack':
-      uiSchema = uiSchemaProviderOpenStack;
-      break;
-
-    case 'VSphere':
-      uiSchema = uiSchemaProviderVSphere;
-      break;
-
-    default:
-      uiSchema = uiSchemaProviderDefault;
-      break;
-  }
+  const uiSchema = uiSchemaForProvider[provider];
 
   const latestVersion = Object.keys(uiSchema).sort(compare)[0];
 

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -42,6 +42,25 @@ const uiSchemaProviderAWS: Record<string, GenericObjectType> = {
   },
 };
 
+const uiSchemaProviderAzure: Record<string, GenericObjectType> = {
+  v0: {
+    'ui:options': {
+      order: [
+        'clusterName',
+        'clusterDescription',
+        'organization',
+        'controlPlane',
+        '*',
+      ],
+    },
+    clusterName: {
+      'ui:options': {
+        widget: ClusterNameWidget,
+      },
+    },
+  },
+};
+
 const uiSchemaProviderCloudDirector: Record<string, GenericObjectType> = {
   v0: {
     'ui:options': {
@@ -119,6 +138,7 @@ const uiSchemaProviderVSphere: Record<string, GenericObjectType> = {
 
 export const prototypeProviders = [
   'AWS',
+  'Azure',
   'Cloud Director',
   'GCP',
   'Open Stack',
@@ -159,6 +179,10 @@ export function getUiSchema(
   switch (provider) {
     case 'AWS':
       uiSchema = uiSchemaProviderAWS;
+      break;
+
+    case 'Azure':
+      uiSchema = uiSchemaProviderAzure;
       break;
 
     case 'Cloud Director':

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -1,11 +1,12 @@
 import { GenericObjectType, UiSchema } from '@rjsf/utils';
 import { generateUID } from 'MAPI/utils';
 import { compare } from 'utils/semver';
+import { VersionImpl } from 'utils/Version';
 
 import ClusterNameWidget from './ClusterNameWidget';
 
 const uiSchemaProviderAWS: Record<string, GenericObjectType> = {
-  v0: {
+  0: {
     'ui:options': {
       order: [
         'clusterName',
@@ -24,7 +25,7 @@ const uiSchemaProviderAWS: Record<string, GenericObjectType> = {
 };
 
 const uiSchemaProviderAzure: Record<string, GenericObjectType> = {
-  v0: {
+  0: {
     'ui:options': {
       order: [
         'clusterName',
@@ -43,7 +44,7 @@ const uiSchemaProviderAzure: Record<string, GenericObjectType> = {
 };
 
 const uiSchemaProviderCloudDirector: Record<string, GenericObjectType> = {
-  v0: {
+  0: {
     'ui:options': {
       order: [
         'clusterDescription',
@@ -57,7 +58,7 @@ const uiSchemaProviderCloudDirector: Record<string, GenericObjectType> = {
 };
 
 const uiSchemaProviderGCP: Record<string, GenericObjectType> = {
-  v0: {
+  0: {
     'ui:options': {
       order: [
         'clusterName',
@@ -76,7 +77,7 @@ const uiSchemaProviderGCP: Record<string, GenericObjectType> = {
 };
 
 const uiSchemaProviderOpenStack: Record<string, GenericObjectType> = {
-  v0: {
+  0: {
     'ui:options': {
       order: [
         'clusterName',
@@ -95,7 +96,7 @@ const uiSchemaProviderOpenStack: Record<string, GenericObjectType> = {
 };
 
 const uiSchemaProviderVSphere: Record<string, GenericObjectType> = {
-  v0: {
+  0: {
     'ui:options': {
       order: ['cluster', 'controlPlane', '*'],
     },
@@ -168,8 +169,7 @@ export function getUiSchema(
   provider: PrototypeProviders,
   version: string
 ): UiSchema {
-  // select major version
-  const majorVersion = version.split('.')[0];
+  const majorVersion = new VersionImpl(version.slice(1)).getMajor();
 
   const uiSchema = uiSchemaForProvider[provider];
 

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -1,0 +1,88 @@
+import { GenericObjectType, UiSchema } from '@rjsf/utils';
+import { generateUID } from 'MAPI/utils';
+
+import ClusterNameWidget from './ClusterNameWidget';
+
+export const prototypeProviders = [
+  'AWS',
+  'Cloud Director',
+  'GCP',
+  'Open Stack',
+  'VSphere',
+] as const;
+
+export type PrototypeProviders = typeof prototypeProviders[number];
+
+export const getDefaultFormData = (provider: PrototypeProviders) => {
+  switch (provider) {
+    case 'VSphere':
+      return {
+        cluster: {
+          name: generateUID(5),
+        },
+      };
+    default:
+      return {
+        clusterName: generateUID(5),
+      };
+  }
+};
+
+const uiSchemaProviderDefault: Record<string, GenericObjectType> = {
+  v0: {
+    'ui:options': {
+      order: ['clusterName', 'clusterDescription', '*'],
+    },
+    clusterName: {
+      'ui:options': {
+        widget: ClusterNameWidget,
+      },
+    },
+  },
+};
+
+const uiSchemaProviderVSphere: Record<string, GenericObjectType> = {
+  v0: {
+    'ui:options': {
+      order: ['cluster', '*'],
+    },
+    cluster: {
+      'ui:options': {
+        order: ['name', '*'],
+      },
+      name: {
+        'ui:options': {
+          widget: ClusterNameWidget,
+        },
+      },
+    },
+  },
+};
+
+export function getUiSchema(
+  provider: PrototypeProviders,
+  branchName: string
+): UiSchema {
+  // TODO: replace when we use app version instead of branch name
+  const version = branchName.includes('release-')
+    ? branchName.replace('release-', '')
+    : 'v0.0.0';
+
+  // select major version
+  const majorVersion = version.split('.')[0];
+
+  // eslint-disable-next-line @typescript-eslint/init-declarations
+  let uiSchema;
+
+  switch (provider) {
+    case 'VSphere':
+      uiSchema = uiSchemaProviderVSphere;
+      break;
+
+    default:
+      uiSchema = uiSchemaProviderDefault;
+      break;
+  }
+
+  return uiSchema[majorVersion];
+}

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -147,13 +147,8 @@ export const getDefaultFormData = (
 
 export function getUiSchema(
   provider: PrototypeProviders,
-  branchName: string
+  version: string
 ): UiSchema {
-  // TODO: replace when we use app version instead of branch name
-  const version = branchName.includes('release-')
-    ? branchName.replace('release-', '')
-    : 'v0.0.0';
-
   // select major version
   const majorVersion = version.split('.')[0];
 

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -3,35 +3,92 @@ import { generateUID } from 'MAPI/utils';
 
 import ClusterNameWidget from './ClusterNameWidget';
 
-export const prototypeProviders = [
-  'AWS',
-  'Cloud Director',
-  'GCP',
-  'Open Stack',
-  'VSphere',
-] as const;
-
-export type PrototypeProviders = typeof prototypeProviders[number];
-
-export const getDefaultFormData = (provider: PrototypeProviders) => {
-  switch (provider) {
-    case 'VSphere':
-      return {
-        cluster: {
-          name: generateUID(5),
-        },
-      };
-    default:
-      return {
-        clusterName: generateUID(5),
-      };
-  }
-};
-
 const uiSchemaProviderDefault: Record<string, GenericObjectType> = {
   v0: {
     'ui:options': {
-      order: ['clusterName', 'clusterDescription', '*'],
+      order: [
+        'clusterName',
+        'clusterDescription',
+        'organization',
+        'controlPlane',
+        '*',
+      ],
+    },
+    clusterName: {
+      'ui:options': {
+        widget: ClusterNameWidget,
+      },
+    },
+  },
+};
+
+const uiSchemaProviderAWS: Record<string, GenericObjectType> = {
+  v0: {
+    'ui:options': {
+      order: [
+        'clusterName',
+        'clusterDescription',
+        'organization',
+        'controlPlane',
+        '*',
+      ],
+    },
+    clusterName: {
+      'ui:options': {
+        widget: ClusterNameWidget,
+      },
+    },
+  },
+};
+
+const uiSchemaProviderCloudDirector: Record<string, GenericObjectType> = {
+  v0: {
+    'ui:options': {
+      order: [
+        'clusterDescription',
+        'cluster',
+        'organization',
+        'controlPlane',
+        '*',
+      ],
+    },
+    clusterName: {
+      'ui:options': {
+        widget: ClusterNameWidget,
+      },
+    },
+  },
+};
+
+const uiSchemaProviderGCP: Record<string, GenericObjectType> = {
+  v0: {
+    'ui:options': {
+      order: [
+        'clusterName',
+        'clusterDescription',
+        'organization',
+        'controlPlane',
+        '*',
+      ],
+    },
+    clusterName: {
+      'ui:options': {
+        widget: ClusterNameWidget,
+      },
+    },
+  },
+};
+
+const uiSchemaProviderOpenStack: Record<string, GenericObjectType> = {
+  v0: {
+    'ui:options': {
+      order: [
+        'clusterName',
+        'clusterDescription',
+        'organization',
+        'controlPlane',
+        '*',
+      ],
     },
     clusterName: {
       'ui:options': {
@@ -44,11 +101,11 @@ const uiSchemaProviderDefault: Record<string, GenericObjectType> = {
 const uiSchemaProviderVSphere: Record<string, GenericObjectType> = {
   v0: {
     'ui:options': {
-      order: ['cluster', '*'],
+      order: ['cluster', 'controlPlane', '*'],
     },
     cluster: {
       'ui:options': {
-        order: ['name', '*'],
+        order: ['name', 'organization', '*'],
       },
       name: {
         'ui:options': {
@@ -57,6 +114,35 @@ const uiSchemaProviderVSphere: Record<string, GenericObjectType> = {
       },
     },
   },
+};
+
+export const prototypeProviders = [
+  'AWS',
+  'Cloud Director',
+  'GCP',
+  'Open Stack',
+  'VSphere',
+] as const;
+
+export type PrototypeProviders = typeof prototypeProviders[number];
+
+export const getDefaultFormData = (
+  provider: PrototypeProviders,
+  organization: string
+) => {
+  switch (provider) {
+    case 'VSphere':
+      return {
+        cluster: {
+          name: generateUID(5),
+        },
+      };
+    default:
+      return {
+        clusterName: generateUID(5),
+        organization,
+      };
+  }
 };
 
 export function getUiSchema(
@@ -75,6 +161,22 @@ export function getUiSchema(
   let uiSchema;
 
   switch (provider) {
+    case 'AWS':
+      uiSchema = uiSchemaProviderAWS;
+      break;
+
+    case 'Cloud Director':
+      uiSchema = uiSchemaProviderCloudDirector;
+      break;
+
+    case 'GCP':
+      uiSchema = uiSchemaProviderGCP;
+      break;
+
+    case 'Open Stack':
+      uiSchema = uiSchemaProviderOpenStack;
+      break;
+
     case 'VSphere':
       uiSchema = uiSchemaProviderVSphere;
       break;

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -1,5 +1,6 @@
 import { GenericObjectType, UiSchema } from '@rjsf/utils';
 import { generateUID } from 'MAPI/utils';
+import { compare } from 'utils/semver';
 
 import ClusterNameWidget from './ClusterNameWidget';
 
@@ -181,5 +182,9 @@ export function getUiSchema(
       break;
   }
 
-  return uiSchema[majorVersion];
+  const latestVersion = Object.keys(uiSchema).sort(compare)[0];
+
+  // fallback to latest version if version specified by schema does
+  // not have a corresponding ui schema
+  return uiSchema[majorVersion] ?? uiSchema[latestVersion];
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1181.

This PR adds a way for us to define UI schema to be used in the cluster app creation form.

Currently, UI schema are defined separately for each provider, with one UI schema for each major version. This is based on [previous discussions](https://github.com/giantswarm/roadmap/issues/1181#issuecomment-1340797851) we had about breaking changes in cluster apps, and we can adjust the granularity of this support if required.

A preliminary UI schema has been defined for each provider (including `Azure`, a new addition). More information about what can be defined via UI schema may be found in the [docs](https://react-jsonschema-form.readthedocs.io/en/latest/api-reference/uiSchema/), but the most relevant functionality for us would be:
- the ability to define the ordering of object properties
- overriding the default form component with our own React component
- making a field as read-only/disabling editing
- overriding title and/or description
- autofocus on fields