### PR TITLE
chore: hold lint-staged and nock on v13 line in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -92,6 +92,20 @@
       matchPackageNames: ["pytest"],
       allowedVersions: "<9",
     },
+    {
+      // lint-staged majors >13 require newer Node/tooling and repeatedly fail
+      // CI without benefit -- it's a dev-only pre-commit helper. Hold on 13.x.
+      matchPackageNames: ["lint-staged"],
+      allowedVersions: "<14",
+    },
+    {
+      // nock v14 switches to native fetch interception, which conflicts with
+      // our jsdom test setup (~13 suites left with timing/isolation races
+      // after the core fix). Dev-only test mock; hold on 13.x until the test
+      // suite is migrated.
+      matchPackageNames: ["nock"],
+      allowedVersions: "<14",
+    },
   ],
   prConcurrentLimit: 5,
 }


### PR DESCRIPTION
## Summary

- Add `allowedVersions: "<14"` renovate guardrails for `lint-staged` and `nock`, following the existing brace-expansion/pytest pattern.
- `lint-staged` is a dev-only pre-commit helper; the v17 bump PR (#4795) has been failing CI for weeks with no benefit to shipping code.
- `nock` v14 switches to native fetch interception, which conflicts with our jsdom test setup. The bump PR (#4797) got the core fix but ~13 suites still fail with timing/isolation races that need a dedicated test-suite migration, out of scope for a dependency bump.

Both are devDependencies with no production impact. The corresponding renovate PRs #4795 and #4797 will be closed.

Made with [Cursor](https://cursor.com)