### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/helm/fe-docs/templates/kyverno-policy-exception.yaml
+++ b/helm/fe-docs/templates/kyverno-policy-exception.yaml
@@ -1,5 +1,5 @@
 {{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   namespace: {{ .Release.Namespace }}

--- a/helm/happa/templates/kyverno-policy-exception.yaml
+++ b/helm/happa/templates/kyverno-policy-exception.yaml
@@ -1,5 +1,5 @@
 {{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: happa


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.