### PR TITLE
Add tests for cluster details on CAPZ

### DIFF
--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
@@ -156,3 +156,35 @@ describe('ClusterDetailWidgetKubernetesAPI on CAPA', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('ClusterDetailWidgetKubernetesAPI on CAPZ', () => {
+  const provider: PropertiesOf<typeof Providers> =
+    window.config.info.general.provider;
+  const providerFlavor = window.config.info.general.providerFlavor;
+  const audience = window.config.audience;
+
+  beforeAll(() => {
+    window.config.info.general.provider = Providers.CAPZ;
+    window.config.info.general.providerFlavor = ProviderFlavors.CAPI;
+    window.config.audience = 'https://api.test.gigantic.io';
+
+    (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
+      defaultPermissions
+    );
+  });
+  afterAll(() => {
+    window.config.info.general.provider = provider;
+    window.config.info.general.providerFlavor = providerFlavor;
+    window.config.audience = audience;
+  });
+
+  it('displays the kubernetes API endpoint URL for the cluster', () => {
+    renderWithStore(ClusterDetailWidgetKubernetesAPI, {
+      cluster: capiv1beta1Mocks.randomClusterCAPZ1,
+    });
+
+    expect(
+      screen.getByText(`https://api.test12.gigantic.io:6443`)
+    ).toBeInTheDocument();
+  });
+});

--- a/test/mockHttpCalls/capiv1beta1/clusters.ts
+++ b/test/mockHttpCalls/capiv1beta1/clusters.ts
@@ -291,7 +291,7 @@ export const randomClusterCAPZ1: capiv1beta1.ICluster = {
   spec: {
     clusterNetwork: {},
     controlPlaneEndpoint: {
-      host: 'test12-9615ac82.westeurope.cloudapp.azure.com',
+      host: 'api.test12.gigantic.io',
       port: 6443,
     },
     controlPlaneRef: {


### PR DESCRIPTION
### What does this PR do?

This PR adds tests for cluster details features on CAPZ so that they have the same coverage as other providers.

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/25907.