### PR TITLE
Remove shared app collection from circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,18 +87,6 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
-          name: push-happa-to-shared-app-collection
-          app_name: "happa"
-          app_collection_repo: "shared-app-collection"
-          requires:
-            - push-happa-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
           name: push-happa-to-aws-app-collection
           app_name: "happa"
           app_collection_repo: "aws-app-collection"


### PR DESCRIPTION
### What does this PR do?

This PR removes the job that pushes happa to the shared app collection catalog, as the catalog will be archived in 2 weeks.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2355

### What is needed from the reviewers?

Nothing special.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

No.