### PR TITLE
Hide fields in cluster creation form for CAPA

### DIFF
--- a/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
@@ -50,6 +50,9 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
   0: {
     uiSchema: {
       'ui:order': ['global', '*'],
+      baseDomain: {
+        'ui:widget': 'hidden',
+      },
       global: {
         connectivity: {
           'ui:order': ['sshSsoPublicKey', '*'],
@@ -108,6 +111,9 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
             },
           },
         },
+      },
+      managementCluster: {
+        'ui:widget': 'hidden',
       },
       provider: {
         'ui:widget': 'hidden',


### PR DESCRIPTION
### What does this PR do?

In cluster creation form on CAPA values for `baseDomain` and `managementCluster` fields are populated from the catalog and we don't expect users to edit these values, so the fields should be hidden.

On other providers there is no such problem.

### How does it look like?

![Group 1 (1)](https://github.com/giantswarm/happa/assets/445309/add16259-b4fd-45d3-b40c-dc0dca0b43e4)

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/3397.