### PR TITLE
chore(deps): remove validate.js (dead code)

### DIFF
--- a/docs/dependency-security-plan.md
+++ b/docs/dependency-security-plan.md
@@ -53,10 +53,13 @@ for the major bump.
 Heavy use in `src/utils/schema/` but a 5.17 → 5.x patch should be drop-in.
 Run schema-related tests deliberately.
 
-## PR 5 — Replace `validate.js`
+## PR 5 — Remove `validate.js`
 
-One file (`src/utils/helpers.ts`). AJV is already a direct dependency and is
-the natural replacement. Removes an unfixable ReDoS in an unmaintained package.
+`validate.js` was used by a single helper, `validateOrRaise`, in
+`src/utils/helpers.ts`. The helper is dead code — defined and exported
+but only consumed by its own unit test. Deleted the helper, its test,
+and the `validate.js` direct dependency outright. No replacement
+needed.
 
 ## PR 6 — Replace `connected-react-router`
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "swr": "2.2.4",
     "underscore": "1.13.8",
     "uuid": "14.0.0",
-    "validate.js": "0.13.1",
     "web-vitals": "3.5.2"
   },
   "devDependencies": {

--- a/src/utils/__tests__/helpers.ts
+++ b/src/utils/__tests__/helpers.ts
@@ -12,7 +12,6 @@ import {
   makeKubeConfigTextFile,
   toTitleCase,
   truncate,
-  validateOrRaise,
 } from 'utils/helpers';
 
 describe('helpers', () => {
@@ -215,37 +214,6 @@ describe('helpers', () => {
       expect(result).toStrictEqual({ unit: 'PiB', value: '312.570' });
 
       /* eslint-enable no-magic-numbers */
-    });
-  });
-
-  describe('validateOrRaise', () => {
-    it('validates a certain object, with validate.js constraints', () => {
-      const obj: { email: string; token?: string } = {
-        email: '@@google.com',
-      };
-
-      const constraints = {
-        email: {
-          presence: true,
-          email: true,
-          length: {
-            minimum: 15,
-          },
-        },
-        token: { presence: true },
-      };
-
-      expect(() => {
-        validateOrRaise(obj, constraints);
-      }).toThrowError(
-        new Error(`email: is not a valid email, is too short (minimum is 15 characters)
-token: can't be blank`)
-      );
-
-      obj.email = 'test@someemail.com';
-      obj.token = 'some-token';
-
-      validateOrRaise(obj, constraints);
     });
   });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -7,7 +7,7 @@ import toDate from 'date-fns-tz/toDate';
 import utcToZonedTime from 'date-fns-tz/utcToZonedTime';
 import ipRegex from 'ip-regex';
 import { getOrganizationByID } from 'model/stores/organization/utils';
-import validate from 'validate.js';
+
 /**
  * Format code in a user-friendly way.
  * Note: Newline backticks need to be escaped.
@@ -157,38 +157,6 @@ export function convertMBtoBytes(mb: number): number {
 export function convertMiBtoBytes(mebibytes: number): number {
   // eslint-disable-next-line no-magic-numbers
   return mebibytes * 1024 * 1024;
-}
-
-/**
- * Helper method that validates an object based on constraints.
- * @param validatable - The object to validate.
- * @param constraints - The `validate.js` constraints.
- * @throws {TypeError} Error with a helpful message if the validation fails.
- */
-export function validateOrRaise<T>(
-  validatable: T,
-  constraints: Partial<Record<keyof T, Record<string, unknown>>>
-): void {
-  const validationErrors: Record<string, string[]> = validate(
-    validatable,
-    constraints,
-    {
-      fullMessages: false,
-    }
-  );
-  if (!validationErrors) return;
-
-  /**
-   * If there are validation errors, throw a TypeError that
-   * has readable information about what went wrong.
-   */
-  const messages = Object.entries(validationErrors).map(
-    ([field, errorMessages]) => {
-      return `${field}: ${errorMessages.join(', ')}`;
-    }
-  );
-
-  throw new TypeError(messages.join('\n'));
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -17116,11 +17116,6 @@ validate.io-number@^1.0.3:
   resolved "https://registry.yarnpkg.com/validate.io-number/-/validate.io-number-1.0.3.tgz#f63ffeda248bf28a67a8d48e0e3b461a1665baf8"
   integrity sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==
 
-validate.js@0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/validate.js/-/validate.js-0.13.1.tgz#b58bfac04a0f600a340f62e5227e70d95971e92a"
-  integrity sha512-PnFM3xiZ+kYmLyTiMgTYmU7ZHkjBZz2/+F0DaALc/uUtVzdCt1wAosvYJ5hFQi/hz8O4zb52FQhHZRC+uVkJ+g==
-
 value-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"


### PR DESCRIPTION
### What does this PR do?

Removes the `validate.js` direct dependency and the
`validateOrRaise` helper that was the only thing using it.

`validateOrRaise` was defined and exported in `src/utils/helpers.ts`,
but the only caller anywhere in the codebase was its own unit test —
no production code path consumed it. Deleted the helper, the test, and
the dependency. No replacement needed.

### What is the effect of this change to users?

No user-facing change.

- Clears the `validate.js` ReDoS advisory (no upstream fix available).
- Clears several transitive findings from `validate.js`'s own dep tree.
- `yarn audit` total drops 378 → 363 (-15 findings; -18 high,
  +3 moderate offset from background shifts in the transitive tree).

### How does it look like?

n/a — no UI change.

### Any background context you can provide?

PR of the dependency security plan in
`docs/dependency-security-plan.md`. Originally scoped as
"replace with AJV"; turned out to be dead code, so the plan doc is
updated to reflect the simpler outcome.

### What is needed from the reviewers?

Sanity-check that nothing else relied on `validateOrRaise`. I grepped
the whole `src/`, `test/`, and `scripts/` trees and found only the
two files this PR touches.

### Do the docs need to be updated?

`docs/dependency-security-plan.md` updated.

### Should this change be mentioned in the release notes?

`kind/security`.