### PR TITLE
update docker file to enable lua

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,83 @@
 FROM quay.io/giantswarm/alpine:3.18.3 AS compress
-
 RUN apk --no-cache add findutils gzip
-
-# Copy happa built static files.
 COPY dist /www
-
 RUN find /www \
   -type f -regextype posix-extended \
   -size +512c \
   -iregex '.*\.(css|csv|html?|js|svg|txt|xml|json|webmanifest|ttf)' \
   -exec gzip -9 -k '{}' \;
 
+FROM alpine:3.18.3 as nginx-builder
+
+ENV NGINX_VERSION=1.23.4 \
+    NGX_DEVEL_KIT_VERSION=0.3.2 \
+    LUA_NGINX_MODULE_VERSION=0.10.24
+
+RUN apk update && apk add --no-cache \
+    gcc \
+    libc-dev \
+    make \
+    openssl-dev \
+    pcre-dev \
+    zlib-dev \
+    linux-headers \
+    curl \
+    gd-dev \
+    geoip-dev \
+    libxslt-dev \
+    perl-dev \
+    luajit-dev \
+    luajit \
+    lua-resty-core
+
+RUN curl -fSL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar xz -C /tmp \
+    && curl -fSL https://github.com/simpl/ngx_devel_kit/archive/v${NGX_DEVEL_KIT_VERSION}.tar.gz | tar xz -C /tmp \
+    && curl -fSL https://github.com/openresty/lua-nginx-module/archive/v${LUA_NGINX_MODULE_VERSION}.tar.gz | tar xz -C /tmp
+
+RUN cd /tmp/nginx-${NGINX_VERSION} \
+    && ./configure \
+        --prefix=/etc/nginx \
+        --sbin-path=/usr/sbin/nginx \
+        --modules-path=/usr/lib/nginx/modules \
+        --with-http_ssl_module \
+        --with-http_sub_module \
+        --with-http_gzip_static_module \
+        --with-http_stub_status_module \
+        --with-http_realip_module \
+        --with-http_auth_request_module \
+        --with-http_v2_module \
+        --with-ld-opt="-Wl,-rpath,/usr/lib" \
+        --add-module=/tmp/ngx_devel_kit-${NGX_DEVEL_KIT_VERSION} \
+        --add-module=/tmp/lua-nginx-module-${LUA_NGINX_MODULE_VERSION} \
+    && make \
+    && make install
+
 FROM quay.io/giantswarm/nginx:1.23-alpine
 
 ENV NODE_VERSION 16.7.0
 
-RUN apk add --no-cache binutils libstdc++ build-base pcre pcre-dev nginx-mod-http-lua-1.24.0-r7
-RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz"; \
-      tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-      && ln -s /usr/local/bin/node /usr/local/bin/nodejs;
+RUN apk add --no-cache binutils libstdc++
+RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
+    && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 COPY nginx /etc/nginx/
-RUN mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak && \
-    { \
-    echo 'load_module /usr/lib/nginx/modules/ndk_http_module.so;'; \
-    echo 'load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;'; \
-    cat /etc/nginx/nginx.conf.bak; \
-    } > /etc/nginx/nginx.conf
-
-COPY --chown=nginx tsconfig.json/ /tsconfig.json
-COPY --chown=nginx scripts/ /scripts
-COPY --from=compress --chown=nginx /www /www
+COPY tsconfig.json/ /tsconfig.json
+COPY scripts/ /scripts
+COPY --from=compress /www /www
+COPY --from=nginx-builder /etc/nginx/ /etc/nginx/
+COPY --from=nginx-builder /usr/sbin/nginx /usr/sbin/nginx
+COPY --from=nginx-builder /usr/lib/nginx/modules /usr/lib/nginx/modules
 
 RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
 RUN chown -R nginx:nginx /scripts/
-
 RUN chown -R nginx:nginx /var/log/nginx/
-
 RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
+
 USER nginx
+
 ENTRYPOINT ["sh", "-c", "scripts/prepare.ts && exec \"$@\"", "sh"]
 CMD ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN curl -fSL https://luajit.org/download/LuaJIT-${LUAJIT_VERSION}.tar.gz | tar 
 ENV LUAJIT_LIB=/usr/local/lib
 ENV LUAJIT_INC=/usr/local/include/luajit-2.1
 
+RUN cp /usr/local/bin/luajit usr/local/bin/luajit
 
 RUN curl -fSL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar xz -C /tmp \
     && curl -fSL https://github.com/simpl/ngx_devel_kit/archive/v${NGX_DEVEL_KIT_VERSION}.tar.gz | tar xz -C /tmp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,16 +68,16 @@ RUN cd /tmp/nginx-${NGINX_VERSION} \
 
 FROM quay.io/giantswarm/nginx:1.23-alpine
 
