### PR TITLE
Align ui-schemas

### DIFF
--- a/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
@@ -90,9 +90,6 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
       'cluster-shared': {
         'ui:widget': 'hidden',
       },
-      defaultMachinePools: {
-        'ui:widget': 'hidden',
-      },
       kubectlImage: {
         'ui:widget': 'hidden',
       },
@@ -103,6 +100,13 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
         'ui:order': ['name', 'description', '*'],
         name: {
           'ui:widget': ClusterNameWidget,
+        },
+      },
+      nodePools: {
+        items: {
+          instanceType: {
+            'ui:widget': InstanceTypeWidget,
+          },
         },
       },
       provider: {
@@ -194,6 +198,13 @@ const formPropsProviderCAPZ: Record<string, FormPropsPartial> = {
         },
         organization: {
           'ui:widget': 'hidden',
+        },
+      },
+      nodePools: {
+        items: {
+          instanceType: {
+            'ui:widget': InstanceTypeWidget,
+          },
         },
       },
       provider: {

--- a/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
@@ -236,7 +236,7 @@ const formPropsProviderCloudDirector: Record<string, FormPropsPartial> = {
         '*',
       ],
     },
-    formData: (organization) => {
+    formData: (_clusterName, organization) => {
       return {
         organization,
       };
@@ -341,7 +341,7 @@ const formPropsTest: Record<string, FormPropsPartial> = {
         ],
       },
     },
-    formData: (_organization) => {
+    formData: (_clusterName, _organization) => {
       return {};
     },
   },

--- a/src/components/UI/JSONSchemaForm/utils.ts
+++ b/src/components/UI/JSONSchemaForm/utils.ts
@@ -125,7 +125,7 @@ export const DEFAULT_NUMERIC_VALUE = null;
 export const DEFAULT_ARRAY_VALUE = [];
 export const DEFAULT_OBJECT_VALUE = {};
 
-function isNumeric(schema: RJSFSchema) {
+function isNumericSchema(schema: RJSFSchema) {
   return Boolean(
     schema.type === 'integer' ||
       schema.type?.includes('integer') ||
@@ -134,17 +134,33 @@ function isNumeric(schema: RJSFSchema) {
   );
 }
 
+function isStringSchema(schema: RJSFSchema) {
+  return Boolean(schema.type === 'string' || schema.type?.includes('string'));
+}
+
+function isBooleanSchema(schema: RJSFSchema) {
+  return Boolean(schema.type === 'boolean' || schema.type?.includes('boolean'));
+}
+
+function isObjectSchema(schema: RJSFSchema) {
+  return Boolean(schema.type === 'object' || schema.type?.includes('object'));
+}
+
+function isArraySchema(schema: RJSFSchema) {
+  return Boolean(schema.type === 'array' || schema.type?.includes('array'));
+}
+
 function getImplicitDefaultValue(schema: RJSFSchema) {
   switch (true) {
-    case schema.type === 'string':
+    case isStringSchema(schema):
       return DEFAULT_STRING_VALUE;
-    case isNumeric(schema):
+    case isNumericSchema(schema):
       return DEFAULT_NUMERIC_VALUE;
-    case schema.type === 'boolean':
+    case isBooleanSchema(schema):
       return DEFAULT_BOOLEAN_VALUE;
-    case schema.type === 'array':
+    case isArraySchema(schema):
       return DEFAULT_ARRAY_VALUE;
-    case schema.type === 'object':
+    case isObjectSchema(schema):
       return DEFAULT_OBJECT_VALUE;
     default:
       return undefined;
@@ -305,7 +321,7 @@ export function cleanPayload(
       } else {
         const cleanValue = cleanDeep({ value: newValue }, options).value;
         newValue = value;
-        if (isNumeric(valueSchema)) {
+        if (isNumericSchema(valueSchema)) {
           newValue = value === null && defaultValue !== null ? 0 : value;
         }
 


### PR DESCRIPTION
### What does this PR do?

Several UI schemas were not in sync with corresponding provider schemas. In this PR:
- `defaultMachinePools` setting was deleted from uiSchema for CAPA;
- UI schemas for CAPA and CAPZ were changed to use custom instance type selector in `nodePools` settings.

Additionally, the way we check schema type was improved to allow using multiple types, e.g. `["string", null]`. Previously we only checked it for numeric values, but it also in use in Cloud Director schema:

```
"kubeadm": {
      "type": [
            "null",
            "object"
      ],
      ...
},
```

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/2511.
