### PR TITLE
Replace oidc-client with oidc-client-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lunr": "2.3.9",
     "mermaid": "9.3.0",
     "normalize.css": "8.0.1",
-    "oidc-client": "https://github.com/giantswarm/oidc-client-js.git",
+    "oidc-client-ts": "^2.2.1",
     "platform": "1.3.6",
     "react": "18.2.0",
     "react-breadcrumbs": "2.1.7",

--- a/src/utils/MapiAuth/makeDefaultConfig.ts
+++ b/src/utils/MapiAuth/makeDefaultConfig.ts
@@ -30,7 +30,7 @@ export function makeDefaultConfig(): IOAuth2Config {
     automaticSilentRenew: false,
     includeIDTokenInSilentRenew: true,
     loadUserInfo: false,
-    revokeAccessTokenOnLogout: true,
+    revokeTokensOnSignout: true,
     filterProtocolClaims: true,
     validateSubOnSilentRenew: true,
     persistenceMethod: localStorage,
@@ -41,7 +41,7 @@ export function makeDefaultConfig(): IOAuth2Config {
       jwksUri: `${authority}/keys`,
       userInfoEndpoint: `${authority}/userinfo`,
 
-      idTokenSigningAlgValuesSupported: ['RS256'],
+      tokenEndpointAuthSigningAlgValuesSupported: ['RS256'],
       tokenEndpointAuthMethodsSupported: ['client_secret_basic'],
       scopesSupported: [
         'openid',

--- a/src/utils/OAuth2/OAuth2CustomMetadata.ts
+++ b/src/utils/OAuth2/OAuth2CustomMetadata.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import { OidcMetadata } from 'oidc-client';
+import { OidcMetadata } from 'oidc-client-ts';
 
 export interface IOAuth2CustomMetadata {
   issuer: string;
@@ -10,7 +10,7 @@ export interface IOAuth2CustomMetadata {
   userInfoEndpoint: string;
   endSessionEndpoint: string;
 
-  idTokenSigningAlgValuesSupported: string[];
+  tokenEndpointAuthSigningAlgValuesSupported: string[];
   tokenEndpointAuthMethodsSupported: string[];
   scopesSupported: string[];
   responseTypesSupported: string[];
@@ -31,8 +31,8 @@ export function convertToOIDCMetadata(
     userinfo_endpoint: metadata.userInfoEndpoint,
     end_session_endpoint: metadata.endSessionEndpoint,
 
-    id_token_signing_alg_values_supported:
-      metadata.idTokenSigningAlgValuesSupported,
+    token_endpoint_auth_signing_alg_values_supported:
+      metadata.tokenEndpointAuthSigningAlgValuesSupported,
     token_endpoint_auth_methods_supported:
       metadata.tokenEndpointAuthMethodsSupported,
     scopes_supported: metadata.scopesSupported,

--- a/src/utils/OAuth2/OAuth2User.ts
+++ b/src/utils/OAuth2/OAuth2User.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 
 import { AuthorizationTypes } from 'model/constants';
-import { User } from 'oidc-client';
+import { User } from 'oidc-client-ts';
 
 export interface IOAuth2User {
   idToken: string;
@@ -17,10 +17,10 @@ export interface IOAuth2User {
 export function getUserFromOIDCUser(user: User): IOAuth2User {
   return {
     authorizationType: AuthorizationTypes.BEARER,
-    idToken: user.id_token,
+    idToken: user.id_token ?? '',
     refreshToken: user.refresh_token ?? '',
-    expiresAt: user.expires_at,
-    groups: user.profile.groups ?? [],
+    expiresAt: user.expires_at ?? 0,
+    groups: (user.profile.groups as string[]) ?? [],
     email: user.profile.email ?? '',
     emailVerified: user.profile.email_verified ?? false,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7288,7 +7288,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2, base64-js@^1.5.1:
+base64-js@^1.0.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -8575,11 +8575,6 @@ core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.18.3.tgz#86a0bba2d8ec3df860fefcc07a8d119779f01509"
   integrity sha512-tReEhtMReZaPFVw7dajMx0vlsz3oOb8ajgPoHVYGxr8ErnZ6PcYEvvmjGmXlfpnxpkYSdOQttjB+MvVbCGfvLw==
 
-core-js@^3.8.3:
-  version "3.21.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.21.1.tgz#f2e0ddc1fc43da6f904706e8e955bc19d06a0d94"
-  integrity sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -8718,7 +8713,7 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^4.0.0:
+crypto-js@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
   integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
@@ -13868,6 +13863,11 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 khroma@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/khroma/-/khroma-2.0.0.tgz#7577de98aed9f36c7a474c4d453d94c0d6c6588b"
@@ -15787,15 +15787,13 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-"oidc-client@https://github.com/giantswarm/oidc-client-js.git":
-  version "1.11.6-beta.1"
-  resolved "https://github.com/giantswarm/oidc-client-js.git#922109a2aa18af8cc12a455e2a4eeaacdcfa551a"
+oidc-client-ts@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/oidc-client-ts/-/oidc-client-ts-2.2.1.tgz#aa397119db54952acd08efe04bac4eff9a9169db"
+  integrity sha512-g/W+DsUVeHZ8A7xUSTeK4bI6BNs9ROtMiiOOo+0M6IiTHxueJ757GD8e/8nPBL+k/o6bkfM5mWg4cZcSI8Iosw==
   dependencies:
-    acorn "^7.4.1"
-    base64-js "^1.5.1"
-    core-js "^3.8.3"
-    crypto-js "^4.0.0"
-    serialize-javascript "^4.0.0"
+    crypto-js "^4.1.1"
+    jwt-decode "^3.1.2"
 
 on-finished@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
### What does this PR do?

This PR replaces our fork of `oidc-client-js` with `oidc-client-ts`. The TS fork of the project has been actively maintained over the past year, and is also now suggested as a successor to `oidc-client-js`.

Some properties and methods were renamed, and some defaults have changed, but there should be no major changes to functionality.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/694.