-ENV NODE_VERSION 16.7.0 \
-    LUAJIT_VERSION=2.1.0-beta3
+ENV NODE_VERSION 16.7.0
+ENV LUAJIT_VERSION=2.1.0-beta3
 
 RUN apk add --no-cache binutils libstdc++ pcre
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
     && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-RUN curl -fSL "https://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz" | tar xz -C /tmp \
-    && cd "/tmp/LuaJIT-$LUAJIT_VERSION" \
+RUN curl -fSL https://luajit.org/download/LuaJIT-${LUAJIT_VERSION}.tar.gz | tar xz -C /tmp \
+    && cd /tmp/LuaJIT-${LUAJIT_VERSION} \
     && make \
     && make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
 
-RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gd-dev geoip-dev libxslt-dev perl-dev lua-dev
+RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gd-dev geoip-dev libxslt-dev perl-dev lua-dev luajit luajit-dev
 
 ENV NGINX_VERSION 1.23.1
 ENV NDK_VERSION 0.3.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,10 @@ RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/n
 
 USER root
 
-RUN echo 'load_module /usr/lib/nginx/modules/ndk_http_module.so;' >> /etc/nginx/nginx.conf && \
-    echo 'load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;' >> /etc/nginx/nginx.conf
+RUN cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak && \
+    echo 'load_module /usr/lib/nginx/modules/ndk_http_module.so;' > /etc/nginx/nginx.conf && \
+    echo 'load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;' >> /etc/nginx/nginx.conf && \
+    cat /etc/nginx/nginx.conf.bak >> /etc/nginx/nginx.conf
 
 USER nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak && \
     echo 'load_module modules/ngx_http_lua_module.so;'; \
     echo 'load_module /usr/lib/nginx/modules/ndk_http_module.so;'; \
     echo 'load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;'; \
+    echo 'pcre_jit on;';\
     cat /etc/nginx/nginx.conf.bak; \
     } > /etc/nginx/nginx.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN curl -fSL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar xz 
     && curl -fSL https://github.com/simpl/ngx_devel_kit/archive/v${NGX_DEVEL_KIT_VERSION}.tar.gz | tar xz -C /tmp \
     && curl -fSL https://github.com/openresty/lua-nginx-module/archive/v${LUA_NGINX_MODULE_VERSION}.tar.gz | tar xz -C /tmp
 
+RUN mkdir -p /usr/lib/nginx/modules
+
 RUN cd /tmp/nginx-${NGINX_VERSION} \
     && ./configure \
         --prefix=/etc/nginx \

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,12 @@ RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/rele
       tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
       && ln -s /usr/local/bin/node /usr/local/bin/nodejs;
 
+RUN wget http://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz && \
+    tar -zxf LuaJIT-$LUAJIT_VERSION.tar.gz && \
+    cd LuaJIT-$LUAJIT_VERSION && \
+    make && \
+    make install
+
 COPY nginx /etc/nginx/
 COPY --chown=nginx tsconfig.json/ /tsconfig.json
 COPY --chown=nginx scripts/ /scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
 
 RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gd-dev geoip-dev libxslt-dev perl-dev
 
-ARG NGINX_VERSION=1.23.0
+ARG NGINX_VERSION=1.23.4
 ARG NDK_VERSION=0.3.1
 ARG LUA_NGINX_MODULE_VERSION=0.10.26
 ARG LUAJIT_VERSION=2.1.0-beta3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,8 @@
-FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
-
-RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gd-dev geoip-dev libxslt-dev perl-dev lua-dev luajit luajit-dev
-
-ENV LUAJIT_LIB /usr/lib
-ENV LUAJIT_INC /usr/include/luajit-2.1
-
-ENV NGINX_VERSION 1.23.1
-ENV NDK_VERSION 0.3.1
-ENV LUA_MODULE_VERSION 0.10.15
-
-RUN curl -fSL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar zxvf - -C /tmp \
-    && curl -fSL https://github.com/simpl/ngx_devel_kit/archive/v${NDK_VERSION}.tar.gz | tar zxvf - -C /tmp \
-    && curl -fSL https://github.com/openresty/lua-nginx-module/archive/v${LUA_MODULE_VERSION}.tar.gz | tar zxvf - -C /tmp
-
-RUN set -x \
-    && cd /tmp/nginx-${NGINX_VERSION} \
-    && ./configure --with-compat --add-dynamic-module=/tmp/ngx_devel_kit-${NDK_VERSION} --add-dynamic-module=/tmp/lua-nginx-module-${LUA_MODULE_VERSION} \
-    && make modules || { echo 'Configure or make failed'; exit 1; }
-
-FROM quay.io/giantswarm/alpine:3.18.4 AS compress
+FROM quay.io/giantswarm/alpine:3.18.3 AS compress
 
 RUN apk --no-cache add findutils gzip
 
