### PR TITLE
chore(renovate): hold eslint v9, jest v30, storybook v10 majors

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -106,6 +106,32 @@
       matchPackageNames: ["nock"],
       allowedVersions: "<14",
     },
+    {
+      // eslint v9 requires the eslintrc -> flat-config migration plus plugin
+      // compatibility updates, and the grouped major PR also trips the
+      // security/snyk gate. Dev-only linting tooling, no production benefit.
+      // Hold on the 8.x line until the flat-config migration is scheduled
+      // (giantswarm/happa#4839). @typescript-eslint is held together because
+      // its major bump is coupled to that migration.
+      matchPackageNames: ["eslint", "@typescript-eslint{/,}**"],
+      allowedVersions: "<9",
+    },
+    {
+      // jest v30 changes jsdom/transform/config behaviour and the test suite
+      // fails under it (giantswarm/happa#4828). Dev-only test runner, no
+      // production benefit. Hold on the 29.x line until the migration is
+      // scheduled (giantswarm/happa#4839).
+      matchPackageNames: ["jest", "jest-environment-jsdom", "@types/jest"],
+      allowedVersions: "<30",
+    },
+    {
+      // storybook v10 needs the CSF3 / Vite-builder migration; the major bump
+      // fails build-fe-docs, build, and test (giantswarm/happa#4835).
+      // Dev-only component docs, no production benefit. Hold on the 7.x line
+      // until the migration is scheduled (giantswarm/happa#4839).
+      matchPackageNames: ["storybook", "@storybook{/,}**"],
+      allowedVersions: "<8",
+    },
   ],
   prConcurrentLimit: 5,
 }


### PR DESCRIPTION
### What does this PR do?

Adds Renovate `allowedVersions` holds for three frontend dev-dependency majors that are structurally unmergeable as plain bumps and re-churn on every marge sweep. Same guardrail pattern as the brace-expansion/pytest/lint-staged/nock holds (#4808, #4831).

- **eslint** held `<9` (group includes `@typescript-eslint`): v9 needs the eslintrc -> flat-config migration plus plugin compat updates, and the grouped major PR also trips `security/snyk` (#4826).
- **jest** held `<30` (`jest`, `jest-environment-jsdom`, `@types/jest`): v30 changes jsdom/transform/config behaviour, test suite fails (#4828).
- **storybook** held `<8` (`storybook`, `@storybook/*`): v10 needs the CSF3 / Vite-builder migration; major bump fails `build-fe-docs`, `build`, and `test` (#4835).

All three are dev/test/build-only tooling with no production benefit. The holds keep them on their current majors until the dedicated migrations are scheduled, tracked in #4839. The three stale Renovate PRs (#4826, #4828, #4835) are being closed.

### What is the effect of this change to users?

None -- Renovate config only, no product or dependency code changes.

### Any background context you can provide?

See #4839 for the migration tracking. Each major requires focused migration work, not a dependency rescue; leaving the PRs open made the marge sweep churn on them every run.

### Should this change be mentioned in the release notes?

No.

Made with [Cursor](https://cursor.com)