### PR TITLE
Move CAPA userconfig values to global chart values

### DIFF
--- a/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
@@ -50,75 +50,73 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
   0: {
     uiSchema: {
       'ui:order': [
-        'metadata',
-        'providerSpecific',
-        'controlPlane',
-        'connectivity',
-        'nodePools',
+        'global',
         '*',
       ],
-      baseDomain: {
-        'ui:widget': 'hidden',
-      },
-      connectivity: {
-        'ui:order': ['sshSsoPublicKey', '*'],
-        bastion: {
+      global: {
+        connectivity: {
+          'ui:order': ['sshSsoPublicKey', '*'],
+          baseDomain: {
+            'ui:widget': 'hidden',
+          },
+          bastion: {
+            instanceType: {
+              'ui:widget': InstanceTypeWidget,
+            },
+          },
+        },
+        controlPlane: {
+          'ui:order': [
+            'apiMode',
+            'instanceType',
+            'replicas',
+            'rootVolumeSizeGB',
+            'etcdVolumeSizeGB',
+            'kubeletVolumeSizeGB',
+            'containerdVolumeSizeGB',
+            'oidc',
+            '*',
+          ],
           instanceType: {
             'ui:widget': InstanceTypeWidget,
           },
+          oidc: {
+            'ui:order': ['issuerUrl', 'clientId', '*'],
+          },
         },
-      },
-      controlPlane: {
-        'ui:order': [
-          'apiMode',
-          'instanceType',
-          'replicas',
-          'rootVolumeSizeGB',
-          'etcdVolumeSizeGB',
-          'kubeletVolumeSizeGB',
-          'containerdVolumeSizeGB',
-          'oidc',
-          '*',
-        ],
-        instanceType: {
-          'ui:widget': InstanceTypeWidget,
+        providerSpecific: {
+          'ui:order': [
+            'region',
+            'flatcarAwsAccount',
+            'awsClusterRoleIdentityName',
+            '*',
+          ],
         },
-        oidc: {
-          'ui:order': ['issuerUrl', 'clientId', '*'],
+        managementCluster: {
+          'ui:widget': 'hidden',
         },
-      },
-      'cluster-shared': {
-        'ui:widget': 'hidden',
-      },
-      kubectlImage: {
-        'ui:widget': 'hidden',
-      },
-      managementCluster: {
-        'ui:widget': 'hidden',
-      },
-      metadata: {
-        'ui:order': ['name', 'description', '*'],
-        name: {
-          'ui:widget': ClusterNameWidget,
+        kubectlImage: {
+          'ui:widget': 'hidden',
         },
-      },
-      nodePools: {
-        items: {
-          instanceType: {
-            'ui:widget': InstanceTypeWidget,
+        metadata: {
+          'ui:order': ['name', 'description', '*'],
+          name: {
+            'ui:widget': ClusterNameWidget,
+          },
+        },
+        nodePools: {
+          items: {
+            instanceType: {
+              'ui:widget': InstanceTypeWidget,
+            },
           },
         },
       },
       provider: {
         'ui:widget': 'hidden',
       },
-      providerSpecific: {
-        'ui:order': [
-          'region',
-          'flatcarAwsAccount',
-          'awsClusterRoleIdentityName',
-          '*',
-        ],
+      'cluster-shared': {
+        'ui:widget': 'hidden',
       },
     },
     formData: (clusterName, organization) => {


### PR DESCRIPTION
**BREAKING CHANGE**

New contract for CAPA clusters, see https://github.com/giantswarm/cluster-aws/tree/master/helm/cluster-aws#values-schema-documentation

Issue: https://github.com/giantswarm/roadmap/issues/2954

### What does this PR do?

We moved helm values of `cluster-aws` into `global chart values` because we want to split Common Clusters CR's and Provider CR's in different repos.
Therefore we need to move all shared values into `global chart values` for making them visible between multiple helm charts, e.g. cluster-aws <-> cluster.

More information on `global chart values` [here](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#global-chart-values).

The userconfig changes from:

```yaml
apiVersion: v1
data:
  values: |
    connectivity:
      availabilityZoneUsageLimit: 3
      bastion:
        enabled: true
      network: {}
      topology: {}
    controlPlane: {}
    metadata:
      name: nick
      organization: giantswarm
    nodePools:
      nodepool0:
        instanceType: m5.xlarge
        maxSize: 10
        minSize: 3
        rootVolumeSizeGB: 300
    providerSpecific: {}
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    giantswarm.io/cluster: nick
  name: nick-userconfig
  namespace: org-giantswarm
```

to

```yaml
apiVersion: v1
data:
  values: |
    global:
      connectivity:
        availabilityZoneUsageLimit: 3
        bastion:
          enabled: true
        network: {}
        topology: {}
      controlPlane: {}
      metadata:
        name: nick
        organization: giantswarm
      nodePools:
        nodepool0:
          instanceType: m5.xlarge
          maxSize: 10
          minSize: 3
          rootVolumeSizeGB: 300
      providerSpecific: {}
kind: ConfigMap
metadata:
  creationTimestamp: null
  labels:
    giantswarm.io/cluster: nick
  name: nick-userconfig
  namespace: org-giantswarm
```

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated