### PR TITLE
Remove `kubernetes.auth.controlPlaneAdminTargetGroup`

### DIFF
--- a/ats/test-values.yaml
+++ b/ats/test-values.yaml
@@ -50,8 +50,6 @@ guestCluster:
   base: ""
 
 kubernetes:
-  auth:
-    controlPlaneAdminTargetGroup: ""
   versions: {}
 
 happa:

--- a/helm/happa/values.schema.json
+++ b/helm/happa/values.schema.json
@@ -224,14 +224,6 @@
         "kubernetes": {
             "type": "object",
             "properties": {
-                "auth": {
-                    "type": "object",
-                    "properties": {
-                        "controlPlaneAdminTargetGroup": {
-                            "type": "string"
-                        }
-                    }
-                },
                 "versions": {
                     "type": "object"
                 }

--- a/helm/happa/values.yaml
+++ b/helm/happa/values.yaml
@@ -61,8 +61,6 @@ guestCluster:
   base: ""
 
 kubernetes:
-  auth:
-    controlPlaneAdminTargetGroup: ""
   versions: {}
 
 happa:


### PR DESCRIPTION
### What does this PR do?

This PR removes `kubernetes.auth.controlPlaneAdminTargetGroup` from happa's `values.yaml`. We don't currently use this value anywhere within the codebase, and its value is currently [configured](https://github.com/giantswarm/config/blob/7003df373c606d9db26c6ea8d4a4a7c004acf450/default/apps/happa/configmap-values.yaml.template#L28) in `config` to overlap with `oidc.giantswarm.writeAllGroups`.

### Any background context you can provide?

No tracking issue. We realized with the changes in https://github.com/giantswarm/config/pull/1743 that the value doesn't seem to be used and is a duplicate.