### PR TITLE
JSON schema form 2020-12 draft support

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@rjsf/validator-ajv8": "5.1.0",
     "@sentry/react": "7.36.0",
     "@sentry/tracing": "7.36.0",
+    "ajv": "^8.12.0",
     "bootstrap": "3.4.1",
     "bowser": "2.11.0",
     "clean-deep": "3.4.0",

--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppBundles.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppBundles.tsx
@@ -1,6 +1,7 @@
 import { IChangeEvent } from '@rjsf/core';
 import { EnumOptionsType, RJSFSchema } from '@rjsf/utils';
-import validator from '@rjsf/validator-ajv8';
+import { customizeValidator } from '@rjsf/validator-ajv8';
+import Ajv2020 from 'ajv/dist/2020';
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import cleanDeep from 'clean-deep';
 import { push, replace } from 'connected-react-router';
@@ -47,6 +48,8 @@ import {
   PrototypeSchemas,
   prototypeSchemas,
 } from './schemaUtils';
+
+const validator = customizeValidator({ AjvClass: Ajv2020 });
 
 const Wrapper = styled.div`
   position: relative;

--- a/src/components/UI/JSONSchemaForm/test.schema.json
+++ b/src/components/UI/JSONSchemaForm/test.schema.json
@@ -152,13 +152,6 @@
                     "title": "Integer",
                     "type": "integer"
                 },
-                "integerLimit": {
-                    "description": "Integer field with minimum value 2 and maximum value 5.",
-                    "title": "Integer with min/max values",
-                    "type": "integer",
-                    "maximum": 5,
-                    "minimum": 2
-                },
                 "integerEnum": {
                     "description": "Integer field with enumerated values and custom labels.",
                     "oneOf": [

--- a/src/components/UI/JSONSchemaForm/test.schema.json
+++ b/src/components/UI/JSONSchemaForm/test.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "arrayFields": {
             "properties": {


### PR DESCRIPTION
### What does this PR do?
By default, the `@rjsf/validator-ajv8` uses the `draft-07` schema version. In this PR, validator was customized to use `draft-2020-12` version. It allows us to specify the latest draft for schemas, like this
```
{
    "$schema": "https://json-schema.org/draft/2020-12/schema"
}
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1181.
