### PR TITLE
Expose container port explicitly to mitigate kubelinter complaint

### DIFF
--- a/helm/happa/templates/deployment.yaml
+++ b/helm/happa/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             {{- . | toYaml | nindent 14 }}
           {{- end }}
           {{- end }}
+        ports:
+          - containerPort: 8000
+            name: http
         env:
           - name: HAPPA_CONFIG_PATH
             value: "/var/run/{{ .Values.name }}/configmap/config.yaml"


### PR DESCRIPTION
Mitigates these kubelinter complaints as seen [here](https://app.circleci.com/pipelines/github/giantswarm/happa/18443/workflows/1c2cfa20-90fa-4b52-9f39-a49b2f9b93b7/jobs/134668):

```
/root/project/helm/happa/templates/deployment.yaml: (object: giantswarm/happa apps/v1, Kind=Deployment)
container "happa" does not expose port 8000 for the HTTPGet (check: liveness-port, remediation:
Check which ports you've exposed and ensure they match what you have specified in the liveness probe.)

/root/project/helm/happa/templates/deployment.yaml: (object: giantswarm/happa apps/v1, Kind=Deployment)
container "happa" does not expose port 8000 for the HTTPGet (check: readiness-port, remediation:
Check which ports you've exposed and ensure they match what you have specified in the readiness probe.)
```