### PR TITLE
Increase NGINX header size for Happa API

### DIFF
--- a/helm/happa/templates/happaapi-ingress.yaml
+++ b/helm/happa/templates/happaapi-ingress.yaml
@@ -17,6 +17,9 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-headers: DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, Impersonate-User, Impersonate-Group
     nginx.ingress.kubernetes.io/enable-cors: "true"
 
+    nginx.ingress.kubernetes.io/server-snippet: |
+      large_client_header_buffers 4 32k;
+
     {{- if .Values.ingress.tls.letsencrypt }}
     cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"
     {{- else if ne .Values.ingress.tls.clusterIssuer "" }}


### PR DESCRIPTION
### What does this PR do?

When a user is a member of many AD groups authentication header can become bigger than a limit NGINX sets by default (8KB). As a result requests to the API are being aborted. In this PR, header size limit was increased for happa API ingress.