+# Copy happa built static files.
 COPY dist /www
 
 RUN find /www \
@@ -33,13 +14,11 @@ RUN find /www \
 FROM quay.io/giantswarm/nginx:1.23-alpine
 
 ENV NODE_VERSION 16.7.0
-COPY --from=build-nginx /tmp/nginx-$NGINX_VERSION/objs/ngx_http_lua_module.so /usr/lib/nginx/modules/ngx_http_lua_module.so
-COPY --from=build-nginx /tmp/nginx-$NGINX_VERSION/objs/ndk_http_module.so /usr/lib/nginx/modules/ndk_http_module.so
 
 RUN apk add --no-cache binutils libstdc++
-RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
-    && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz"; \
+      tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs;
 
 COPY nginx /etc/nginx/
 COPY --chown=nginx tsconfig.json/ /tsconfig.json
@@ -55,9 +34,6 @@ RUN chown -R nginx:nginx /var/log/nginx/
 RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
-
-RUN echo 'load_module modules/ndk_http_module.so;' >> /etc/nginx/nginx.conf \
-    && echo 'load_module modules/ngx_http_lua_module.so;' >> /etc/nginx/nginx.conf
 
 USER nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
 
 RUN apk add --no-cache nginx nginx-mod-http-lua
-RUN rm -r /etc/nginx/conf.d && rm /etc/nginx/nginx.conf
 RUN mkdir -p /run/nginx
-COPY ./nginx.conf /etc/nginx/nginx.conf
 
 FROM quay.io/giantswarm/alpine:3.18.3 AS compress
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ COPY --from=compress /www /www
 RUN mkdir -p /etc/nginx/logs/
 RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
-
+RUN addgroup -S nginx && adduser -S nginx -G nginx
 RUN chown -R nginx:nginx /www
 RUN chown -R nginx:nginx /etc/nginx/logs/
 RUN chmod u=rwx /www

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
 
 RUN apk add --no-cache nginx nginx-mod-http-lua
+RUN rm -r /etc/nginx/conf.d && rm /etc/nginx/nginx.conf
+RUN mkdir -p /run/nginx
+COPY ./nginx.conf /etc/nginx/nginx.conf
 
 FROM quay.io/giantswarm/alpine:3.18.3 AS compress
 
@@ -43,7 +46,7 @@ COPY --from=build-nginx /usr/local/nginx/modules/ngx_http_lua_module.so /usr/lib
 COPY --from=build-nginx /usr/local/lib/libluajit* /usr/local/lib/
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-COPY --from=build-nginx /path/to/your/nginx/conf /etc/nginx/nginx.conf
+COPY --from=build-nginx /etc/nginx/nginx.conf /etc/nginx/nginx.conf
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ COPY --from=build-nginx /usr/local/lib/libluajit-5.1.so* /usr/local/lib/
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
-RUN ldconfig
+RUN ldconfig /
 
 RUN chown -R nginx:nginx /var/log/nginx/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,22 @@ RUN find /www \
 
 FROM quay.io/giantswarm/nginx:1.23-alpine
 
+ENV NDK_VERSION=0.3.1
+ENV LUA_NGINX_MODULE_VERSION=0.10.26
 ENV LUAJIT_VERSION=2.1.0-beta3
 ENV NODE_VERSION 16.7.0
 
-RUN apk add --no-cache binutils libstdc++ build-base
+RUN apk add --no-cache binutils libstdc++ build-base pcre pcre-dev
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz"; \
       tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
       && ln -s /usr/local/bin/node /usr/local/bin/nodejs;
+
+RUN ./configure \
+    --with-compat \
+    --with-pcre \
+    --add-dynamic-module=../ngx_devel_kit-$NDK_VERSION \
+    --add-dynamic-module=../lua-nginx-module-$LUA_NGINX_MODULE_VERSION && \
+    make modules
 
 RUN wget http://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz && \
     tar -zxf LuaJIT-$LUAJIT_VERSION.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN cd /tmp/nginx-${NGINX_VERSION} \
     && make install \
     && ls -la /usr/lib/nginx/
 
