### PR TITLE
Increase NGINX header size for happa API

### DIFF
--- a/helm/happa/templates/happaapi-ingress.yaml
+++ b/helm/happa/templates/happaapi-ingress.yaml
@@ -17,10 +17,8 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-headers: DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, Impersonate-User, Impersonate-Group
     nginx.ingress.kubernetes.io/enable-cors: "true"
 
-    nginx.ingress.kubernetes.io/client-header-buffer-size: 32k
-    nginx.ingress.kubernetes.io/http2-max-field-size: 32k
-    nginx.ingress.kubernetes.io/http2-max-header-size: 32k
-    nginx.ingress.kubernetes.io/large-client-header-buffers: 4 32k
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      large_client_header_buffers 4 32k;
 
     {{- if .Values.ingress.tls.letsencrypt }}
     cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"


### PR DESCRIPTION
### What does this PR do?

When a user is a member of many AD groups authentication header can become bigger than a limit NGINX sets by default (8KB). As a result requests to the API are being aborted. In this PR, header size limit was increased for happa API ingress.