### PR TITLE
ci: pin happa image build to linux/amd64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,10 @@ workflows:
       - architect/push-to-registries:
           context: architect
           name: push-to-registries
+          # The happa Dockerfile is not arm64-ready (npm is unavailable in the
+          # arm64 nginx stage), so pin the pre-architect-v9 single-platform
+          # build until the Dockerfile supports multi-arch.
+          platforms: linux/amd64
           requires:
             - test
             - lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# NOTE: this image is currently built for linux/amd64 only (see .circleci/config.yml);
+# the final nginx stage lacks npm on arm64 -- tracked in #4815.
 FROM gsoci.azurecr.io/giantswarm/alpine:3.24.0 AS compress
 
 RUN apk --no-cache add findutils gzip


### PR DESCRIPTION
## Problem

The architect v9 bump (#4813, merged 2026-06-10) switched `architect/push-to-registries` to always-multi-arch buildx with default platforms `linux/amd64,linux/arm64`. The happa Dockerfile is not arm64-ready: `RUN npm install -g typescript ts-node ...` fails with exit 127 in the `linux/arm64` nginx stage (npm is not available there), while the identical step succeeds on `linux/amd64`.

`ci/circleci: push-to-registries` is a **required** status check on `main`, so since the v9 merge every happa PR is unmergeable (first observed on #4812, build 143040).

## Solution

Pin `platforms: linux/amd64` on the happa image's `push-to-registries` job -- the pre-v9 status quo -- until the Dockerfile is made arm64-capable. The fe-docs image builds fine on both platforms and stays multi-arch.

Made with [Cursor](https://cursor.com)