+ENV NODE_VERSION 16.7.0
 
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
     && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
 
-COPY --from=build-nginx /usr/local/nginx/modules/* /usr/lib/nginx/modules/
-COPY --from=build-nginx /usr/local/lib/libluajit* /usr/local/lib/
+COPY --from=build-nginx /usr/nginx/modules/* /usr/lib/nginx/modules/
+COPY --from=build-nginx /usr/lib/libluajit* /usr/local/lib/
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 COPY --from=build-nginx /etc/nginx/nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN cd /nginx-$NGINX_VERSION && \
     --add-dynamic-module=../lua-nginx-module-$LUA_NGINX_MODULE_VERSION && \
     make modules
 
-RUN cp /nginx-$NGINX_VERSION/objs/ndk_http_module.so /usr/lib/nginx/modules/ && \
+RUN mkdir -p /usr/lib/nginx/modules/ && \
+    cp /nginx-$NGINX_VERSION/objs/ndk_http_module.so /usr/lib/nginx/modules/ && \
     cp /nginx-$NGINX_VERSION/objs/ngx_http_lua_module.so /usr/lib/nginx/modules/
 
 FROM quay.io/giantswarm/alpine:3.18.3 AS compress

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
 
 RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gd-dev geoip-dev libxslt-dev perl-dev lua-dev luajit luajit-dev
 
+ENV LUAJIT_LIB /usr/lib
+ENV LUAJIT_INC /usr/include/luajit-2.1
+
 ENV NGINX_VERSION 1.23.1
 ENV NDK_VERSION 0.3.1
 ENV LUA_MODULE_VERSION 0.10.15
@@ -15,13 +18,6 @@ RUN set -x \
     && ./configure --with-compat --add-dynamic-module=/tmp/ngx_devel_kit-${NDK_VERSION} --add-dynamic-module=/tmp/lua-nginx-module-${LUA_MODULE_VERSION} \
     && make modules || { echo 'Configure or make failed'; exit 1; }
 
-
-RUN cd /tmp/nginx-$NGINX_VERSION \
-    && ./configure \
-        --with-compat \
-        --add-dynamic-module=/tmp/ngx_devel_kit-$NDK_VERSION \
-        --add-dynamic-module=/tmp/lua-nginx-module-$LUA_MODULE_VERSION \
-    && make modules
 FROM quay.io/giantswarm/alpine:3.18.4 AS compress
 
 RUN apk --no-cache add findutils gzip

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,12 @@ RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
 
+COPY --from=build-nginx /usr/local/nginx/modules/ngx_http_lua_module.so /usr/lib/nginx/modules/
+COPY --from=build-nginx /usr/local/lib/libluajit* /usr/local/lib/
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+COPY --from=build-nginx /path/to/your/nginx/conf /etc/nginx/nginx.conf
+
 USER root
 
 RUN mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM quay.io/giantswarm/nginx:1.23-alpine
 
 ENV NODE_VERSION 16.7.0
 
-RUN apk add --no-cache binutils libstdc++ build-base pcre pcre-dev nginx-mod-http-lua
+RUN apk add --no-cache binutils libstdc++ build-base pcre pcre-dev nginx-mod-http-lua=1.24.0-r15
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz"; \
       tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
       && ln -s /usr/local/bin/node /usr/local/bin/nodejs;

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-hea
 
 ARG NGINX_VERSION=1.23.0
 ARG NDK_VERSION=0.3.1
-ARG LUA_NGINX_MODULE_VERSION=0.10.20
+ARG LUA_NGINX_MODULE_VERSION=0.10.26
 ARG LUAJIT_VERSION=2.1.0-beta3
 
 RUN wget https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,17 +73,13 @@ RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
 
-USER nginx
-
-ENTRYPOINT ["sh", "-c", "scripts/prepare.ts && exec \"$@\"", "sh"]
-
-CMD ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]
-
-EXPOSE 8000
-
 USER root
 
 RUN echo 'load_module /usr/lib/nginx/modules/ndk_http_module.so;' >> /etc/nginx/nginx.conf && \
     echo 'load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;' >> /etc/nginx/nginx.conf
 
 USER nginx
+
+ENTRYPOINT ["sh", "-c", "scripts/prepare.ts && exec \"$@\"", "sh"]
+
+CMD ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ USER root
 
 RUN mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak && \
     { \
-    echo 'load_module modules/ngx_http_lua_module.so;'; \
     echo 'load_module /usr/lib/nginx/modules/ndk_http_module.so;'; \
     echo 'load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;'; \
     echo 'pcre_jit on;';\

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ RUN chown -R nginx:nginx /scripts/
 COPY --from=build-nginx /usr/lib/nginx/modules/ /usr/lib/nginx/modules/
 COPY --from=build-nginx /usr/local/lib/libluajit-5.1.so* /usr/local/lib/
 
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
 RUN ldconfig
 
 RUN chown -R nginx:nginx /var/log/nginx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,8 @@ FROM quay.io/giantswarm/nginx:1.23-alpine
 ENV NODE_VERSION 16.7.0
 ENV LUAJIT_VERSION=2.1.0-beta3
 
-RUN apk add --no-cache binutils libstdc++ pcre
+RUN apk add --no-cache binutils libstdc++ pcre build-base
+
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
     && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,10 @@ COPY --from=nginx-builder /etc/nginx/ /etc/nginx/
 COPY --from=nginx-builder /usr/sbin/nginx /usr/sbin/nginx
 COPY --from=nginx-builder /usr/lib/nginx/modules /usr/lib/nginx/modules
 
+COPY --from=nginx-builder /usr/local/bin/luajit /usr/local/bin/
+COPY --from=nginx-builder /usr/local/lib/libluajit-5.1.so* /usr/local/lib/
+RUN echo '/usr/local/lib' >> /etc/ld.so.conf.d/local.conf && ldconfig /usr/local/lib/
+
 RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
 RUN chown -R nginx:nginx /scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ COPY --from=nginx-builder /usr/sbin/nginx /usr/sbin/nginx
 COPY --from=nginx-builder /usr/lib/nginx/modules /usr/lib/nginx/modules
 
 COPY --from=nginx-builder /usr/local/bin/luajit /usr/local/bin/
-COPY --from=nginx-builder /usr/local/lib/libluajit-5.1.so* /usr/local/lib/
+COPY --from=nginx-builder /usr/local/lib/libluajit* /usr/local/lib/
 RUN echo '/usr/local/lib' >> /etc/ld.so.conf.d/local.conf && ldconfig /usr/local/lib/
 
 RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN find /www \
 
 FROM quay.io/giantswarm/nginx:1.23-alpine
 
+ENV LUAJIT_VERSION=2.1.0-beta3
 ENV NODE_VERSION 16.7.0
 
 RUN apk add --no-cache binutils libstdc++

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,6 @@ RUN mkdir -p /etc/nginx/logs/
 RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
 
-#RUN chown -R nginx:nginx /scripts/
-RUN chown -R nginx:nginx /var/log/nginx/
 RUN chown -R nginx:nginx /www
 RUN chown -R nginx:nginx /etc/nginx/logs/
 RUN chmod u=rwx /www

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ FROM alpine:3.18.3 as nginx-builder
 
 ENV NGINX_VERSION=1.23.4 \
     NGX_DEVEL_KIT_VERSION=0.3.2 \
-    LUA_NGINX_MODULE_VERSION=0.10.24
+    LUA_NGINX_MODULE_VERSION=0.10.24 \
+    LUAJIT_VERSION=2.1.0-beta3
 
 RUN apk update && apk add --no-cache \
     gcc \
@@ -29,6 +30,16 @@ RUN apk update && apk add --no-cache \
     luajit-dev \
     luajit \
     lua-resty-core
+
+RUN curl -fSL https://luajit.org/download/LuaJIT-${LUAJIT_VERSION}.tar.gz | tar xz -C /tmp \
+    && cd /tmp/LuaJIT-${LUAJIT_VERSION} \
+    && make \
+    && make install
+
+# Set environment variables so the NGINX `./configure` script can find LuaJIT
+ENV LUAJIT_LIB=/usr/local/lib
+ENV LUAJIT_INC=/usr/local/include/luajit-2.1
+
 
 RUN curl -fSL https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz | tar xz -C /tmp \
     && curl -fSL https://github.com/simpl/ngx_devel_kit/archive/v${NGX_DEVEL_KIT_VERSION}.tar.gz | tar xz -C /tmp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-hea
 ARG NGINX_VERSION=1.23.0
 ARG NDK_VERSION=0.3.1
 ARG LUA_NGINX_MODULE_VERSION=0.10.20
-ARG LUAJIT_VERSION=2.0.5
+ARG LUAJIT_VERSION=2.1.0-beta3
 
 RUN wget https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz && \
     tar -zxf nginx-$NGINX_VERSION.tar.gz && \
@@ -21,7 +21,7 @@ RUN wget http://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz && \
     make install
 
 ENV LUAJIT_LIB=/usr/local/lib
-ENV LUAJIT_INC=/usr/local/include/luajit-2.0.5
+ENV LUAJIT_INC=/usr/local/include/luajit-2.1
 
 RUN cd /nginx-$NGINX_VERSION && \
     ./configure \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,33 @@
+FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
+
+RUN apk add --no-cache \
+    gcc \
+    libc-dev \
+    make \
+    openssl-dev \
+    pcre-dev \
+    zlib-dev \
+    linux-headers \
+    curl \
+    gd-dev \
+    geoip-dev \
+    libxslt-dev \
+    perl-dev
+
+ENV NGINX_VERSION 1.23.1
+ENV NDK_VERSION 0.3.1
+ENV LUA_MODULE_VERSION 0.10.15
+
+RUN curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz | tar zxvf - -C /tmp \
+    && curl -fSL https://github.com/simpl/ngx_devel_kit/archive/v$NDK_VERSION.tar.gz | tar zxvf - -C /tmp \
+    && curl -fSL https://github.com/openresty/lua-nginx-module/archive/v$LUA_MODULE_VERSION.tar.gz | tar zxvf - -C /tmp
+
+RUN cd /tmp/nginx-$NGINX_VERSION \
+    && ./configure \
+        --with-compat \
+        --add-dynamic-module=/tmp/ngx_devel_kit-$NDK_VERSION \
+        --add-dynamic-module=/tmp/lua-nginx-module-$LUA_MODULE_VERSION \
+    && make modules
 FROM quay.io/giantswarm/alpine:3.18.4 AS compress
 
 RUN apk --no-cache add findutils gzip
@@ -14,11 +44,13 @@ RUN find /www \
 FROM quay.io/giantswarm/nginx:1.23-alpine
 
 ENV NODE_VERSION 16.7.0
+COPY --from=build-nginx /tmp/nginx-$NGINX_VERSION/objs/ngx_http_lua_module.so /usr/lib/nginx/modules/ngx_http_lua_module.so
+COPY --from=build-nginx /tmp/nginx-$NGINX_VERSION/objs/ndk_http_module.so /usr/lib/nginx/modules/ndk_http_module.so
 
 RUN apk add --no-cache binutils libstdc++
-RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz"; \
-      tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-      && ln -s /usr/local/bin/node /usr/local/bin/nodejs;
+RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
+    && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 COPY nginx /etc/nginx/
 COPY --chown=nginx tsconfig.json/ /tsconfig.json
@@ -34,6 +66,9 @@ RUN chown -R nginx:nginx /var/log/nginx/
 RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
+
+RUN echo 'load_module modules/ndk_http_module.so;' >> /etc/nginx/nginx.conf \
+    && echo 'load_module modules/ngx_http_lua_module.so;' >> /etc/nginx/nginx.conf
 
 USER nginx
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-hea
 ARG NGINX_VERSION=1.23.0
 ARG NDK_VERSION=0.3.1
 ARG LUA_NGINX_MODULE_VERSION=0.10.20
+ARG LUAJIT_VERSION=2.0.5
 
 RUN wget https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz && \
     tar -zxf nginx-$NGINX_VERSION.tar.gz && \
@@ -12,6 +13,15 @@ RUN wget https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz && \
     tar -zxf v$NDK_VERSION.tar.gz && \
     wget https://github.com/openresty/lua-nginx-module/archive/v$LUA_NGINX_MODULE_VERSION.tar.gz && \
     tar -zxf v$LUA_NGINX_MODULE_VERSION.tar.gz
+
+RUN wget http://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz && \
+    tar -zxf LuaJIT-$LUAJIT_VERSION.tar.gz && \
+    cd LuaJIT-$LUAJIT_VERSION && \
+    make && \
+    make install
+
+ENV LUAJIT_LIB=/usr/local/lib
+ENV LUAJIT_INC=/usr/local/include/luajit-2.0.5
 
 RUN cd /nginx-$NGINX_VERSION && \
     ./configure \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,8 @@ RUN cd /tmp/nginx-${NGINX_VERSION} \
         --add-module=/tmp/ngx_devel_kit-${NGX_DEVEL_KIT_VERSION} \
         --add-module=/tmp/lua-nginx-module-${LUA_NGINX_MODULE_VERSION} \
     && make \
-    && make install
+    && make install \
+    && ls -la /usr/lib/nginx/
 
 FROM quay.io/giantswarm/nginx:1.23-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,15 @@ RUN chown -R nginx:nginx /etc/nginx/logs/
 RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
+USER root
 
+RUN mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak && \
+    { \
+    echo 'load_module /usr/lib/nginx/modules/ndk_http_module.so;'; \
+    echo 'load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;'; \
+    echo 'pcre_jit on;';\
+    cat /etc/nginx/nginx.conf.bak; \
+    } > /etc/nginx/nginx.conf
 USER nginx
 
 ENTRYPOINT ["sh", "-c", "scripts/prepare.ts && exec \"$@\"", "sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,8 @@ RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/rele
     && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-RUN curl -fSL https://luajit.org/download/LuaJIT-${LUAJIT_VERSION}.tar.gz | tar xz -C /tmp \
-    && cd /tmp/LuaJIT-${LUAJIT_VERSION} \
+RUN curl -fSL "https://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz" | tar xz -C /tmp \
+    && cd /tmp/LuaJIT-$LUAJIT_VERSION \
     && make \
     && make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak && \
     cat /etc/nginx/nginx.conf.bak; \
     } > /etc/nginx/nginx.conf
 
-USER nginx
 COPY --chown=nginx tsconfig.json/ /tsconfig.json
 COPY --chown=nginx scripts/ /scripts
 COPY --from=compress --chown=nginx /www /www
@@ -42,6 +41,6 @@ RUN chown -R nginx:nginx /var/log/nginx/
 RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
-
+USER nginx
 ENTRYPOINT ["sh", "-c", "scripts/prepare.ts && exec \"$@\"", "sh"]
 CMD ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ENTRYPOINT ["sh", "-c", "scripts/prepare.ts && exec \"$@\"", "sh"]
 
 CMD ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]
 
-EXPOSE 80
+EXPOSE 8000
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
 RUN chown -R nginx:nginx /scripts/
 RUN chown -R nginx:nginx /var/log/nginx/
+RUN chown -R nginx:nginx /www
 RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/rele
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 RUN curl -fSL "https://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz" | tar xz -C /tmp \
-    && cd /tmp/LuaJIT-$LUAJIT_VERSION \
+    && cd "/tmp/LuaJIT-$LUAJIT_VERSION" \
     && make \
     && make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,5 +81,9 @@ CMD ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx.conf", "-g", "daemon off;"]
 
 EXPOSE 80
 
+USER root
+
 RUN echo 'load_module /usr/lib/nginx/modules/ndk_http_module.so;' >> /etc/nginx/nginx.conf && \
     echo 'load_module /usr/lib/nginx/modules/ngx_http_lua_module.so;' >> /etc/nginx/nginx.conf
+
+USER nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM quay.io/giantswarm/nginx:1.23-alpine
 
 ENV NODE_VERSION 16.7.0
 
-RUN apk add --no-cache binutils libstdc++ build-base pcre pcre-dev nginx-mod-http-lua=1.24.0-r15
+RUN apk add --no-cache binutils libstdc++ build-base pcre pcre-dev nginx-mod-http-lua-1.24.0-r7
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz"; \
       tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
       && ln -s /usr/local/bin/node /usr/local/bin/nodejs;

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ FROM quay.io/giantswarm/nginx:1.23-alpine
 
 ENV NODE_VERSION 16.7.0
 
-RUN apk add --no-cache binutils libstdc++ luajit libpcre
+RUN apk add --no-cache binutils libstdc++ luajit pcre
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
     && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ COPY --from=compress /www /www
 RUN mkdir -p /etc/nginx/logs/
 RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
-RUN chown -R nginx:nginx /scripts/
+
+#RUN chown -R nginx:nginx /scripts/
 RUN chown -R nginx:nginx /var/log/nginx/
 RUN chown -R nginx:nginx /www
 RUN chown -R nginx:nginx /etc/nginx/logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,11 +90,13 @@ COPY --from=nginx-builder /etc/nginx/ /etc/nginx/
 COPY --from=nginx-builder /usr/sbin/nginx /usr/sbin/nginx
 COPY --from=nginx-builder /usr/lib/nginx/modules /usr/lib/nginx/modules
 
+RUN mkdir /etc/nginx/logs/
 RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
 RUN chown -R nginx:nginx /scripts/
 RUN chown -R nginx:nginx /var/log/nginx/
 RUN chown -R nginx:nginx /www
+RUN chown -R nginx:nginx /etc/nginx/logs/
 RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ COPY --from=nginx-builder /etc/nginx/ /etc/nginx/
 COPY --from=nginx-builder /usr/sbin/nginx /usr/sbin/nginx
 COPY --from=nginx-builder /usr/lib/nginx/modules /usr/lib/nginx/modules
 
-RUN mkdir /etc/nginx/logs/
+RUN mkdir -p /etc/nginx/logs/
 RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
 RUN chown -R nginx:nginx /scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ FROM quay.io/giantswarm/nginx:1.23-alpine
 
 ENV NODE_VERSION 16.7.0
 
-RUN apk add --no-cache binutils libstdc++ luajit pcre
+RUN apk add --no-cache binutils libstdc++ pcre
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
     && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN chmod u=rwx /www
 RUN touch /etc/nginx/resolvers.conf && chown nginx:nginx /etc/nginx/resolvers.conf
 RUN echo resolver $(awk '/^nameserver/{print $2}' /etc/resolv.conf) ";" > /etc/nginx/resolvers.conf
 
-COPY --from=build-nginx /usr/local/nginx/modules/ngx_http_lua_module.so /usr/lib/nginx/modules/
+COPY --from=build-nginx /usr/local/nginx/modules/* /usr/lib/nginx/modules/
 COPY --from=build-nginx /usr/local/lib/libluajit* /usr/local/lib/
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
 
-RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gd-dev geoip-dev libxslt-dev perl-dev
+RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gd-dev geoip-dev libxslt-dev perl-dev lua-dev
 
 ENV NGINX_VERSION 1.23.1
 ENV NDK_VERSION 0.3.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,6 @@
 FROM quay.io/giantswarm/alpine:3.18.4 AS build-nginx
 
-RUN apk add --no-cache gcc libc-dev make openssl-dev pcre-dev zlib-dev linux-headers curl gd-dev geoip-dev libxslt-dev perl-dev
-
-ARG NGINX_VERSION=1.23.4
-ARG NDK_VERSION=0.3.1
-ARG LUA_NGINX_MODULE_VERSION=0.10.26
-ARG LUAJIT_VERSION=2.1.0-beta3
-
-RUN wget https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz && \
-    tar -zxf nginx-$NGINX_VERSION.tar.gz && \
-    wget https://github.com/simpl/ngx_devel_kit/archive/v$NDK_VERSION.tar.gz && \
-    tar -zxf v$NDK_VERSION.tar.gz && \
-    wget https://github.com/openresty/lua-nginx-module/archive/v$LUA_NGINX_MODULE_VERSION.tar.gz && \
-    tar -zxf v$LUA_NGINX_MODULE_VERSION.tar.gz
-
-RUN wget http://luajit.org/download/LuaJIT-$LUAJIT_VERSION.tar.gz && \
-    tar -zxf LuaJIT-$LUAJIT_VERSION.tar.gz && \
-    cd LuaJIT-$LUAJIT_VERSION && \
-    make && \
-    make install
-
-ENV LUAJIT_LIB=/usr/local/lib
-ENV LUAJIT_INC=/usr/local/include/luajit-2.1
-
-RUN cd /nginx-$NGINX_VERSION && \
-    ./configure \
-    --with-compat \
-    --add-dynamic-module=../ngx_devel_kit-$NDK_VERSION \
-    --add-dynamic-module=../lua-nginx-module-$LUA_NGINX_MODULE_VERSION && \
-    make modules
-
-RUN mkdir -p /usr/lib/nginx/modules/ && \
-    cp /nginx-$NGINX_VERSION/objs/ndk_http_module.so /usr/lib/nginx/modules/ && \
-    cp /nginx-$NGINX_VERSION/objs/ngx_http_lua_module.so /usr/lib/nginx/modules/
+RUN apk add --no-cache nginx nginx-mod-http-lua
 
 FROM quay.io/giantswarm/alpine:3.18.3 AS compress
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ FROM quay.io/giantswarm/nginx:1.23-alpine
 ENV LUAJIT_VERSION=2.1.0-beta3
 ENV NODE_VERSION 16.7.0
 
-RUN apk add --no-cache binutils libstdc++
+RUN apk add --no-cache binutils libstdc++ build-base
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz"; \
       tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
       && ln -s /usr/local/bin/node /usr/local/bin/nodejs;

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ FROM quay.io/giantswarm/nginx:1.23-alpine
 
 ENV NODE_VERSION 16.7.0
 
-RUN apk add --no-cache binutils libstdc++
+RUN apk add --no-cache binutils libstdc++ luajit libpcre
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
     && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs


### PR DESCRIPTION
### What does this PR do?

Relevant [issue](https://github.com/giantswarm/roadmap/issues/3220)

Update nginx server image to support NDK & LUA

### What is the effect of this change to users?

Allow us to expose an endpoint `/jwt-token` via nginx, that reads the `Teleport-Jwt-Assertion` header and write as response.
