### PR TITLE
fix(helm): add startupProbe and raise CPU limit to stop happa startup crashloop

### DIFF
--- a/helm/happa/Chart.yaml
+++ b/helm/happa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: happa
 description: Web user interface for Giant Swarm Kubernetes as a Service.
 home: https://github.com/giantswarm/happa
-version: 1.1.1
+version: 1.1.2
 icon: https://s.giantswarm.io/app-icons/giantswarm/1/light.svg
 appVersion: ''
 annotations:

--- a/helm/happa/templates/deployment.yaml
+++ b/helm/happa/templates/deployment.yaml
@@ -63,6 +63,18 @@ spec:
             value: "/var/run/{{ .Values.name }}/configmap/config.yaml"
           - name: HAPPA_VERSION
             value: "{{ .Chart.AppVersion }}"
+        # The startup does CPU-bound work (config templating + gzip) before nginx
+        # binds :8000. On busy/overcommitted nodes this can exceed the liveness
+        # window, so a startupProbe gates liveness/readiness until nginx is up
+        # (up to failureThreshold * periodSeconds = 150s) and prevents crashloops.
+        startupProbe:
+          httpGet:
+            path: /
+            port: 8000
+            scheme: HTTP
+          periodSeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /
@@ -82,7 +94,7 @@ spec:
             cpu: 100m
             memory: 20Mi
           limits:
-            cpu: 250m
+            cpu: 500m
             memory: 250Mi
         volumeMounts:
         - mountPath: /tmp


### PR DESCRIPTION
## What

- Add a `startupProbe` to the happa Deployment (30 × 5s = up to 150s) so liveness/readiness only kick in once nginx is actually listening on `:8000`.
- Raise the happa container CPU limit `250m → 500m`.
- Bump chart version `1.1.1 → 1.1.2`.

## Why

happa was observed CrashLoopBackOff-ing on gazelle after being rescheduled onto a CPU-overcommitted node (node CPU limits ~331% overcommit).

Root cause is a **startup race**, not a crash or OOM:

- happa's startup does CPU-bound work — config computation (dotenvx env injection), `index.ejs` templating, and `gzip -f -9` of `index.html` + `metadata.json` — **before** nginx binds `:8000`.
- Under the `250m` CPU limit on a contended node, that work gets throttled past the liveness probe window (~40s).
- The liveness probe then fails with `connection refused` and SIGKILLs the container (**exit 137**, `Reason: Error` — not `OOMKilled`; steady-state memory is only ~3–5Mi vs the 250Mi limit).
- It loops until it eventually wins the CPU race, then runs fine.

A `startupProbe` is the correct fix: it gives the CPU-bound startup time to finish without liveness killing it, while liveness still guards the steady state. The CPU limit bump reduces throttling so startup completes faster.

## Testing

- `helm template` renders the Deployment with the new `startupProbe` and `500m` CPU limit as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)