### PR TITLE
Update docs URL for GitOps icon

### DIFF
--- a/src/model/constants/docs.ts
+++ b/src/model/constants/docs.ts
@@ -118,7 +118,7 @@ export const labellingWorkloadClustersURL =
 
 // GitOps restrictions in the web UI
 export const gitopsRestrictions =
-  'https://docs.giantswarm.io/advanced/gitops/#web-ui-restrictions';
+  'https://docs.giantswarm.io/advanced/gitops/manage-workload-clusters/#web-ui-restrictions';
 
 // CRD names we expect to find a docs schema page for,
 // grouped by publisher domain.


### PR DESCRIPTION
### What does this PR do?

Updates the docs URL that we use when indicating that a cluster is managed via gitops.

### What is the effect of this change to users?

The user will land on the page with the relevant content section. Currently, the user gets sent to the Gitops overview page https://docs.giantswarm.io/advanced/gitops/#web-ui-restrictions by redirection.

### How does it look like?

No visible change

### Any background context you can provide?

n/a

### Should this change be mentioned in the release notes?

If yes, please apply one of the following labels: `kind/feature`, `kind/change`, `kind/bug`, `kind/removal`, `kind/ux-enhancement`, `kind/security`
