### PR TITLE
Hide cluster property from cluster-aws creation form

### DIFF
--- a/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
+++ b/src/components/MAPI/clusters/CreateClusterAppBundles/schemaUtils.ts
@@ -53,6 +53,9 @@ const formPropsProviderCAPA: Record<string, FormPropsPartial> = {
       baseDomain: {
         'ui:widget': 'hidden',
       },
+      cluster: {
+        'ui:widget': 'hidden',
+      },
       global: {
         connectivity: {
           'ui:order': ['sshSsoPublicKey', '*'],


### PR DESCRIPTION
### What does this PR do?

[Helm values](https://github.com/giantswarm/cluster-aws/blob/main/helm/cluster-aws/values.schema.json#L254) under `cluster` property are read only and should not be visible to a user. In this PR I hide `cluster` section in the AWS cluster creation form.

### How does it look like?

<img width="1028" alt="Screenshot 2024-05-28 at 13 53 00" src="https://github.com/giantswarm/happa/assets/445309/1b4e6f0f-0737-432f-b77d-8284ce841248">
