### PR TITLE
Prevent job runs for commits to default branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ job_filters: &job_filters
     tags:
       only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
     branches:
-      only: /.*/
+      ignore:
+        - main
 
 whitelist: &whitelist
   paths:
@@ -72,6 +73,9 @@ workflows:
             - launch-container
           # Needed to trigger job also on git tag.
           filters:
+            branches:
+              ignore:
+                - main
             tags:
               only: /^v.*/
 


### PR DESCRIPTION
### What does this PR do?

Exclude the main branch from CircleCI runs

### Any background context you can provide?

https://github.com/giantswarm/giantswarm/issues/31824

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

No
