### PR TITLE
Add cluster creation progress UI

### DIFF
--- a/src/components/MAPI/clusters/Cluster.tsx
+++ b/src/components/MAPI/clusters/Cluster.tsx
@@ -17,15 +17,19 @@ const Cluster: React.FC<React.PropsWithChildren<{}>> = () => {
 
   return (
     <Switch>
-      <Route
-        component={
-          isAdmin && providerFlavor === ProviderFlavors.CAPI
-            ? CreateClusterAppBundles
-            : CreateCluster
-        }
-        exact
-        path={OrganizationsRoutes.Clusters.New}
-      />
+      {isAdmin && providerFlavor === ProviderFlavors.CAPI ? (
+        <Route
+          component={CreateClusterAppBundles}
+          exact
+          path={OrganizationsRoutes.Clusters.NewStatus}
+        />
+      ) : (
+        <Route
+          component={CreateCluster}
+          exact
+          path={OrganizationsRoutes.Clusters.New}
+        />
+      )}
       <Route
         path={OrganizationsRoutes.Clusters.GettingStarted.Overview}
         component={GettingStarted}

--- a/src/components/MAPI/clusters/CreateClusterAppBundles/CreateClusterStatus.tsx
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/CreateClusterStatus.tsx
@@ -1,0 +1,380 @@
+import { useAuthProvider } from 'Auth/MAPI/MapiAuthProvider';
+import { Box } from 'grommet';
+import { usePermissionsForApps } from 'MAPI/apps/permissions/usePermissionsForApps';
+import { findDefaultAppsBundle, getChildApps } from 'MAPI/apps/utils';
+import { Cluster, ControlPlaneNode } from 'MAPI/types';
+import {
+  extractErrorMessage,
+  fetchCluster,
+  fetchClusterKey,
+  fetchControlPlaneNodesForCluster,
+  fetchControlPlaneNodesForClusterKey,
+} from 'MAPI/utils';
+import { GenericResponseError } from 'model/clients/GenericResponseError';
+import { OrganizationsRoutes } from 'model/constants/routes';
+import * as applicationv1alpha1 from 'model/services/mapi/applicationv1alpha1';
+import * as metav1 from 'model/services/mapi/metav1';
+import { selectOrganizations } from 'model/stores/organization/selectors';
+import React, { useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { useRouteMatch } from 'react-router';
+import useSWR from 'swr';
+import Button from 'UI/Controls/Button';
+import ErrorMessage from 'UI/Display/ErrorMessage';
+import ClusterCreationStatusComponent, {
+  ClusterCreationStatus,
+} from 'UI/Display/MAPI/clusters/ClusterCreationStatus';
+import StatusList from 'UI/Display/StatusList';
+import StatusListItem from 'UI/Display/StatusList/StatusListItem';
+import { useHttpClientFactory } from 'utils/hooks/useHttpClientFactory';
+import RoutePath from 'utils/routePath';
+
+import { computeControlPlaneNodesStats } from '../ClusterDetail/utils';
+import { usePermissionsForClusters } from '../permissions/usePermissionsForClusters';
+import { usePermissionsForCPNodes } from '../permissions/usePermissionsForCPNodes';
+import { CLUSTER_CREATION_FORM_MAX_WIDTH } from '.';
+
+const CLUSTER_CREATION_PROGRESS_MAX_WIDTH = '650px';
+
+// eslint-disable-next-line no-magic-numbers
+const REFRESH_INTERVAL = 10 * 1000; // 10 seconds
+
+function getStatusComponent(
+  status: ClusterCreationStatus,
+  totalCount?: number,
+  readyCount?: number
+) {
+  return (
+    <ClusterCreationStatusComponent
+      status={status}
+      totalCount={totalCount}
+      readyCount={readyCount}
+    />
+  );
+}
+
+function getClusterAppCreatedStatus(clusterApp?: applicationv1alpha1.IApp) {
+  const status = clusterApp
+    ? ClusterCreationStatus.Ok
+    : ClusterCreationStatus.Waiting;
+
+  return getStatusComponent(status);
+}
+
+function getClusterCreatedStatus(
+  cluster?: Cluster,
+  clusterApp?: applicationv1alpha1.IApp
+) {
+  const status = cluster
+    ? ClusterCreationStatus.Ok
+    : clusterApp
+    ? ClusterCreationStatus.InProgress
+    : ClusterCreationStatus.Waiting;
+
+  return getStatusComponent(status);
+}
+
+function getControlPlaneReadyStatus(
+  cluster?: Cluster,
+  controlPlaneNodes: ControlPlaneNode[] = []
+) {
+  const stats = computeControlPlaneNodesStats(controlPlaneNodes);
+
+  const status =
+    stats.readyCount > 0
+      ? ClusterCreationStatus.Ok
+      : cluster
+      ? ClusterCreationStatus.InProgress
+      : ClusterCreationStatus.Waiting;
+
+  return getStatusComponent(status);
+}
+
+function getClusterAppDeployedStatus(clusterApp?: applicationv1alpha1.IApp) {
+  if (typeof clusterApp === 'undefined') {
+    return getStatusComponent(ClusterCreationStatus.Waiting);
+  }
+
+  const appStatus = applicationv1alpha1.getAppStatus(clusterApp);
+
+  const status =
+    appStatus === applicationv1alpha1.statusDeployed
+      ? ClusterCreationStatus.Ok
+      : appStatus === applicationv1alpha1.statusFailed
+      ? ClusterCreationStatus.Failed
+      : ClusterCreationStatus.InProgress;
+
+  return getStatusComponent(status);
+}
+
+function getDefaultAppsDeployedStatus(appList?: applicationv1alpha1.IAppList) {
+  if (typeof appList === 'undefined') {
+    return getStatusComponent(ClusterCreationStatus.Waiting);
+  }
+
+  const provider = window.config.info.general.provider;
+  const defaultAppsBundle = findDefaultAppsBundle(appList.items, provider);
+  if (typeof defaultAppsBundle === 'undefined') {
+    return getStatusComponent(ClusterCreationStatus.Waiting);
+  }
+
+  const childApps = getChildApps(appList.items, defaultAppsBundle);
+  const deployedApps = childApps.filter((app) => {
+    const appStatus = applicationv1alpha1.getAppStatus(app);
+
+    return appStatus === applicationv1alpha1.statusDeployed;
+  });
+
+  if (deployedApps.length > 0 && deployedApps.length === childApps.length) {
+    return getStatusComponent(ClusterCreationStatus.Ok);
+  }
+
+  if (deployedApps.length > 0) {
+    return getStatusComponent(
+      ClusterCreationStatus.InProgress,
+      childApps.length,
+      deployedApps.length
+    );
+  }
+
+  return getStatusComponent(ClusterCreationStatus.InProgress);
+}
+
+interface ICreateClusterAppBundlesStatusProps {}
+
+const CreateClusterAppBundlesStatus: React.FC<
+  React.PropsWithChildren<ICreateClusterAppBundlesStatusProps>
+> = ({ ...props }) => {
+  const match = useRouteMatch<{
+    orgId: string;
+    clusterId: string;
+  }>();
+  const { orgId, clusterId } = match.params;
+  const organizations = useSelector(selectOrganizations());
+  const selectedOrg = orgId ? organizations[orgId] : undefined;
+
+  const provider = window.config.info.general.provider;
+
+  const namespace = selectedOrg?.namespace ?? '';
+
+  const clientFactory = useHttpClientFactory();
+  const auth = useAuthProvider();
+
+  const appsPermissions = usePermissionsForApps(provider, namespace, true);
+  const clusterAppClient = useRef(clientFactory());
+  const clusterAppKey = appsPermissions.canGet
+    ? applicationv1alpha1.getAppKey(namespace, clusterId)
+    : null;
+  const { data: clusterApp, error: clusterAppError } = useSWR<
+    applicationv1alpha1.IApp,
+    GenericResponseError
+  >(
+    clusterAppKey,
+    () =>
+      applicationv1alpha1.getApp(
+        clusterAppClient.current,
+        auth,
+        namespace,
+        clusterId
+      ),
+    {
+      refreshInterval: (latestData) => {
+        if (typeof latestData === 'undefined') {
+          return REFRESH_INTERVAL;
+        }
+
+        const appStatus = applicationv1alpha1.getAppStatus(latestData);
+
+        return appStatus === applicationv1alpha1.statusFailed ||
+          appStatus === applicationv1alpha1.statusDeployed
+          ? 0
+          : REFRESH_INTERVAL;
+      },
+    }
+  );
+
+  const clusterPermissions = usePermissionsForClusters(provider, namespace);
+  const clusterKey =
+    clusterApp && clusterPermissions.canGet
+      ? fetchClusterKey(provider, namespace, clusterId)
+      : null;
+
+  const { data: cluster, error: clusterError } = useSWR<
+    Cluster,
+    GenericResponseError
+  >(
+    clusterKey,
+    () => fetchCluster(clientFactory, auth, provider, namespace, clusterId),
+    {
+      refreshInterval: (latestData) => {
+        return typeof latestData === 'undefined' ? REFRESH_INTERVAL : 0;
+      },
+    }
+  );
+
+  const { canList } = usePermissionsForCPNodes(
+    provider,
+    cluster?.metadata.namespace ?? ''
+  );
+
+  const controlPlaneNodesKey =
+    cluster && canList ? fetchControlPlaneNodesForClusterKey(cluster) : null;
+
+  const { data: controlPlaneNodes, error: controlPlaneNodesError } = useSWR<
+    ControlPlaneNode[],
+    GenericResponseError
+  >(
+    controlPlaneNodesKey,
+    () => fetchControlPlaneNodesForCluster(clientFactory, auth, cluster!),
+    {
+      refreshInterval: (latestData) => {
+        if (typeof latestData === 'undefined') {
+          return REFRESH_INTERVAL;
+        }
+
+        return cluster?.status?.controlPlaneReady === true
+          ? 0
+          : REFRESH_INTERVAL;
+      },
+    }
+  );
+
+  const appListClient = useRef(clientFactory());
+  const appListGetOptions = {
+    namespace,
+    labelSelector: {
+      matchingLabels: {
+        [applicationv1alpha1.labelCluster]: clusterId,
+      },
+    },
+  };
+
+  const appListKey = appsPermissions.canList
+    ? applicationv1alpha1.getAppListKey(appListGetOptions)
+    : null;
+
+  const { data: appList, error: appListError } = useSWR<
+    applicationv1alpha1.IAppList,
+    GenericResponseError
+  >(
+    appListKey,
+    () =>
+      applicationv1alpha1.getAppList(
+        appListClient.current,
+        auth,
+        appListGetOptions
+      ),
+    {
+      refreshInterval: (latestData) => {
+        if (
+          typeof latestData === 'undefined' ||
+          typeof latestData.items === 'undefined'
+        ) {
+          return REFRESH_INTERVAL;
+        }
+
+        const notDeployedApps = latestData.items.filter((app) => {
+          const appStatus = applicationv1alpha1.getAppStatus(app);
+
+          return appStatus !== applicationv1alpha1.statusDeployed;
+        });
+
+        return notDeployedApps.length > 0 ? REFRESH_INTERVAL : 0;
+      },
+    }
+  );
+
+  const clusterAppCreated = getClusterAppCreatedStatus(clusterApp);
+  const clusterCreated = getClusterCreatedStatus(cluster, clusterApp);
+  const controlPlaneReady = getControlPlaneReadyStatus(
+    cluster,
+    controlPlaneNodes
+  );
+  const clusterAppDeployed = getClusterAppDeployedStatus(clusterApp);
+  const defaultAppsDeployed = getDefaultAppsDeployedStatus(appList);
+
+  const clusterPath = useMemo(() => {
+    if (!orgId || !clusterId) return '';
+
+    return RoutePath.createUsablePath(
+      OrganizationsRoutes.Clusters.Detail.Home,
+      { orgId, clusterId }
+    );
+  }, [orgId, clusterId]);
+
+  const error = useMemo(() => {
+    const errors = [
+      clusterAppError,
+      clusterError,
+      controlPlaneNodesError,
+      appListError,
+    ].filter((err) => {
+      return (
+        err &&
+        !metav1.isStatusError(err.data, metav1.K8sStatusErrorReasons.NotFound)
+      );
+    });
+
+    return errors.length > 0 ? errors[0] : undefined;
+  }, [clusterAppError, clusterError, controlPlaneNodesError, appListError]);
+
+  return (
+    <Box {...props}>
+      <Box
+        width={{ max: CLUSTER_CREATION_PROGRESS_MAX_WIDTH }}
+        margin={{ bottom: 'medium' }}
+      >
+        <StatusList>
+          <StatusListItem status={clusterAppCreated}>
+            Cluster app resources created
+          </StatusListItem>
+          <StatusListItem status={clusterCreated}>
+            Cluster resource created
+          </StatusListItem>
+          <StatusListItem status={controlPlaneReady}>
+            Control plane ready
+          </StatusListItem>
+          <StatusListItem status={clusterAppDeployed}>
+            Cluster app bundle deployed
+          </StatusListItem>
+          <StatusListItem status={defaultAppsDeployed}>
+            Default apps bundle deployed
+          </StatusListItem>
+        </StatusList>
+      </Box>
+
+      {error && (
+        <Box
+          border={{ side: 'top' }}
+          margin={{ top: 'medium' }}
+          pad={{ top: 'medium' }}
+        >
+          <ErrorMessage
+            width={{ max: CLUSTER_CREATION_FORM_MAX_WIDTH }}
+            details={extractErrorMessage(error)}
+          >
+            An error occurred during creation of the cluster. If you want to
+            contact Giant Swarm support for assistance, please provide the
+            details given below.
+          </ErrorMessage>
+        </Box>
+      )}
+
+      <Box
+        border={{ side: 'top' }}
+        margin={{ top: 'medium' }}
+        pad={{ top: 'medium' }}
+      >
+        <Button
+          href={clusterPath}
+          primary={true}
+          disabled={typeof cluster === 'undefined'}
+        >
+          Show cluster details
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default CreateClusterAppBundlesStatus;

--- a/src/components/UI/Display/ErrorMessage/index.tsx
+++ b/src/components/UI/Display/ErrorMessage/index.tsx
@@ -1,0 +1,54 @@
+import { Box, BoxProps, Paragraph, Text } from 'grommet';
+import React from 'react';
+import styled from 'styled-components';
+import { FlashMessageType } from 'styles';
+import FlashMessage from 'UI/Display/FlashMessage';
+
+const StyledFlashMessage = styled(FlashMessage)`
+  code {
+    display: inline-block;
+    color: inherit;
+    font-size: inherit;
+    background-color: transparent;
+    padding: 0;
+    margin: 0;
+    border-radius: 0;
+  }
+`;
+
+interface IErrorMessageProps extends BoxProps {
+  title?: string;
+  error?: string;
+  details?: string;
+}
+
+const ErrorMessage: React.FC<React.PropsWithChildren<IErrorMessageProps>> = ({
+  title,
+  error,
+  details,
+  children,
+  ...props
+}) => {
+  return (
+    <Box {...props}>
+      <Box direction='row' gap='xsmall' align='baseline'>
+        <i className='fa fa-warning' aria-hidden={true} role='presentation' />
+        <Text>{children}</Text>
+      </Box>
+      <Box margin={{ top: 'medium' }}>
+        <StyledFlashMessage type={FlashMessageType.Danger}>
+          {error ? (
+            <Paragraph fill dangerouslySetInnerHTML={{ __html: `${error}:` }} />
+          ) : null}
+          {details ? (
+            <Paragraph fill margin='none'>
+              <code>{details}</code>
+            </Paragraph>
+          ) : null}
+        </StyledFlashMessage>
+      </Box>
+    </Box>
+  );
+};
+
+export default ErrorMessage;

--- a/src/components/UI/Display/MAPI/clusters/ClusterCreationStatus/index.tsx
+++ b/src/components/UI/Display/MAPI/clusters/ClusterCreationStatus/index.tsx
@@ -1,0 +1,98 @@
+import { Box, Image, Text } from 'grommet';
+import { spinner } from 'images';
+import React from 'react';
+import styled from 'styled-components';
+
+const Icon = styled(Text)`
+  line-height: 20px;
+`;
+
+export enum ClusterCreationStatus {
+  Waiting = 'WAITING',
+  Ok = 'OK',
+  Failed = 'FAILED',
+  InProgress = 'IN_PROGRESS',
+}
+
+function formatStatus(
+  status: ClusterCreationStatus,
+  totalCount?: number,
+  readyCount?: number
+) {
+  switch (status) {
+    case ClusterCreationStatus.Waiting:
+      return 'Waiting';
+    case ClusterCreationStatus.Ok:
+      return 'OK';
+    case ClusterCreationStatus.Failed:
+      return 'Failed';
+    case ClusterCreationStatus.InProgress:
+      return typeof totalCount !== 'undefined' &&
+        typeof readyCount !== 'undefined'
+        ? `${readyCount} of ${totalCount}`
+        : 'In progress';
+    default:
+      return '';
+  }
+}
+
+interface IClusterCreationStatusProps {
+  status: ClusterCreationStatus;
+  totalCount?: number;
+  readyCount?: number;
+}
+
+const ClusterCreationStatusComponent: React.FC<IClusterCreationStatusProps> = ({
+  status,
+  totalCount,
+  readyCount,
+}) => {
+  let statusEl = <Text>{formatStatus(status)}</Text>;
+
+  if (status === ClusterCreationStatus.Ok) {
+    statusEl = (
+      <Box direction='row'>
+        <Icon
+          color='text-success'
+          className='fa fa-done'
+          role='presentation'
+          aria-hidden='true'
+          size='28px'
+          margin={{ right: '4px' }}
+        />
+        <Text color='text-success'>{formatStatus(status)}</Text>
+      </Box>
+    );
+  }
+
+  if (status === ClusterCreationStatus.Failed) {
+    statusEl = (
+      <Box direction='row'>
+        <Icon
+          color='text-error'
+          className='fa fa-close'
+          role='presentation'
+          aria-hidden='true'
+          size='30px'
+          margin={{ right: '4px' }}
+        />
+        <Text color='text-error'>{formatStatus(status)}</Text>
+      </Box>
+    );
+  }
+
+  if (status === ClusterCreationStatus.InProgress) {
+    statusEl = (
+      <Box direction='row'>
+        <Box height='20px' width='20px' margin={{ left: '5px', right: '9px' }}>
+          <Image src={spinner} className='loader' />
+        </Box>
+        <Text>{formatStatus(status, totalCount, readyCount)}</Text>
+      </Box>
+    );
+  }
+
+  return <Box width={{ min: '110px' }}>{statusEl}</Box>;
+};
+
+export default ClusterCreationStatusComponent;

--- a/src/components/UI/Display/StatusList/StatusListItem.tsx
+++ b/src/components/UI/Display/StatusList/StatusListItem.tsx
@@ -1,0 +1,66 @@
+import { Box, Text } from 'grommet';
+import { normalizeColor } from 'grommet/utils';
+import React from 'react';
+import styled from 'styled-components';
+import { Tooltip, TooltipContainer } from 'UI/Display/Tooltip';
+
+const Line = styled.div`
+  position: relative;
+  flex: 1;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 6px;
+    right: 12px;
+    bottom: 4px;
+    height: 1px;
+    background-color: ${({ theme }) => normalizeColor('border-xweak', theme)};
+  }
+`;
+
+const Icon = styled(Text)`
+  font-size: 18px;
+  line-height: 20px;
+`;
+
+interface IStatusListItemProps {
+  status: React.ReactNode;
+  info?: string;
+}
+
+const StatusListItem: React.FC<
+  React.PropsWithChildren<IStatusListItemProps>
+> = ({ status, info, children }) => {
+  return (
+    <Box direction='row'>
+      <Text>{children}</Text>
+      {info ? (
+        <TooltipContainer
+          content={
+            <Tooltip>
+              <Text
+                size='xsmall'
+                color='text-strong'
+                textAlign='center'
+                wordBreak='break-word'
+              >
+                {info}
+              </Text>
+            </Tooltip>
+          }
+        >
+          <Icon
+            className='fa fa-info'
+            aria-label='info'
+            margin={{ left: '5px' }}
+          />
+        </TooltipContainer>
+      ) : null}
+      <Line />
+      {status}
+    </Box>
+  );
+};
+
+export default StatusListItem;

--- a/src/components/UI/Display/StatusList/index.tsx
+++ b/src/components/UI/Display/StatusList/index.tsx
@@ -1,0 +1,29 @@
+import { Box, BoxProps, Heading } from 'grommet';
+import React from 'react';
+import styled from 'styled-components';
+
+const Title = styled(Heading)`
+  font-size: 18px;
+  line-height: 22px;
+`;
+
+interface IClusterCreationProgressProps extends BoxProps {
+  title?: string;
+}
+
+const StatusList: React.FC<
+  React.PropsWithChildren<IClusterCreationProgressProps>
+> = ({ title, children, ...props }) => {
+  return (
+    <Box {...props}>
+      {title ? (
+        <Title level='4' fill margin={{ top: 'none', bottom: '28px' }}>
+          {title}
+        </Title>
+      ) : null}
+      <Box gap='medium'>{children}</Box>
+    </Box>
+  );
+};
+
+export default StatusList;

--- a/src/model/constants/routes.ts
+++ b/src/model/constants/routes.ts
@@ -42,6 +42,7 @@ const OrganizationsRoutes = {
   Clusters: {
     Home: '/organizations/:orgId/clusters',
     New: '/organizations/:orgId/clusters/new',
+    NewStatus: '/organizations/:orgId/clusters/new/:clusterId?',
     Detail: {
       Home: '/organizations/:orgId/clusters/:clusterId',
       KeyPairs: '/organizations/:orgId/clusters/:clusterId/keypairs',

--- a/src/model/services/mapi/applicationv1alpha1/createApp.ts
+++ b/src/model/services/mapi/applicationv1alpha1/createApp.ts
@@ -17,5 +17,12 @@ export function createApp(
     namespace: app.metadata.namespace!,
   });
 
-  return createResource<IApp>(client, auth, url.toString(), app);
+  return createResource<IApp>(client, auth, url.toString(), app).catch((err) =>
+    Promise.reject(
+      new Error(
+        `App resource named ${app.metadata.name} in namespace ${app.metadata.namespace}`,
+        { cause: err }
+      )
+    )
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2081,7 +2081,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.21.0":
+"@babel/runtime@^7.21.0", "@babel/runtime@^7.3.1":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
   integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==


### PR DESCRIPTION
### What does this PR do?

Cluster creation progress UI was added to the cluster creation flow.

Node pools section that is present in the specs was not implemented in this version. It would require additional investigation and could be implemented in a separate PR.

Error handling implementation is a little bit different from the specs - if an error happens during the initial app resources creation (on form submit), it's being displayed immediately on the form page, above the submit button, and redirection to the progress step doesn't happen. All other errors are being displayed on the progress page, according to the specs.

### How does it look like?

<img width="809" alt="Screenshot 2023-05-19 at 13 16 14" src="https://github.com/giantswarm/happa/assets/445309/a4cccf58-51a3-4552-a1d4-296d05709e77">

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2431.
