### PR TITLE
Improve display of validation errors in cluster creation form

### DIFF
--- a/src/components/MAPI/clusters/CreateClusterAppBundles/ClusterAppSchemaTester.tsx
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/ClusterAppSchemaTester.tsx
@@ -361,8 +361,10 @@ const ClusterAppSchemaTester: React.FC<IClusterAppSchemaTesterProps> = (
                   render={({ formDataPreview }) => {
                     return (
                       <Box
-                        margin={{ top: 'large' }}
                         width={{ max: 'large' }}
+                        margin={{ top: 'medium' }}
+                        pad={{ top: 'medium' }}
+                        border='top'
                         gap='small'
                       >
                         <Text weight='bold'>Form data preview</Text>

--- a/src/components/MAPI/clusters/CreateClusterAppBundles/CreateClusterAppBundlesForm.tsx
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/CreateClusterAppBundlesForm.tsx
@@ -42,9 +42,11 @@ interface ICreateClusterAppBundlesFormProps {
   onChange?: (args: {
     formData: RJSFSchema | undefined;
     cleanFormData: RJSFSchema | undefined;
+    clusterName: string;
   }) => void;
   onError?: (errors: RJSFValidationError[]) => void;
   formData?: RJSFSchema;
+  clusterName?: string;
   id?: string;
 }
 
@@ -61,8 +63,11 @@ const CreateClusterAppBundlesForm: React.FC<
   formData,
   ...props
 }) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const clusterName = useMemo(() => generateUID(5), [provider, appVersion]);
+  const clusterName = useMemo(
+    () => props.clusterName || generateUID(5),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [provider, appVersion]
+  );
 
   const [formProps, setFormProps] = useState<
     Pick<FormProps<RJSFSchema>, 'uiSchema' | 'formData'>
@@ -96,7 +101,7 @@ const CreateClusterAppBundlesForm: React.FC<
     setCleanFormData(cleanData);
 
     if (onChange) {
-      onChange({ formData: data, cleanFormData: cleanData });
+      onChange({ formData: data, cleanFormData: cleanData, clusterName });
     }
   };
 

--- a/src/components/MAPI/clusters/CreateClusterAppBundles/CreateClusterAppBundlesForm.tsx
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/CreateClusterAppBundlesForm.tsx
@@ -1,5 +1,5 @@
 import { FormProps, IChangeEvent } from '@rjsf/core';
-import { RJSFSchema } from '@rjsf/utils';
+import { RJSFSchema, RJSFValidationError } from '@rjsf/utils';
 import { customizeValidator } from '@rjsf/validator-ajv8';
 import Ajv2020 from 'ajv/dist/2020';
 import yaml from 'js-yaml';
@@ -43,6 +43,7 @@ interface ICreateClusterAppBundlesFormProps {
     formData: RJSFSchema | undefined;
     cleanFormData: RJSFSchema | undefined;
   }) => void;
+  onError?: (errors: RJSFValidationError[]) => void;
   formData?: RJSFSchema;
   id?: string;
 }
@@ -109,7 +110,6 @@ const CreateClusterAppBundlesForm: React.FC<
         }}
         validator={validator}
         formData={formProps.formData}
-        showErrorList='bottom'
         onSubmit={handleSubmit}
         onChange={handleFormDataChange}
         {...props}

--- a/src/components/MAPI/clusters/CreateClusterAppBundles/index.tsx
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/index.tsx
@@ -1,4 +1,4 @@
-import { RJSFSchema } from '@rjsf/utils';
+import { RJSFSchema, RJSFValidationError } from '@rjsf/utils';
 import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
 import { push } from 'connected-react-router';
 import { Box, Heading, Text } from 'grommet';
