### PR TITLE
chore(deps): pin patched versions of vulnerable transitive deps

### DIFF
--- a/docs/dependency-security-plan.md
+++ b/docs/dependency-security-plan.md
@@ -1,0 +1,68 @@
+# Dependency Security Remediation Plan
+
+Living plan for clearing the security advisories surfaced by `yarn audit`.
+Build-time-only vulnerabilities (e.g., via `node-sass`, `request`, `storybook`,
+`eslint`, `jest`, `webpack-*`) are deprioritised because they are not reachable
+by users of the deployed app — they only matter for supply-chain hygiene and CI
+image scanning, addressed separately when convenient.
+
+The PRs below are ordered low-risk → high-risk so each one is independently
+shippable.
+
+## PR 1 — Add `resolutions` for transitive vulns
+
+Pin patched versions of transitive deps via the `resolutions` block in
+`package.json`. Targets where a patched version exists and the bump is safe:
+
+- `nanoid` ≥ 3.3.8
+- `qs` ≥ 6.14.1
+- `brace-expansion` ≥ 2.0.2
+- `flatted` ≥ 3.3.3
+- `tar` ≥ 6.2.1
+- `tar-fs` ≥ 2.1.2
+
+Skipped:
+
+- `lodash-es` — the `_.template` code-injection advisory has no upstream fix;
+  mitigation is "don't pass user input to `_.template`".
+- `mdast-util-to-hast`, `tough-cookie`, `postcss`, `serialize-javascript` —
+  already resolved at a patched version in the lockfile.
+- `picomatch` v4 is a major bump that may break webpack-dev-server / micromatch;
+  evaluate separately.
+
+## PR 2 — Bump `react-markdown` to latest 9.x
+
+Four call sites; API stable within 9.x. Verifies markdown surfaces (changelogs,
+app detail pages).
+
+## PR 3 — Bump `mermaid` to latest 10.x
+
+Single call site (`src/components/UI/Display/Documentation/Mermaid.tsx`).
+
+## PR 4 — Bump `@rjsf/core`, `@rjsf/utils`, `@rjsf/validator-ajv8` to latest 5.x
+
+Heavy use in `src/utils/schema/` but a 5.17 → 5.x patch should be drop-in.
+Run schema-related tests deliberately.
+
+## PR 5 — Replace `validate.js`
+
+One file (`src/utils/helpers.ts`). AJV is already a direct dependency and is
+the natural replacement. Removes an unfixable ReDoS in an unmaintained package.
+
+## PR 6 — Replace `connected-react-router`
+
+Migrate to `redux-first-history`. Touches ~20 files; mostly import swaps and
+store-config tweaks. Independent of the others.
+
+## PR 7 — Bootstrap 3 → 5
+
+Largest item. Remove the Renovate exception in `renovate.json5` (currently
+disables `bootstrap` updates). May need to be split into multiple sub-PRs by
+layout area.
+
+## Out of scope for this plan
+
+Build-time vulnerabilities (e.g., `node-sass`, `request`, `@storybook/*`,
+`eslint`, `jest`, `webpack-*`). These are real but only surface during build
+and CI, not in user traffic. Worth cleaning up eventually for supply-chain
+hygiene.

--- a/package.json
+++ b/package.json
@@ -250,7 +250,13 @@
     "node-fetch": "2.7.0",
     "trim": "1.0.1",
     "underscore": "1.13.8",
-    "string-width": "4.2.3"
+    "string-width": "4.2.3",
+    "brace-expansion": "^2.0.2",
+    "flatted": "^3.3.3",
+    "nanoid": "^3.3.8",
+    "qs": "^6.14.1",
+    "tar": "^6.2.1",
+    "tar-fs": "^2.1.2"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6196,18 +6196,10 @@ bplist-parser@^0.2.0:
   dependencies:
     big-integer "^1.6.44"
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+brace-expansion@^1.1.7, brace-expansion@^2.0.1, brace-expansion@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
+  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -6869,11 +6861,6 @@ compute-lcm@^1.1.2:
     validate.io-array "^1.0.3"
     validate.io-function "^1.0.2"
     validate.io-integer-array "^1.0.0"
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 concat-stream@^1.6.2:
   version "1.6.2"
