### PR TITLE
Support removing schema fields

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/CreateClusterAppBundles.tsx
+++ b/src/components/MAPI/clusters/CreateCluster/CreateClusterAppBundles.tsx
@@ -256,7 +256,11 @@ const CreateClusterAppBundles: React.FC<ICreateClusterAppBundlesProps> = (
   const rawSchema = selectedProvider
     ? providerSchema
     : (testSchema as RJSFSchema);
-  const appSchema = rawSchema && preprocessSchema(rawSchema);
+  const appSchema = useMemo(() => {
+    if (!rawSchema) return undefined;
+
+    return preprocessSchema(rawSchema);
+  }, [rawSchema]);
 
   const appSchemaIsLoading =
     appSchema === undefined && providerSchemaError === undefined;

--- a/src/components/MAPI/clusters/CreateCluster/__tests__/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/__tests__/schemaUtils.ts
@@ -1,6 +1,8 @@
+import { RJSFSchema } from '@rjsf/utils';
 import cleanDeep, { CleanOptions } from 'clean-deep';
+import testSchema from 'UI/JSONSchemaForm/test.schema.json';
 
-import { cleanDeepWithException } from '../schemaUtils';
+import { cleanDeepWithException, preprocessSchema } from '../schemaUtils';
 
 describe('schemaUtils', () => {
   describe('cleanDeepWithException', () => {
@@ -94,7 +96,166 @@ describe('schemaUtils', () => {
       }
     });
   });
+
+  describe('preprocessSchema', () => {
+    it('removes fields at the root level', () => {
+      const expected = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        properties: {
+          booleanFields: {
+            properties: {
+              active: {
+                type: 'boolean',
+              },
+              enabled: {
+                description: 'Boolean field with title and description.',
+                title: 'Enabled',
+                type: 'boolean',
+              },
+            },
+            title: 'Boolean fields',
+            type: 'object',
+          },
+        },
+        type: 'object',
+      };
+
+      expect(
+        preprocessSchema(createTestSchema() as RJSFSchema, [
+          '.arrayFields',
+          '.logic',
+          '.objectFields',
+          '.numericFields',
+          '.stringFields',
+        ])
+      ).toStrictEqual(expected);
+    });
+
+    it('removes nested fields', () => {
+      const expected = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        properties: {
+          booleanFields: {
+            properties: {
+              enabled: {
+                description: 'Boolean field with title and description.',
+                title: 'Enabled',
+                type: 'boolean',
+              },
+            },
+            title: 'Boolean fields',
+            type: 'object',
+          },
+        },
+        type: 'object',
+      };
+
+      expect(
+        preprocessSchema(createTestSchema() as RJSFSchema, [
+          '.arrayFields',
+          '.logic',
+          '.objectFields',
+          '.numericFields',
+          '.stringFields',
+          '.booleanFields.active',
+        ])
+      ).toStrictEqual(expected);
+    });
+
+    it('removes nested fields of items', () => {
+      const expected = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        properties: {
+          arrayFields: {
+            properties: {
+              arrayOfObjects: {
+                items: {
+                  properties: {
+                    name: {
+                      type: 'string',
+                    },
+                  },
+                  type: 'object',
+                },
+                title: 'Array of objects',
+                type: 'array',
+              },
+            },
+            title: 'Array fields',
+            type: 'object',
+          },
+        },
+        type: 'object',
+      };
+
+      expect(
+        preprocessSchema(createTestSchema() as RJSFSchema, [
+          '.logic',
+          '.objectFields',
+          '.numericFields',
+          '.stringFields',
+          '.booleanFields',
+          '.arrayFields.arrayOfStrings',
+          '.arrayFields.arrayMinMaxItems',
+          '.arrayFields.arrayOfObjectsWithTitle',
+          '.arrayFields.arrayOfObjects.items.age',
+        ])
+      ).toStrictEqual(expected);
+    });
+
+    it('uses the first non-deprecated subschema for anyOf', () => {
+      const expected = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        properties: {
+          logic: {
+            description: `Uses of 'anyOf', 'oneOf', and 'not'.`,
+            properties: {
+              anyOf: {
+                properties: {
+                  anyOfDeprecated: {
+                    description:
+                      'Only the second declared subschema (number, minimum=3) should be visible.',
+                    minimum: 3,
+                    title: `Property with subschemas using 'anyOf' and 'deprecated'`,
+                    type: 'number',
+                  },
+                  anyOfSimple: {
+                    description:
+                      'Only the first declared subschema (string, minLength=3) should be visible.',
+                    minLength: 3,
+                    title: `Property with two subschemas using 'anyOf'`,
+                    type: 'string',
+                  },
+                },
+                title: `Subschema choice using 'anyOf'`,
+                type: 'object',
+              },
+            },
+            title: 'Logic and subschemas',
+            type: 'object',
+          },
+        },
+        type: 'object',
+      };
+
+      expect(
+        preprocessSchema(createTestSchema() as RJSFSchema, [
+          '.objectFields',
+          '.numericFields',
+          '.stringFields',
+          '.booleanFields',
+          '.arrayFields',
+          '.logic.not',
+          '.logic.oneOf',
+        ])
+      ).toStrictEqual(expected);
+    });
+  });
 });
