### PR TITLE
Bring back renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,103 @@
     // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
   ],
+  "reviewers": [
+    "gusevda"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["@types/jest", "jest"],
+      "groupName": "jest packages",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePrefixes": ["eslint", "@typescript-eslint"],
+      "groupName": "eslint packages",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePrefixes": ["date-fns"],
+      "groupName": "date-fns packages"
+    },
+    {
+      "matchPackagePrefixes": ["@storybook"],
+      "groupName": "storybook packages",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePrefixes": ["@babel", "babel"],
+      "groupName": "babel packages",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePrefixes": ["@sentry"],
+      "groupName": "sentry packages",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePrefixes": ["@testing-library"],
+      "groupName": "testing-library packages"
+    },
+    {
+      "matchPackagePrefixes": [
+        "@types/react",
+        "react",
+        "react-refresh"
+      ],
+      "groupName": "react packages"
+    },
+    {
+      "matchPackagePrefixes": ["@types/react-router", "react-router"],
+      "groupName": "react-router packages"
+    },
+    {
+      "matchPackagePrefixes": [
+        "@webpack",
+        "webpack",
+        "@types/copy-webpack-plugin",
+        "copy-webpack-plugin",
+        "@types/css-minimizer-webpack-plugin",
+        "css-minimizer-webpack-plugin",
+        "@types/mini-css-extract-plugin",
+        "mini-css-extract-plugin",
+        "@types/terser-webpack-plugin",
+        "terser-webpack-plugin",
+        "clean-webpack-plugin",
+        "html-webpack-plugin",
+        "css-loader",
+        "sass-loader",
+        "style-loader",
+        "json-loader",
+        "file-loader",
+        "imports-loader",
+        "webpack-bundle-analyzer",
+        "@types/webpack-bundle-analyzer",
+        "@pmmmwh/react-refresh-webpack-plugin"
+      ],
+      "groupName": "webpack packages",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePrefixes": ["@rjsf"],
+      "groupName": "react-jsonschema-form packages"
+    },
+    {
+      "matchPackagePrefixes": ["@types/node"],
+      "groupName": "node packages",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackageNames": [
+        "@types/bootstrap",
+        "bootstrap"
+      ],
+      "enabled": false
+    }
+  ],
+  "prConcurrentLimit": 1,
+  "schedule": [
+    "every weekend",
+    "every weekday after 6pm",
+    "every weekday before 6am"
+  ]
 }


### PR DESCRIPTION
### What does this PR do?

Renovate config override was removed in scope of [this PR](https://github.com/giantswarm/github/pull/1196), but wasn't copied back to `happa` repo. In this PR I brought back `happa` specific renovate configuration and made it extend the [default preset](https://github.com/giantswarm/renovate-presets/blob/main/default.json5).