### PR TITLE
Use mapiAudience configuration value instead of audience

### DIFF
--- a/helm/happa/templates/configmap.yaml
+++ b/helm/happa/templates/configmap.yaml
@@ -8,7 +8,6 @@ metadata:
 data:
   config.yaml: |
     api-endpoint: {{ .Values.api.address }}
-    audience: {{ .Values.api.address }}
     athena-endpoint: {{ .Values.athena.address }}
     ingress-base-domain: {{ .Values.guestCluster.base }}
     installation-name: {{ .Values.managementCluster.name }}
@@ -34,6 +33,7 @@ data:
     # Giant Swarm Management API
     mapi-audience: {{ .Values.oidc.issuerAddress }}
     mapi-endpoint: {{ .Values.happaapi.address }}
+    mapi-auth-endpoint: {{ .Values.oidc.issuerAddress }}
     mapi-auth-redirect-url: {{ .Values.happa.address }}
     mapi-auth-admin-groups: '{{ .Values.oidc.giantswarm.writeAllGroups | join " " }}'
     

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -62,9 +62,9 @@ const config: Config.InitialOptions = {
     config: {
       apiEndpoint: 'http://1.2.3.4',
       mapiEndpoint: 'http://2.3.4.5',
+      mapiAuthEndpoint: 'http://3.4.5.6',
       athenaEndpoint: 'http://5.5.5.5',
-      audience: 'http://1.2.3.4',
-      mapiAudience: 'http://2.3.4.5',
+      mapiAudience: 'dex.sample.io',
       environment: 'development',
       ingressBaseDomain: 'k8s.sample.io',
       defaultRequestTimeoutSeconds: 10,

--- a/scripts/getConfigurationValues.ts
+++ b/scripts/getConfigurationValues.ts
@@ -3,8 +3,8 @@ import { Configuration } from './Configuration';
 export interface IConfigurationValues {
   apiEndpoint: string;
   mapiEndpoint: string;
+  mapiAuthEndpoint: string;
   athenaEndpoint: string;
-  audience: string;
   mapiAudience: string;
   ingressBaseDomain: string;
   defaultRequestTimeoutSeconds: number;
@@ -74,7 +74,7 @@ export async function getConfigurationValues(
 
   config.setDefault('api-endpoint', 'http://localhost:8000');
   config.setDefault('mapi-endpoint', 'http://localhost:8000');
-  config.setDefault('audience', 'http://localhost:8000');
+  config.setDefault('mapi-auth-endpoint', 'http://localhost:8000');
   config.setDefault('mapi-audience', 'http://localhost:8000');
   config.setDefault('athena-endpoint', 'http://localhost:8000');
   config.setDefault('installation-name', 'development');
@@ -105,8 +105,8 @@ export async function getConfigurationValues(
   return {
     apiEndpoint: config.getString('api-endpoint'),
     mapiEndpoint: config.getString('mapi-endpoint'),
+    mapiAuthEndpoint: config.getString('mapi-audience'),
     athenaEndpoint: config.getString('athena-endpoint'),
-    audience: config.getString('audience'),
     mapiAudience: config.getString('mapi-audience'),
     ingressBaseDomain: config.getString('ingress-base-domain'),
     defaultRequestTimeoutSeconds: config.getNumber(

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -6,13 +6,13 @@ type GlobalEnvironment = 'development' | 'kubernetes' | 'docker-container';
 
 interface IGlobalConfig {
   apiEndpoint: string;
-  audience: string;
   awsCapabilitiesJSON: string;
   azureCapabilitiesJSON: string;
   gcpCapabilitiesJSON: string;
   mapiEndpoint: string;
   athenaEndpoint: string;
   mapiAudience: string;
+  mapiAuthEndpoint: string;
   defaultRequestTimeoutSeconds: number;
   environment: GlobalEnvironment;
   happaVersion: string;

--- a/src/components/MAPI/apps/__tests__/ClusterDetailIngress.tsx
+++ b/src/components/MAPI/apps/__tests__/ClusterDetailIngress.tsx
@@ -184,7 +184,7 @@ describe('ClusterDetailIngress on GCP', () => {
   const provider: PropertiesOf<typeof Providers> =
     window.config.info.general.provider;
   const providerFlavor = window.config.info.general.providerFlavor;
-  const audience = window.config.audience;
+  const mapiAudience = window.config.mapiAudience;
   const orgId = 'org1';
   const cluster = capiv1beta1Mocks.randomClusterGCP1;
   const clusterId = cluster.metadata.name;
@@ -193,7 +193,7 @@ describe('ClusterDetailIngress on GCP', () => {
   beforeAll(() => {
     window.config.info.general.provider = Providers.GCP;
     window.config.info.general.providerFlavor = ProviderFlavors.CAPI;
-    window.config.audience = 'https://api.test.gigantic.io';
+    window.config.mapiAudience = 'api.test.gigantic.io';
 
     (usePermissionsForApps as jest.Mock).mockReturnValue(defaultPermissions);
     (useParams as jest.Mock).mockReturnValue({
@@ -205,7 +205,7 @@ describe('ClusterDetailIngress on GCP', () => {
   afterAll(() => {
     window.config.info.general.provider = provider;
     window.config.info.general.providerFlavor = providerFlavor;
-    window.config.audience = audience;
+    window.config.mapiAudience = mapiAudience;
   });
 
   it('displays instructions with correct API endpoints', async () => {
@@ -259,7 +259,7 @@ describe('ClusterDetailIngress on CAPA', () => {
   const provider: PropertiesOf<typeof Providers> =
     window.config.info.general.provider;
   const providerFlavor = window.config.info.general.providerFlavor;
-  const audience = window.config.audience;
+  const mapiAudience = window.config.mapiAudience;
   const orgId = 'org1';
   const cluster = capiv1beta1Mocks.randomClusterCAPA1;
   const clusterId = cluster.metadata.name;
@@ -268,7 +268,7 @@ describe('ClusterDetailIngress on CAPA', () => {
   beforeAll(() => {
     window.config.info.general.provider = Providers.CAPA;
     window.config.info.general.providerFlavor = ProviderFlavors.CAPI;
-    window.config.audience = 'https://api.test.gigantic.io';
+    window.config.mapiAudience = 'api.test.gigantic.io';
 
     (usePermissionsForApps as jest.Mock).mockReturnValue(defaultPermissions);
     (useParams as jest.Mock).mockReturnValue({
@@ -280,7 +280,7 @@ describe('ClusterDetailIngress on CAPA', () => {
   afterAll(() => {
     window.config.info.general.provider = provider;
     window.config.info.general.providerFlavor = providerFlavor;
-    window.config.audience = audience;
+    window.config.mapiAudience = mapiAudience;
   });
 
   it('displays instructions with correct API endpoints', async () => {
@@ -334,7 +334,7 @@ describe('ClusterDetailIngress on CAPZ', () => {
   const provider: PropertiesOf<typeof Providers> =
     window.config.info.general.provider;
   const providerFlavor = window.config.info.general.providerFlavor;
-  const audience = window.config.audience;
+  const mapiAudience = window.config.mapiAudience;
   const cluster = capiv1beta1Mocks.randomClusterCAPZ1;
   const clusterId = cluster.metadata.name;
   const namespace = cluster.metadata.namespace;
@@ -343,7 +343,7 @@ describe('ClusterDetailIngress on CAPZ', () => {
   beforeAll(() => {
     window.config.info.general.provider = Providers.CAPZ;
     window.config.info.general.providerFlavor = ProviderFlavors.CAPI;
-    window.config.audience = 'https://api.test.gigantic.io';
+    window.config.mapiAudience = 'api.test.gigantic.io';
 
     (usePermissionsForApps as jest.Mock).mockReturnValue(defaultPermissions);
     (useParams as jest.Mock).mockReturnValue({
@@ -355,7 +355,7 @@ describe('ClusterDetailIngress on CAPZ', () => {
   afterAll(() => {
     window.config.info.general.provider = provider;
     window.config.info.general.providerFlavor = providerFlavor;
-    window.config.audience = audience;
+    window.config.mapiAudience = mapiAudience;
   });
 
   it('displays instructions with correct API endpoints', async () => {

--- a/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
+++ b/src/components/MAPI/clusters/ClusterDetail/__tests__/ClusterDetailWidgetKubernetesAPI.tsx
@@ -98,12 +98,12 @@ describe('ClusterDetailWidgetKubernetesAPI on GCP', () => {
   const provider: PropertiesOf<typeof Providers> =
     window.config.info.general.provider;
   const providerFlavor = window.config.info.general.providerFlavor;
-  const audience = window.config.audience;
+  const mapiAudience = window.config.mapiAudience;
 
   beforeAll(() => {
     window.config.info.general.provider = Providers.GCP;
     window.config.info.general.providerFlavor = ProviderFlavors.CAPI;
-    window.config.audience = 'https://api.test.gigantic.io';
+    window.config.mapiAudience = 'api.test.gigantic.io';
 
     (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
       defaultPermissions
@@ -112,7 +112,7 @@ describe('ClusterDetailWidgetKubernetesAPI on GCP', () => {
   afterAll(() => {
     window.config.info.general.provider = provider;
     window.config.info.general.providerFlavor = providerFlavor;
-    window.config.audience = audience;
+    window.config.mapiAudience = mapiAudience;
   });
 
   it('displays the kubernetes API endpoint URL for the cluster', () => {
@@ -161,12 +161,12 @@ describe('ClusterDetailWidgetKubernetesAPI on CAPZ', () => {
   const provider: PropertiesOf<typeof Providers> =
     window.config.info.general.provider;
   const providerFlavor = window.config.info.general.providerFlavor;
-  const audience = window.config.audience;
+  const mapiAudience = window.config.mapiAudience;
 
   beforeAll(() => {
     window.config.info.general.provider = Providers.CAPZ;
     window.config.info.general.providerFlavor = ProviderFlavors.CAPI;
-    window.config.audience = 'https://api.test.gigantic.io';
+    window.config.mapiAudience = 'api.test.gigantic.io';
 
     (usePermissionsForKeyPairs as jest.Mock).mockReturnValue(
       defaultPermissions
@@ -175,7 +175,7 @@ describe('ClusterDetailWidgetKubernetesAPI on CAPZ', () => {
   afterAll(() => {
     window.config.info.general.provider = provider;
     window.config.info.general.providerFlavor = providerFlavor;
-    window.config.audience = audience;
+    window.config.mapiAudience = mapiAudience;
   });
 
   it('displays the kubernetes API endpoint URL for the cluster', () => {

--- a/src/components/MAPI/utils.ts
+++ b/src/components/MAPI/utils.ts
@@ -1827,7 +1827,7 @@ export function getClusterBaseUrl(
 }
 
 function getInstallationBaseURL(providerFlavor: ProviderFlavors): URL {
-  const audienceURL = new URL(window.config.audience);
+  const audienceURL = new URL(`https://${window.config.mapiAudience}`);
   // Remove all characters until the first `.`.
   audienceURL.host = audienceURL.host.substring(
     audienceURL.host.indexOf('.') + 1

--- a/src/components/UI/Controls/Navigation/MainMenu.js
+++ b/src/components/UI/Controls/Navigation/MainMenu.js
@@ -17,7 +17,7 @@ import Hamburger from './Hamburger';
 // We remove the dev port :8000 in case it's there.
 let monitoringURL = null;
 if (window.featureFlags.FEATURE_MONITORING) {
-  const audienceURL = new URL(window.config.mapiEndpoint);
+  const audienceURL = new URL(`https://${window.config.mapiAudience}`);
   const hostnameParts = audienceURL.host.split('.');
   hostnameParts[0] = 'grafana';
   audienceURL.host = hostnameParts.join('.');

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -67,8 +67,8 @@
       var config = {
         apiEndpoint: '{!= apiEndpoint !}',
         mapiEndpoint: '{!= mapiEndpoint !}',
+        mapiAuthEndpoint: '{!= mapiAuthEndpoint !}',
         athenaEndpoint: '{!= athenaEndpoint !}',
-        audience: '{!= audience !}',
         mapiAudience: '{!= mapiAudience !}',
         environment: '{!= environment !}',
         ingressBaseDomain: '{!= ingressBaseDomain !}',

--- a/src/utils/MapiAuth/makeDefaultConfig.ts
+++ b/src/utils/MapiAuth/makeDefaultConfig.ts
@@ -1,7 +1,7 @@
 import { IOAuth2Config } from 'utils/OAuth2/OAuth2';
 
 export function makeDefaultConfig(): IOAuth2Config {
-  let authority = window.config.mapiAudience;
+  let authority = window.config.mapiAuthEndpoint;
   if (!/http(s)?:\/\//.test(authority)) {
     authority = `https://${authority}`;
   }
@@ -10,13 +10,7 @@ export function makeDefaultConfig(): IOAuth2Config {
    * OIDC plugin, and it must be the same as the production, non-proxied
    * authentication provider.
    */
-  let issuer = authority;
-  if (issuer.includes('localhost')) {
-    issuer = window.config.audience.replace(
-      /(api-unsupported|gs-api|api)/,
-      'dex'
-    );
-  }
+  const issuer = `https://${window.config.mapiAudience}`;
 
   return {
     authority,

--- a/webpack.dev.ts
+++ b/webpack.dev.ts
@@ -64,8 +64,8 @@ const config: webpack.Configuration = merge(common, {
       overrides: {
         apiEndpoint: 'http://localhost:8000',
         mapiEndpoint: 'http://localhost:8888',
+        mapiAuthEndpoint: 'http://localhost:9999',
         athenaEndpoint: 'http://localhost:7777',
-        mapiAudience: 'http://localhost:9999',
         mapiAuthRedirectURL: 'http://localhost:7000',
         environment: 'development',
         happaVersion: 'development',
@@ -86,11 +86,11 @@ const config: webpack.Configuration = merge(common, {
         {
           port: 9999,
           host: (options) => {
-            if (!/http(s)?:\/\//.test(options.mapiAudience)) {
-              return `https://${options.mapiAudience}`;
+            if (!/http(s)?:\/\//.test(options.mapiAuthEndpoint)) {
+              return `https://${options.mapiAuthEndpoint}`;
             }
 
-            return options.mapiAudience;
+            return options.mapiAuthEndpoint;
           },
         },
       ],


### PR DESCRIPTION
### What does this PR do?

`getInstallationBaseURL()` function relies on the legacy `audience` configuration value which is not available on new installations. This PR changes uses of `audience` value in favour of `mapiAudience` value.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/3926.