### PR TITLE
Adapt fe-docs chart for new operations cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,10 @@ workflows:
       - architect/push-to-app-catalog:
           executor: app-build-suite
           name: push-happa-to-control-plane-app-catalog
-          app_catalog: "control-plane-catalog"
-          app_catalog_test: "control-plane-test-catalog"
+          app_catalog: control-plane-catalog
+          app_catalog_test: control-plane-test-catalog
           push_to_oci_registry: false
-          chart: "happa"
+          chart: happa
           persist_chart_archive: true
           requires:
             - launch-container
@@ -189,28 +189,20 @@ workflows:
           dockerfile: "./Dockerfile.fe-docs"
           requires:
             - build-fe-docs
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+          <<: *job_filters
 
       - architect/push-to-app-catalog:
           executor: app-build-suite
           name: push-fe-docs-to-operations-platform-app-catalog
           context: architect
-          app_catalog: "giantswarm-operations-platform-catalog"
-          app_catalog_test: "giantswarm-operations-platform-test-catalog"
-          chart: "fe-docs"
+          app_catalog: giantswarm-operations-platform-catalog
+          app_catalog_test: giantswarm-operations-platform-test-catalog
+          chart: fe-docs
           persist_chart_archive: true
           explicit_allow_chart_name_mismatch: true
           requires:
             - push-fe-docs-to-registries
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+          <<: *job_filters
 
 jobs:
   checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,11 +176,7 @@ workflows:
       - build-fe-docs:
           requires:
             - checkout
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+          <<: *job_filters
 
       - architect/push-to-registries:
           context: architect

--- a/Dockerfile.fe-docs
+++ b/Dockerfile.fe-docs
@@ -4,6 +4,8 @@ USER 0
 
 COPY nginx/headers.conf /etc/nginx/headers.conf
 COPY nginx/fe-docs-nginx.conf /etc/nginx/nginx.conf
+RUN rm /etc/nginx/conf.d/default.conf
+
 COPY storybook-static /usr/share/nginx/html
 
 EXPOSE 8080

--- a/Dockerfile.fe-docs
+++ b/Dockerfile.fe-docs
@@ -1,4 +1,4 @@
-FROM quay.io/giantswarm/nginx-unprivileged:1.23-alpine
+FROM gsoci.azurecr.io/giantswarm/nginx-unprivileged:1.25-alpine
 
 USER 0
 

--- a/Dockerfile.fe-docs
+++ b/Dockerfile.fe-docs
@@ -2,6 +2,7 @@ FROM gsoci.azurecr.io/giantswarm/nginx-unprivileged:1.25-alpine
 
 USER 0
 
+COPY nginx/headers.conf /etc/nginx/headers.conf
 COPY nginx/fe-docs-nginx.conf /etc/nginx/nginx.conf
 COPY storybook-static /usr/share/nginx/html
 

--- a/Dockerfile.fe-docs
+++ b/Dockerfile.fe-docs
@@ -2,6 +2,7 @@ FROM quay.io/giantswarm/nginx-unprivileged:1.23-alpine
 
 USER 0
 
+COPY nginx/fe-docs-nginx.conf /etc/nginx/nginx.conf
 COPY storybook-static /usr/share/nginx/html
 
 EXPOSE 8080

--- a/helm/fe-docs/ci/ci-values.yaml
+++ b/helm/fe-docs/ci/ci-values.yaml
@@ -1,0 +1,2 @@
+hostnames:
+  - test-hostname.example.com

--- a/helm/fe-docs/templates/deployment.yaml
+++ b/helm/fe-docs/templates/deployment.yaml
@@ -48,8 +48,8 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 2
           volumeMounts:
-            - mountPath: /var/cache/nginx
-              name: cache-volume
+            - mountPath: /tmp
+              name: nginx-tmp
           securityContext:
             {{- with .Values.containerSecurityContext }}
             {{- . | toYaml | nindent 12 }}
@@ -64,7 +64,7 @@ spec:
             {{- end }}
             {{- end }}
       volumes:
-        - name: cache-volume
+        - name: nginx-tmp
           emptyDir: {}
       serviceAccount: {{ .Values.name }}
       serviceAccountName: {{ .Values.name }}

--- a/helm/fe-docs/templates/deployment.yaml
+++ b/helm/fe-docs/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               memory: 100Mi
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: {{ .Values.port }}
               scheme: HTTP
             initialDelaySeconds: 10

--- a/helm/fe-docs/templates/ingress.yaml
+++ b/helm/fe-docs/templates/ingress.yaml
@@ -14,6 +14,9 @@ spec:
   rules:
     {{- $serviceName := .Values.name -}}
     {{- $port := .Values.port -}}
+    {{- if or (not (.Values.hostnames)) (eq (len .Values.hostnames) 0) }}
+      {{- fail "value for .Values.hostnames must not be empty" }}
+    {{- end }}
     {{- range .Values.hostnames }}
     - host: {{ . }}
       http:

