### PR TITLE
fix(renovate): remove schedule, increase concurrency

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,12 +4,10 @@
   packageRules: [
     {
       groupName: "jest packages",
-      schedule: ["every weekend"],
       matchPackageNames: ["@types/jest{/,}**", "jest{/,}**"],
     },
     {
       groupName: "eslint packages",
-      schedule: ["every weekend"],
       matchPackageNames: ["eslint{/,}**", "@typescript-eslint{/,}**"],
     },
     {
@@ -18,17 +16,14 @@
     },
     {
       groupName: "storybook packages",
-      schedule: ["every weekend"],
       matchPackageNames: ["@storybook{/,}**"],
     },
     {
       groupName: "babel packages",
-      schedule: ["every weekend"],
       matchPackageNames: ["@babel{/,}**", "babel{/,}**"],
     },
     {
       groupName: "sentry packages",
-      schedule: ["every weekend"],
       matchPackageNames: ["@sentry{/,}**"],
     },
     {
@@ -49,7 +44,6 @@
     },
     {
       groupName: "webpack packages",
-      schedule: ["every weekend"],
       matchPackageNames: [
         "@webpack{/,}**",
         "webpack{/,}**",
@@ -80,7 +74,6 @@
     },
     {
       groupName: "node packages",
-      schedule: ["every weekend"],
       matchPackageNames: ["@types/node{/,}**"],
     },
     {
@@ -88,10 +81,5 @@
       enabled: false,
     },
   ],
-  prConcurrentLimit: 1,
-  schedule: [
-    "every weekend",
-    "every weekday after 6pm",
-    "every weekday before 6am",
-  ],
+  prConcurrentLimit: 5,
 }


### PR DESCRIPTION
The goal is to let Renovate propose dependency updates mostly unrestricted.

This PR removes the schedule restrictions and increases the concurrency to 5 PRs.