### PR TITLE
fix(footer): guard against undefined metadata version

### DIFF
--- a/src/components/Footer/FooterUtils.tsx
+++ b/src/components/Footer/FooterUtils.tsx
@@ -5,7 +5,7 @@ import { FlashMessage, messageTTL, messageType } from 'utils/flashMessage';
 import { VersionImpl } from 'utils/Version';
 
 export function formatVersion(version: string): string {
-  if (version.length < 1) return 'VERSION';
+  if (!version || version.length < 1) return 'VERSION';
 
   try {
     const semverVersion = new VersionImpl(version);

--- a/src/components/Footer/__tests__/FooterUtils.ts
+++ b/src/components/Footer/__tests__/FooterUtils.ts
@@ -1,0 +1,26 @@
+import { formatVersion } from '../FooterUtils';
+
+describe('FooterUtils', () => {
+  describe('formatVersion', () => {
+    it('returns the placeholder when the version is undefined', () => {
+      // The metadata version can arrive as `undefined` when `/metadata.json`
+      // is served without a `version` field (e.g. transiently during a
+      // deploy), even though the type says `string`. Guard against it.
+      expect(formatVersion(undefined as unknown as string)).toBe('VERSION');
+    });
+
+    it('returns the placeholder when the version is empty', () => {
+      expect(formatVersion('')).toBe('VERSION');
+    });
+
+    it('returns the version unchanged for a plain semver version', () => {
+      expect(formatVersion('1.72.2')).toBe('1.72.2');
+    });
+
+    it('truncates the pre-release part of a pre-release version', () => {
+      expect(
+        formatVersion('0.0.1-asd123djas123asdasdu98cnas9d81723asd98asy9812')
+      ).toBe('0.0.1-asd12');
+    });
+  });
+});

--- a/src/model/stores/metadata/reducer.ts
+++ b/src/model/stores/metadata/reducer.ts
@@ -27,7 +27,7 @@ const metadataReducer = produce(
 
       case actions.setInitialVersion().types
         .success as typeof METADATA_UPDATE_SET_VERSION_SUCCESS:
-        draft.version.current = action.response;
+        draft.version.current = action.response ?? '';
 
         break;
 


### PR DESCRIPTION
### What does this PR do?

Fixes a `TypeError: Cannot read properties of undefined (reading 'length')` thrown by `formatVersion` in the Footer ([HAPPA-1BV](https://giantswarm.sentry.io/issues/7536006690/)).

`state.metadata.version.current` is typed as `string`, but it's populated from `/metadata.json` (`configurationRes.data.version`). When that response is valid JSON **without** a `version` field — e.g. transiently during a deploy — `data.version` is `undefined` and flows unvalidated into the store, then into `formatVersion(currentVersion)`, where `version.length` throws.

The fix guards at two points:
- **`formatVersion`** — treat a falsy version like an empty one and return the `'VERSION'` placeholder (directly fixes the crash site).
- **metadata reducer** — coerce a missing response to `''` so the store invariant (`current` is always a string) holds, preventing `undefined` from entering state in the first place.

Adds a `FooterUtils` regression test covering the `undefined` and empty cases.

### What is the effect of this change to users?

The Footer no longer crashes (and no longer trips its error boundary) when the metadata version is momentarily unavailable; it shows the `VERSION` placeholder instead.

### How does it look like?

No visual change in the normal case. In the (transient) failure case, the version label shows `VERSION` instead of crashing the footer subtree.

### Any background context you can provide?

Reported via Sentry: HAPPA-1BV (release `happa@1.72.2`, observed once on `/login`, caught by an error boundary — `handled: yes`).

### What is needed from the reviewers?

Sanity-check the two-layer guard.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

Yes — `kind/bug`.