### PR TITLE
Add react-jsonschema-form group to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,10 @@
       "groupName": "webpack packages"
     },
     {
+      "matchPackagePrefixes": ["@rjsf"],
+      "groupName": "react-jsonschema-form packages"
+    },
+    {
       "matchPackageNames": [
         "@types/bootstrap",
         "bootstrap"


### PR DESCRIPTION
### What does this PR do?

A new group for `react-jsonschema-form` packages was added to the `renovate` config.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1181.