### PR TITLE
Remove orgId from happa link

### DIFF
--- a/src/components/UI/Controls/Navigation/MainMenu.js
+++ b/src/components/UI/Controls/Navigation/MainMenu.js
@@ -22,7 +22,6 @@ if (window.featureFlags.FEATURE_MONITORING) {
   hostnameParts[0] = 'grafana';
   audienceURL.host = hostnameParts.join('.');
   audienceURL.pathname = '/';
-  audienceURL.search = '?orgId=1';
   monitoringURL = audienceURL.toString();
 }
 


### PR DESCRIPTION
### What does this PR do?

Towards https://gigantic.slack.com/archives/C01RPJ7TSCE/p1750161492488549?thread_ts=1748341853.182179&cid=C01RPJ7TSCE and https://github.com/giantswarm/giantswarm/issues/33560

This PR removes the orgID parameter from the happa monitoring link because users might not have access to this organization.

### What is the effect of this change to users?

### How does it look like?

(Please add screenshots or screen recordings demonstrating the change.)

### Any background context you can provide?

(Please link public issues or summarize if not public.)

### What is needed from the reviewers?

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

If yes, please apply one of the following labels: `kind/feature`, `kind/change`, `kind/bug`, `kind/removal`, `kind/ux-enhancement`, `kind/security`
