### PR TITLE
chore(deps): bump @rjsf packages to 5.24.13

### DIFF
--- a/docs/dependency-security-plan.md
+++ b/docs/dependency-security-plan.md
@@ -33,11 +33,20 @@ Skipped:
 ## PR 2 — Bump `react-markdown` to latest 9.x
 
 Four call sites; API stable within 9.x. Verifies markdown surfaces (changelogs,
-app detail pages).
+app detail pages). _Shipped in #4744 — also added a `mdast-util-to-hast`
+resolution since the bump alone did not move the transitive._
 
-## PR 3 — Bump `mermaid` to latest 10.x
+## PR 3 — Bump `mermaid`
 
-Single call site (`src/components/UI/Display/Documentation/Mermaid.tsx`).
+**Dropped.** `mermaid@10.9.5` is already the latest 10.x. The reported vuln
+is the `lodash-es` `_.template` code-injection advisory, which has no upstream
+fix in any lodash version. `mermaid@11.x` would swap `lodash-es` for
+`es-toolkit` — but `lodash-es` is also pulled by `@rjsf/*`, `redux@^3`
+(transitive via `connected-react-router`), and `dagre-d3-es`, so the advisory
+would persist anyway. Additionally, `mermaid@11` requires
+`@braintree/sanitize-url ^7.1.1`, which conflicts with the existing
+resolution at `6.0.4`. Revisit as a standalone effort if/when we're ready
+for the major bump.
 
 ## PR 4 — Bump `@rjsf/core`, `@rjsf/utils`, `@rjsf/validator-ajv8` to latest 5.x
 

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
   "mainInput": "main",
   "mainOutput": "main",
   "dependencies": {
-    "@rjsf/core": "5.17.0",
-    "@rjsf/utils": "5.17.0",
-    "@rjsf/validator-ajv8": "5.17.0",
+    "@rjsf/core": "5.24.13",
+    "@rjsf/utils": "5.24.13",
+    "@rjsf/validator-ajv8": "5.24.13",
     "@sentry/react": "7.54.0",
     "@sentry/tracing": "7.54.0",
     "ajv": "8.20.0",

--- a/src/components/UI/JSONSchemaForm/ArrayFieldItem/index.tsx
+++ b/src/components/UI/JSONSchemaForm/ArrayFieldItem/index.tsx
@@ -45,7 +45,7 @@ const ArrayFieldItem: React.FC<ArrayFieldTemplateItemType> = ({
       <ArrayFieldItemActionsWrapper>
         {hasToolbar && (
           <ArrayFieldItemActions
-            disabled={disabled || readonly}
+            disabled={Boolean(disabled || readonly)}
             hasMoveDown={hasMoveDown}
             hasMoveUp={hasMoveUp}
             hasRemove={hasRemove}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3168,21 +3168,20 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@rjsf/core@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.17.0.tgz#2a964d555ba6dc018e381159371c2396df9136af"
-  integrity sha512-0woSU+VU+t2kbDNSyMQhjxJOXJbk3F6lSHxf8XmS4yV3sXP/yr/vo7J3qcvXbSvCLPYMQHvskBFhCIaQqyHWBg==
+"@rjsf/core@5.24.13":
+  version "5.24.13"
+  resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-5.24.13.tgz#ef98e5dc6ac064b2be2f56e0887c99df2b1f8d44"
+  integrity sha512-ONTr14s7LFIjx2VRFLuOpagL76sM/HPy6/OhdBfq6UukINmTIs6+aFN0GgcR0aXQHFDXQ7f/fel0o/SO05Htdg==
   dependencies:
     lodash "^4.17.21"
     lodash-es "^4.17.21"
     markdown-to-jsx "^7.4.1"
-    nanoid "^3.3.7"
     prop-types "^15.8.1"
 
-"@rjsf/utils@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.17.0.tgz#baf9a108bdd8e8c7f5a3441d8e88447c3926d501"
-  integrity sha512-Hy2uAxMKWZIZSMzc2AiHrdACYvHj9GDynrdApMgUTxfjpzj5DT7Rghl/FGj7gg8Zy8VtdVNTCbkIzfS8xt4x7g==
+"@rjsf/utils@5.24.13":
+  version "5.24.13"
+  resolved "https://registry.yarnpkg.com/@rjsf/utils/-/utils-5.24.13.tgz#b19ca434bf518ec3e652c4a0510b293ff5fac279"
+  integrity sha512-rNF8tDxIwTtXzz5O/U23QU73nlhgQNYJ+Sv5BAwQOIyhIE2Z3S5tUiSVMwZHt0julkv/Ryfwi+qsD4FiE5rOuw==
   dependencies:
     json-schema-merge-allof "^0.8.1"
     jsonpointer "^5.0.1"
@@ -3190,10 +3189,10 @@
     lodash-es "^4.17.21"
     react-is "^18.2.0"
 
-"@rjsf/validator-ajv8@5.17.0":
-  version "5.17.0"
-  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.17.0.tgz#460a9f7804db26b62c04ba3e4d434618b120027b"
-  integrity sha512-ZLTpvZDzBt1+Wftao2AkpRaSvxaVRrutvFX3/oy640/KsWUfl0ofV33ai9O4aptKSnOPjfRiLqPJgbPHgQAhmw==
+"@rjsf/validator-ajv8@5.24.13":
+  version "5.24.13"
+  resolved "https://registry.yarnpkg.com/@rjsf/validator-ajv8/-/validator-ajv8-5.24.13.tgz#8d56ca1e92c87f6b6234d97e07e96f80016a68c0"
+  integrity sha512-oWHP7YK581M8I5cF1t+UXFavnv+bhcqjtL1a7MG/Kaffi0EwhgcYjODrD8SsnrhncsEYMqSECr4ZOEoirnEUWw==
   dependencies:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"


### PR DESCRIPTION
### What does this PR do?

Bumps all three `@rjsf/*` packages from `5.17.0` to `5.24.13` (latest 5.x):
- `@rjsf/core`
- `@rjsf/utils`
- `@rjsf/validator-ajv8`

Includes one type fix: `ArrayFieldTemplateItemType.disabled` is now
typed `boolean | undefined` instead of `boolean`, so the single call
site in `src/components/UI/JSONSchemaForm/ArrayFieldItem/index.tsx`
coerces with `Boolean(...)` to match the local
`ArrayFieldItemActions` prop type.

Also updates `docs/dependency-security-plan.md` to drop the mermaid PR
(latest 10.x is the current version; the `lodash-es` advisory has no
upstream fix and persists via `@rjsf`, `redux@^3`, and `dagre-d3-es`
regardless).

### What is the effect of this change to users?

No user-facing change expected. JSON-schema form rendering surfaces
(app install, cluster create, schema testers) should behave identically.

`yarn audit` total unchanged at 378 — the `lodash-es` advisories
pulled in by `@rjsf` have no upstream fix; this is hygiene, not a
findings-reducing change.

### How does it look like?

n/a — no UI change.

### Any background context you can provide?

PR of the dependency security plan in
`docs/dependency-security-plan.md`. Renumbered after dropping the
mermaid item (see the doc for rationale).

Affected schema utils:
- `src/utils/schema/*`
- `src/components/UI/JSONSchemaForm/*`

### What is needed from the reviewers?

Sanity-check that JSON-schema form rendering still works correctly —
especially anywhere arrays of objects appear (the
`ArrayFieldItem.disabled` type change is the only behavioural surface
this PR touches).

### Do the docs need to be updated?

`docs/dependency-security-plan.md` updated.

### Should this change be mentioned in the release notes?

`kind/change`.