@@ -9174,10 +9161,10 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@^3.2.9:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
-  integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
+flatted@^3.2.9, flatted@^3.3.3:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 flow-parser@0.*:
   version "0.227.0"
@@ -13206,10 +13193,10 @@ nan@^2.17.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
   integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
 
-nanoid@^3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
-  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+nanoid@^3.3.7, nanoid@^3.3.8:
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
+  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -14401,31 +14388,12 @@ pure-rand@^6.0.0:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.4.tgz#50b737f6a925468679bff00ad20eade53f37d5c7"
   integrity sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==
 
-qs@6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
-  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
-  dependencies:
-    side-channel "^1.0.4"
-
-qs@^6.10.0, qs@^6.11.0, qs@^6.11.2, qs@^6.5.1:
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
-  integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
-  dependencies:
-    side-channel "^1.0.4"
-
-qs@~6.14.0:
-  version "6.14.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
-  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+qs@6.11.0, qs@^6.10.0, qs@^6.11.0, qs@^6.11.2, qs@^6.14.1, qs@^6.5.1, qs@~6.14.0, qs@~6.5.2:
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
+  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
   dependencies:
     side-channel "^1.1.0"
-
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-string@^4.2.2:
   version "4.3.4"
@@ -16227,10 +16195,10 @@ tapable@^2.3.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.2.tgz#86755feabad08d82a26b891db044808c6ad00f15"
   integrity sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==
 
-tar-fs@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
-  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+tar-fs@^2.1.1, tar-fs@^2.1.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.4.tgz#800824dbf4ef06ded9afea4acafe71c67c76b930"
+  integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
   dependencies:
     chownr "^1.1.1"
     mkdirp-classic "^0.5.2"
@@ -16248,10 +16216,10 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^6.0.2, tar@^6.1.11, tar@^6.1.2, tar@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.0.tgz#b14ce49a79cb1cd23bc9b016302dea5474493f73"
-  integrity sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==
+tar@^6.0.2, tar@^6.1.11, tar@^6.1.2, tar@^6.2.0, tar@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
### What does this PR do?

Adds yarn `resolutions` entries for six transitive dependencies that
have known security advisories with available patches:

| package | resolved version | advisory |
|---|---|---|
| `nanoid` | `^3.3.8` | predictable IDs when given non-integer values |
| `qs` | `^6.14.1` | `arrayLimit` bypass DoS |
| `brace-expansion` | `^2.0.2` | ReDoS + zero-step memory exhaustion |
| `flatted` | `^3.3.3` | prototype pollution + unbounded recursion DoS |
| `tar` | `^6.2.1` | multiple node-tar path-traversal advisories |
| `tar-fs` | `^2.1.2` | link-following / path traversal |

No direct dependencies change.

Also adds `docs/dependency-security-plan.md` — a multi-PR remediation
plan to coordinate the remaining work (`react-markdown`, `mermaid`,
`@rjsf/*`, `validate.js`, `connected-react-router`, `bootstrap`).
Build-time-only vulns (e.g. via `node-sass`, `request`, `@storybook/*`,
`eslint`, `jest`, `webpack-*`) are deprioritised in the plan because
they're not reachable by users of the deployed app.

### What is the effect of this change to users?

None at runtime — these are transitive dependency pins. Existing direct
deps continue to work unchanged.

`yarn audit` total drops from **465 → 370** findings
(8 critical / 170 high / 149 moderate / 49 low; -1 high, -48 moderate,
-40 low).

The 8 remaining criticals are all `form-data`. The tree has multiple
form-data majors (2.x and 4.x), so a blanket resolution is risky and is
deferred to a follow-up.

### How does it look like?

n/a — no UI change.

### Any background context you can provide?

PR 1 of a multi-PR security remediation effort documented in
`docs/dependency-security-plan.md`.

### What is needed from the reviewers?

- Confirm the `resolutions` choices look safe.
- Sanity-check the lockfile diff (only transitive versions move).

### Do the docs need to be updated?

The new `docs/dependency-security-plan.md` is the relevant doc.

### Should this change be mentioned in the release notes?

`kind/security`.