--- a/helm/fe-docs/values.schema.json
+++ b/helm/fe-docs/values.schema.json
@@ -2,6 +2,33 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "properties": {
+    "containerSecurityContext": {
+      "type": "object",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean"
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array"
+            }
+          }
+        },
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "podSeccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "groupID": {
       "type": "integer"
     },
@@ -44,6 +71,14 @@
     },
     "userID": {
       "type": "integer"
+    },
+    "podSeccompProfile": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      }
     },
     "podSecurityStandards": {
       "type": "object",

--- a/helm/fe-docs/values.yaml
+++ b/helm/fe-docs/values.yaml
@@ -16,9 +16,14 @@ global:
   podSecurityStandards:
     enforced: false
 
+podSeccompProfile:
+  type: RuntimeDefault
+
 containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
   runAsNonRoot: true
+  podSeccompProfile:
+    type: RuntimeDefault

--- a/nginx/fe-docs-nginx.conf
+++ b/nginx/fe-docs-nginx.conf
@@ -43,7 +43,7 @@ http {
   scgi_temp_path        /tmp/scgi_temp;
 
   server {
-    listen 8000;
+    listen 8080;
 
     access_log /dev/stdout custom;
     client_max_body_size 0;

--- a/nginx/fe-docs-nginx.conf
+++ b/nginx/fe-docs-nginx.conf
@@ -1,0 +1,69 @@
+error_log stderr warn;
+worker_processes 1;
+pid /tmp/nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+  charset utf-8;
+  keepalive_timeout  60;
+
+  include /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile       on;
+  tcp_nopush     on;
+
+  # Enable gzip
+  gzip on;
+  gzip_static on;
+  gzip_comp_level 6;
+  gzip_min_length 512;
+  gzip_vary on;
+  gzip_proxied any;
+
+  gzip_types text/plain text/xml text/css
+             text/comma-separated-values
+             text/javascript application/javascript
+             application/atom+xml application/json
+             image/svg+xml;
+
+  log_format  custom  '"$request" '
+      '$status $body_bytes_sent $request_time '
+      '"$http_x_forwarded_for" '
+      '"$http_user_agent" "$http_referer"';
+
+  # running as non-root requires a writeable path
+  client_body_temp_path /tmp/client_temp;
+  proxy_temp_path       /tmp/proxy_temp_path;
+  fastcgi_temp_path     /tmp/fastcgi_temp;
+  uwsgi_temp_path       /tmp/uwsgi_temp;
+  scgi_temp_path        /tmp/scgi_temp;
+
+  server {
+    listen 8000;
+
+    access_log /dev/stdout custom;
+    client_max_body_size 0;
+    chunked_transfer_encoding on;
+
+    error_page 404 /404.html;
+
+    root /www;
+
+    include headers.conf;
+
+    location / {
+      index index.html;
+
+      try_files $uri $uri/ /index.html;
+    }
+
+    location = /404.html {
+      add_header Cache-Control "no-cache" always;
+      include headers.conf;
+    }
+  }
+}

--- a/nginx/fe-docs-nginx.conf
+++ b/nginx/fe-docs-nginx.conf
@@ -37,7 +37,7 @@ http {
 
   # running as non-root requires a writeable path
   client_body_temp_path /tmp/client_temp;
-  proxy_temp_path       /tmp/proxy_temp_path;
+  proxy_temp_path       /tmp/proxy_temp;
   fastcgi_temp_path     /tmp/fastcgi_temp;
   uwsgi_temp_path       /tmp/uwsgi_temp;
   scgi_temp_path        /tmp/scgi_temp;

--- a/nginx/fe-docs-nginx.conf
+++ b/nginx/fe-docs-nginx.conf
@@ -51,7 +51,7 @@ http {
 
     error_page 404 /404.html;
 
-    root /www;
+    root /usr/share/nginx/html;
 
     include headers.conf;
 

--- a/nginx/fe-docs-nginx.conf
+++ b/nginx/fe-docs-nginx.conf
@@ -57,8 +57,6 @@ http {
 
     location / {
       index index.html;
-
-      try_files $uri $uri/ /index.html;
     }
 
     location = /404.html {

--- a/nginx/fe-docs-nginx.conf
+++ b/nginx/fe-docs-nginx.conf
@@ -55,6 +55,11 @@ http {
 
     include headers.conf;
 
+    location /healthz {
+      add_header Content-Type text/plain;
+      return 200 'Doing fine';
+    }
+
     location / {
       index index.html;
     }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29470

This PR attempts to make the fe-docs chart deployable on k8s 1.25

Included changes:

- Adds security details to values.yaml which are already applied in the chart
- Updates schema for values.yaml
- Adds ci values
- Sets explicit NGINX configuration for fe-docs
- Updates nginx-unprivileged to 1.25
- Sets separate liveness probe path