### PR TITLE
Roll back Happa API ingress configuration change

### DIFF
--- a/helm/happa/templates/happaapi-ingress.yaml
+++ b/helm/happa/templates/happaapi-ingress.yaml
@@ -17,9 +17,6 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-headers: DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, Impersonate-User, Impersonate-Group
     nginx.ingress.kubernetes.io/enable-cors: "true"
 
-    nginx.ingress.kubernetes.io/server-snippet: |
-      large_client_header_buffers 4 32k;
-
     {{- if .Values.ingress.tls.letsencrypt }}
     cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"
     {{- else if ne .Values.ingress.tls.clusterIssuer "" }}


### PR DESCRIPTION
### What does this PR do?

`large_client_header_buffers` Ingress configuration was deleted. We will need to configure it again when `allow-snippet-annotations` is enabled on all MCs.

### Any background context you can provide?

Towards https://github.com/giantswarm/adidas/issues/1133.