### PR TITLE
Apps: Remove exceptions for `nginx-ingress-controller-app`.

### DIFF
--- a/__tests__/Apps.js
+++ b/__tests__/Apps.js
@@ -230,8 +230,6 @@ describe('Apps and App Catalog', () => {
     });
 
     it('installs an app in a cluster, with custom settings', async () => {
-      const testApp = 'nginx-ingress-controller-app';
-
       const installAppResponse = {
         code: 'RESOURCE_CREATED',
         message: `We're installing your app called 'test-app' on ${V4_CLUSTER.id}`,
@@ -241,7 +239,7 @@ describe('Apps and App Catalog', () => {
           spec: {
             catalog: 'giantswarm-incubator',
             name: 'nginx-ingress-controller-app',
-            namespace: 'kube-system',
+            namespace: 'test-app',
             version: '1.1.1',
           },
         })
@@ -273,7 +271,7 @@ describe('Apps and App Catalog', () => {
         AppsRoutes.AppDetail,
         {
           catalogName: 'giantswarm-incubator',
-          app: testApp,
+          app: 'nginx-ingress-controller-app',
           version: '1.1.1',
         }
       );

--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppForm.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppForm.tsx
@@ -1,12 +1,11 @@
 import { Box, FormField } from 'grommet';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import VersionPicker from 'UI/Controls/VersionPicker/VersionPicker';
 import { IVersion } from 'UI/Controls/VersionPicker/VersionPickerUtils';
 import FileInput from 'UI/Inputs/FileInput';
 import TextInput from 'UI/Inputs/TextInput';
 
 interface IInstallAppFormProps {
-  appName: string;
   name: string;
   nameError: string;
   namespace: string;
@@ -31,7 +30,6 @@ const InstallAppForm: React.FC<
   onChangeValuesYAML,
   onChangeSecretsYAML,
   onChangeVersion,
-  appName,
   name,
   nameError,
   version,
@@ -77,26 +75,6 @@ const InstallAppForm: React.FC<
     [onChangeNamespace]
   );
 
-  const [formAbilities, setFormAbilities] = useState({
-    hasFixedNamespace: false,
-    appNamespace: '',
-  });
-
-  useEffect(() => {
-    let appNamespace = '';
-
-    // Some apps have special rules about what namespace they are allowed to be in.
-    if (appName === 'nginx-ingress-controller-app') {
-      appNamespace = 'kube-system';
-      updateNamespace(appNamespace);
-    }
-
-    setFormAbilities({
-      hasFixedNamespace: false,
-      appNamespace,
-    });
-  }, [appName, updateNamespace]);
-
   return (
     <Box direction='column' gap='small' height={{ min: 'fit-content' }}>
       <TextInput
@@ -127,17 +105,7 @@ const InstallAppForm: React.FC<
         />
       </FormField>
 
-      {isAppBundle ? null : formAbilities.hasFixedNamespace ? (
-        <TextInput
-          help={`This app must be installed in the ${formAbilities.appNamespace} namespace`}
-          key='fixed-namespace'
-          label='Namespace'
-          id='fixed-namespace'
-          readOnly={true}
-          value={formAbilities.appNamespace}
-          margin={{ bottom: 'large' }}
-        />
-      ) : (
+      {isAppBundle ? null : (
         <TextInput
           help='We recommend that you create a dedicated namespace. The namespace will be created if it does not exist yet.'
           key='dedicated-namespace'

--- a/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
+++ b/src/components/Apps/AppDetail/InstallAppModal/InstallAppModal.tsx
@@ -355,7 +355,6 @@ const InstallAppModal: React.FC<
                 visible={visible}
               >
                 <InstallAppForm
-                  appName={props.app.name}
                   name={name}
                   nameError={nameError}
                   namespace={namespace}

--- a/src/components/MAPI/apps/AppInstallModal.tsx
+++ b/src/components/MAPI/apps/AppInstallModal.tsx
@@ -507,7 +507,6 @@ const AppInstallModal: React.FC<
         auth,
         selectedClusterID,
         selectedClusterNamespace,
-        isClusterApp,
         {
           name: name,
           catalogName: catalogName,
@@ -704,7 +703,6 @@ const AppInstallModal: React.FC<
                 visible={visible}
               >
                 <InstallAppForm
-                  appName={appName}
                   name={name}
                   nameError={nameError}
                   namespace={namespace}

--- a/src/components/MAPI/apps/__tests__/utils.ts
+++ b/src/components/MAPI/apps/__tests__/utils.ts
@@ -131,7 +131,6 @@ describe('utils', () => {
         authProvider,
         'some-cluster',
         'some-cluster',
-        false,
         {
           name: 'cool-app',
           namespace: 'cool-app-ns',
@@ -200,7 +199,6 @@ describe('utils', () => {
         authProvider,
         'some-cluster',
         'some-cluster',
-        false,
         {
           name: 'cool-app',
           namespace: 'cool-app-ns',
@@ -253,7 +251,6 @@ describe('utils', () => {
         authProvider,
         'some-cluster',
         'some-cluster',
-        false,
         {
           name: 'cool-app',
           namespace: 'cool-app-ns',

--- a/src/components/MAPI/apps/utils.ts
+++ b/src/components/MAPI/apps/utils.ts
@@ -51,15 +51,7 @@ function getUserSecretName(appName: string): string {
   return `${appName}-user-secrets`;
 }
 
-export function getClusterConfigMapName(
-  clusterID: string,
-  appName?: string,
-  isClusterApp?: boolean
-): string {
-  if (appName === 'nginx-ingress-controller-app' && !isClusterApp) {
-    return 'ingress-controller-values';
-  }
-
+export function getClusterConfigMapName(clusterID: string): string {
   return `${clusterID}-cluster-values`;
 }
 
@@ -225,15 +217,9 @@ export async function createApp(
   auth: IOAuth2Provider,
   clusterID: string,
   appsNamespace: string,
-  isClusterApp: boolean,
   appConfig: IAppConfig
 ): Promise<applicationv1alpha1.IApp> {
-  const clusterConfigMapName = getClusterConfigMapName(
-    clusterID,
-    appConfig.chartName,
-    isClusterApp
-  );
-
+  const clusterConfigMapName = getClusterConfigMapName(clusterID);
   const kubeConfigSecretName = getKubeConfigSecretName(clusterID);
 
   const app: applicationv1alpha1.IApp = {
@@ -785,26 +771,19 @@ export function createIngressApp(
   isClusterApp: boolean,
   ingressAppCatalogEntry: applicationv1alpha1.IAppCatalogEntry
 ) {
-  return createApp(
-    clientFactory,
-    auth,
-    clusterID,
-    appsNamespace,
-    isClusterApp,
-    {
-      name: generateAppResourceName(
-        ingressAppCatalogEntry.spec.appName,
-        clusterID,
-        isClusterApp
-      ),
-      catalogName: ingressAppCatalogEntry.spec.catalog.name,
-      chartName: ingressAppCatalogEntry.spec.appName,
-      version: ingressAppCatalogEntry.spec.version,
-      namespace: 'kube-system',
-      configMapContents: '',
-      secretContents: '',
-    }
-  );
+  return createApp(clientFactory, auth, clusterID, appsNamespace, {
+    name: generateAppResourceName(
+      ingressAppCatalogEntry.spec.appName,
+      clusterID,
+      isClusterApp
+    ),
+    catalogName: ingressAppCatalogEntry.spec.catalog.name,
+    chartName: ingressAppCatalogEntry.spec.appName,
+    version: ingressAppCatalogEntry.spec.version,
+    namespace: 'kube-system',
+    configMapContents: '',
+    secretContents: '',
+  });
 }
 
 export function getClusterK8sEndpoint(


### PR DESCRIPTION
### What does this PR do?

This PR removes deprecated exceptions for the `nginx-ingress-controller-app`.

### What is the effect of this change to users?

`nginx-ingress-controller-app` does not get installed to `kube-system` by default anymore.

### How does it look like?

(Please add screenshots or screen recordings demonstrating the change.)

### Any background context you can provide?

The `ingress-controller-values` are not used and the upcoming major release isn't called `nginx-ingress-controller-app` anymore.

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

No.
