### PR TITLE
chore: delete custom CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,0 @@
-# Managed in https://github.com/giantswarm/github/tree/main/repositories/override/happa/CODEOWNERS
-
-# Teams:
-* @giantswarm/team-honeybadger
-
-# Individuals:
-package.json @gusevda
-yarn.lock @gusevda
-/.circleci/config.yml @gusevda


### PR DESCRIPTION
to allow overriding with the devctl generated one

Related: https://github.com/giantswarm/github/pull/5355