### PR TITLE
JSON schema form select boxes empty option

### DIFF
--- a/src/components/UI/JSONSchemaForm/SelectWidget/index.tsx
+++ b/src/components/UI/JSONSchemaForm/SelectWidget/index.tsx
@@ -1,10 +1,13 @@
 import { EnumOptionsType, WidgetProps } from '@rjsf/utils';
-import React from 'react';
+import { Box } from 'grommet';
+import React, { useMemo } from 'react';
 import Select from 'UI/Inputs/Select';
 
 const SelectWidget: React.FC<WidgetProps> = ({
   id,
-  options,
+  disabled,
+  options: { emptyValue, enumOptions },
+  required,
   value,
   onChange,
 }) => {
@@ -12,24 +15,54 @@ const SelectWidget: React.FC<WidgetProps> = ({
     onChange(option.value);
   };
 
-  const enumOptions =
-    options.enumOptions?.map((option) => ({
-      label: option.label,
-      value: option.value,
-    })) || [];
+  const options = useMemo(() => {
+    const selectOptions = [
+      {
+        label: '',
+        value: emptyValue,
+      },
+    ];
 
-  const selectedOption = enumOptions.find((option) => option.value === value);
+    if (enumOptions) {
+      enumOptions.forEach((option: EnumOptionsType) =>
+        selectOptions.push({
+          label: option.label,
+          value: option.value,
+        })
+      );
+    }
+
+    return selectOptions;
+  }, [emptyValue, enumOptions]);
+
+  const selectedOption = options.find((option) => option.value === value);
+  const selectedIndex = selectedOption
+    ? options.indexOf(selectedOption)
+    : undefined;
 
   return (
     <Select
       id={id}
       value={selectedOption}
+      disabled={disabled}
+      required={required}
       onChange={(e) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         handleChange(e.option);
       }}
-      options={enumOptions}
-    />
+      options={options}
+      selected={selectedIndex ? [selectedIndex] : undefined}
+    >
+      {({ label }: EnumOptionsType) => (
+        <Box
+          pad='small'
+          height={{ min: '30px' }}
+          aria-label={label === '' ? 'empty value' : undefined}
+        >
+          {label}
+        </Box>
+      )}
+    </Select>
   );
 };
 


### PR DESCRIPTION
### What does this PR do?
In this PR, an empty option was added to select boxes, that are rendered for fields with enums. This allows a user to unset a field after a value was selected.

### How does it look like?

Before:
<img width="852" alt="Screenshot 2023-03-02 at 17 20 32" src="https://user-images.githubusercontent.com/445309/222454593-8ae66ba0-e79b-4ee5-916e-142f914116be.png">

After:
<img width="852" alt="Screenshot 2023-03-02 at 17 20 10" src="https://user-images.githubusercontent.com/445309/222455188-b9893aab-f363-4647-8018-66ddef8181dd.png">

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/2065.
