### PR TITLE
Hide Azure cluster app schema properties

### DIFF
--- a/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateCluster/schemaUtils.ts
@@ -73,6 +73,9 @@ const formPropsProviderAzure: Record<string, FormPropsPartial> = {
         'includeClusterResourceSet',
         '*',
       ],
+      baseDomain: {
+        'ui:widget': 'hidden',
+      },
       connectivity: {
         'ui:order': ['sshSSOPublicKey', '*'],
         network: {
@@ -91,6 +94,15 @@ const formPropsProviderAzure: Record<string, FormPropsPartial> = {
           'ui:order': ['issuerUrl', 'clientId', '*'],
         },
       },
+      'cluster-shared': {
+        'ui:widget': 'hidden',
+      },
+      machinePools: {
+        'ui:widget': 'hidden',
+      },
+      managementCluster: {
+        'ui:widget': 'hidden',
+      },
       metadata: {
         'ui:order': ['name', 'description', '*'],
         name: {
@@ -99,6 +111,9 @@ const formPropsProviderAzure: Record<string, FormPropsPartial> = {
         organization: {
           'ui:widget': 'hidden',
         },
+      },
+      provider: {
+        'ui:widget': 'hidden',
       },
       providerSpecific: {
         'ui:order': ['location', 'subscriptionId', '*'],


### PR DESCRIPTION
### What does this PR do?

This PR hides properties that are currently part of the schema for internal purposes only, but should be filled in automatically e. g. by operators.

### What is the effect of this change to users?

The form appears more clean and does not offfer input widgets for purely internal settings.

### How does it look like?

![image](https://user-images.githubusercontent.com/273727/221144581-59cf5ac8-a5c4-46b8-883b-35f216746a5c.png)

### Any background context you can provide?

There is more detail in https://github.com/giantswarm/roadmap/issues/1733

### Should this change be mentioned in the release notes?

Not necessary