### PR TITLE
Extend allowed origins

### DIFF
--- a/helm/happa/templates/happaapi-ingress.yaml
+++ b/helm/happa/templates/happaapi-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 
-    nginx.ingress.kubernetes.io/cors-allow-origin: {{ .Values.happa.address | quote }}
+    nginx.ingress.kubernetes.io/cors-allow-origin: {{ concat (list .Values.happa.address) .Values.happaapi.allowedOrigins | join ", " | quote }}
     nginx.ingress.kubernetes.io/cors-allow-headers: DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, Impersonate-User, Impersonate-Group
     nginx.ingress.kubernetes.io/enable-cors: "true"
 

--- a/helm/happa/values.schema.json
+++ b/helm/happa/values.schema.json
@@ -205,6 +205,9 @@
         "address": {
           "type": "string"
         },
+        "allowedOrigins": {
+          "type": "array"
+        },
         "host": {
           "type": "string"
         },

--- a/helm/happa/values.yaml
+++ b/helm/happa/values.yaml
@@ -75,6 +75,7 @@ happa:
 happaapi:
   address: ""
   host: check
+  allowedOrigins: []
 
 athena:
   address: ""


### PR DESCRIPTION
### What does this PR do?

Extends allowed origins for Happa API ingress.

### What is the effect of this change to users?

Support for more allowed origins.

### How does it look like?

N/A

### Any background context you can provide?

See this [issue](https://github.com/giantswarm/giantswarm/issues/32009)

### What is needed from the reviewers?

A review of the proposed change.

### Do the docs need to be updated?

Nope.

### Should this change be mentioned in the release notes?

IDK, should it?
