### PR TITLE
Payload cleaning fix

### DIFF
--- a/src/components/UI/JSONSchemaForm/__tests__/schemaUtils.ts
+++ b/src/components/UI/JSONSchemaForm/__tests__/schemaUtils.ts
@@ -253,11 +253,11 @@ describe('JSONSchemaForm:schemaUtils', () => {
                       type: 'string',
                       title: 'Key',
                     },
-                    age: {
-                      type: ['number', 'null'],
-                    },
-                    name: {
+                    instanceType: {
                       type: 'string',
+                    },
+                    minSize: {
+                      type: ['number', 'null'],
                     },
                   },
                 },
@@ -378,11 +378,11 @@ describe('JSONSchemaForm:schemaUtils', () => {
                       title: 'Key',
                       pattern: '^[a-z]{5,10}$',
                     },
-                    age: {
-                      type: ['number', 'null'],
-                    },
-                    name: {
+                    instanceType: {
                       type: 'string',
+                    },
+                    minSize: {
+                      type: ['number', 'null'],
                     },
                   },
                 },
@@ -459,11 +459,11 @@ describe('JSONSchemaForm:schemaUtils', () => {
                       title: 'Key',
                       pattern: '^[a-z]{5,10}$',
                     },
-                    age: {
-                      type: ['number', 'null'],
-                    },
-                    name: {
+                    instanceType: {
                       type: 'string',
+                    },
+                    minSize: {
+                      type: ['number', 'null'],
                     },
                   },
                 },
@@ -652,11 +652,11 @@ function createTestSchema(fieldsToPick: string[] = []) {
             additionalProperties: {
               type: 'object',
               properties: {
-                age: {
-                  type: 'number',
-                },
-                name: {
+                instanceType: {
                   type: 'string',
+                },
+                minSize: {
+                  type: 'number',
                 },
               },
             },
@@ -714,11 +714,11 @@ function createTestSchema(fieldsToPick: string[] = []) {
               '^[a-z]{5,10}$': {
                 type: 'object',
                 properties: {
-                  age: {
-                    type: 'number',
-                  },
-                  name: {
+                  instanceType: {
                     type: 'string',
+                  },
+                  minSize: {
+                    type: 'number',
                   },
                 },
               },
@@ -741,11 +741,11 @@ function createTestSchema(fieldsToPick: string[] = []) {
               '^[a-z]{5,10}$': {
                 type: 'object',
                 properties: {
-                  age: {
-                    type: 'number',
-                  },
-                  name: {
+                  instanceType: {
                     type: 'string',
+                  },
+                  minSize: {
+                    type: 'number',
                   },
                 },
               },

--- a/src/components/UI/JSONSchemaForm/utils.ts
+++ b/src/components/UI/JSONSchemaForm/utils.ts
@@ -1,5 +1,6 @@
 import {
   findSchemaDefinition,
+  mergeObjects,
   RJSFSchema,
   RJSFValidationError,
 } from '@rjsf/utils';
@@ -216,7 +217,9 @@ function getValueSchema(
     typeof valueSchema !== 'boolean' &&
     valueSchema.$ref
   ) {
-    return findSchemaDefinition(valueSchema.$ref, rootSchema);
+    const refSchema = findSchemaDefinition(valueSchema.$ref, rootSchema);
+
+    return mergeObjects(refSchema, valueSchema);
   }
 
   return valueSchema;

--- a/src/components/UI/JSONSchemaForm/utils.ts
+++ b/src/components/UI/JSONSchemaForm/utils.ts
@@ -176,28 +176,6 @@ function getDefaultValueFromParent(
   return defaultValues?.[key as keyof typeof defaultValues];
 }
 
-function getDefaultValueFromSchema(schema: RJSFSchema, rootSchema: RJSFSchema) {
-  if (typeof schema.default === 'undefined') {
-    return undefined;
-  }
-
-  if (Array.isArray(schema.default) || isPlainObject(schema.default)) {
-    return cleanPayload(
-      schema.default,
-      {
-        ...schema,
-        default: undefined,
-      },
-      rootSchema,
-      {
-        cleanDefaultValues: true,
-      }
-    );
-  }
-
-  return schema.default;
-}
-
 function getValueSchema(
   key: number,
   schema: RJSFSchema,
@@ -271,10 +249,7 @@ export function cleanPayload(
         defaultValues,
         objectSchema
       );
-      const defaultValueFromSchema = getDefaultValueFromSchema(
-        valueSchema,
-        rootSchema
-      );
+      const defaultValueFromSchema = valueSchema.default;
       const implicitDefaultValue = getImplicitDefaultValue(valueSchema);
 
       const defaultValue =


### PR DESCRIPTION
### What does this PR do?

In our implementation we clean up generated form data from the default values. The way how the default values are being populated into the form data was changed in the [5.7.0](https://github.com/rjsf-team/react-jsonschema-form/releases/tag/v5.7.0) release of the `react-jsonschema-form` library. It broke our cleanup function. In this PR several improvements were made:
- implicit default values ('', [], {}, false, etc.) are being deleted from the schema during the schema preprocessing step.
- additional check for default values of array properties were added.
- when there is a referenced schema for a property, it's being merged with "local" schema. Otherwise default values were missing when they were overridden in local schema.

### How does it look like?

Broken user config before:
<img width="660" alt="Screenshot 2023-06-02 at 17 46 55" src="https://github.com/giantswarm/happa/assets/445309/133db1e7-5fb0-4466-ac12-de9f1230100d">

After:
<img width="661" alt="Screenshot 2023-06-02 at 17 50 07" src="https://github.com/giantswarm/happa/assets/445309/4c35baf1-ee87-45fa-a523-bdb297c9a8c4">

### Any background context you can provide?
Towards https://github.com/giantswarm/roadmap/issues/1181.
