### PR TITLE
Switch image registry to gsoci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
             docker run --name happa-branch \
               -p 8000:8000 \
               -d \
-              "quay.io/giantswarm/happa:$(cat VERSION)"
+              "gsoci.azurecr.io/giantswarm/happa:$(cat VERSION)"
             sleep 10
             CURL_OUTPUT=$(ssh remote-docker "curl -s http://localhost:8000")
             echo "${CURL_OUTPUT}" | grep "Giant Swarm web interface"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/giantswarm/alpine:3.18.4 AS compress
+FROM gsoci.azurecr.io/giantswarm/alpine:3.18.4 AS compress
 
 RUN apk --no-cache add findutils gzip
 
@@ -11,7 +11,7 @@ RUN find /www \
   -iregex '.*\.(css|csv|html?|js|svg|txt|xml|json|webmanifest|ttf)' \
   -exec gzip -9 -k '{}' \;
 
-FROM quay.io/giantswarm/nginx:1.23-alpine as builder
+FROM gsoci.azurecr.io/giantswarm/nginx:1.23-alpine as builder
 
 ARG ENABLED_MODULES="ndk lua"
 
@@ -73,14 +73,14 @@ RUN apk update \
     done \
     && echo "BUILT_MODULES=\"$BUILT_MODULES\"" > /tmp/packages/modules.env
 
-FROM quay.io/giantswarm/nginx:1.23-alpine
+FROM gsoci.azurecr.io/giantswarm/nginx:1.23-alpine
 RUN --mount=type=bind,target=/tmp/packages/,source=/tmp/packages/,from=builder \
     . /tmp/packages/modules.env \
     && for module in $BUILT_MODULES; do \
            apk add --no-cache --allow-untrusted /tmp/packages/nginx-module-${module}-${NGINX_VERSION}*.apk; \
        done
 
-ENV NODE_VERSION 16.7.0
+ENV NODE_VERSION=16.7.0
 
 RUN apk add --no-cache binutils libstdc++
 RUN curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz"; \

--- a/ats/test-values.yaml
+++ b/ats/test-values.yaml
@@ -82,7 +82,7 @@ oidc:
 
 
 registry:
-  domain: quay.io
+  domain: gsoci.azurecr.io
   pullSecret:
     dockerConfigJSON: "e30="
 


### PR DESCRIPTION
Changes Dockerfile and more to use gsoci.azurecr.io in favour of quay.io

Towards https://github.com/giantswarm/roadmap/issues/3935