### PR TITLE
Fix user installed apps view

### DIFF
--- a/src/components/MAPI/apps/ClusterDetailApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailApps.tsx
@@ -138,9 +138,13 @@ const ClusterDetailApps: React.FC<
       return [];
     }
 
-    const apps = filterUserInstalledApps(appList.items, isClusterApp, provider);
+    const apps = filterUserInstalledApps(
+      removeChildApps(appList.items),
+      isClusterApp,
+      provider
+    );
 
-    return removeChildApps(apps).sort(compareApps);
+    return apps.sort(compareApps);
   }, [appList, isClusterApp, provider]);
 
   const defaultApps = useMemo(() => {
@@ -148,9 +152,13 @@ const ClusterDetailApps: React.FC<
       return [];
     }
 
-    const apps = filterDefaultApps(appList.items, isClusterApp, provider);
+    const apps = filterDefaultApps(
+      removeChildApps(appList.items),
+      isClusterApp,
+      provider
+    );
 
-    return removeChildApps(apps).sort(compareApps);
+    return apps.sort(compareApps);
   }, [appList, isClusterApp, provider]);
 
   return (

--- a/src/components/MAPI/apps/ClusterDetailWidgetApps.tsx
+++ b/src/components/MAPI/apps/ClusterDetailWidgetApps.tsx
@@ -108,9 +108,11 @@ const ClusterDetailWidgetApps: React.FC<
       return undefined;
     }
 
-    const apps = filterUserInstalledApps(appList.items, isClusterApp, provider);
-
-    return removeChildApps(apps);
+    return filterUserInstalledApps(
+      removeChildApps(appList.items),
+      isClusterApp,
+      provider
+    );
   }, [appList, isClusterApp, provider]);
 
   const insufficientPermissionsForApps = canListApps === false;


### PR DESCRIPTION
### What does this PR do?

When there is an app bundle in the list of the preinstalled apps (on Vintage), child apps of that bundle were duplicated in the list of apps installed by a user. The problem is in the order of steps needed to prepare a list of apps for being displayed. The order is:
1) split all the apps into preinstalled or installed by a user;
2) filter out all the child apps of app bundles (display logic works that way that we only need a "top level" apps);
3) sort the lists by app name;
In this order, second step of filtering child apps works incorrectly when there is an app bundle in the preinstalled apps list.

In this PR the order of apps preparation steps was changed - now the filtering of the child apps happens in the beginning.

### What is the effect of this change to users?

Incorrectly displayed list of user installed apps should be fixes.

### How does it look like?

Before:
<img width="816" alt="Screenshot 2023-01-20 at 14 28 57" src="https://user-images.githubusercontent.com/445309/213687311-580226f5-553f-4c57-8fcd-d004b8894830.png">

After:
<img width="816" alt="Screenshot 2023-01-20 at 14 38 18" src="https://user-images.githubusercontent.com/445309/213687345-fe4443d2-ed6b-4c00-92b5-e203b3c6272d.png">

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1893.