### PR TITLE
Fix fe-docs for K8s 1.25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@5.0.0
+  architect: giantswarm/architect@5.0.1
 
 defaults: &defaults
   working_directory: ~/happa


### PR DESCRIPTION
This PR is an attempt to make the `fe-docs` chart deployable on Kubernetes 1.25.