### PR TITLE
Allow hiding schema fields

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -97,7 +97,6 @@ const formPropsProviderAzure: Record<string, FormPropsPartial> = {
           'ui:widget': ClusterNameWidget,
         },
         organization: {
-          'ui:label': false,
           'ui:widget': 'hidden',
         },
       },

--- a/src/components/UI/JSONSchemaForm/ObjectFieldTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ObjectFieldTemplate/index.tsx
@@ -10,9 +10,11 @@ const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = ({
 
   return (
     <Box gap={isArrayItem ? 'none' : 'small'}>
-      {properties.map((element) => (
-        <div key={element.name}>{element.content}</div>
-      ))}
+      {properties.map((element) => {
+        return element.hidden ? null : (
+          <div key={element.name}>{element.content}</div>
+        );
+      })}
     </Box>
   );
 };


### PR DESCRIPTION
### What does this PR do?

This PR allows hiding schema fields in the JSON schema form UI via the `ui:widget: hidden` UI schema configuration. Note that this differs from the mechanism in https://github.com/giantswarm/happa/pull/4112, in that it only hides the display of the field but still allows values for that field in form data.

### Any background context you can provide?
Towards https://github.com/giantswarm/roadmap/issues/2052 and https://github.com/giantswarm/roadmap/issues/1181