### PR TITLE
Update readme and release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/happa/tree/main.svg?style=shield&circle-token=6e98ba111259986b590f228cd20e20fcea3dd2e5)](https://circleci.com/gh/giantswarm/happa/tree/master)
+[![CircleCI](https://circleci.com/gh/giantswarm/happa/tree/main.svg?style=shield&circle-token=6e98ba111259986b590f228cd20e20fcea3dd2e5)](https://circleci.com/gh/giantswarm/happa/tree/main)
 [![Docker Repository on Quay](https://quay.io/repository/giantswarm/happa/status 'Docker Repository on Quay')](https://quay.io/repository/giantswarm/happa)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=shield)](https://github.com/prettier/prettier)
 [![Known Vulnerabilities](https://snyk.io/test/github/giantswarm/happa/badge.svg?targetFile=package.json)](https://snyk.io/test/github/giantswarm/happa?targetFile=package.json)
@@ -114,9 +114,7 @@ https://fortawesome.com/kits/d940f7eb/docs
 
 ## Updating dependencies
 
-Dependabot is configured to automatically create pull requests (PRs) that update our dependencies
-when they go stale. After approval and a `@dependabot merge` comment, dependabot
-automatically merges open PRs.
+Renovate is configured for this repository to automatically create pull requests (PRs) that update our dependencies and to request reviews from the relevant teams/individuals. Reviewers can be configured in the `CODEOWNERS` file, and more information regarding Renovate configurations can be found [here](https://intranet.giantswarm.io/docs/dev-and-releng/ci/tools/renovate/).
 
 ## Coding style
 
@@ -136,4 +134,4 @@ We use the following config params:
 
 To avoid pushing code that will fail the CI due to codestyle issues, we've added a pre-commit hook using [`husky`](https://github.com/typicode/husky/).
 
-This runs before every commit, and it will not let commits go through if the `prettier` check has not passed.
+This runs before every commit, and it will not let commits go through if the `tsc`, `eslint`, or `prettier` checks have not passed.

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -5,13 +5,11 @@ over from there and auto deploys the release to our installations.
 
 ## Create and push a new release
 
-Read [here](https://intranet.giantswarm.io/docs/dev-and-releng/happa-release/) for the explanation of the manual steps to take.
+Read [here](https://intranet.giantswarm.io/docs/dev-and-releng/releases/happa/) for the explanation of the manual steps to take.
 
 ## Prerequisites
 
 CircleCI must be set up with certain environment variables:
 
 - `RELEASE_TOKEN` - A GitHub token with the permission to write to repositories
-  - [giantswarm/happa](https://github.com/giantswarm/gsctl/)
-- `GITHUB_USER_EMAIL` - Email address of the github user owning the personal token above
-- `GITHUB_USER_NAME` - Username of the above github user
+- `SENTRY_API_KEY` - A Sentry token with admin access to releases and read access to organizations


### PR DESCRIPTION
The README and release docs contained some broken links and outdated info that should be updated by this PR.

Closes https://github.com/giantswarm/roadmap/issues/2107.