### PR TITLE
Add formidable 3.5.1 to resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
   "resolutions": {
     "@braintree/sanitize-url": "6.0.4",
     "@types/react": "18.2.79",
+    "formidable": "3.5.1",
     "kind-of": "6.0.3",
     "lodash": "4.17.21",
     "http-proxy": "1.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8529,20 +8529,14 @@ format@^0.2.0:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
-formidable@^1.2.0:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.6.tgz#d2a51d60162bbc9b4a055d8457a7c75315d1a168"
-  integrity sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==
-
-formidable@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.2.tgz#fa973a2bec150e4ce7cac15589d7a25fc30ebd89"
-  integrity sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==
+formidable@3.5.1, formidable@^1.2.0, formidable@^2.1.2:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.5.1.tgz#9360a23a656f261207868b1484624c4c8d06ee1a"
+  integrity sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==
   dependencies:
     dezalgo "^1.0.4"
     hexoid "^1.0.0"
     once "^1.4.0"
-    qs "^6.11.0"
 
 forwarded@0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### What does this PR do?

`formidable` package was locked to version 3.5.1 to fix [the security issue](https://github.com/giantswarm/happa/security/dependabot/91). This package is installed as a dependency for the `superagent` package which is used by the [giantswarm-js-client](https://github.com/giantswarm/giantswarm-js-client) (Rest API).

There is an [upstream issue](https://github.com/ladjs/superagent/issues/1799) in the `superagent` repo to fix the issue, once it's resolved we will need to update the `superagent` package on our side.

