### PR TITLE
fix(docker): pin build tooling to stop startup crash; poll for readiness in launch-container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,9 @@ jobs:
             # relying on a fixed sleep to avoid flaky "connection refused" fails.
             CURL_OUTPUT=""
             for attempt in $(seq 1 30); do
-              CURL_OUTPUT=$(ssh remote-docker "curl -s http://localhost:8000")
+              # `|| true` keeps a not-yet-ready container (curl exit 7) from
+              # aborting the step under `set -e` before we can retry.
+              CURL_OUTPUT=$(ssh remote-docker "curl -s http://localhost:8000") || true
               if echo "${CURL_OUTPUT}" | grep -q "Giant Swarm web interface"; then
                 echo "Container is serving (attempt ${attempt})."
                 break

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,8 +254,21 @@ jobs:
               -p 8000:8000 \
               -d \
               "gsoci.azurecr.io/giantswarm/happa:$(cat VERSION)"
-            sleep 10
-            CURL_OUTPUT=$(ssh remote-docker "curl -s http://localhost:8000")
+
+            # The container runs scripts/prepare.ts (via ts-node) before nginx
+            # starts serving, so it can take a while to come up. Poll instead of
+            # relying on a fixed sleep to avoid flaky "connection refused" fails.
+            CURL_OUTPUT=""
+            for attempt in $(seq 1 30); do
+              CURL_OUTPUT=$(ssh remote-docker "curl -s http://localhost:8000")
+              if echo "${CURL_OUTPUT}" | grep -q "Giant Swarm web interface"; then
+                echo "Container is serving (attempt ${attempt})."
+                break
+              fi
+              echo "Waiting for container to serve (attempt ${attempt})..."
+              sleep 2
+            done
+
             echo "${CURL_OUTPUT}" | grep "Giant Swarm web interface"
 
   build-fe-docs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,20 @@ COPY --chown=nginx tsconfig.json/ /tsconfig.json
 COPY --chown=nginx scripts/ /scripts
 COPY --from=compress --chown=nginx /www /www
 
-RUN npm install -g typescript ts-node ejs @types/ejs tslib @types/node js-yaml @types/js-yaml dotenv
+# Pin these to the versions happa itself declares (see package.json). Leaving
+# them unpinned lets `npm install -g` float to `latest`, which broke the image
+# when TypeScript 7 was published: ts-node 10.9.2 is incompatible with it, so
+# scripts/prepare.ts crashed on startup and the container never served.
+RUN npm install -g \
+      typescript@6.0.3 \
+      ts-node@10.9.2 \
+      ejs@6.0.1 \
+      @types/ejs@3.1.5 \
+      tslib@2.8.1 \
+      @types/node@24.13.2 \
+      js-yaml@4.2.0 \
+      @types/js-yaml@4.0.9 \
+      dotenv@16.6.1
 RUN cd /scripts && npm link ejs @types/ejs js-yaml @types/js-yaml dotenv
 RUN chown -R nginx:nginx /scripts/
 


### PR DESCRIPTION
### What does this PR do?

Two related changes:

1. **`Dockerfile` — pin the globally-installed build tooling** (`typescript`, `ts-node`, `ejs`, `@types/*`, `tslib`, `js-yaml`, `dotenv`) to the versions happa declares in `package.json`. They were installed unpinned, so builds floated to npm `latest`.

2. **`.circleci/config.yml` — make the `launch-container` smoke test poll** for container readiness (30 × 2s) instead of a single fixed `sleep 10`, with `|| true` so an early not-ready curl doesn't abort the step under `set -e`.

### What is the effect of this change to users?

Fresh happa images start and serve again. Since **TypeScript 7** was published to npm, the unpinned `npm install -g typescript` pulled it in; it's incompatible with the pinned `ts-node@10.9.2`, so the entrypoint's `scripts/prepare.ts` crashed on startup (`TypeError: Cannot read property 'fileExists' of undefined`), nginx never started, and the container never served on port 8000. This is the real cause of the recent "startup crashloop" (which #4862's `startupProbe` only masked). Older PRs passed CI only because they were built before TS 7 landed.

### How does it look like?

N/A (build/CI change). Verified locally against the exact failing image: with the pins in place, `prepare.ts` runs, the container stays up, and `curl http://localhost:8000` returns the UI (HTTP 200, "Giant Swarm web interface").

### Any background context you can provide?

Surfaced while investigating why the websocket-driver bump (#4863) failed `launch-container`. The dependency bump was a red herring — websocket-driver isn't in the nginx runtime image; the container was crashing for everyone. Adding the retry loop turned the confusing 10s "flake" into a clear, reproducible startup-crash signal, which led to the root cause.

### What is needed from the reviewers?

Sanity-check the pinned versions against `package.json`, and the smoke-test loop.

### Do the docs need to be updated?

No.

### Should this change be mentioned in the release notes?

Yes — `kind/bug` (fixes happa container startup crashloop).