### PR TITLE
feat(analytics): track only authenticated pageviews via TelemetryDeck JS SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# happa — notes for Claude Code
+
+happa is the Giant Swarm web UI: a React 18 SPA (TypeScript, Redux + redux-thunk,
+styled-components, OIDC via `oidc-client-ts`, Sentry for error reporting). The
+notes below are non-obvious things that are easy to get wrong — read them before
+adding code or tests.
+
+## Package management / Node
+
+- **Package manager is yarn 1 (classic)** (`yarn.lock`). Don't use npm.
+- `package.json` pins **`engines.node: "20"`**. On any other local Node version,
+  `yarn add`/`yarn install` fail the engine check — add `--ignore-engines`
+  (local only; don't change the pin).
+- Dependencies are pinned **exact** (no `^`), e.g. `"react": "18.3.1"`. Install
+  new deps with `yarn add --exact <pkg>@<version>`.
+
+## Imports
+
+- Absolute imports resolve from **both `src/` and `src/components/`**
+  (tsconfig `paths: "*": ["src/components/*", "src/*"]`, plus jest
+  `moduleDirectories`). So `model/...`, `utils/...` are `src`-rooted, while
+  `Route`, `UI/...`, `Auth/...`, `MAPI/...` are `src/components`-rooted. Both
+  forms are correct — match the surrounding file.
+
+## Tests (jest)
+
+- **Test files are named after the module under test**, inside a `__tests__/`
+  dir — e.g. `src/utils/errors/__tests__/ErrorReporter.ts`, NOT
+  `ErrorReporter.test.ts`. Jest's default `testMatch` picks up everything under
+  `__tests__/`.
+- `window.config` and `window.featureFlags` are injected into **every** test via
+  `globals` in `jest.config.ts`, with **`environment: 'development'`**. Code
+  gated on the environment therefore runs in *dev* mode by default in tests;
+  override `window.config.environment` per-test to exercise other branches.
+- Useful scripts: `yarn test`, `yarn typecheck` (`tsc`), `yarn lint`
+  (`eslint --ext .js,.ts,.tsx ./src/`), `yarn lint:fix`.
+
+## Environment & config
+
+- `GlobalEnvironment` (`src/@types/global.d.ts`) is
+  **`'development' | 'kubernetes' | 'docker-container'`** — there is no
+  `'production'`/`'staging'`. Runtime config (`apiEndpoint`, `environment`,
+  installation info, feature flags, Sentry DSN, …) is injected into
+  `window.config` / `window.featureFlags` by the EJS template at serve time.
+
+## Routing & auth state
+
+- **React Router v5** (not v6), integrated with `redux-first-history`. Current
+  location is in Redux at `state.router.location`; routing hooks/`matchPath`
+  come from `react-router`.
+- Auth lives in Redux at `state.main.loggedInUser` (selector `getLoggedInUser`).
+  `components/Layout.tsx` is the authenticated root (redirects to `/login` when
+  there's no user); `/login`, `/admin-login`, `/logout` render outside it.
+
+## Build artifacts
+
+- The app shell is `src/index.ejs`, rendered by webpack's `HtmlWebpackPlugin`.
+  **`dist/` is a gitignored build artifact** — never edit files in `dist/`
+  (e.g. a stale `dist/index.ejs`); only change `src/index.ejs`.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@rjsf/validator-ajv8": "5.24.13",
     "@sentry/react": "7.120.4",
     "@sentry/tracing": "7.120.4",
+    "@telemetrydeck/sdk": "2.0.4",
     "ajv": "8.20.0",
     "bootstrap": "3.4.1",
     "bowser": "2.14.1",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -31,6 +31,7 @@ import { Redirect, Switch } from 'react-router-dom';
 import { Dispatch } from 'redux';
 import Route from 'Route';
 import OrganizationCreatedNote from 'UI/Display/Organizations/OrganizationCreatedNote';
+import { usePageViewTracking } from 'utils/telemetry/usePageViewTracking';
 
 import Apps from './Apps/Apps';
 import ExceptionNotificationTest from './ExceptionNotificationTest/ExceptionNotificationTest';
@@ -52,6 +53,10 @@ const Layout: React.FC<React.PropsWithChildren<{}>> = () => {
   const dispatch: Dispatch<any> = useDispatch();
 
   const authProvider = useAuthProvider();
+
+  // Track pageviews, but only for authenticated navigation (this component is
+  // the authenticated root), so bot probes and login pages are never counted.
+  usePageViewTracking();
 
   useEffect(() => {
     dispatch(batchedLayout(authProvider));

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import theme from 'styles/theme';
 import { FlashMessagesController } from 'UI/Util/FlashMessages/FlashMessagesController';
+import { isExternalReportingEnabled } from 'utils/config';
 import ErrorReporter from 'utils/errors/ErrorReporter';
 import { SentryErrorNotifier } from 'utils/errors/SentryErrorNotifier';
 import { makeDefaultConfig } from 'utils/MapiAuth/makeDefaultConfig';
@@ -29,7 +30,7 @@ const flashMessagesController = FlashMessagesController.getInstance();
 // Configure the redux store.
 const { store, history } = configureStore({} as IState, baseHistory, auth);
 
-if (window.config.environment !== 'development') {
+if (isExternalReportingEnabled()) {
   const errorReporter = ErrorReporter.getInstance();
   errorReporter.notifier = new SentryErrorNotifier({
     projectName: 'happa',

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -173,6 +173,5 @@
     </noscript>
 
     <div id="app"></div>
-    <script async src="https://cdn.telemetrydeck.com/websdk/telemetrydeck.min.js" data-app-id="746BB2DF-C3C7-4DE8-82A7-9848CEEE9585"></script>
   </body>
 </html>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,12 @@
+/**
+ * Whether data may be sent to external reporting services (Sentry error
+ * reporting, TelemetryDeck analytics). Disabled in development so local
+ * traffic never reaches those services.
+ */
+export function isExternalReportingEnabled(): boolean {
+  return window.config.environment !== 'development';
+}
+
 export function getK8sVersionEOLDate(version: string) {
   if (!version) return null;
 

--- a/src/utils/telemetry/TelemetryService.ts
+++ b/src/utils/telemetry/TelemetryService.ts
@@ -1,19 +1,11 @@
 import TelemetryDeck from '@telemetrydeck/sdk';
+import { isExternalReportingEnabled } from 'utils/config';
 
 /**
  * TelemetryDeck application ID. Not a secret; it only identifies the analytics
  * app to send signals to.
  */
 const TELEMETRY_APP_ID = '746BB2DF-C3C7-4DE8-82A7-9848CEEE9585';
-
-/**
- * Whether analytics should be sent. Disabled in development so local traffic
- * never pollutes the dashboard (mirrors the Sentry gate in
- * `src/components/index.tsx`).
- */
-function isTrackingEnabled(): boolean {
-  return window.config.environment !== 'development';
-}
 
 /**
  * A singleton wrapper around the TelemetryDeck SDK for sending pageview
@@ -38,7 +30,7 @@ class TelemetryService {
    * `clientUser` in sync. The SDK hashes `clientUser` before sending.
    */
   private getClient(clientUser: string): TelemetryDeck | null {
-    if (!isTrackingEnabled()) {
+    if (!isExternalReportingEnabled()) {
       return null;
     }
 

--- a/src/utils/telemetry/TelemetryService.ts
+++ b/src/utils/telemetry/TelemetryService.ts
@@ -1,0 +1,80 @@
+import TelemetryDeck from '@telemetrydeck/sdk';
+
+/**
+ * TelemetryDeck application ID. Not a secret; it only identifies the analytics
+ * app to send signals to.
+ */
+const TELEMETRY_APP_ID = '746BB2DF-C3C7-4DE8-82A7-9848CEEE9585';
+
+/**
+ * Whether analytics should be sent. Disabled in development so local traffic
+ * never pollutes the dashboard (mirrors the Sentry gate in
+ * `src/components/index.tsx`).
+ */
+function isTrackingEnabled(): boolean {
+  return window.config.environment !== 'development';
+}
+
+/**
+ * A singleton wrapper around the TelemetryDeck SDK for sending pageview
+ * signals. Tracking is disabled in development, mirroring the Sentry gate in
+ * `src/components/index.tsx`.
+ */
+class TelemetryService {
+  private static _instance: TelemetryService | null = null;
+
+  public static getInstance(): TelemetryService {
+    if (!TelemetryService._instance) {
+      TelemetryService._instance = new TelemetryService();
+    }
+
+    return TelemetryService._instance;
+  }
+
+  private client: TelemetryDeck | null = null;
+
+  /**
+   * Lazily creates the SDK client (only when enabled) and keeps its
+   * `clientUser` in sync. The SDK hashes `clientUser` before sending.
+   */
+  private getClient(clientUser: string): TelemetryDeck | null {
+    if (!isTrackingEnabled()) {
+      return null;
+    }
+
+    if (this.client) {
+      this.client.clientUser = clientUser;
+    } else {
+      this.client = new TelemetryDeck({ appID: TELEMETRY_APP_ID, clientUser });
+    }
+
+    return this.client;
+  }
+
+  /**
+   * Sends a pageview signal for an authenticated navigation. Best-effort:
+   * failures are swallowed so analytics can never disrupt the app.
+   *
+   * @param route - normalized route pattern (no concrete resource IDs)
+   * @param clientUser - stable user identifier, hashed by the SDK
+   */
+  public trackPageView(route: string, clientUser: string): void {
+    const client = this.getClient(clientUser);
+    if (!client) {
+      return;
+    }
+
+    client
+      .signal('pageview', {
+        route,
+        host: window.location.hostname,
+        installation: window.config.info.general.installationName,
+        environment: window.config.environment,
+      })
+      .catch(() => {
+        // Analytics is best-effort; never surface failures to the user.
+      });
+  }
+}
+
+export default TelemetryService;

--- a/src/utils/telemetry/__tests__/TelemetryService.ts
+++ b/src/utils/telemetry/__tests__/TelemetryService.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 
 describe('TelemetryService', () => {
   it('is a singleton', () => {
-    expect(new TelemetryService()).toEqual(TelemetryService.getInstance());
+    expect(TelemetryService.getInstance()).toBe(TelemetryService.getInstance());
   });
 
   it('does not track in development', () => {

--- a/src/utils/telemetry/__tests__/TelemetryService.ts
+++ b/src/utils/telemetry/__tests__/TelemetryService.ts
@@ -1,0 +1,80 @@
+import TelemetryDeck from '@telemetrydeck/sdk';
+
+import TelemetryService from '../TelemetryService';
+
+jest.mock('@telemetrydeck/sdk', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const MockedTelemetryDeck = TelemetryDeck as jest.MockedClass<
+  typeof TelemetryDeck
+>;
+
+const signal = jest.fn().mockResolvedValue(undefined);
+const originalEnvironment = window.config.environment;
+
+function setEnvironment(environment: GlobalEnvironment) {
+  window.config.environment = environment;
+}
+
+beforeEach(() => {
+  MockedTelemetryDeck.mockReset();
+  signal.mockClear();
+  MockedTelemetryDeck.mockImplementation(
+    () => ({ clientUser: '', signal } as unknown as TelemetryDeck)
+  );
+});
+
+afterEach(() => {
+  setEnvironment(originalEnvironment);
+});
+
+describe('TelemetryService', () => {
+  it('is a singleton', () => {
+    expect(new TelemetryService()).toEqual(TelemetryService.getInstance());
+  });
+
+  it('does not track in development', () => {
+    setEnvironment('development');
+
+    new TelemetryService().trackPageView('/', 'user@example.com');
+
+    expect(MockedTelemetryDeck).not.toHaveBeenCalled();
+    expect(signal).not.toHaveBeenCalled();
+  });
+
+  it('sends a pageview signal with route, host, installation and environment', () => {
+    setEnvironment('kubernetes');
+
+    new TelemetryService().trackPageView(
+      '/organizations/:orgId',
+      'user@example.com'
+    );
+
+    expect(MockedTelemetryDeck).toHaveBeenCalledWith({
+      appID: expect.any(String),
+      clientUser: 'user@example.com',
+    });
+    expect(signal).toHaveBeenCalledWith('pageview', {
+      route: '/organizations/:orgId',
+      host: 'localhost',
+      installation: 'test',
+      environment: 'kubernetes',
+    });
+  });
+
+  it('reuses the client and updates clientUser across pageviews', () => {
+    setEnvironment('kubernetes');
+
+    const service = new TelemetryService();
+    service.trackPageView('/', 'a@example.com');
+    service.trackPageView('/apps', 'b@example.com');
+
+    expect(MockedTelemetryDeck).toHaveBeenCalledTimes(1);
+    expect(signal).toHaveBeenCalledTimes(2);
+    expect(MockedTelemetryDeck.mock.results[0].value.clientUser).toBe(
+      'b@example.com'
+    );
+  });
+});

--- a/src/utils/telemetry/__tests__/normalizePath.ts
+++ b/src/utils/telemetry/__tests__/normalizePath.ts
@@ -1,0 +1,45 @@
+import { normalizePath } from '../normalizePath';
+
+describe('normalizePath', () => {
+  it('maps the home route', () => {
+    expect(normalizePath('/')).toBe('/');
+  });
+
+  it('maps a static route', () => {
+    expect(normalizePath('/organizations')).toBe('/organizations');
+  });
+
+  it('strips the org ID from the organization detail route', () => {
+    expect(normalizePath('/organizations/acme')).toBe('/organizations/:orgId');
+  });
+
+  it('strips concrete IDs from the cluster detail route', () => {
+    expect(normalizePath('/organizations/acme/clusters/abc123')).toBe(
+      '/organizations/:orgId/clusters/:clusterId'
+    );
+  });
+
+  it('maps deep cluster detail sub-routes', () => {
+    expect(
+      normalizePath('/organizations/acme/clusters/abc123/worker-nodes')
+    ).toBe('/organizations/:orgId/clusters/:clusterId/worker-nodes');
+  });
+
+  it('maps the app detail route', () => {
+    expect(normalizePath('/apps/giantswarm/my-app/1.2.3')).toBe(
+      '/apps/:catalogName/:app/:version'
+    );
+  });
+
+  it('prefers the static cluster-creation route over the param variants', () => {
+    expect(normalizePath('/organizations/acme/clusters/new')).toBe(
+      '/organizations/:orgId/clusters/new'
+    );
+  });
+
+  it('returns null for unknown / probing paths', () => {
+    expect(normalizePath('/horde/login.php')).toBeNull();
+    expect(normalizePath('/wp-admin')).toBeNull();
+    expect(normalizePath('/organizations/acme/unknown-subpage')).toBeNull();
+  });
+});

--- a/src/utils/telemetry/__tests__/usePageViewTracking.ts
+++ b/src/utils/telemetry/__tests__/usePageViewTracking.ts
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { usePageViewTracking } from '../usePageViewTracking';
+
+const mockTrackPageView = jest.fn();
+let mockPathname = '/';
+let mockUser: { email: string } | null = null;
+
+jest.mock('../TelemetryService', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({ trackPageView: mockTrackPageView }),
+  },
+}));
+
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
+  useLocation: () => ({ pathname: mockPathname }),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: () => mockUser,
+}));
+
+describe('usePageViewTracking', () => {
+  beforeEach(() => {
+    mockTrackPageView.mockClear();
+    mockPathname = '/';
+    mockUser = null;
+  });
+
+  it('does not track when there is no logged-in user', () => {
+    mockUser = null;
+    mockPathname = '/organizations/acme';
+
+    renderHook(() => usePageViewTracking());
+
+    expect(mockTrackPageView).not.toHaveBeenCalled();
+  });
+
+  it('does not track paths that do not map to a known route', () => {
+    mockUser = { email: 'user@example.com' };
+    mockPathname = '/horde/login.php';
+
+    renderHook(() => usePageViewTracking());
+
+    expect(mockTrackPageView).not.toHaveBeenCalled();
+  });
+
+  it('tracks the normalized route for an authenticated navigation', () => {
+    mockUser = { email: 'user@example.com' };
+    mockPathname = '/organizations/acme';
+
+    renderHook(() => usePageViewTracking());
+
+    expect(mockTrackPageView).toHaveBeenCalledTimes(1);
+    expect(mockTrackPageView).toHaveBeenCalledWith(
+      '/organizations/:orgId',
+      'user@example.com'
+    );
+  });
+
+  it('tracks again when the route changes', () => {
+    mockUser = { email: 'user@example.com' };
+    mockPathname = '/organizations/acme';
+
+    const { rerender } = renderHook(() => usePageViewTracking());
+    expect(mockTrackPageView).toHaveBeenCalledTimes(1);
+
+    mockPathname = '/organizations/acme/clusters/abc123';
+    rerender();
+
+    expect(mockTrackPageView).toHaveBeenCalledTimes(2);
+    expect(mockTrackPageView).toHaveBeenLastCalledWith(
+      '/organizations/:orgId/clusters/:clusterId',
+      'user@example.com'
+    );
+  });
+
+  it('does not re-track when neither route nor user changes', () => {
+    mockUser = { email: 'user@example.com' };
+    mockPathname = '/organizations/acme';
+
+    const { rerender } = renderHook(() => usePageViewTracking());
+    rerender();
+
+    expect(mockTrackPageView).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/telemetry/normalizePath.ts
+++ b/src/utils/telemetry/normalizePath.ts
@@ -1,0 +1,79 @@
+import {
+  AccountSettingsRoutes,
+  AppsRoutes,
+  ExceptionNotificationTestRoutes,
+  MainRoutes,
+  OrganizationsRoutes,
+} from 'model/constants/routes';
+import { matchPath } from 'react-router';
+
+/**
+ * Recursively collects all route pattern strings from the (possibly nested)
+ * route definition objects in `model/constants/routes`.
+ */
+function collectRoutePatterns(routes: Record<string, unknown>): string[] {
+  return Object.values(routes).flatMap((value) => {
+    if (typeof value === 'string') {
+      return [value];
+    }
+
+    if (value !== null && typeof value === 'object') {
+      return collectRoutePatterns(value as Record<string, unknown>);
+    }
+
+    return [];
+  });
+}
+
+const ROUTE_PATTERNS = Array.from(
+  new Set(
+    [
+      MainRoutes,
+      AppsRoutes,
+      AccountSettingsRoutes,
+      ExceptionNotificationTestRoutes,
+      OrganizationsRoutes,
+    ].flatMap(collectRoutePatterns)
+  )
+);
+
+function countParams(pattern: string): number {
+  return pattern.split('/').filter((segment) => segment.startsWith(':')).length;
+}
+
+function countSegments(pattern: string): number {
+  return pattern.split('/').filter(Boolean).length;
+}
+
+/**
+ * Patterns ordered from most to least specific, so that the first exact match
+ * found is the best one. When several patterns match the same concrete path
+ * (e.g. a static segment vs. an optional parameter), fewer parameters wins;
+ * ties are broken by the longer pattern.
+ */
+const SORTED_PATTERNS = [...ROUTE_PATTERNS].sort((a, b) => {
+  const paramDiff = countParams(a) - countParams(b);
+  if (paramDiff !== 0) {
+    return paramDiff;
+  }
+
+  return countSegments(b) - countSegments(a);
+});
+
+/**
+ * Maps a concrete pathname to its route pattern, e.g.
+ * `/organizations/acme/clusters/abc123` ->
+ * `/organizations/:orgId/clusters/:clusterId`.
+ *
+ * Returning the pattern (never the concrete path) keeps real resource names
+ * out of analytics and avoids high-cardinality noise. Returns `null` for paths
+ * that don't correspond to a known route (e.g. bot probes like
+ * `/horde/login.php`), so those are never tracked.
+ */
+export function normalizePath(pathname: string): string | null {
+  const match = SORTED_PATTERNS.find((pattern) =>
+    Boolean(matchPath(pathname, { path: pattern, exact: true }))
+  );
+
+  return match ?? null;
+}

--- a/src/utils/telemetry/usePageViewTracking.ts
+++ b/src/utils/telemetry/usePageViewTracking.ts
@@ -1,0 +1,33 @@
+import { getLoggedInUser } from 'model/stores/main/selectors';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
+
+import { normalizePath } from './normalizePath';
+import TelemetryService from './TelemetryService';
+
+/**
+ * Sends a TelemetryDeck pageview signal for each authenticated navigation.
+ *
+ * Tracking is gated on a logged-in user, so bot probes and unauthenticated
+ * pages (login, logout, OAuth callback) are never tracked. The effect runs
+ * once the user becomes known and again on every route change, which covers
+ * both the initial pageview and subsequent in-app navigation.
+ */
+export function usePageViewTracking(): void {
+  const { pathname } = useLocation();
+  const email = useSelector(getLoggedInUser)?.email;
+
+  useEffect(() => {
+    if (!email) {
+      return;
+    }
+
+    const route = normalizePath(pathname);
+    if (!route) {
+      return;
+    }
+
+    TelemetryService.getInstance().trackPageView(route, email);
+  }, [pathname, email]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4314,6 +4314,11 @@
   resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.5.tgz#043b731d4f56a79b4897a3de1af35e75d56bc63a"
   integrity sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==
 
+"@telemetrydeck/sdk@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@telemetrydeck/sdk/-/sdk-2.0.4.tgz#f846151784fbc165280c74db830a91865b1381c1"
+  integrity sha512-x4S83AqSo6wvLJ6nRYdyJEqd9qmblUdBgsTRrjH5z++b9pnf2NMc8NpVAa48KIB1pRuP/GTGzXxVYdNoie/DVg==
+
 "@testing-library/dom@^9.0.0":
   version "9.3.4"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.4.tgz#50696ec28376926fec0a1bf87d9dbac5e27f60ce"


### PR DESCRIPTION
### What does this PR do?

Replaces the auto-tracking TelemetryDeck **Web SDK** with the manual **JS SDK** (`@telemetrydeck/sdk`), so pageview signals fire **only for authenticated, in-app navigation**.

- Removes the Web SDK `<script>` from `src/index.ejs` and adds `@telemetrydeck/sdk` (pinned exact).
- `TelemetryService` — singleton wrapper (mirrors `ErrorReporter`), disabled in `development` (same gate as Sentry), hashes the logged-in user's email as `clientUser`.
- `normalizePath` — maps concrete paths to route patterns (e.g. `/organizations/acme/clusters/abc123` → `/organizations/:orgId/clusters/:clusterId`) and returns `null` for unknown paths, so org/cluster names and bot/probe paths never reach analytics.
- `usePageViewTracking` hook wired into `Layout` (the authenticated root). Each signal carries `route`, `host` (`window.location.hostname`), `installation`, and `environment`.
- Adds a repo-root `CLAUDE.md` documenting non-obvious workspace conventions encountered while building this (test naming, `window.config` in tests, `GlobalEnvironment` values, dual `src`/`src/components` import roots, Node-20/yarn engine pin, RR v5).

### What is the effect of this change to users?

No visible UI change. Analytics now reflect real, authenticated usage instead of being polluted by unauthenticated bot/probing requests (e.g. `/horde/login.php`). As a side effect, in-app SPA route changes are now tracked properly (the Web SDK mostly only fired once on load).

### How does it look like?

No user-facing UI. Behavior is observable only in the TelemetryDeck dashboard / network traffic (signals to `telemetrydeck.com` with the payload described above).

### Any background context you can provide?

The Web SDK auto-fired a pageview on load for *any* path the SPA shell was served on, so bot scans for paths like `/horde/login.php` showed up as pageviews. Filtering on authentication is the simplest robust filter — bots never authenticate, and the login/logout/OAuth-callback pages render outside `Layout` so they're excluded by construction.

### What is needed from the reviewers?

- Sanity-check the **authenticated-only** filtering approach and the signal payload (note: hashed email is sent as `clientUser`; `host`/`installation` identify the deployment).
- Confirm the TelemetryDeck **appID** carried over (`746BB2DF-…`) is correct.
- Skim `normalizePath` route-pattern matching (uses `matchPath`, "fewer params wins" tie-break).

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

Borderline (not user-visible, but changes what telemetry is sent). Suggested label: `kind/change`.