@@ -109,6 +109,7 @@ const CreateClusterAppBundles: React.FC<ICreateClusterAppBundlesProps> = (
 
   const [page, setPage] = useState<Pages>(Pages.CreationFormPage);
   const [isCreating, setIsCreating] = useState<boolean>(false);
+  const [hasErrors, setHasErrors] = useState<boolean>(false);
 
   const clusterDefaultAppsACEClient = useRef(clientFactory());
   const {
@@ -284,6 +285,9 @@ const CreateClusterAppBundles: React.FC<ICreateClusterAppBundlesProps> = (
                     organization={organizationID}
                     appVersion={latestClusterAppACE!.spec.version}
                     onSubmit={handleSubmit}
+                    onError={(errors: RJSFValidationError[]) =>
+                      setHasErrors(errors.length > 0)
+                    }
                     formData={formPayload.formData}
                     key={`${provider}${latestClusterAppACE!.spec.version}`}
                     id={CREATE_CLUSTER_FORM_ID}
@@ -356,6 +360,7 @@ const CreateClusterAppBundles: React.FC<ICreateClusterAppBundlesProps> = (
                 primary={true}
                 type='submit'
                 form={CREATE_CLUSTER_FORM_ID}
+                disabled={hasErrors}
                 loading={isCreating}
                 id={FormSubmitterID.CreateCluster}
               >

--- a/src/components/UI/JSONSchemaForm/ErrorListTemplate/ErrorList.tsx
+++ b/src/components/UI/JSONSchemaForm/ErrorListTemplate/ErrorList.tsx
@@ -12,13 +12,13 @@ interface IErrorListProps {
 }
 
 const ErrorList: React.FC<IErrorListProps> = ({ errors }) => {
-  return errors.length > 0 ? (
+  return (
     <StyledList>
       {errors.map((error, idx) => (
         <li key={idx}>{error.stack}</li>
       ))}
     </StyledList>
-  ) : null;
+  );
 };
 
 export default ErrorList;

--- a/src/components/UI/JSONSchemaForm/ErrorListTemplate/ErrorList.tsx
+++ b/src/components/UI/JSONSchemaForm/ErrorListTemplate/ErrorList.tsx
@@ -1,0 +1,24 @@
+import { RJSFValidationError } from '@rjsf/utils';
+import React from 'react';
+import styled from 'styled-components';
+
+const StyledList = styled.ul`
+  padding-inline-start: 1em;
+  list-style-position: inside;
+`;
+
+interface IErrorListProps {
+  errors: RJSFValidationError[];
+}
+
+const ErrorList: React.FC<IErrorListProps> = ({ errors }) => {
+  return errors.length > 0 ? (
+    <StyledList>
+      {errors.map((error, idx) => (
+        <li key={idx}>{error.stack}</li>
+      ))}
+    </StyledList>
+  ) : null;
+};
+
+export default ErrorList;

--- a/src/components/UI/JSONSchemaForm/ErrorListTemplate/ValidationStatus.tsx
+++ b/src/components/UI/JSONSchemaForm/ErrorListTemplate/ValidationStatus.tsx
@@ -64,7 +64,7 @@ const ValidationStatus: React.FC<IValidationStatusProps> = ({ errors }) => {
           </Box>
         )}
       </Box>
-      <ErrorList errors={errors} />
+      {errors.length > 0 && <ErrorList errors={errors} />}
     </Box>
   );
 };

--- a/src/components/UI/JSONSchemaForm/ErrorListTemplate/ValidationStatus.tsx
+++ b/src/components/UI/JSONSchemaForm/ErrorListTemplate/ValidationStatus.tsx
@@ -1,0 +1,72 @@
+import { RJSFValidationError } from '@rjsf/utils';
+import { Box, Text } from 'grommet';
+import { normalizeColor } from 'grommet/utils';
+import React from 'react';
+import styled from 'styled-components';
+import { Tooltip, TooltipContainer } from 'UI/Display/Tooltip';
+
+import ErrorList from './ErrorList';
+
+const StyledStatusIcon = styled.i<{ color: string }>`
+  display: inline-block;
+  font-size: 24px;
+  color: ${({ theme, color }) => normalizeColor(color, theme)};
+`;
+
+function formatErrorText(errors: RJSFValidationError[]) {
+  return `${errors.length} error${errors.length > 1 ? 's' : ''} found`;
+}
+
+interface IValidationStatusProps {
+  errors: RJSFValidationError[];
+}
+
+const ValidationStatus: React.FC<IValidationStatusProps> = ({ errors }) => {
+  return (
+    <Box
+      gap='small'
+      margin={{ top: 'small' }}
+      pad={{ top: 'medium' }}
+      border='top'
+    >
+      <Box direction='row' align='center' gap='medium'>
+        <Box direction='row' align='baseline' gap='xsmall'>
+          <Text>Validation result</Text>
+          <TooltipContainer
+            content={
+              <Tooltip>
+                {`As a first step, the form data is validated against the cluster app's schema.`}
+              </Tooltip>
+            }
+          >
+            <i className='fa fa-info' aria-hidden={true} role='presentation' />
+          </TooltipContainer>
+        </Box>
+        {errors.length > 0 ? (
+          <Box direction='row' align='center' gap='xsmall'>
+            <StyledStatusIcon
+              className='fa fa-close'
+              aria-hidden={true}
+              role='presentation'
+              color='text-error'
+            />
+            <Text color='text-error'>{formatErrorText(errors)}</Text>
+          </Box>
+        ) : (
+          <Box direction='row' align='center' gap='xsmall'>
+            <StyledStatusIcon
+              color='text-success'
+              className='fa fa-done'
+              aria-hidden={true}
+              role='presentation'
+            />
+            <Text color='text-success'>OK</Text>
+          </Box>
+        )}
+      </Box>
+      <ErrorList errors={errors} />
+    </Box>
+  );
+};
+
+export default ValidationStatus;

--- a/src/components/UI/JSONSchemaForm/ErrorListTemplate/ValidationStatus.tsx
+++ b/src/components/UI/JSONSchemaForm/ErrorListTemplate/ValidationStatus.tsx
@@ -1,10 +1,12 @@
 import { RJSFValidationError } from '@rjsf/utils';
 import { Box, Text } from 'grommet';
 import { normalizeColor } from 'grommet/utils';
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { Tooltip, TooltipContainer } from 'UI/Display/Tooltip';
 
+import { IFormContext } from '..';
+import { isTouchedField, mapErrorPropertyToField } from '../utils';
 import ErrorList from './ErrorList';
 
 const StyledStatusIcon = styled.i<{ color: string }>`
@@ -18,10 +20,22 @@ function formatErrorText(errors: RJSFValidationError[]) {
 }
 
 interface IValidationStatusProps {
-  errors: RJSFValidationError[];
+  formContext: IFormContext;
 }
 
-const ValidationStatus: React.FC<IValidationStatusProps> = ({ errors }) => {
+const ValidationStatus: React.FC<IValidationStatusProps> = ({
+  formContext,
+}) => {
+  const filteredErrors = useMemo(() => {
+    return formContext.errors?.filter((e) =>
+      isTouchedField(
+        mapErrorPropertyToField(e, formContext.idConfigs),
+        formContext.touchedFields,
+        formContext.idConfigs.idSeparator
+      )
+    );
+  }, [formContext]);
+
   return (
     <Box
       gap='small'
@@ -42,7 +56,7 @@ const ValidationStatus: React.FC<IValidationStatusProps> = ({ errors }) => {
             <i className='fa fa-info' aria-hidden={true} role='presentation' />
           </TooltipContainer>
         </Box>
-        {errors.length > 0 ? (
+        {filteredErrors && filteredErrors.length > 0 ? (
           <Box direction='row' align='center' gap='xsmall'>
             <StyledStatusIcon
               className='fa fa-close'
@@ -50,7 +64,7 @@ const ValidationStatus: React.FC<IValidationStatusProps> = ({ errors }) => {
               role='presentation'
               color='text-error'
             />
-            <Text color='text-error'>{formatErrorText(errors)}</Text>
+            <Text color='text-error'>{formatErrorText(filteredErrors)}</Text>
           </Box>
         ) : (
           <Box direction='row' align='center' gap='xsmall'>
@@ -64,7 +78,9 @@ const ValidationStatus: React.FC<IValidationStatusProps> = ({ errors }) => {
           </Box>
         )}
       </Box>
-      {errors.length > 0 && <ErrorList errors={errors} />}
+      {filteredErrors && filteredErrors.length > 0 && (
+        <ErrorList errors={filteredErrors} />
+      )}
     </Box>
   );
 };

--- a/src/components/UI/JSONSchemaForm/ErrorListTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ErrorListTemplate/index.tsx
@@ -1,24 +1,13 @@
 import { ErrorListProps, RJSFSchema } from '@rjsf/utils';
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { IFormContext } from '..';
-import { isTouchedField, mapErrorPropertyToField } from '../utils';
-import ErrorList from './ErrorList';
+import ValidationStatus from './ValidationStatus';
 
 const ErrorListTemplate: React.FC<
   ErrorListProps<RJSFSchema, RJSFSchema, IFormContext>
-> = ({ errors, formContext = {} as IFormContext }) => {
-  const filteredErrors = useMemo(() => {
-    return errors.filter((e) =>
-      isTouchedField(
-        mapErrorPropertyToField(e, formContext.idConfigs),
-        formContext.touchedFields,
-        formContext.idConfigs.idSeparator
-      )
-    );
-  }, [errors, formContext]);
-
-  return <ErrorList errors={filteredErrors} />;
+> = ({ formContext = {} as IFormContext }) => {
+  return <ValidationStatus formContext={formContext} />;
 };
 
 export default ErrorListTemplate;

--- a/src/components/UI/JSONSchemaForm/ErrorListTemplate/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ErrorListTemplate/index.tsx
@@ -1,11 +1,9 @@
 import { ErrorListProps, RJSFSchema } from '@rjsf/utils';
-import { Box, Paragraph } from 'grommet';
 import React, { useMemo } from 'react';
-import { FlashMessageType } from 'styles';
-import FlashMessage from 'UI/Display/FlashMessage';
 
 import { IFormContext } from '..';
 import { isTouchedField, mapErrorPropertyToField } from '../utils';
+import ErrorList from './ErrorList';
 
 const ErrorListTemplate: React.FC<
   ErrorListProps<RJSFSchema, RJSFSchema, IFormContext>
@@ -20,18 +18,7 @@ const ErrorListTemplate: React.FC<
     );
   }, [errors, formContext]);
 
-  return filteredErrors.length > 0 ? (
-    <FlashMessage type={FlashMessageType.Danger}>
-      <Paragraph size='xlarge'>Errors</Paragraph>
-      <Box>
-        {filteredErrors.map((error, idx) => (
-          <Paragraph key={idx} fill>
-            {error.stack}
-          </Paragraph>
-        ))}
-      </Box>
-    </FlashMessage>
-  ) : null;
+  return <ErrorList errors={filteredErrors} />;
 };
 
 export default ErrorListTemplate;

--- a/src/components/UI/JSONSchemaForm/index.tsx
+++ b/src/components/UI/JSONSchemaForm/index.tsx
@@ -288,7 +288,14 @@ const JSONSchemaForm: React.FC<IJSONSchemaFormProps> = ({
         showErrorList={false}
         {...props}
       />
-      <ValidationStatus errors={ref.current?.state.errors ?? []} />
+      <ValidationStatus
+        formContext={{
+          ...formContext,
+          ...state,
+          errors: ref.current?.state.errors,
+          idConfigs,
+        }}
+      />
     </>
   );
 };

--- a/src/components/UI/JSONSchemaForm/index.tsx
+++ b/src/components/UI/JSONSchemaForm/index.tsx
@@ -7,6 +7,7 @@ import ArrayFieldTemplate from './ArrayFieldTemplate';
 import BaseInputTemplate from './BaseInputTemplate';
 import CheckboxWidget from './CheckboxWidget';
 import ErrorListTemplate from './ErrorListTemplate';
+import ValidationStatus from './ErrorListTemplate/ValidationStatus';
 import FieldErrorTemplate from './FieldErrorTemplate';
 import FieldTemplate from './FieldTemplate';
 import MultiSchemaField from './MultiSchemaField';
@@ -138,6 +139,7 @@ interface IJSONSchemaFormProps extends Omit<FormProps<RJSFSchema>, 'onChange'> {
 
 const JSONSchemaForm: React.FC<IJSONSchemaFormProps> = ({
   onChange,
+  onError,
   onBlur,
   idPrefix = 'root',
   idSeparator = '_',
@@ -230,11 +232,17 @@ const JSONSchemaForm: React.FC<IJSONSchemaFormProps> = ({
 
   const idConfigs: IIdConfigs = { idPrefix, idSeparator };
 
+  const ref = useRef<Form<RJSFSchema> | null>(null);
+
   const handleChange = (data: IChangeEvent<RJSFSchema>, id?: string) => {
     addTouchedField(id);
 
     if (data.formData) {
       onChangeCallback(data.formData, id);
+    }
+
+    if (onError && ref.current?.state.errors) {
+      onError(ref.current.state.errors);
     }
   };
 
@@ -247,36 +255,41 @@ const JSONSchemaForm: React.FC<IJSONSchemaFormProps> = ({
 
   const handleSubmitAttempted = (errors: RJSFValidationError[]) => {
     dispatch({ type: 'attemptSubmitAction', value: errors });
+    if (onError) {
+      onError(errors);
+    }
   };
 
-  const ref = useRef<Form<RJSFSchema> | null>(null);
-
   return (
-    <Form
-      fields={customFields}
-      widgets={customWidgets}
-      templates={customTemplates}
-      onChange={handleChange}
-      onBlur={handleBlur}
-      onError={handleSubmitAttempted}
-      formContext={{
-        ...formContext,
-        ...state,
-        errors: ref.current?.state.errors,
-        toggleTouchedFields,
-        idConfigs,
-      }}
-      transformErrors={transformErrors}
-      idSeparator={idConfigs.idSeparator}
-      idPrefix={idConfigs.idPrefix}
-      ref={ref}
-      noHtml5Validate
-      liveValidate
-      formData={formData}
-      schema={preprocessedSchema}
-      validator={validator}
-      {...props}
-    />
+    <>
+      <Form
+        fields={customFields}
+        widgets={customWidgets}
+        templates={customTemplates}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        onError={handleSubmitAttempted}
+        formContext={{
+          ...formContext,
+          ...state,
+          errors: ref.current?.state.errors,
+          toggleTouchedFields,
+          idConfigs,
+        }}
+        transformErrors={transformErrors}
+        idSeparator={idConfigs.idSeparator}
+        idPrefix={idConfigs.idPrefix}
+        ref={ref}
+        noHtml5Validate
+        liveValidate
+        formData={formData}
+        schema={preprocessedSchema}
+        validator={validator}
+        showErrorList={false}
+        {...props}
+      />
+      <ValidationStatus errors={ref.current?.state.errors ?? []} />
+    </>
   );
 };
 


### PR DESCRIPTION
### What does this PR do?

This PR improves the display of validation errors in the cluster creation form to align with the spec.

As the the default error list component from `react-json-schema-form` is only rendered when there are errors, we handle displaying the error list outside of the library's form component to allow displaying an `OK` status when there are no validation errors.

### How does it look like?
Validation OK (default state):
<img width="600" alt="Screenshot 2023-05-17 at 15 28 26" src="https://github.com/giantswarm/happa/assets/62935115/12e7ce75-1c58-4cc1-a4e2-e30974b8de51">

Tooltip displayed when hovering over the info icon displays more information regarding validation:
<img width="300" alt="Screenshot 2023-05-17 at 17 56 56" src="https://github.com/giantswarm/happa/assets/62935115/7e82060a-0b44-4d4a-885c-2e0876885260">

Error states:
<img width="650" alt="Screenshot 2023-05-17 at 13 49 52" src="https://github.com/giantswarm/happa/assets/62935115/3626fd2d-e03a-4abf-ba05-247f68c17dde">

<img width="650" alt="Screenshot 2023-05-17 at 13 49 22" src="https://github.com/giantswarm/happa/assets/62935115/a988d093-d7f7-4b1b-a268-89896db7ac0a">

The "Create cluster now" button is also displayed in a disabled state when there are validation errors:
<img width="600" alt="Screenshot 2023-05-17 at 18 02 42" src="https://github.com/giantswarm/happa/assets/62935115/ee41981f-fb03-4391-81e4-b90839cf94ae">

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2431.
