### PR TITLE
NGINX modules ndk,lua + route for teleport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,74 @@ RUN find /www \
   -iregex '.*\.(css|csv|html?|js|svg|txt|xml|json|webmanifest|ttf)' \
   -exec gzip -9 -k '{}' \;
 
+FROM quay.io/giantswarm/nginx:1.23-alpine as builder
+
+ARG ENABLED_MODULES="ndk lua"
+
+SHELL ["/bin/ash", "-exo", "pipefail", "-c"]
+
+RUN if [ "$ENABLED_MODULES" = "" ]; then \
+        echo "No additional modules enabled, exiting"; \
+        exit 1; \
+    fi
+
+COPY ./ /modules/
+
+RUN apk update \
+    && apk add linux-headers openssl-dev pcre2-dev zlib-dev openssl abuild \
+               musl-dev libxslt libxml2-utils make mercurial gcc unzip git \
+               xz g++ coreutils \
+    # allow abuild as a root user \
+    && printf "#!/bin/sh\\nSETFATTR=true /usr/bin/abuild -F \"\$@\"\\n" > /usr/local/bin/abuild \
+    && chmod +x /usr/local/bin/abuild \
+    && hg clone -r ${NGINX_VERSION}-${PKG_RELEASE} https://hg.nginx.org/pkg-oss/ \
+    && cd pkg-oss \
+    && mkdir /tmp/packages \
+    && for module in $ENABLED_MODULES; do \
+        echo "Building $module for nginx-$NGINX_VERSION"; \
+        if [ -d /modules/$module ]; then \
+            echo "Building $module from user-supplied sources"; \
+            # check if module sources file is there and not empty
+            if [ ! -s /modules/$module/source ]; then \
+                echo "No source file for $module in modules/$module/source, exiting"; \
+                exit 1; \
+            fi; \
+            # some modules require build dependencies
+            if [ -f /modules/$module/build-deps ]; then \
+                echo "Installing $module build dependencies"; \
+                apk update && apk add $(cat /modules/$module/build-deps | xargs); \
+            fi; \
+            # if a module has a build dependency that is not in a distro, provide a
+            # shell script to fetch/build/install those
+            # note that shared libraries produced as a result of this script will
+            # not be copied from the builder image to the main one so build static
+            if [ -x /modules/$module/prebuild ]; then \
+                echo "Running prebuild script for $module"; \
+                /modules/$module/prebuild; \
+            fi; \
+            /pkg-oss/build_module.sh -v $NGINX_VERSION -f -y -o /tmp/packages -n $module $(cat /modules/$module/source); \
+            BUILT_MODULES="$BUILT_MODULES $(echo $module | tr '[A-Z]' '[a-z]' | tr -d '[/_\-\.\t ]')"; \
+        elif make -C /pkg-oss/alpine list | grep -E "^$module\s+\d+" > /dev/null; then \
+            echo "Building $module from pkg-oss sources"; \
+            cd /pkg-oss/alpine; \
+            make abuild-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
+            apk add $(. ./abuild-module-$module/APKBUILD; echo $makedepends;); \
+            make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
+            find ~/packages -type f -name "*.apk" -exec mv -v {} /tmp/packages/ \;; \
+            BUILT_MODULES="$BUILT_MODULES $module"; \
+        else \
+            echo "Don't know how to build $module module, exiting"; \
+            exit 1; \
+        fi; \
+    done \
+    && echo "BUILT_MODULES=\"$BUILT_MODULES\"" > /tmp/packages/modules.env
+
 FROM quay.io/giantswarm/nginx:1.23-alpine
+RUN --mount=type=bind,target=/tmp/packages/,source=/tmp/packages/,from=builder \
+    . /tmp/packages/modules.env \
+    && for module in $BUILT_MODULES; do \
+           apk add --no-cache --allow-untrusted /tmp/packages/nginx-module-${module}-${NGINX_VERSION}*.apk; \
+       done
 
 ENV NODE_VERSION 16.7.0
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -63,7 +63,6 @@ http {
       add_header Content-type text/plain;
 
       content_by_lua_block {
-        ngx.say(ngx.req.get_headers()['User-Agent'])
         ngx.say(ngx.req.get_headers()['Teleport-Jwt-Assertion'])
       }
     }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,6 @@
+load_module modules/ndk_http_module.so;
+load_module modules/ngx_http_lua_module.so;
+
 error_log stderr warn;
 worker_processes 1;
 # running as non-root requires a writeable path
@@ -55,7 +58,14 @@ http {
     root /www;
 
     include headers.conf;
+    location /test {
+      add_header Content-type text/plain;
 
+      content_by_lua_block {
+        ngx.say(ngx.req.get_headers()['User-Agent'])
+        ngx.say(ngx.req.get_headers()['Teleport-Jwt-Assertion'])
+      }
+    }
     location /catalogs {
       root /dev/null;
       if ($arg_url !~* https:\/\/kubernetes-charts\.storage\.googleapis\.com\/index\.yaml) {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -58,7 +58,8 @@ http {
     root /www;
 
     include headers.conf;
-    location /test {
+
+    location /jwt-token {
       add_header Content-type text/plain;
 
       content_by_lua_block {


### PR DESCRIPTION
### What does this PR do?

Relevant [issue](https://github.com/giantswarm/roadmap/issues/3220)

Update nginx server image to support NDK & LUA

### What is the effect of this change to users?

Allow us to expose an endpoint `/jwt-token` via nginx, that reads the `Teleport-Jwt-Assertion` header and write as response.
