### PR TITLE
Fix k8s api url for eks clusters

### DIFF
--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1678,7 +1678,9 @@ export function getClusterK8sAPIUrl(
     hostname = getClusterBaseUrl(cluster, providerFlavor).host;
   }
 
-  return `https://${hostname}${port ? `:${port}` : ''}`;
+  const url = `${hostname}${port ? `:${port}` : ''}`;
+
+  return url.startsWith('https://') ? url : `https://${url}`;
 }
 
 export function getK8sAPIUrl(providerFlavor: ProviderFlavors): string {


### PR DESCRIPTION
### What does this PR do?

For EKS clusters kubernetes API URL is being displayed incorrectly -
```
https://https://9577...0FF2.gr7.eu-central-1.eks.amazonaws.com:443
```
 `https://` part is duplicated.

In this PR kubernetes API URL was fixed.

### How does it look like?

Before:
<img width="1190" alt="Screenshot 2023-11-28 at 12 43 55" src="https://github.com/giantswarm/happa/assets/445309/8ff19cde-ff5c-4b26-b829-f9e67d6a6b60">

After:
<img width="1190" alt="Screenshot 2023-11-28 at 12 44 05" src="https://github.com/giantswarm/happa/assets/445309/03691fea-f76b-42e5-aecc-b04f399bf6e5">

### Any background context you can provide?

Towards https://github.com/giantswarm/giantswarm/issues/27781.
