### PR TITLE
fix(ci): unbreak build-fe-docs and chart tests

### DIFF
--- a/ats/Pipfile
+++ b/ats/Pipfile
@@ -5,6 +5,6 @@ verify_ssl = true
 
 [packages]
 pytest-helm-charts = "==1.3.4"
-pytest = "==9.0.3"
+pytest = "==8.4.2"
 pykube-ng = "==23.6.0"
 pytest-rerunfailures = "==11.1.2"

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "underscore": "1.13.8",
     "ws": "^8.17.1",
     "string-width": "4.2.3",
-    "brace-expansion": "^5.0.0",
+    "brace-expansion": "^2.0.2",
     "flatted": "^3.3.3",
     "mdast-util-to-hast": "^13.2.1",
     "nanoid": "^5.0.0",

--- a/renovate.json5
+++ b/renovate.json5
@@ -79,6 +79,19 @@
       matchPackageNames: ["@types/bootstrap", "bootstrap"],
       enabled: false,
     },
+    {
+      // brace-expansion v5 is ESM-only and breaks the CJS `require(...).default`
+      // interop used by Storybook's bundled minimatch, failing the build-fe-docs
+      // job. Stay on the ReDoS-patched v2 line until our toolchain supports v5.
+      matchPackageNames: ["brace-expansion"],
+      allowedVersions: "<3",
+    },
+    {
+      // pytest 9 conflicts with pytest-helm-charts (<9). Hold pytest on the 8.x
+      // line until pytest-helm-charts allows pytest 9.
+      matchPackageNames: ["pytest"],
+      allowedVersions: "<9",
+    },
   ],
   prConcurrentLimit: 5,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6504,10 +6504,10 @@ bail@^2.0.0:
   resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
   integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
 
-balanced-match@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
-  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -6648,12 +6648,12 @@ bplist-parser@^0.2.0:
   dependencies:
     big-integer "^1.6.44"
 
-brace-expansion@^1.1.7, brace-expansion@^2.0.1, brace-expansion@^5.0.0, brace-expansion@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+brace-expansion@^1.1.7, brace-expansion@^2.0.1, brace-expansion@^2.0.2, brace-expansion@^5.0.5:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
   dependencies:
-    balanced-match "^4.0.2"
+    balanced-match "^1.0.0"
 
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"


### PR DESCRIPTION
### What does this PR do?

Reverts two dependency bumps that were merged to `main` and broke CI for **all** open PRs:

- **`brace-expansion` v5** (#4781) → back to `^2.0.2`. v5 is ESM-only and breaks the CommonJS `require(...).default` interop that Storybook's bundled `minimatch@9.0.3` relies on, crashing the `build-fe-docs` job with `TypeError: (0 , brace_expansion_1.default) is not a function`. `^2.0.2` still includes the ReDoS fix (GHSA / CVE-2025-5889).
- **`pytest` v9** (#4747) → back to `==8.4.2`. `pytest-helm-charts==1.3.4` (latest) requires `pytest<9`, so v9 makes `ats/Pipfile.lock` unresolvable and fails the `execute chart tests` job (`Your Pipfile.lock is out of date … Aborting deploy`). No `pytest-helm-charts` release supports pytest 9 yet.

Also adds Renovate guardrails (`allowedVersions`) so neither bump is re-proposed until our toolchain can support it.

### What is the effect of this change to users?

None — CI/test-tooling only. No product code changes.

### Any background context you can provide?

The pytest v9 bump was security-labelled (GHSA-6w46-j5rx-g56g, `/tmp/pytest-of-{user}` handling, fixed only in 9.0.3). That advisory is local-multi-user DoS/privesc; this is a test-only dependency running in ephemeral single-user KinD CI containers, so the practical exposure is negligible. We can move to pytest 9 once `pytest-helm-charts` supports it.

### What is needed from the reviewers?

Confirm the trade-off on holding pytest at 8.x is acceptable.

### Verification

- `yarn storybook:build` → `Preview built`, succeeds (failed before).
- `pipenv install --deploy` in `python:3.12.7` → exit 0, no hash mismatch (failed before).

### Should this change be mentioned in the release notes?

No.