### PR TITLE
Re-arrange AWS cluster creation form properties, hide some

### DIFF
--- a/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
@@ -53,24 +53,72 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
   0: {
     uiSchema: {
       'ui:order': [
-        'clusterName',
-        'clusterDescription',
-        'organization',
+        'metadata',
+        'providerSpecific',
         'controlPlane',
+        'connectivity',
+        'nodePools',
         '*',
       ],
-      bastion: {
-        instanceType: {
-          'ui:widget': InstanceTypeWidget,
-        },
+      baseDomain: {
+        'ui:widget': 'hidden',
       },
-      clusterName: {
-        'ui:widget': ClusterNameWidget,
+      connectivity: {
+        'ui:order': ['sshSsoPublicKey', '*'],
+        bastion: {
+          instanceType: {
+            'ui:widget': InstanceTypeWidget,
+          },
+        },
       },
       controlPlane: {
+        'ui:order': [
+          'apiMode',
+          'instanceType',
+          'replicas',
+          'rootVolumeSizeGB',
+          'etcdVolumeSizeGB',
+          'kubeletVolumeSizeGB',
+          'containerdVolumeSizeGB',
+          'oidc',
+          '*',
+        ],
         instanceType: {
           'ui:widget': InstanceTypeWidget,
         },
+        oidc: {
+          'ui:order': ['issuerUrl', 'clientId', '*'],
+        },
+      },
+      'cluster-shared': {
+        'ui:widget': 'hidden',
+      },
+      defaultMachinePools: {
+        'ui:widget': 'hidden',
+      },
+      kubectlImage: {
+        'ui:widget': 'hidden',
+      },
+      managementCluster: {
+        'ui:widget': 'hidden',
+      },
+      metadata: {
+        'ui:order': ['name', 'description', '*'],
+        name: {
+          // TODO: fix crash
+          //'ui:widget': ClusterNameWidget,
+        },
+      },
+      provider: {
+        'ui:widget': 'hidden',
+      },
+      providerSpecific: {
+        'ui:order': [
+          'region',
+          'flatcarAwsAccount',
+          'awsClusterRoleIdentityName',
+          '*',
+        ],
       },
     },
     formData: (clusterName, organization) => {

--- a/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
@@ -105,8 +105,7 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
       metadata: {
         'ui:order': ['name', 'description', '*'],
         name: {
-          // TODO: fix crash
-          //'ui:widget': ClusterNameWidget,
+          'ui:widget': ClusterNameWidget,
         },
       },
       provider: {
@@ -123,8 +122,10 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
     },
     formData: (clusterName, organization) => {
       return {
-        clusterName,
-        organization,
+        metadata: {
+          name: clusterName,
+          organization,
+        },
       };
     },
   },


### PR DESCRIPTION
### What does this PR do?

This PR adds configuration to improve the AWS CAPI cluster creation form by

- Hiding unwanted properties
- Sorting properties
- Customizing certain properties (instance type, cluster name)

### What is the effect of this change to users?

See below

### How does it look like?

![image](https://user-images.githubusercontent.com/273727/229762514-dab907e6-f6b0-4b07-b272-fd5b7f4f54fa.png)


### Any background context you can provide?

Issue https://github.com/giantswarm/roadmap/issues/1181

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

No