+
+function createTestSchema() {
+  return structuredClone(testSchema);
+}
 
 function createTestObject() {
   return {

--- a/src/components/MAPI/clusters/CreateCluster/__tests__/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/__tests__/schemaUtils.ts
@@ -1,6 +1,5 @@
 import { RJSFSchema } from '@rjsf/utils';
 import cleanDeep, { CleanOptions } from 'clean-deep';
-import testSchema from 'UI/JSONSchemaForm/test.schema.json';
 
 import { cleanDeepWithException, preprocessSchema } from '../schemaUtils';
 
@@ -124,9 +123,6 @@ describe('schemaUtils', () => {
         preprocessSchema(createTestSchema() as RJSFSchema, [
           '.arrayFields',
           '.logic',
-          '.objectFields',
-          '.numericFields',
-          '.stringFields',
         ])
       ).toStrictEqual(expected);
     });
@@ -154,9 +150,6 @@ describe('schemaUtils', () => {
         preprocessSchema(createTestSchema() as RJSFSchema, [
           '.arrayFields',
           '.logic',
-          '.objectFields',
-          '.numericFields',
-          '.stringFields',
           '.booleanFields.active',
         ])
       ).toStrictEqual(expected);
@@ -191,13 +184,7 @@ describe('schemaUtils', () => {
       expect(
         preprocessSchema(createTestSchema() as RJSFSchema, [
           '.logic',
-          '.objectFields',
-          '.numericFields',
-          '.stringFields',
           '.booleanFields',
-          '.arrayFields.arrayOfStrings',
-          '.arrayFields.arrayMinMaxItems',
-          '.arrayFields.arrayOfObjectsWithTitle',
           '.arrayFields.arrayOfObjects.items.age',
         ])
       ).toStrictEqual(expected);
@@ -240,9 +227,6 @@ describe('schemaUtils', () => {
 
       expect(
         preprocessSchema(createTestSchema() as RJSFSchema, [
-          '.objectFields',
-          '.numericFields',
-          '.stringFields',
           '.booleanFields',
           '.arrayFields',
           '.logic.not',
@@ -254,7 +238,91 @@ describe('schemaUtils', () => {
 });
 
 function createTestSchema() {
-  return structuredClone(testSchema);
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    properties: {
+      arrayFields: {
+        properties: {
+          arrayOfObjects: {
+            items: {
+              properties: {
+                age: {
+                  type: 'number',
+                },
+                name: {
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+            title: 'Array of objects',
+            type: 'array',
+          },
+        },
+        title: 'Array fields',
+        type: 'object',
+      },
+      booleanFields: {
+        properties: {
+          active: {
+            type: 'boolean',
+          },
+          enabled: {
+            description: 'Boolean field with title and description.',
+            title: 'Enabled',
+            type: 'boolean',
+          },
+        },
+        title: 'Boolean fields',
+        type: 'object',
+      },
+      logic: {
+        description: `Uses of 'anyOf', 'oneOf', and 'not'.`,
+        properties: {
+          anyOf: {
+            properties: {
+              anyOfDeprecated: {
+                anyOf: [
+                  {
+                    deprecated: true,
+                    minLength: 3,
+                    type: 'string',
+                  },
+                  {
+                    minimum: 3,
+                    type: 'number',
+                  },
+                ],
+                description:
+                  'Only the second declared subschema (number, minimum=3) should be visible.',
+                title: `Property with subschemas using 'anyOf' and 'deprecated'`,
+              },
+              anyOfSimple: {
+                anyOf: [
+                  {
+                    minLength: 3,
+                    type: 'string',
+                  },
+                  {
+                    minimum: 3,
+                    type: 'number',
+                  },
+                ],
+                description:
+                  'Only the first declared subschema (string, minLength=3) should be visible.',
+                title: `Property with two subschemas using 'anyOf'`,
+              },
+            },
+            title: `Subschema choice using 'anyOf'`,
+            type: 'object',
+          },
+        },
+        title: 'Logic and subschemas',
+        type: 'object',
+      },
+    },
+    type: 'object',
+  };
 }
 
 function createTestObject() {

--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -300,8 +300,20 @@ export function cleanDeepWithException<T>(
   );
 }
 
-export function preprocessSchema(schema: RJSFSchema): RJSFSchema {
-  const processSubschemas = (obj: RJSFSchema) => {
+export function preprocessSchema(
+  schema: RJSFSchema,
+  fieldsToRemove: string[] = ['.internal']
+): RJSFSchema {
+  const processSubschemas = (obj: RJSFSchema, path?: string | null) => {
+    for (const field of fieldsToRemove) {
+      const fieldParentPath = field.slice(0, field.lastIndexOf('.'));
+      const fieldKey = field.slice(field.lastIndexOf('.') + 1);
+
+      if (fieldParentPath === path) {
+        delete obj.properties?.[fieldKey];
+      }
+    }
+
     // If the type is not defined and the schema uses 'anyOf' or 'oneOf',
     // use first not deprecated subschema from the list
     if (!obj.type && (obj.anyOf || obj.oneOf)) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -497,32 +497,42 @@ export function isValidURL(str: string): boolean {
  * Traverses a JSON schema object recursively
  * @param obj
  * @param processFn
+ * @param path
  * @returns obj
  */
 // eslint-disable-next-line complexity
 export function traverseJSONSchemaObject(
   obj: RJSFSchema,
-  processFn: (obj: RJSFSchema) => void
+  processFn: (obj: RJSFSchema, path?: string | null) => void,
+  path: string = ''
 ): Record<string, unknown> {
   switch (true) {
     case obj.type === 'object' &&
       obj.properties &&
       typeof obj.properties === 'object':
-      for (const value of Object.values(
+      for (const [k, v] of Object.entries(
         obj.properties as Record<string, unknown>
       )) {
-        traverseJSONSchemaObject(value as Record<string, unknown>, processFn);
+        traverseJSONSchemaObject(
+          v as Record<string, unknown>,
+          processFn,
+          `${path}.${k}`
+        );
       }
       break;
 
     case obj.type === 'array' && obj.items && typeof obj.items === 'object':
-      traverseJSONSchemaObject(obj.items as Record<string, unknown>, processFn);
+      traverseJSONSchemaObject(
+        obj.items as Record<string, unknown>,
+        processFn,
+        `${path}.items`
+      );
       break;
 
     case obj.type === 'array' && Array.isArray(obj.items):
       for (const x of obj.items as Record<string, unknown>[]) {
         if (typeof x === 'object') {
-          traverseJSONSchemaObject(x, processFn);
+          traverseJSONSchemaObject(x, processFn, `${path}.items`);
         }
       }
       break;
@@ -530,7 +540,7 @@ export function traverseJSONSchemaObject(
     case obj.anyOf !== undefined:
       for (const x of obj.anyOf!) {
         if (typeof x === 'object') {
-          traverseJSONSchemaObject(x, processFn);
+          traverseJSONSchemaObject(x, processFn, path);
         }
       }
       break;
@@ -538,7 +548,7 @@ export function traverseJSONSchemaObject(
     case obj.allOf !== undefined:
       for (const x of obj.allOf!) {
         if (typeof x === 'object') {
-          traverseJSONSchemaObject(x, processFn);
+          traverseJSONSchemaObject(x, processFn, path);
         }
       }
       break;
@@ -546,13 +556,13 @@ export function traverseJSONSchemaObject(
     case obj.oneOf !== undefined:
       for (const x of obj.oneOf!) {
         if (typeof x === 'object') {
-          traverseJSONSchemaObject(x, processFn);
+          traverseJSONSchemaObject(x, processFn, path);
         }
       }
       break;
   }
 
-  processFn(obj);
+  processFn(obj, path);
 
   return obj;
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds support for removing schema fields during the schema preprocessing step. This allows us to specify fields to omit from JSON schema for both the form data and the form UI.

An example use case for this functionality is the `internal` field for cluster app schema. The removal of this field during preprocessing has also been implemented by this PR.

### Any background context you can provide?
Towards https://github.com/giantswarm/roadmap/issues/2052 and https://github.com/giantswarm/roadmap/issues/1181.